### PR TITLE
ADB-41 Implement pushdown function

### DIFF
--- a/gpAux/extensions/pxf/Makefile
+++ b/gpAux/extensions/pxf/Makefile
@@ -1,7 +1,7 @@
 EXTENSION = pxf
 DATA = pxf--1.0.sql
 MODULE_big = pxf
-OBJS       = src/pxfprotocol.o src/pxfbridge.o src/pxfuriparser.o src/libchurl.o src/pxfutils.o src/pxfheaders.o src/pxffragment.o src/gpdbwritableformatter.o
+OBJS       = src/pxfprotocol.o src/pxfbridge.o src/pxfuriparser.o src/libchurl.o src/pxfutils.o src/pxfheaders.o src/pxffragment.o src/gpdbwritableformatter.o src/pxffilters.o
 REGRESS    = setup pxf pxfinvalid
 
 ifdef USE_PGXS

--- a/gpAux/extensions/pxf/src/pxfbridge.c
+++ b/gpAux/extensions/pxf/src/pxfbridge.c
@@ -196,6 +196,7 @@ add_querydata_to_http_headers(gphadoop_context *context)
 	inputData.headers = context->churl_headers;
 	inputData.gphduri = context->gphd_uri;
 	inputData.rel = context->relation;
+	inputData.filterstr = context->filterstr;
 	build_http_headers(&inputData);
 }
 

--- a/gpAux/extensions/pxf/src/pxfbridge.h
+++ b/gpAux/extensions/pxf/src/pxfbridge.h
@@ -40,6 +40,7 @@ typedef struct
 	ListCell   *current_fragment;
 	StringInfoData write_file_name;
 	Relation	relation;
+	char *filterstr;
 } gphadoop_context;
 
 /*

--- a/gpAux/extensions/pxf/src/pxffilters.c
+++ b/gpAux/extensions/pxf/src/pxffilters.c
@@ -1,0 +1,1350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * pxffilters.c
+ *
+ * Functions for handling push down of supported scan level filters to PXF.
+ *
+ */
+#include "pxffilters.h"
+
+#include "catalog/pg_operator.h"
+#include "optimizer/clauses.h"
+#include "parser/parse_expr.h"
+#include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/lsyscache.h"
+
+static List* pxf_make_expression_items_list(List *quals, Node *parent, int *logicalOpsNum);
+static void pxf_free_filter(PxfFilterDesc* filter);
+static char* pxf_serialize_filter_list(List *filters);
+static bool opexpr_to_pxffilter(OpExpr *expr, PxfFilterDesc *filter);
+static bool scalar_array_op_expr_to_pxffilter(ScalarArrayOpExpr *expr, PxfFilterDesc *filter);
+static bool var_to_pxffilter(Var *var, PxfFilterDesc *filter);
+static bool supported_filter_type(Oid type);
+static bool supported_operator_type_op_expr(Oid type, PxfFilterDesc *filter);
+static bool supported_operator_type_scalar_array_op_expr(Oid type, PxfFilterDesc *filter, bool useOr);
+static void scalar_const_to_str(Const *constval, StringInfo buf);
+static void list_const_to_str(Const *constval, StringInfo buf);
+static List* append_attr_from_var(Var* var, List* attrs);
+static void enrich_trivial_expression(List *expressionItems);
+static List* get_attrs_from_expr(Expr *expr, bool* expressionIsSupported);
+
+/*
+ * All supported HAWQ operators, and their respective HDFS operator code.
+ * Note that it is OK to use hardcoded OIDs, since these are all pinned
+ * down system catalog operators.
+ * see pg_operator.h
+ */
+dbop_pxfop_map pxf_supported_opr_op_expr[] =
+{
+	/* int2 */
+	{Int2EqualOperator  /* int2eq */, PXFOP_EQ},
+	{95  /* int2lt */, PXFOP_LT},
+	{520 /* int2gt */, PXFOP_GT},
+	{522 /* int2le */, PXFOP_LE},
+	{524 /* int2ge */, PXFOP_GE},
+	{519 /* int2ne */, PXFOP_NE},
+
+	/* int4 */
+	{Int4EqualOperator  /* int4eq */, PXFOP_EQ},
+	{97  /* int4lt */, PXFOP_LT},
+	{521 /* int4gt */, PXFOP_GT},
+	{523 /* int4le */, PXFOP_LE},
+	{525 /* int4ge */, PXFOP_GE},
+	{518 /* int4lt */, PXFOP_NE},
+
+	/* int8 */
+	{Int8EqualOperator /* int8eq */, PXFOP_EQ},
+	{412 /* int8lt */, PXFOP_LT},
+	{413 /* int8gt */, PXFOP_GT},
+	{414 /* int8le */, PXFOP_LE},
+	{415 /* int8ge */, PXFOP_GE},
+	{411 /* int8lt */, PXFOP_NE},
+
+	/* text */
+	{TextEqualOperator  /* texteq  */, PXFOP_EQ},
+	{664 /* text_lt */, PXFOP_LT},
+	{666 /* text_gt */, PXFOP_GT},
+	{665 /* text_le */, PXFOP_LE},
+	{667 /* text_ge */, PXFOP_GE},
+	{531 /* textlt  */, PXFOP_NE},
+	{1209 /* textlike  */, PXFOP_LIKE},
+
+	/* int2 to int4 */
+	{Int24EqualOperator /* int24eq */, PXFOP_EQ},
+	{534  /* int24lt */, PXFOP_LT},
+	{536 /* int24gt */, PXFOP_GT},
+	{540 /* int24le */, PXFOP_LE},
+	{542 /* int24ge */, PXFOP_GE},
+	{538 /* int24ne */, PXFOP_NE},
+
+	/* int4 to int2 */
+	{Int42EqualOperator /* int42eq */, PXFOP_EQ},
+	{535  /* int42lt */, PXFOP_LT},
+	{537 /* int42gt */, PXFOP_GT},
+	{541 /* int42le */, PXFOP_LE},
+	{543 /* int42ge */, PXFOP_GE},
+	{539 /* int42ne */, PXFOP_NE},
+
+	/* int8 to int4 */
+	{Int84EqualOperator /* int84eq */, PXFOP_EQ},
+	{418  /* int84lt */, PXFOP_LT},
+	{419 /* int84gt */, PXFOP_GT},
+	{420 /* int84le */, PXFOP_LE},
+	{430 /* int84ge */, PXFOP_GE},
+	{417 /* int84ne */, PXFOP_NE},
+
+	/* int4 to int8 */
+	{Int48EqualOperator /* int48eq */, PXFOP_EQ},
+	{37  /* int48lt */, PXFOP_LT},
+	{76 /* int48gt */, PXFOP_GT},
+	{80 /* int48le */, PXFOP_LE},
+	{82 /* int48ge */, PXFOP_GE},
+	{36 /* int48ne */, PXFOP_NE},
+
+	/* int2 to int8 */
+	{Int28EqualOperator /* int28eq */, PXFOP_EQ},
+	{1864  /* int28lt */, PXFOP_LT},
+	{1865 /* int28gt */, PXFOP_GT},
+	{1866 /* int28le */, PXFOP_LE},
+	{1867 /* int28ge */, PXFOP_GE},
+	{1863 /* int28ne */, PXFOP_NE},
+
+	/* int8 to int2 */
+	{Int82EqualOperator /* int82eq */, PXFOP_EQ},
+	{1870  /* int82lt */, PXFOP_LT},
+	{1871 /* int82gt */, PXFOP_GT},
+	{1872 /* int82le */, PXFOP_LE},
+	{1873 /* int82ge */, PXFOP_GE},
+	{1869 /* int82ne */, PXFOP_NE},
+
+	/* date */
+	{DateEqualOperator  /* date_eq */, PXFOP_EQ},
+	{1095  /* date_lt */, PXFOP_LT},
+	{1097 /* date_gt */, PXFOP_GT},
+	{1096 /* date_le */, PXFOP_LE},
+	{1098 /* date_ge */, PXFOP_GE},
+	{1094 /* date_ne */, PXFOP_NE},
+
+	/* timestamp */
+	{TimestampEqualOperator  /* timestamp_eq */, PXFOP_EQ},
+	{2062  /* timestamp_lt */, PXFOP_LT},
+	{2064 /* timestamp_gt */, PXFOP_GT},
+	{2063 /* timestamp_le */, PXFOP_LE},
+	{2065 /* timestamp_ge */, PXFOP_GE},
+	{2061 /* timestamp_ne */, PXFOP_NE},
+
+	/* float8 */
+	{Float8EqualOperator  /* float8eq */, PXFOP_EQ},
+	{672 /* float8lt */, PXFOP_LT},
+	{674 /* float8gt */, PXFOP_GT},
+	{673 /* float8le */, PXFOP_LE},
+	{675 /* float8ge */, PXFOP_GE},
+	{671 /* float8ne */, PXFOP_NE},
+
+	/* float48 */
+	{1120 /* float48eq */, PXFOP_EQ},
+	{1122 /* float48lt */, PXFOP_LT},
+	{1123 /* float48gt */, PXFOP_GT},
+	{1124 /* float48le */, PXFOP_LE},
+	{1125 /* float48ge */, PXFOP_GE},
+	{1121 /* float48ne */, PXFOP_NE},
+
+	/* bpchar */
+	{BPCharEqualOperator  /* bpchareq */, PXFOP_EQ},
+	{1058  /* bpcharlt */, PXFOP_LT},
+	{1060 /* bpchargt */, PXFOP_GT},
+	{1059 /* bpcharle */, PXFOP_LE},
+	{1061 /* bpcharge */, PXFOP_GE},
+	{1057 /* bpcharne */, PXFOP_NE},
+
+	/* boolean */
+	{BooleanEqualOperator  /* booleq */, PXFOP_EQ},
+	{58  /* boollt */, PXFOP_LT},
+	{59 /* boolgt */, PXFOP_GT},
+	{1694 /* boolle */, PXFOP_LE},
+	{1695 /* boolge */, PXFOP_GE},
+	{85 /* boolne */, PXFOP_NE}
+};
+
+
+dbop_pxfop_array_map pxf_supported_opr_scalar_array_op_expr[] =
+{
+	/* int2 */
+	{Int2EqualOperator  /* int2eq */, PXFOP_IN, true},
+
+	/* int4 */
+	{Int4EqualOperator  /* int4eq */, PXFOP_IN, true},
+
+	/* int8 */
+	{Int8EqualOperator /* int8eq */, PXFOP_IN, true},
+
+	/* text */
+	{TextEqualOperator  /* texteq  */, PXFOP_IN, true},
+
+	/* int2 to int4 */
+	{Int24EqualOperator /* int24eq */, PXFOP_IN, true},
+
+	/* int4 to int2 */
+	{Int42EqualOperator /* int42eq */, PXFOP_IN, true},
+
+	/* int8 to int4 */
+	{Int84EqualOperator /* int84eq */, PXFOP_IN, true},
+
+	/* int4 to int8 */
+	{Int48EqualOperator /* int48eq */, PXFOP_IN, true},
+
+	/* int2 to int8 */
+	{Int28EqualOperator /* int28eq */, PXFOP_IN, true},
+
+	/* int8 to int2 */
+	{Int82EqualOperator /* int82eq */, PXFOP_IN, true},
+
+	/* date */
+	{DateEqualOperator  /* date_eq */, PXFOP_IN, true},
+
+	/* timestamp */
+	{TimestampEqualOperator  /* timestamp_eq */, PXFOP_IN, true},
+
+	/* float8 */
+	{Float8EqualOperator  /* float8eq */, PXFOP_IN, true},
+
+	/* float48 */
+	{1120 /* float48eq */, PXFOP_IN, true},
+
+	/* bpchar */
+	{BPCharEqualOperator  /* bpchareq */, PXFOP_IN, true},
+
+	/* boolean */
+	{BooleanEqualOperator  /* booleq */, PXFOP_IN, true},
+
+	/* bytea */
+	// TODO: uncomment once HAWQ-1085 is done
+	//,{ByteaEqualOperator  /* byteaeq */, PXFOP_IN, true},
+};
+
+Oid pxf_supported_types[] =
+{
+	INT2OID,
+	INT4OID,
+	INT8OID,
+	FLOAT4OID,
+	FLOAT8OID,
+	NUMERICOID,
+	TEXTOID,
+	VARCHAROID,
+	BPCHAROID,
+	CHAROID,
+	BOOLOID,
+	DATEOID,
+	TIMESTAMPOID,
+	/* complex datatypes*/
+	INT2ARRAYOID,
+	INT4ARRAYOID,
+	INT8ARRAYOID,
+	TEXTARRAYOID
+};
+
+static void
+pxf_free_expression_items_list(List *expressionItems, bool freeBoolExprNodes)
+{
+	ExpressionItem 	*expressionItem = NULL;
+	int previousLength;
+
+	while (list_length(expressionItems) > 0)
+	{
+		expressionItem = (ExpressionItem *) lfirst(list_head(expressionItems));
+		if (freeBoolExprNodes && nodeTag(expressionItem->node) == T_BoolExpr)
+		{
+			pfree((BoolExpr *)expressionItem->node);
+		}
+		pfree(expressionItem);
+
+		/* to avoid freeing already freed items - delete all occurrences of current expression*/
+		previousLength = expressionItems->length + 1;
+		while (expressionItems != NULL && previousLength > expressionItems->length)
+		{
+			previousLength = expressionItems->length;
+			expressionItems = list_delete_ptr(expressionItems, expressionItem);
+		}
+	}
+}
+
+/*
+ * pxf_make_expression_items_list
+ *
+ * Given a scan node qual list, find the filters that are eligible to be used
+ * by PXF, construct an expressions list, which consists of OpExpr or BoolExpr nodes
+ * and return it to the caller.
+ *
+ * Basically this function just transforms expression tree to Reversed Polish Notation list.
+ *
+ *
+ */
+static List *
+pxf_make_expression_items_list(List *quals, Node *parent, int *logicalOpsNum)
+{
+	ExpressionItem *expressionItem = NULL;
+	List			*result = NIL;
+	ListCell		*lc = NULL;
+	ListCell		*ilc = NULL;
+
+	if (list_length(quals) == 0)
+		return NIL;
+
+	foreach (lc, quals)
+	{
+		Node *node = (Node *) lfirst(lc);
+		NodeTag tag = nodeTag(node);
+		expressionItem = (ExpressionItem *) palloc0(sizeof(ExpressionItem));
+		expressionItem->node = node;
+		expressionItem->parent = parent;
+		expressionItem->processed = false;
+
+		switch (tag)
+		{
+			case T_Var: // IN(single_value)
+			case T_OpExpr:
+			case T_ScalarArrayOpExpr:
+			case T_NullTest:
+			{
+				result = lappend(result, expressionItem);
+				break;
+			}
+			case T_BoolExpr:
+			{
+				(*logicalOpsNum)++;
+				BoolExpr	*expr = (BoolExpr *) node;
+				List *inner_result = pxf_make_expression_items_list(expr->args, node, logicalOpsNum);
+				result = list_concat(result, inner_result);
+
+				int childNodesNum = 0;
+
+				/* Find number of child nodes on first level*/
+				foreach (ilc, inner_result)
+				{
+					ExpressionItem *ei = (ExpressionItem *) lfirst(ilc);
+					if (!ei->processed && ei->parent == node)
+					{
+						ei->processed = true;
+						childNodesNum++;
+					}
+				}
+
+				if (expr->boolop == NOT_EXPR) {
+					for (int i = 0; i < childNodesNum; i++)
+					{
+						result = lappend(result, expressionItem);
+					}
+				}
+				else if (expr->boolop == AND_EXPR || expr->boolop == OR_EXPR) {
+					for (int i = 0; i < childNodesNum - 1; i++)
+					{
+						result = lappend(result, expressionItem);
+					}
+				}
+				else {
+					ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("internal error in pxffilters.c:pxf_make_expression_items_list. "
+								 "Found unknown boolean expression type")));
+				}
+				break;
+			}
+			default:
+				elog(DEBUG1, "pxf_make_expression_items_list: unsupported node tag %d", tag);
+				break;
+		}
+	}
+
+	return result;
+}
+
+static void
+pxf_free_filter(PxfFilterDesc* filter)
+{
+	if (!filter)
+		return;
+
+	if (filter->l.conststr)
+	{
+		if (filter->l.conststr->data)
+			pfree(filter->l.conststr->data);
+		pfree(filter->l.conststr);
+	}
+	if (filter->r.conststr)
+	{
+		if (filter->r.conststr->data)
+			pfree(filter->r.conststr->data);
+		pfree(filter->r.conststr);
+	}
+
+	pfree(filter);
+}
+
+/*
+ * pxf_serialize_filter_list
+ *
+ * Takes expression items list in RPN notation, produce a
+ * serialized string representation in order to communicate this list
+ * over the wire.
+ *
+ * The serialized string is in a RPN (Reversed Polish Notation) format
+ * as flattened tree. Operands and operators are represented with their
+ * respective codes. Each filter is serialized as follows:
+ *
+ * <attcode><attnum><constcode><constval><constsizecode><constsize><constdata><constvalue><opercode><opernum>
+ *
+ * Example filter list:
+ *
+ * Column(0) > 1 AND Column(0) < 5 AND Column(2) == "third"
+ *
+ * Yields the following serialized string:
+ *
+ * a0c23s1d1o2a1c23s1d5o1a2c25s5dthirdo5l0l0
+ *
+ * Where:
+ *
+ * a0     - first column of table
+ * c23    - scalar constant with type oid 23(INT4)
+ * s1     - size of constant in bytes
+ * d1     - serialized constant value
+ * o2     - greater than operation
+ * a1     - second column of table
+ * c23    - scalar constant with type oid 23(INT4)
+ * s1     - size of constant in bytes
+ * d5     - serialized constant value
+ * o1     - less than operation
+ * a2     - third column of table
+ * c25    - scalar constant with type oid 25(TEXT)
+ * s5     - size of constant in bytes
+ * dthird - serialized constant value
+ * o5     - equals operation
+ * l0     - AND operator
+ * l0     - AND operator
+ *
+ */
+static char *
+pxf_serialize_filter_list(List *expressionItems)
+{
+	StringInfo	 resbuf;
+	ListCell	*lc = NULL;
+
+	if (list_length(expressionItems) == 0) {
+		return NULL;
+	}
+
+	resbuf = makeStringInfo();
+
+	/*
+	 * Iterate through the expression items in the list and serialize them one after the other.
+	 */
+	foreach (lc, expressionItems)
+	{
+		ExpressionItem *expressionItem = (ExpressionItem *) lfirst(lc);
+		Node *node = expressionItem->node;
+		NodeTag tag = nodeTag(node);
+
+		switch (tag)
+		{
+			case T_Var:
+			{
+				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_Var)", tag);
+				PxfFilterDesc *filter = (PxfFilterDesc *) palloc0(sizeof(PxfFilterDesc));
+				Var *var = (Var *) node;
+				if (var_to_pxffilter(var, filter))
+				{
+					PxfOperand l = filter->l;
+					PxfOperand r = filter->r;
+					PxfOperatorCode o = filter->op;
+					if (pxfoperand_is_attr(l) && pxfoperand_is_scalar_const(r))
+					{
+						appendStringInfo(resbuf, "%c%d%c%d%c%lu%c%s",
+												 PXF_ATTR_CODE, l.attnum - 1, /* Java attrs are 0-based */
+												 PXF_SCALAR_CONST_CODE, r.consttype,
+												 PXF_SIZE_BYTES, strlen(r.conststr->data),
+												 PXF_CONST_DATA, (r.conststr)->data);
+					}
+					else
+					{
+						/* var_to_pxffilter() should have never let this happen */
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+								 errmsg("internal error in pxffilters.c:pxf_serialize_"
+										 "filter_list. Found a non const+attr filter")));
+					}
+					appendStringInfo(resbuf, "%c%d", PXF_OPERATOR_CODE, o);
+					pxf_free_filter(filter);
+
+				}
+				else
+				{
+					/* if at least one expression item is not supported, whole filter doesn't make sense*/
+					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
+					pfree(filter);
+					pfree(resbuf->data);
+					return NULL;
+				}
+				break;
+			}
+			case T_OpExpr:
+			{
+				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_OpExpr)", tag);
+				PxfFilterDesc *filter = (PxfFilterDesc *) palloc0(sizeof(PxfFilterDesc));
+				OpExpr *expr = (OpExpr *) node;
+				if (opexpr_to_pxffilter(expr, filter))
+				{
+					PxfOperand l = filter->l;
+					PxfOperand r = filter->r;
+					PxfOperatorCode o = filter->op;
+					if (pxfoperand_is_attr(l) && pxfoperand_is_scalar_const(r))
+					{
+						appendStringInfo(resbuf, "%c%d%c%d%c%lu%c%s",
+												 PXF_ATTR_CODE, l.attnum - 1, /* Java attrs are 0-based */
+												 PXF_SCALAR_CONST_CODE, r.consttype,
+												 PXF_SIZE_BYTES, strlen(r.conststr->data),
+												 PXF_CONST_DATA, (r.conststr)->data);
+					}
+					else if (pxfoperand_is_scalar_const(l) && pxfoperand_is_attr(r))
+					{
+						appendStringInfo(resbuf, "%c%d%c%lu%c%s%c%d",
+												 PXF_SCALAR_CONST_CODE, l.consttype,
+												 PXF_SIZE_BYTES, strlen(l.conststr->data),
+												 PXF_CONST_DATA, (l.conststr)->data,
+												 PXF_ATTR_CODE, r.attnum - 1); /* Java attrs are 0-based */
+					}
+					else
+					{
+						/* opexpr_to_pxffilter() should have never let this happen */
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+								 errmsg("internal error in pxffilters.c:pxf_serialize_"
+										 "filter_list. Found a non const+attr filter")));
+					}
+					appendStringInfo(resbuf, "%c%d", PXF_OPERATOR_CODE, o);
+					pxf_free_filter(filter);
+				} else {
+					/* if at least one expression item is not supported, whole filter doesn't make sense*/
+					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
+					pfree(filter);
+					pfree(resbuf->data);
+					return NULL;
+				}
+				break;
+			}
+			case T_ScalarArrayOpExpr:
+			{
+				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_ScalarArrayOpExpr)", tag);
+				ScalarArrayOpExpr *expr = (ScalarArrayOpExpr *) node;
+				PxfFilterDesc *filter = (PxfFilterDesc *) palloc0(sizeof(PxfFilterDesc));
+				if (scalar_array_op_expr_to_pxffilter(expr, filter))
+				{
+					PxfOperand l = filter->l;
+					PxfOperand r = filter->r;
+					PxfOperatorCode o = filter->op;
+					if (pxfoperand_is_attr(l) && pxfoperand_is_list_const(r))
+					{
+						appendStringInfo(resbuf, "%c%d%c%d%s",
+												 PXF_ATTR_CODE, l.attnum - 1, /* Java attrs are 0-based */
+												 PXF_LIST_CONST_CODE, r.consttype,
+												 r.conststr->data);
+					}
+					else if (pxfoperand_is_list_const(l) && pxfoperand_is_attr(r))
+					{
+						appendStringInfo(resbuf, "%c%d%s%c%d",
+												 PXF_SCALAR_CONST_CODE, l.consttype,
+												 l.conststr->data,
+												 PXF_ATTR_CODE, r.attnum - 1); /* Java attrs are 0-based */
+					}
+					else
+					{
+						/* scalararrayopexpr_to_pxffilter() should have never let this happen */
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+								 errmsg("internal error in pxffilters.c:pxf_serialize_"
+										 "filter_list. Found a non const+attr filter")));
+					}
+					appendStringInfo(resbuf, "%c%d", PXF_OPERATOR_CODE, o);
+					pxf_free_filter(filter);
+				} else {
+					/* if at least one expression item is not supported, whole filter doesn't make sense*/
+					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
+					pfree(filter);
+					pfree(resbuf->data);
+					return NULL;
+				}
+				break;
+			}
+			case T_BoolExpr:
+			{
+				BoolExpr *expr = (BoolExpr *) node;
+				BoolExprType boolType = expr->boolop;
+				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_BoolExpr), bool node type %d", tag, boolType);
+				appendStringInfo(resbuf, "%c%d", PXF_LOGICAL_OPERATOR_CODE, boolType);
+				break;
+			}
+			case T_NullTest:
+			{
+				elog(DEBUG1, "pxf_serialize_filter_list: node tag %d (T_NullTest)", tag);
+				NullTest *expr = (NullTest *) node;
+				Var *var = (Var *) expr->arg;
+
+				//TODO: add check for supported operation
+				if (!supported_filter_type(var->vartype))
+				{
+					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
+					return NULL;
+				}
+
+				/* filter expression for T_NullTest will not have any constant value */
+				if (expr->nulltesttype == IS_NULL)
+				{
+					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, var->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NULL);
+				}
+				else if (expr->nulltesttype == IS_NOT_NULL)
+				{
+					appendStringInfo(resbuf, "%c%d%c%d", PXF_ATTR_CODE, var->varattno - 1, PXF_OPERATOR_CODE, PXFOP_IS_NOTNULL);
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							 errmsg("internal error in pxffilters.c:pxf_serialize_"
+									 "filter_list. Found a NullTest filter with incorrect NullTestType")));
+				}
+				break;
+			}
+			default:
+			{
+				elog(DEBUG5, "Skipping tag: %d", tag);
+			}
+		}
+	}
+
+	if (resbuf->len == 0)
+	{
+		pfree(resbuf->data);
+		return NULL;
+	}
+
+	return resbuf->data;
+}
+
+
+/*
+ * opexpr_to_pxffilter
+ *
+ * check if an OpExpr qualifies to be pushed-down to PXF.
+ * if it is - create it and return a success code.
+ */
+static bool
+opexpr_to_pxffilter(OpExpr *expr, PxfFilterDesc *filter)
+{
+	Node	*leftop 	= NULL;
+	Node	*rightop	= NULL;
+	Oid		 rightop_type = InvalidOid;
+	Oid		 leftop_type = InvalidOid;
+
+	if ((!expr) || (!filter))
+		return false;
+
+	leftop = get_leftop((Expr*)expr);
+	rightop	= get_rightop((Expr*)expr);
+	leftop_type = exprType(leftop);
+	rightop_type = exprType(rightop);
+
+	/* only binary oprs supported currently */
+	if (!rightop)
+	{
+		elog(DEBUG1, "opexpr_to_pxffilter: unary op! leftop_type: %d, op: %d",
+			 leftop_type, expr->opno);
+		return false;
+	}
+
+	elog(DEBUG1, "opexpr_to_gphdfilter: leftop (expr type: %d, arg type: %d), "
+			"rightop_type (expr type: %d, arg type %d), op: %d",
+			leftop_type, nodeTag(leftop),
+			rightop_type, nodeTag(rightop),
+			expr->opno);
+
+	/*
+	 * check if supported type -
+	 */
+	if (!supported_filter_type(rightop_type) || !supported_filter_type(leftop_type))
+		return false;
+
+	/*
+	 * check if supported operator -
+	 */
+	if (!supported_operator_type_op_expr(expr->opno, filter))
+		return false;
+
+	/* arguments must be VAR and CONST */
+	if (IsA(leftop,  Var) && IsA(rightop, Const))
+	{
+		filter->l.opcode = PXF_ATTR_CODE;
+		filter->l.attnum = ((Var *) leftop)->varattno;
+		filter->l.consttype = InvalidOid;
+		if (filter->l.attnum <= InvalidAttrNumber)
+			return false; /* system attr not supported */
+
+		filter->r.opcode = PXF_SCALAR_CONST_CODE;
+		filter->r.attnum = InvalidAttrNumber;
+		filter->r.conststr = makeStringInfo();
+		scalar_const_to_str((Const *)rightop, filter->r.conststr);
+		filter->r.consttype = ((Const *)rightop)->consttype;
+	}
+	else if (IsA(leftop, Const) && IsA(rightop, Var))
+	{
+		filter->l.opcode = PXF_SCALAR_CONST_CODE;
+		filter->l.attnum = InvalidAttrNumber;
+		filter->l.conststr = makeStringInfo();
+		scalar_const_to_str((Const *)leftop, filter->l.conststr);
+		filter->l.consttype = ((Const *)leftop)->consttype;
+
+		filter->r.opcode = PXF_ATTR_CODE;
+		filter->r.attnum = ((Var *) rightop)->varattno;
+		filter->r.consttype = InvalidOid;
+		if (filter->r.attnum <= InvalidAttrNumber)
+			return false; /* system attr not supported */
+	}
+	else
+	{
+		elog(DEBUG1, "opexpr_to_pxffilter: expression is not a Var+Const");
+		return false;
+	}
+
+	return true;
+}
+
+static bool
+scalar_array_op_expr_to_pxffilter(ScalarArrayOpExpr *expr, PxfFilterDesc *filter)
+{
+
+	Node	*leftop 	= NULL;
+	Node	*rightop	= NULL;
+
+	leftop = (Node *) linitial(expr->args);
+	rightop = (Node *) lsecond(expr->args);
+	Oid		 leftop_type = exprType(leftop);
+	Oid		 rightop_type = exprType(rightop);
+
+	/*
+	 * check if supported type -
+	 */
+	if (!supported_filter_type(rightop_type) || !supported_filter_type(leftop_type))
+		return false;
+
+	/*
+	 * check if supported operator -
+	 */
+	if(!supported_operator_type_scalar_array_op_expr(expr->opno, filter, expr->useOr))
+		return false;
+
+	if (IsA(leftop, Var) && IsA(rightop, Const))
+	{
+		filter->l.opcode = PXF_ATTR_CODE;
+		filter->l.attnum = ((Var *) leftop)->varattno;
+		filter->l.consttype = InvalidOid;
+		if (filter->l.attnum <= InvalidAttrNumber)
+			return false; /* system attr not supported */
+
+		filter->r.opcode = PXF_LIST_CONST_CODE;
+		filter->r.attnum = InvalidAttrNumber;
+		filter->r.conststr = makeStringInfo();
+		list_const_to_str((Const *)rightop, filter->r.conststr);
+		filter->r.consttype = ((Const *)rightop)->consttype;
+	}
+	else if (IsA(leftop, Const) && IsA(rightop, Var))
+	{
+		filter->l.opcode = PXF_LIST_CONST_CODE;
+		filter->l.attnum = InvalidAttrNumber;
+		filter->l.conststr = makeStringInfo();
+		list_const_to_str((Const *)leftop, filter->l.conststr);
+		filter->l.consttype = ((Const *)leftop)->consttype;
+
+		filter->r.opcode = PXF_ATTR_CODE;
+		filter->r.attnum = ((Var *) rightop)->varattno;
+		filter->r.consttype = InvalidOid;
+		if (filter->r.attnum <= InvalidAttrNumber)
+			return false; /* system attr not supported */
+	}
+	else
+	{
+		elog(DEBUG1, "pxf_serialize_filter_list: expression is not a Var+Const");
+		return false;
+	}
+
+
+
+	return true;
+}
+
+static bool
+var_to_pxffilter(Var *var, PxfFilterDesc *filter)
+{
+	Oid var_type = InvalidOid;
+
+	if ((!var) || (!filter))
+		return false;
+
+	var_type = exprType((Node *)var);
+
+	/*
+	 * check if supported type -
+	 */
+	if (!supported_filter_type(var_type))
+		return false;
+
+	/* arguments must be VAR and CONST */
+	if (IsA(var,  Var))
+	{
+		filter->l.opcode = PXF_ATTR_CODE;
+		filter->l.attnum = var->varattno;
+		filter->l.consttype = InvalidOid;
+		if (filter->l.attnum <= InvalidAttrNumber)
+			return false; /* system attr not supported */
+
+		filter->r.opcode = PXF_SCALAR_CONST_CODE;
+		filter->r.attnum = InvalidAttrNumber;
+		filter->r.conststr = makeStringInfo();
+		appendStringInfo(filter->r.conststr, TrueConstValue);
+		filter->r.consttype = BOOLOID;
+	}
+	else
+	{
+		elog(DEBUG1, "var_to_pxffilter: expression is not a Var");
+		return false;
+	}
+
+	return true;
+}
+
+static List*
+append_attr_from_var(Var* var, List* attrs)
+{
+	AttrNumber varattno = var->varattno;
+	/* system attr not supported */
+	if (varattno > InvalidAttrNumber)
+		return lappend_int(attrs, varattno - 1);
+
+	return attrs;
+}
+
+/*
+ * append_attr_from_func_args
+ *
+ * extracts all columns from FuncExpr into attrs
+ * assigns false to expressionIsSupported if at least one of items is not supported
+ */
+static List*
+append_attr_from_func_args(FuncExpr *expr, List* attrs, bool* expressionIsSupported) {
+	if (!expressionIsSupported) {
+		return NIL;
+	}
+	ListCell *lc = NULL;
+	foreach (lc, expr->args)
+	{
+		Node *node = (Node *) lfirst(lc);
+		if (IsA(node, FuncExpr)) {
+			attrs = append_attr_from_func_args((FuncExpr *) node, attrs, expressionIsSupported);
+		} else if (IsA(node, Var)) {
+			attrs = append_attr_from_var((Var *) node, attrs);
+		} else if (IsA(node, OpExpr)) {
+			attrs = get_attrs_from_expr((OpExpr *) node, expressionIsSupported);
+		} else {
+			*expressionIsSupported = false;
+			return NIL;
+		}
+	}
+
+	return attrs;
+
+}
+
+/*
+ * get_attrs_from_expr
+ *
+ * extracts and returns list of all columns from Expr
+ * assigns false to expressionIsSupported if at least one of items is not supported
+ */
+static List*
+get_attrs_from_expr(Expr *expr, bool* expressionIsSupported)
+{
+	Node *leftop = NULL;
+	Node *rightop = NULL;
+	List *attrs = NIL;
+
+	*expressionIsSupported = true;
+
+	if ((!expr))
+		return attrs;
+
+	if (IsA(expr, OpExpr))
+	{
+		leftop = get_leftop(expr);
+		rightop	= get_rightop(expr);
+	} else if (IsA(expr, ScalarArrayOpExpr))
+	{
+		ScalarArrayOpExpr *saop = (ScalarArrayOpExpr *) expr;
+		leftop = (Node *) linitial(saop->args);
+		rightop = (Node *) lsecond(saop->args);
+	} else {
+		// If expression type is not known, report that it's not supported
+		*expressionIsSupported = false;
+		return NIL;
+	}
+
+	// We support following combinations of operands:
+	// Var, Const
+	// Relabel, Const
+	// FuncExpr, Const
+	// Const, Var
+	// Const, Relabel
+	// Const, FuncExpr
+	// For most of datatypes column is represented by Var node
+	// For varchar column is represented by RelabelType node
+	if (IsA(leftop, Var) && IsA(rightop, Const))
+	{
+		attrs = append_attr_from_var((Var *) leftop, attrs);
+	} else if (IsA(leftop, RelabelType) && IsA(rightop, Const))
+	{
+		attrs = append_attr_from_var((Var *) ((RelabelType *) leftop)->arg, attrs);
+	} else if (IsA(leftop, FuncExpr) && IsA(rightop, Const)) {
+		FuncExpr *expr = (FuncExpr *) leftop;
+		attrs = append_attr_from_func_args(expr, attrs, expressionIsSupported);
+	}
+	else if (IsA(rightop, Var) && IsA(leftop, Const))
+	{
+		attrs = append_attr_from_var((Var *) rightop, attrs);
+	} else if (IsA(rightop, RelabelType) && IsA(leftop, Const))
+	{
+		attrs = append_attr_from_var((Var *) ((RelabelType *) rightop)->arg, attrs);
+	} else if (IsA(rightop, FuncExpr) && IsA(leftop, Const)) {
+		FuncExpr *expr = (FuncExpr *) rightop;
+		attrs = append_attr_from_func_args(expr, attrs, expressionIsSupported);
+	}
+	else {
+		// If operand type or combination is not known, report that it's not supported
+		// to avoid partially extracted attributes from expression
+		*expressionIsSupported = false;
+		return NIL;
+	}
+
+	return attrs;
+
+}
+
+/*
+ * supported_filter_type
+ *
+ * Return true if the type is supported by pxffilters.
+ * Supported defines are defined in pxf_supported_types.
+ */
+static bool
+supported_filter_type(Oid type)
+{
+	int		 nargs 		= sizeof(pxf_supported_types) / sizeof(Oid);
+	int 	 i;
+
+	/* is type supported? */
+	for (i = 0; i < nargs; i++)
+	{
+		if (type == pxf_supported_types[i])
+			return true;
+	}
+
+	elog(DEBUG1, "supported_filter_type: filter pushdown is not supported for datatype oid: %d", type);
+
+	return false;
+}
+
+
+static bool
+supported_operator_type_op_expr(Oid type, PxfFilterDesc *filter)
+{
+
+	int nargs = sizeof(pxf_supported_opr_op_expr) / sizeof(dbop_pxfop_map);
+	int i;
+	/* is operator supported? if so, set the corresponding PXFOP */
+	for (i = 0; i < nargs; i++)
+	{
+		/* NOTE: switch to hash table lookup if   */
+		/* array grows. for now it's cheap enough */
+		if(type == pxf_supported_opr_op_expr[i].dbop)
+		{
+			filter->op = pxf_supported_opr_op_expr[i].pxfop;
+			return true; /* filter qualifies! */
+		}
+	}
+
+		elog(DEBUG1, "opexpr_to_pxffilter: operator is not supported, operator code: %d", type);
+
+		return false;
+}
+
+static bool
+supported_operator_type_scalar_array_op_expr(Oid type, PxfFilterDesc *filter, bool useOr)
+{
+
+	int nargs = sizeof(pxf_supported_opr_scalar_array_op_expr) / sizeof(dbop_pxfop_array_map);
+	int i;
+	/* is operator supported? if so, set the corresponding PXFOP */
+	for (i = 0; i < nargs; i++)
+	{
+		/* NOTE: switch to hash table lookup if   */
+		/* array grows. for now it's cheap enough */
+		if(useOr == pxf_supported_opr_scalar_array_op_expr[i].useOr && type == pxf_supported_opr_scalar_array_op_expr[i].dbop)
+		{
+			filter->op = pxf_supported_opr_scalar_array_op_expr[i].pxfop;
+			return true; /* filter qualifies! */
+		}
+	}
+
+		elog(DEBUG1, "supported_operator_type_scalar_array_op_expr: operator is not supported, operator code: %d", type);
+
+		return false;
+}
+
+
+
+/*
+ * const_to_str
+ *
+ * Extract the value stored in a const operand into a string. If the operand
+ * type is text based, make sure to escape the value with surrounding quotes.
+ */
+static void
+scalar_const_to_str(Const *constval, StringInfo buf)
+{
+	Oid			typoutput;
+	bool		typIsVarlena;
+	char	   *extval;
+
+	if (constval->constisnull)
+	{
+		/* TODO: test this edge case and its consequences */
+		appendStringInfo(buf, NullConstValue);
+		return;
+	}
+
+	getTypeOutputInfo(constval->consttype,
+					  &typoutput, &typIsVarlena);
+
+	extval = OidOutputFunctionCall(typoutput, constval->constvalue);
+
+	switch (constval->consttype)
+	{
+		case INT2OID:
+		case INT4OID:
+		case INT8OID:
+		case FLOAT4OID:
+		case FLOAT8OID:
+		case NUMERICOID:
+		case TEXTOID:
+		case VARCHAROID:
+		case BPCHAROID:
+		case CHAROID:
+		case BYTEAOID:
+		case DATEOID:
+		case TIMESTAMPOID:
+			appendStringInfo(buf, "%s", extval);
+			break;
+		case BOOLOID:
+			if (strcmp(extval, "t") == 0)
+				appendStringInfo(buf, TrueConstValue);
+			else
+				appendStringInfo(buf, FalseConstValue);
+			break;
+		default:
+			/* should never happen. we filter on types earlier */
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("internal error in pxffilters.c:scalar_const_to_str. "
+							"Using unsupported data type (%d) (value %s)",
+							constval->consttype, extval)));
+
+	}
+
+	pfree(extval);
+}
+
+
+/*
+ * list_const_to_str
+ *
+ * Extracts the value stored in a list constant to a string.
+ * Currently supported data types: int2[], int4[], int8[], text[], boolean[]
+ * Example:
+ * Input: ['abc', 'xyz']
+ * Output: s3dabcs3dxyz
+ *
+ */
+static void
+list_const_to_str(Const *constval, StringInfo buf)
+{
+	StringInfo	interm_buf;
+	Datum *dats;
+	ArrayType  *arr;
+	int len;
+
+	if (constval->constisnull)
+	{
+		elog(DEBUG1, "Null constant is not expected in this context.");
+		return;
+	}
+
+	if (constval->constbyval) {
+		elog(DEBUG1, "Constant passed by value is not expected in this context.");
+		return;
+	}
+
+	arr = DatumGetArrayTypeP(constval->constvalue);
+
+	interm_buf = makeStringInfo();
+
+	switch (constval->consttype)
+	{
+		case INT2ARRAYOID:
+		{
+			int16 value;
+			deconstruct_array(arr, INT2OID, sizeof (value), true, 's', &dats, NULL, &len);
+
+			for (int i = 0; i < len; i++)
+			{
+				value = DatumGetInt16(dats[i]);
+
+				appendStringInfo(interm_buf, "%hd", value);
+
+				appendStringInfo(buf, "%c%d%c%s",
+						PXF_SIZE_BYTES, interm_buf->len,
+						PXF_CONST_DATA, interm_buf->data);
+				resetStringInfo(interm_buf);
+			}
+			break;
+		}
+		case INT4ARRAYOID:
+		{
+			int32 value;
+			deconstruct_array(arr, INT4OID, sizeof (value), true, 'i', &dats, NULL, &len);
+
+			for (int i = 0; i < len; i++)
+			{
+				value = DatumGetInt32(dats[i]);
+
+				appendStringInfo(interm_buf, "%d", value);
+
+				appendStringInfo(buf, "%c%d%c%s",
+						PXF_SIZE_BYTES, interm_buf->len,
+						PXF_CONST_DATA, interm_buf->data);
+				resetStringInfo(interm_buf);
+			}
+			break;
+		}
+		case INT8ARRAYOID:
+		{
+			int64 value;
+			deconstruct_array(arr, INT8OID, sizeof (value), true, 'd', &dats, NULL, &len);
+
+			for (int i = 0; i < len; i++)
+			{
+				value = DatumGetInt64(dats[i]);
+
+				appendStringInfo(interm_buf, "%ld", value);
+
+				appendStringInfo(buf, "%c%d%c%s",
+						PXF_SIZE_BYTES, interm_buf->len,
+						PXF_CONST_DATA, interm_buf->data);
+				resetStringInfo(interm_buf);
+			}
+			break;
+		}
+		case TEXTARRAYOID:
+		{
+			char *value;
+
+			deconstruct_array(arr, TEXTOID, -1, false, 'i', &dats, NULL, &len);
+
+			for (int i = 0; i < len; i++)
+			{
+				value = DatumGetCString(DirectFunctionCall1(textout, dats[i]));
+
+				appendStringInfo(interm_buf, "%s", value);
+
+				appendStringInfo(buf, "%c%d%c%s",
+						PXF_SIZE_BYTES, interm_buf->len,
+						PXF_CONST_DATA, interm_buf->data);
+				resetStringInfo(interm_buf);
+			}
+			break;
+		}
+		default:
+			/* should never happen. we filter on types earlier */
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("internal error in pxffilters.c:list_const_to_str. "
+							"Using unsupported data type (%d)",
+							constval->consttype)));
+
+	}
+
+	pfree(interm_buf->data);
+}
+
+
+/*
+ * serializePxfFilterQuals
+ *
+ * Wrapper around pxf_make_filter_list -> pxf_serialize_filter_list.
+ *
+ * The function accepts the scan qual list and produces a serialized
+ * string that represents the push down filters (See called functions
+ * headers for more information).
+ */
+char *serializePxfFilterQuals(List *quals)
+{
+	char	*result = NULL;
+
+	if (quals == NULL) {
+		return result;
+	}
+
+    int logicalOpsNum = 0;
+    List *expressionItems = pxf_make_expression_items_list(quals, NULL, &logicalOpsNum);
+
+    // Trivial expression means list of OpExpr implicitly ANDed
+    bool isTrivialExpression = logicalOpsNum == 0 && expressionItems && expressionItems->length > 1;
+    if (isTrivialExpression) {
+        enrich_trivial_expression(expressionItems);
+    }
+
+    result  = pxf_serialize_filter_list(expressionItems);
+    pxf_free_expression_items_list(expressionItems, isTrivialExpression);
+
+	elog(DEBUG1, "serializePxfFilterQuals: resulting filter string is '%s'", (result == NULL) ? "null" : result);
+
+	return result;
+}
+
+/*
+ * Takes list of expression items which supposed to be just a list of OpExpr
+ * and adds needed number of AND items
+ */
+void enrich_trivial_expression(List *expressionItems) {
+	int logicalOpsNumNeeded = expressionItems->length - 1;
+	if (logicalOpsNumNeeded > 0)
+	{
+		ExpressionItem *andExpressionItem = (ExpressionItem *) palloc0(sizeof(ExpressionItem));
+		BoolExpr *andExpr = makeNode(BoolExpr);
+
+		andExpr->boolop = AND_EXPR;
+
+		andExpressionItem->node = (Node *) andExpr;
+		andExpressionItem->parent = NULL;
+		andExpressionItem->processed = false;
+
+		for (int i = 0; i < logicalOpsNumNeeded; i++) {
+			expressionItems = lappend(expressionItems, andExpressionItem);
+		}
+	}
+}
+
+/*
+ * Returns a list of attributes, extracted from quals.
+ * Returns NIL if any error occurred.
+ * Supports AND, OR, NOT operations.
+ * Supports =, <, <=, >, >=, IS NULL, IS NOT NULL, BETWEEN, IN operators.
+ * List might contain duplicates.
+ * Caller should release memory once result is not needed.
+ */
+List* extractPxfAttributes(List* quals, bool* qualsAreSupported)
+{
+
+	if (!(*qualsAreSupported)) {
+		return NIL;
+	}
+	ListCell		*lc = NULL;
+	List *attributes = NIL;
+	bool expressionIsSupported;
+	*qualsAreSupported = true;
+
+	if (list_length(quals) == 0)
+		return NIL;
+
+	foreach (lc, quals)
+	{
+		Node *node = (Node *) lfirst(lc);
+		NodeTag tag = nodeTag(node);
+
+		switch (tag)
+		{
+			case T_OpExpr:
+			case T_ScalarArrayOpExpr:
+			{
+				Expr* expr = (Expr *) node;
+				List			*attrs = get_attrs_from_expr(expr, &expressionIsSupported);
+				if (!expressionIsSupported) {
+					*qualsAreSupported = false;
+					return NIL;
+				}
+				attributes = list_concat(attributes, attrs);
+				break;
+			}
+			case T_BoolExpr:
+			{
+				BoolExpr* expr = (BoolExpr *) node;
+				bool innerBoolQualsAreSupported = true;
+				List *inner_result = extractPxfAttributes(expr->args, &innerBoolQualsAreSupported);
+				if (!innerBoolQualsAreSupported) {
+					*qualsAreSupported = false;
+					return NIL;
+				}
+				attributes = list_concat(attributes, inner_result);
+				break;
+			}
+			case T_NullTest:
+			{
+				NullTest* expr = (NullTest *) node;
+				attributes = append_attr_from_var((Var *) expr->arg, attributes);
+				break;
+			}
+			case T_BooleanTest:
+			{
+				BooleanTest* expr = (BooleanTest *) node;
+				attributes = append_attr_from_var((Var *) expr->arg, attributes);
+				break;
+			}
+			default:
+			{
+				/*
+				 * tag is not supported, it's risk of having:
+				 * 1) false-positive tuples
+				 * 2) unable to join tables
+				 * 3) etc
+				 */
+				elog(INFO, "extractPxfAttributes: unsupported node tag %d, unable to extract attribute from qualifier", tag);
+				return NIL;
+			}
+		}
+	}
+
+	return attributes;
+}

--- a/gpAux/extensions/pxf/src/pxffilters.c
+++ b/gpAux/extensions/pxf/src/pxffilters.c
@@ -1,13 +1,13 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements.	See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -21,7 +21,6 @@
  * pxffilters.c
  *
  * Functions for handling push down of supported scan level filters to PXF.
- *
  */
 #include "pxffilters.h"
 
@@ -56,7 +55,7 @@ static List* get_attrs_from_expr(Expr *expr, bool* expressionIsSupported);
 dbop_pxfop_map pxf_supported_opr_op_expr[] =
 {
 	/* int2 */
-	{Int2EqualOperator  /* int2eq */, PXFOP_EQ},
+	{Int2EqualOperator	/* int2eq */, PXFOP_EQ},
 	{95  /* int2lt */, PXFOP_LT},
 	{520 /* int2gt */, PXFOP_GT},
 	{522 /* int2le */, PXFOP_LE},
@@ -64,7 +63,7 @@ dbop_pxfop_map pxf_supported_opr_op_expr[] =
 	{519 /* int2ne */, PXFOP_NE},
 
 	/* int4 */
-	{Int4EqualOperator  /* int4eq */, PXFOP_EQ},
+	{Int4EqualOperator	/* int4eq */, PXFOP_EQ},
 	{97  /* int4lt */, PXFOP_LT},
 	{521 /* int4gt */, PXFOP_GT},
 	{523 /* int4le */, PXFOP_LE},
@@ -80,12 +79,12 @@ dbop_pxfop_map pxf_supported_opr_op_expr[] =
 	{411 /* int8lt */, PXFOP_NE},
 
 	/* text */
-	{TextEqualOperator  /* texteq  */, PXFOP_EQ},
+	{TextEqualOperator	/* texteq  */, PXFOP_EQ},
 	{664 /* text_lt */, PXFOP_LT},
 	{666 /* text_gt */, PXFOP_GT},
 	{665 /* text_le */, PXFOP_LE},
 	{667 /* text_ge */, PXFOP_GE},
-	{531 /* textlt  */, PXFOP_NE},
+	{531 /* textlt	*/, PXFOP_NE},
 	{1209 /* textlike  */, PXFOP_LIKE},
 
 	/* int2 to int4 */
@@ -137,7 +136,7 @@ dbop_pxfop_map pxf_supported_opr_op_expr[] =
 	{1869 /* int82ne */, PXFOP_NE},
 
 	/* date */
-	{DateEqualOperator  /* date_eq */, PXFOP_EQ},
+	{DateEqualOperator	/* date_eq */, PXFOP_EQ},
 	{1095  /* date_lt */, PXFOP_LT},
 	{1097 /* date_gt */, PXFOP_GT},
 	{1096 /* date_le */, PXFOP_LE},
@@ -175,30 +174,22 @@ dbop_pxfop_map pxf_supported_opr_op_expr[] =
 	{1059 /* bpcharle */, PXFOP_LE},
 	{1061 /* bpcharge */, PXFOP_GE},
 	{1057 /* bpcharne */, PXFOP_NE},
-
-	/* boolean */
-	{BooleanEqualOperator  /* booleq */, PXFOP_EQ},
-	{58  /* boollt */, PXFOP_LT},
-	{59 /* boolgt */, PXFOP_GT},
-	{1694 /* boolle */, PXFOP_LE},
-	{1695 /* boolge */, PXFOP_GE},
-	{85 /* boolne */, PXFOP_NE}
 };
 
 
 dbop_pxfop_array_map pxf_supported_opr_scalar_array_op_expr[] =
 {
 	/* int2 */
-	{Int2EqualOperator  /* int2eq */, PXFOP_IN, true},
+	{Int2EqualOperator	/* int2eq */, PXFOP_IN, true},
 
 	/* int4 */
-	{Int4EqualOperator  /* int4eq */, PXFOP_IN, true},
+	{Int4EqualOperator	/* int4eq */, PXFOP_IN, true},
 
 	/* int8 */
 	{Int8EqualOperator /* int8eq */, PXFOP_IN, true},
 
 	/* text */
-	{TextEqualOperator  /* texteq  */, PXFOP_IN, true},
+	{TextEqualOperator	/* texteq  */, PXFOP_IN, true},
 
 	/* int2 to int4 */
 	{Int24EqualOperator /* int24eq */, PXFOP_IN, true},
@@ -219,7 +210,7 @@ dbop_pxfop_array_map pxf_supported_opr_scalar_array_op_expr[] =
 	{Int82EqualOperator /* int82eq */, PXFOP_IN, true},
 
 	/* date */
-	{DateEqualOperator  /* date_eq */, PXFOP_IN, true},
+	{DateEqualOperator	/* date_eq */, PXFOP_IN, true},
 
 	/* timestamp */
 	{TimestampEqualOperator  /* timestamp_eq */, PXFOP_IN, true},
@@ -232,13 +223,6 @@ dbop_pxfop_array_map pxf_supported_opr_scalar_array_op_expr[] =
 
 	/* bpchar */
 	{BPCharEqualOperator  /* bpchareq */, PXFOP_IN, true},
-
-	/* boolean */
-	{BooleanEqualOperator  /* booleq */, PXFOP_IN, true},
-
-	/* bytea */
-	// TODO: uncomment once HAWQ-1085 is done
-	//,{ByteaEqualOperator  /* byteaeq */, PXFOP_IN, true},
 };
 
 Oid pxf_supported_types[] =
@@ -266,7 +250,7 @@ Oid pxf_supported_types[] =
 static void
 pxf_free_expression_items_list(List *expressionItems, bool freeBoolExprNodes)
 {
-	ExpressionItem 	*expressionItem = NULL;
+	ExpressionItem	*expressionItem = NULL;
 	int previousLength;
 
 	while (list_length(expressionItems) > 0)
@@ -423,23 +407,23 @@ pxf_free_filter(PxfFilterDesc* filter)
  *
  * Where:
  *
- * a0     - first column of table
- * c23    - scalar constant with type oid 23(INT4)
- * s1     - size of constant in bytes
- * d1     - serialized constant value
- * o2     - greater than operation
- * a1     - second column of table
- * c23    - scalar constant with type oid 23(INT4)
- * s1     - size of constant in bytes
- * d5     - serialized constant value
- * o1     - less than operation
- * a2     - third column of table
- * c25    - scalar constant with type oid 25(TEXT)
- * s5     - size of constant in bytes
+ * a0	  - first column of table
+ * c23	  - scalar constant with type oid 23(INT4)
+ * s1	  - size of constant in bytes
+ * d1	  - serialized constant value
+ * o2	  - greater than operation
+ * a1	  - second column of table
+ * c23	  - scalar constant with type oid 23(INT4)
+ * s1	  - size of constant in bytes
+ * d5	  - serialized constant value
+ * o1	  - less than operation
+ * a2	  - third column of table
+ * c25	  - scalar constant with type oid 25(TEXT)
+ * s5	  - size of constant in bytes
  * dthird - serialized constant value
- * o5     - equals operation
- * l0     - AND operator
- * l0     - AND operator
+ * o5	  - equals operation
+ * l0	  - AND operator
+ * l0	  - AND operator
  *
  */
 static char *
@@ -607,7 +591,7 @@ pxf_serialize_filter_list(List *expressionItems)
 				NullTest *expr = (NullTest *) node;
 				Var *var = (Var *) expr->arg;
 
-				//TODO: add check for supported operation
+				/* TODO: add check for supported operation */
 				if (!supported_filter_type(var->vartype))
 				{
 					elog(DEBUG1, "Query will not be optimized to use filter push-down.");
@@ -658,7 +642,7 @@ pxf_serialize_filter_list(List *expressionItems)
 static bool
 opexpr_to_pxffilter(OpExpr *expr, PxfFilterDesc *filter)
 {
-	Node	*leftop 	= NULL;
+	Node	*leftop		= NULL;
 	Node	*rightop	= NULL;
 	Oid		 rightop_type = InvalidOid;
 	Oid		 leftop_type = InvalidOid;
@@ -667,7 +651,7 @@ opexpr_to_pxffilter(OpExpr *expr, PxfFilterDesc *filter)
 		return false;
 
 	leftop = get_leftop((Expr*)expr);
-	rightop	= get_rightop((Expr*)expr);
+	rightop = get_rightop((Expr*)expr);
 	leftop_type = exprType(leftop);
 	rightop_type = exprType(rightop);
 
@@ -739,7 +723,7 @@ static bool
 scalar_array_op_expr_to_pxffilter(ScalarArrayOpExpr *expr, PxfFilterDesc *filter)
 {
 
-	Node	*leftop 	= NULL;
+	Node	*leftop		= NULL;
 	Node	*rightop	= NULL;
 
 	leftop = (Node *) linitial(expr->args);
@@ -901,27 +885,27 @@ get_attrs_from_expr(Expr *expr, bool* expressionIsSupported)
 	if (IsA(expr, OpExpr))
 	{
 		leftop = get_leftop(expr);
-		rightop	= get_rightop(expr);
+		rightop = get_rightop(expr);
 	} else if (IsA(expr, ScalarArrayOpExpr))
 	{
 		ScalarArrayOpExpr *saop = (ScalarArrayOpExpr *) expr;
 		leftop = (Node *) linitial(saop->args);
 		rightop = (Node *) lsecond(saop->args);
 	} else {
-		// If expression type is not known, report that it's not supported
+		/*	If expression type is not known, report that it's not supported */
 		*expressionIsSupported = false;
 		return NIL;
 	}
 
-	// We support following combinations of operands:
-	// Var, Const
-	// Relabel, Const
-	// FuncExpr, Const
-	// Const, Var
-	// Const, Relabel
-	// Const, FuncExpr
-	// For most of datatypes column is represented by Var node
-	// For varchar column is represented by RelabelType node
+	/*	We support following combinations of operands: */
+	/*	Var, Const */
+	/*	Relabel, Const */
+	/*	FuncExpr, Const */
+	/*	Const, Var */
+	/*	Const, Relabel */
+	/*	Const, FuncExpr */
+	/*	For most of datatypes column is represented by Var node */
+	/*	For varchar column is represented by RelabelType node */
 	if (IsA(leftop, Var) && IsA(rightop, Const))
 	{
 		attrs = append_attr_from_var((Var *) leftop, attrs);
@@ -943,8 +927,8 @@ get_attrs_from_expr(Expr *expr, bool* expressionIsSupported)
 		attrs = append_attr_from_func_args(expr, attrs, expressionIsSupported);
 	}
 	else {
-		// If operand type or combination is not known, report that it's not supported
-		// to avoid partially extracted attributes from expression
+		/*	If operand type or combination is not known, report that it's not supported */
+		/*	to avoid partially extracted attributes from expression */
 		*expressionIsSupported = false;
 		return NIL;
 	}
@@ -962,8 +946,8 @@ get_attrs_from_expr(Expr *expr, bool* expressionIsSupported)
 static bool
 supported_filter_type(Oid type)
 {
-	int		 nargs 		= sizeof(pxf_supported_types) / sizeof(Oid);
-	int 	 i;
+	int		 nargs		= sizeof(pxf_supported_types) / sizeof(Oid);
+	int		 i;
 
 	/* is type supported? */
 	for (i = 0; i < nargs; i++)
@@ -1227,17 +1211,17 @@ char *serializePxfFilterQuals(List *quals)
 		return result;
 	}
 
-    int logicalOpsNum = 0;
-    List *expressionItems = pxf_make_expression_items_list(quals, NULL, &logicalOpsNum);
+	int logicalOpsNum = 0;
+	List *expressionItems = pxf_make_expression_items_list(quals, NULL, &logicalOpsNum);
 
-    // Trivial expression means list of OpExpr implicitly ANDed
-    bool isTrivialExpression = logicalOpsNum == 0 && expressionItems && expressionItems->length > 1;
-    if (isTrivialExpression) {
-        enrich_trivial_expression(expressionItems);
-    }
+	/*	Trivial expression means list of OpExpr implicitly ANDed */
+	bool isTrivialExpression = logicalOpsNum == 0 && expressionItems && expressionItems->length > 1;
+	if (isTrivialExpression) {
+		enrich_trivial_expression(expressionItems);
+	}
 
-    result  = pxf_serialize_filter_list(expressionItems);
-    pxf_free_expression_items_list(expressionItems, isTrivialExpression);
+	result	= pxf_serialize_filter_list(expressionItems);
+	pxf_free_expression_items_list(expressionItems, isTrivialExpression);
 
 	elog(DEBUG1, "serializePxfFilterQuals: resulting filter string is '%s'", (result == NULL) ? "null" : result);
 

--- a/gpAux/extensions/pxf/src/pxffilters.h
+++ b/gpAux/extensions/pxf/src/pxffilters.h
@@ -1,0 +1,142 @@
+/*
+ * pxffilters.h
+ *
+ * Header for handling push down of supported scan level filters to PXF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#ifndef _PXF_FILTERS_H_
+#define _PXF_FILTERS_H_
+
+#include "postgres.h"
+#include "access/attnum.h"
+#include "executor/executor.h"
+#include "nodes/pg_list.h"
+
+/*
+ * each supported operator has a code that will describe the operator
+ * type in the final serialized string that gets pushed down.
+ *
+ * NOTE: the codes could be forced into a single byte, but list will
+ * grow larger in the future, so why bother.
+ */
+typedef enum PxfOperatorCode
+{
+	PXFOP_LT = 1,
+	PXFOP_GT,
+	PXFOP_LE,
+	PXFOP_GE,
+	PXFOP_EQ,
+	PXFOP_NE,
+	PXFOP_LIKE,
+	PXFOP_IS_NULL,
+	PXFOP_IS_NOTNULL,
+	PXFOP_IN
+
+} PxfOperatorCode;
+
+/*
+ * each supported operand from both sides of the operator is represented
+ * by a code that will describe the operator type in the final serialized
+ * string that gets pushed down.
+ */
+#define PXF_ATTR_CODE				'a'
+#define PXF_SCALAR_CONST_CODE		'c'
+#define PXF_LIST_CONST_CODE			'm'
+#define PXF_SIZE_BYTES				's'
+#define PXF_CONST_DATA				'd'
+#define PXF_OPERATOR_CODE			'o'
+#define PXF_LOGICAL_OPERATOR_CODE	'l'
+
+#define NullConstValue   "NULL"
+#define TrueConstValue   "true"
+#define FalseConstValue   "false"
+
+/*
+ * An Operand has any of the above codes, and the information specific to
+ * its type. This could be compacted but filter structures are expected to
+ * be very few and very small so it's ok as is.
+ */
+typedef struct PxfOperand
+{
+	char		opcode;		/* PXF_ATTR_CODE, PXF_SCALAR_CONST_CODE, PXF_LIST_CONST_CODE*/
+	AttrNumber 	attnum;		/* used when opcode is PXF_ATTR_CODE */
+	StringInfo 	conststr;	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
+	Oid 		consttype; 	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
+
+} PxfOperand;
+
+/*
+ * A PXF filter has a left and right operands, and an operator.
+ */
+typedef struct PxfFilterDesc
+{
+	PxfOperand 		l;		/* left operand */
+	PxfOperand 		r;		/* right operand or InvalidAttrNumber if none */
+	PxfOperatorCode	op;		/* operator code */
+
+} PxfFilterDesc;
+
+/*
+ * HAWQ operator OID to PXF operator code mapping used for OpExpr
+ */
+typedef struct dbop_pxfop_map
+{
+	Oid				dbop;
+	PxfOperatorCode	pxfop;
+
+} dbop_pxfop_map;
+
+/*
+ * HAWQ operator OID to PXF operator code mapping used for ScalarArrayOpExpr
+ */
+typedef struct dbop_pxfop_array_map
+{
+	Oid				dbop;
+	PxfOperatorCode	pxfop;
+	bool			useOr;
+
+} dbop_pxfop_array_map;
+
+typedef struct ExpressionItem
+{
+	Node	*node;
+	Node	*parent;
+	bool	processed;
+} ExpressionItem;
+
+static inline bool pxfoperand_is_attr(PxfOperand x)
+{
+	return (x.opcode == PXF_ATTR_CODE);
+}
+
+static inline bool pxfoperand_is_scalar_const(PxfOperand x)
+{
+	return (x.opcode == PXF_SCALAR_CONST_CODE);
+}
+
+static inline bool pxfoperand_is_list_const(PxfOperand x)
+{
+	return (x.opcode == PXF_LIST_CONST_CODE);
+}
+
+char *serializePxfFilterQuals(List *quals);
+List* extractPxfAttributes(List* quals, bool* qualsAreSupported);
+
+#endif // _PXF_FILTERS_H_

--- a/gpAux/extensions/pxf/src/pxffilters.h
+++ b/gpAux/extensions/pxf/src/pxffilters.h
@@ -4,14 +4,14 @@
  * Header for handling push down of supported scan level filters to PXF.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements.	See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -64,8 +64,8 @@ typedef enum PxfOperatorCode
 #define PXF_OPERATOR_CODE			'o'
 #define PXF_LOGICAL_OPERATOR_CODE	'l'
 
-#define NullConstValue   "NULL"
-#define TrueConstValue   "true"
+#define NullConstValue	 "NULL"
+#define TrueConstValue	 "true"
 #define FalseConstValue   "false"
 
 /*
@@ -76,9 +76,9 @@ typedef enum PxfOperatorCode
 typedef struct PxfOperand
 {
 	char		opcode;		/* PXF_ATTR_CODE, PXF_SCALAR_CONST_CODE, PXF_LIST_CONST_CODE*/
-	AttrNumber 	attnum;		/* used when opcode is PXF_ATTR_CODE */
-	StringInfo 	conststr;	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
-	Oid 		consttype; 	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
+	AttrNumber	attnum;		/* used when opcode is PXF_ATTR_CODE */
+	StringInfo	conststr;	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
+	Oid			consttype;	/* used when opcode is PXF_SCALAR_CONST_CODE or PXF_LIST_CONST_CODE*/
 
 } PxfOperand;
 
@@ -87,9 +87,9 @@ typedef struct PxfOperand
  */
 typedef struct PxfFilterDesc
 {
-	PxfOperand 		l;		/* left operand */
-	PxfOperand 		r;		/* right operand or InvalidAttrNumber if none */
-	PxfOperatorCode	op;		/* operator code */
+	PxfOperand		l;		/* left operand */
+	PxfOperand		r;		/* right operand or InvalidAttrNumber if none */
+	PxfOperatorCode op;		/* operator code */
 
 } PxfFilterDesc;
 
@@ -99,7 +99,7 @@ typedef struct PxfFilterDesc
 typedef struct dbop_pxfop_map
 {
 	Oid				dbop;
-	PxfOperatorCode	pxfop;
+	PxfOperatorCode pxfop;
 
 } dbop_pxfop_map;
 
@@ -109,7 +109,7 @@ typedef struct dbop_pxfop_map
 typedef struct dbop_pxfop_array_map
 {
 	Oid				dbop;
-	PxfOperatorCode	pxfop;
+	PxfOperatorCode pxfop;
 	bool			useOr;
 
 } dbop_pxfop_array_map;

--- a/gpAux/extensions/pxf/src/pxffragment.c
+++ b/gpAux/extensions/pxf/src/pxffragment.c
@@ -26,7 +26,7 @@ static void pxf_array_element_end(void *state, bool isnull);
  * Returns selected fragments that have been allocated to the current segment
  */
 void
-get_fragments(GPHDUri *uri, Relation relation)
+get_fragments(GPHDUri *uri, Relation relation, char* filter_string)
 {
 
 	List	   *data_fragments = NIL;
@@ -48,6 +48,7 @@ get_fragments(GPHDUri *uri, Relation relation)
 	inputData.headers = client_context.http_headers;
 	inputData.gphduri = uri;
 	inputData.rel = relation;
+	inputData.filterstr = filter_string;
 	build_http_headers(&inputData);
 
 	/*

--- a/gpAux/extensions/pxf/src/pxffragment.h
+++ b/gpAux/extensions/pxf/src/pxffragment.h
@@ -65,7 +65,7 @@ typedef struct FragmentData
 /*
  * Gets the fragments for the given uri location
  */
-extern void get_fragments(GPHDUri *uri, Relation relation);
+extern void get_fragments(GPHDUri *uri, Relation relation, char* filterquals);
 
 /*
  * Frees the given fragment

--- a/gpAux/extensions/pxf/src/pxfheaders.c
+++ b/gpAux/extensions/pxf/src/pxfheaders.c
@@ -39,6 +39,7 @@ build_http_headers(PxfInputData *input)
 	CHURL_HEADERS headers = input->headers;
 	GPHDUri    *gphduri = input->gphduri;
 	Relation	rel = input->rel;
+	char *filterstr = input->filterstr;
 
 	if (rel != NULL)
 	{
@@ -82,8 +83,13 @@ build_http_headers(PxfInputData *input)
 	churl_headers_append(headers, "X-GP-URI", gphduri->uri);
 
 	/* filters */
-	/* TODO port filter logic, for now assume no filters */
-	churl_headers_append(headers, "X-GP-HAS-FILTER", "0");
+	if (filterstr == NULL) {
+		churl_headers_append(headers, "X-GP-HAS-FILTER", "0");
+	}
+	else {
+		churl_headers_append(headers, "X-GP-HAS-FILTER", "1");
+		churl_headers_append(headers, "X-GP-FILTER", filterstr);
+	}
 }
 
 /* Report alignment size to remote component

--- a/gpAux/extensions/pxf/src/pxfheaders.h
+++ b/gpAux/extensions/pxf/src/pxfheaders.h
@@ -34,6 +34,7 @@ typedef struct sPxfInputData
 	CHURL_HEADERS headers;
 	GPHDUri    *gphduri;
 	Relation	rel;
+	char *filterstr;
 } PxfInputData;
 
 /*

--- a/gpAux/extensions/pxf/src/pxfprotocol.c
+++ b/gpAux/extensions/pxf/src/pxfprotocol.c
@@ -1,13 +1,13 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements.	See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -74,7 +74,7 @@ pxfprotocol_validate_urls(PG_FUNCTION_ARGS)
 	if (!GPHDUri_opt_exists(uri, PXF_PROFILE))
 	{
 		List	   *coreOptions = list_make2(ACCESSOR, RESOLVER);
-        if (EXTPROTOCOL_VALIDATOR_GET_DIRECTION(fcinfo) != EXT_VALIDATE_WRITE)
+		if (EXTPROTOCOL_VALIDATOR_GET_DIRECTION(fcinfo) != EXT_VALIDATE_WRITE)
 			coreOptions = lcons(FRAGMENTER, coreOptions);
 
 		GPHDUri_verify_core_options_exist(uri, coreOptions);

--- a/gpAux/extensions/pxf/src/pxfuriparser.c
+++ b/gpAux/extensions/pxf/src/pxfuriparser.c
@@ -216,11 +216,6 @@ GPHDUri_parse_option(char *pair, GPHDUri *uri)
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("Invalid URI %s: option '%s' missing '='", uri->uri, pair)));
 
-	if (strchr(sep + 1, '=') != NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("Invalid URI %s: option '%s' contains duplicate '='", uri->uri, pair)));
-
 	int			key_len = sep - pair;
 
 	if (key_len == 0)

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -288,6 +288,9 @@
               <xref href="#gp_external_max_segs"/>
             </li>
             <li>
+              <xref href="#enable_filter_pushdown"/>
+            </li>
+            <li>
               <xref href="#gp_filerep_tcp_keepalives_count"/>
             </li>
             <li>
@@ -879,7 +882,8 @@
               <xref href="#wal_receiver_status_interval"/>
             </li>
             <li><xref href="#writable_external_table_bufsize" type="section"
-                >writable_external_table_bufsize</xref></li>
+                >writable_external_table_bufsize</xref>
+            </li>
             <li>
               <xref href="#xid_stop_limit"/>
             </li>
@@ -3763,6 +3767,35 @@
             <row>
               <entry colname="col1">integer</entry>
               <entry colname="col2">64</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="enable_filter_pushdown">
+    <title>enable_filter_pushdown</title>
+    <body>
+      <p>Enable filter pushdown when reading data from external tables. If
+      pushdown fails, a query will be executed without it, and GPDB will apply
+      the same constraints to the result.</p>
+      <table id="enable_filter_pushdown_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">Boolean</entry>
+              <entry colname="col2">false</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -98,6 +98,7 @@
             <topicref href="guc-list.xml#gp_enable_sort_limit"/>
             <topicref href="guc-list.xml#gp_external_enable_exec"/>
             <topicref href="guc-list.xml#gp_external_max_segs"/>
+            <topicref href="guc-list.xml#enable_filter_pushdown"/>
             <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_count"/>
             <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_idle"/>
             <topicref href="guc-list.xml#gp_filerep_tcp_keepalives_interval"/>

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -78,7 +78,7 @@ static void FunctionCallPrepareFormatter(FunctionCallInfoData *fcinfo,
 							 FmgrInfo *convFuncs,
 							 Oid *typioparams);
 
-static void open_external_readable_source(FileScanDesc scan);
+static void open_external_readable_source(FileScanDesc scan, List* filter_quals);
 static void open_external_writable_source(ExternalInsertDesc extInsertDesc);
 static int	external_getdata(URL_FILE *extfile, CopyState pstate, int maxread);
 static void external_senddata(URL_FILE *extfile, CopyState pstate);
@@ -440,7 +440,7 @@ external_stopscan(FileScanDesc scan)
 * ----------------------------------------------------------------
 */
 HeapTuple
-external_getnext(FileScanDesc scan, ScanDirection direction)
+external_getnext(FileScanDesc scan, ScanDirection direction, List* filter_quals)
 {
 	HeapTuple	tuple;
 
@@ -460,7 +460,7 @@ external_getnext(FileScanDesc scan, ScanDirection direction)
 	 * only.
 	 */
 	if (!scan->fs_file)
-		open_external_readable_source(scan);
+		open_external_readable_source(scan, filter_quals);
 
 	/* Note: no locking manipulations needed */
 	FILEDEBUG_1;
@@ -1536,7 +1536,7 @@ FunctionCallPrepareFormatter(FunctionCallInfoData *fcinfo,
  * 4) a command to execute
  */
 static void
-open_external_readable_source(FileScanDesc scan)
+open_external_readable_source(FileScanDesc scan, List* filter_quals)
 {
 	extvar_t	extvar;
 
@@ -1556,7 +1556,8 @@ open_external_readable_source(FileScanDesc scan)
 	scan->fs_file = url_fopen(scan->fs_uri,
 							  false /* for read */ ,
 							  &extvar,
-							  scan->fs_pstate);
+							  scan->fs_pstate,
+							  filter_quals);
 }
 
 /*
@@ -1587,7 +1588,8 @@ open_external_writable_source(ExternalInsertDesc extInsertDesc)
 	extInsertDesc->ext_file = url_fopen(extInsertDesc->ext_uri,
 										true /* forwrite */ ,
 										&extvar,
-										extInsertDesc->ext_pstate);
+										extInsertDesc->ext_pstate,
+										NULL);
 }
 
 /*

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -30,7 +30,7 @@ int readable_external_table_timeout = 0;
  * On error, ereport()s
  */
 URL_FILE *
-url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
+url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals)
 {
 	/*
 	 * if 'url' starts with "execute:" then it's a command to execute and
@@ -43,7 +43,7 @@ url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	else if (IS_HTTP_URI(url) || IS_GPFDIST_URI(url) || IS_GPFDISTS_URI(url))
 		return url_curl_fopen(url, forwrite, ev, pstate);
 	else
-		return url_custom_fopen(url, forwrite, ev, pstate);
+		return url_custom_fopen(url, forwrite, ev, pstate, filter_quals);
 }
 
 /*
@@ -83,7 +83,7 @@ url_fclose(URL_FILE *file, bool failOnError, const char *relname)
 		case CFTYPE_CUSTOM:
 			url_custom_fclose(file, failOnError, relname);
 			break;
-			
+
 		default: /* unknown or unsupported type - oh dear */
 			elog(ERROR, "unrecognized external table type: %d", file->type);
 			break;
@@ -151,7 +151,7 @@ url_fread(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
 
 		case CFTYPE_CUSTOM:
 			return url_custom_fread(ptr, size, file, pstate);
-				
+
 		default: /* unknown or supported type */
 			elog(ERROR, "unrecognized external table type: %d", file->type);
     }
@@ -174,7 +174,7 @@ url_fwrite(void *ptr, size_t size, URL_FILE *file, CopyState pstate)
 
 		case CFTYPE_CUSTOM:
 			return url_custom_fwrite(ptr, size, file, pstate);
-			
+
 		default: /* unknown or unsupported type */
 			elog(ERROR, "unrecognized external table type: %d", file->type);
     }

--- a/src/backend/access/external/url_custom.c
+++ b/src/backend/access/external/url_custom.c
@@ -38,7 +38,7 @@ static int32 InvokeExtProtocol(void *ptr, size_t nbytes, URL_CUSTOM_FILE *file, 
 								bool last_call);
 
 URL_FILE *
-url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
+url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals)
 {
 	/* we're using a custom protocol */
 	URL_CUSTOM_FILE   *file;
@@ -79,7 +79,7 @@ url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 										  ALLOCSET_DEFAULT_MAXSIZE);
 
 	oldcontext = MemoryContextSwitchTo(file->protcxt);
-		
+
 	file->protocol_udf = palloc(sizeof(FmgrInfo));
 	file->extprotocol = (ExtProtocolData *) palloc (sizeof(ExtProtocolData));
 
@@ -92,6 +92,7 @@ url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	file->extprotocol->prot_last_call = false;
 	file->extprotocol->prot_url = NULL;
 	file->extprotocol->prot_databuf = NULL;
+	file->extprotocol->filter_quals = filter_quals;
 
 	pfree(prot_name);
 
@@ -154,20 +155,20 @@ InvokeExtProtocol(void *ptr, size_t nbytes, URL_CUSTOM_FILE *file, CopyState pst
 
 	/* must have been created during url_fopen() */
 	Assert(extprotocol);
-	
+
 	extprotocol->type = T_ExtProtocolData;
 	extprotocol->prot_url = file->common.url;
 	extprotocol->prot_relation = (last_call ? NULL : pstate->rel);
 	extprotocol->prot_databuf  = (last_call ? NULL : (char *)ptr);
 	extprotocol->prot_maxbytes = nbytes;
 	extprotocol->prot_last_call = last_call;
-	
+
 	InitFunctionCallInfoData(/* FunctionCallInfoData */ fcinfo,
 							 /* FmgrInfo */ extprotocol_udf,
 							 /* nArgs */ 0,
 							 /* Call Context */ (Node *) extprotocol,
 							 /* ResultSetInfo */ NULL);
-	
+
 	/* invoke the protocol within a designated memory context */
 	oldcontext = MemoryContextSwitchTo(file->protcxt);
 	d = FunctionCallInvoke(&fcinfo);

--- a/src/backend/catalog/pg_extprotocol.c
+++ b/src/backend/catalog/pg_extprotocol.c
@@ -10,7 +10,7 @@
  *
  *
  * IDENTIFICATION
- *	    src/backend/catalog/pg_extprotocol.c
+ *		src/backend/catalog/pg_extprotocol.c
  *
  *-------------------------------------------------------------------------
  */
@@ -61,7 +61,7 @@ ExtProtocolCreate(const char *protocolName,
 	int			i;
 	ObjectAddress myself,
 				referenced;
-	Oid 		ownerId = GetUserId();
+	Oid			ownerId = GetUserId();
 	ScanKeyData skey;
 	SysScanDesc scan;
 	Oid			protOid;
@@ -102,19 +102,19 @@ ExtProtocolCreate(const char *protocolName,
 	if (HeapTupleIsValid(tup))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_OBJECT),
-				 errmsg("protocol \"%s\" already exists", 
+				 errmsg("protocol \"%s\" already exists",
 						protocolName)));
 	systable_endscan(scan);
 
 	/*
 	 * function checks: if supplied, check existence and correct signature in the catalog
 	 */
-	
+
 	if (readfuncName)
 		readfn = ValidateProtocolFunction(readfuncName, EXTPTC_FUNC_READER);
 
 	if (writefuncName)
-		writefn = ValidateProtocolFunction(writefuncName, EXTPTC_FUNC_WRITER);				
+		writefn = ValidateProtocolFunction(writefuncName, EXTPTC_FUNC_WRITER);
 
 	if (validatorfuncName)
 		validatorfn = ValidateProtocolFunction(validatorfuncName, EXTPTC_FUNC_VALIDATOR);
@@ -183,7 +183,7 @@ ExtProtocolCreate(const char *protocolName,
 
 void
 ExtProtocolDeleteByOid(Oid	protOid)
-{		
+{
 	Relation	rel;
 	ScanKeyData skey;
 	SysScanDesc scan;
@@ -223,17 +223,17 @@ ValidateProtocolFunction(List *fnName, ExtPtcFuncType fntype)
 {
 	Oid			fnOid;
 	bool		retset;
-	bool        retstrict;
-	bool        retordered;
+	bool		retstrict;
+	bool		retordered;
 	Oid		   *true_oid_array;
-	Oid 	    actual_rettype;
+	Oid			actual_rettype;
 	Oid			desired_rettype;
 	FuncDetailCode fdresult;
 	AclResult	aclresult;
-	Oid 		inputTypes[1] = {InvalidOid}; /* dummy */
+	Oid			inputTypes[1] = {InvalidOid}; /* dummy */
 	int			nargs = 0; /* true for all 3 function types at the moment */
 	int			nvargs;
-	
+
 	if (fntype == EXTPTC_FUNC_VALIDATOR)
 		desired_rettype = VOIDOID;
 	else
@@ -256,12 +256,12 @@ ValidateProtocolFunction(List *fnName, ExtPtcFuncType fntype)
 				(errcode(ERRCODE_UNDEFINED_FUNCTION),
 				 errmsg("function %s does not exist",
 						func_signature_string(fnName, nargs, inputTypes))));
-	
+
 	if (retset)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
 				 errmsg("Invalid protocol function"),
-				 errdetail("Protocol functions cannot return sets.")));		
+				 errdetail("Protocol functions cannot return sets.")));
 
 	if (actual_rettype != desired_rettype)
 		ereport(ERROR,
@@ -270,7 +270,7 @@ ValidateProtocolFunction(List *fnName, ExtPtcFuncType fntype)
 						func_type_to_name(fntype),
 						func_signature_string(fnName, nargs, inputTypes),
 						(fntype == EXTPTC_FUNC_VALIDATOR ? "void" : "an integer"))));
-	
+
 	if (func_volatile(fnOid) == PROVOLATILE_IMMUTABLE)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
@@ -279,7 +279,7 @@ ValidateProtocolFunction(List *fnName, ExtPtcFuncType fntype)
 						func_signature_string(fnName, nargs, inputTypes)),
 				 errhint("PROTOCOL functions must be declared STABLE or VOLATILE")));
 
-	
+
 	/* Check protocol creator has permission to call the function */
 	aclresult = pg_proc_aclcheck(fnOid, GetUserId(), ACL_EXECUTE);
 	if (aclresult != ACLCHECK_OK)
@@ -293,11 +293,11 @@ ValidateProtocolFunction(List *fnName, ExtPtcFuncType fntype)
  * Finds an external protocol by passed in protocol name.
  * Errors if no such protocol exist, or if no function to
  * execute this protocol exists (for read or write separately).
- * 
+ *
  * Returns the protocol function to use.
  */
 Oid
-LookupExtProtocolFunction(const char *prot_name, 
+LookupExtProtocolFunction(const char *prot_name,
 						  ExtPtcFuncType prot_type,
 						  bool error)
 {
@@ -401,8 +401,8 @@ LookupExtProtocolOid(const char *prot_name, bool missing_ok)
 }
 
 char *
-ExtProtocolGetNameByOid(Oid	protOid)
-{		
+ExtProtocolGetNameByOid(Oid protOid)
+{
 	char		*ptcnamestr;
 	Relation	rel;
 	ScanKeyData skey;
@@ -450,4 +450,3 @@ static char *func_type_to_name(ExtPtcFuncType ftype)
 			return "undefined";
 	}
 }
-

--- a/src/backend/executor/nodeExternalscan.c
+++ b/src/backend/executor/nodeExternalscan.c
@@ -31,6 +31,7 @@
 #include "executor/nodeExternalscan.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/guc.h"
 #include "parser/parsetree.h"
 #include "optimizer/var.h"
 #include "optimizer/clauses.h"
@@ -93,7 +94,7 @@ ExternalConstraintCheck(TupleTableSlot *slot, ExternalScanState *node)
 		if (!ExecQual(qual, econtext, true))
 			return false;
 	}
-	
+
 	return true;
 }
 /* ----------------------------------------------------------------
@@ -115,6 +116,7 @@ ExternalNext(ExternalScanState *node)
 	ScanDirection direction;
 	TupleTableSlot *slot;
 	bool		scanNext = true;
+	List* filter_quals = NULL;
 
 	/*
 	 * get information from the estate and scan state
@@ -124,12 +126,16 @@ ExternalNext(ExternalScanState *node)
 	direction = estate->es_direction;
 	slot = node->ss.ss_ScanTupleSlot;
 
+	if (enable_filter_pushdown) {
+		filter_quals = node->ss.ps.plan->qual;
+	}
+
 	/*
 	 * get the next tuple from the file access methods
 	 */
 	while(scanNext)
 	{
-		tuple = external_getnext(scandesc, direction);
+		tuple = external_getnext(scandesc, direction, filter_quals);
 
 		/*
 		 * save the tuple and the buffer returned to us by the access methods in
@@ -169,7 +175,7 @@ ExternalNext(ExternalScanState *node)
 		}
 		scanNext = false;
 	}
-	
+
 
 	return slot;
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -600,6 +600,8 @@ char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
 
+bool		enable_filter_pushdown = true;
+
 IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
 IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;
 
@@ -2001,7 +2003,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	{
 		{"gp_enable_query_metrics", PGC_POSTMASTER, UNGROUPED,
 			gettext_noop("Enable all query metrics collection."),
-			NULL	
+			NULL
 		},
 		&gp_enable_query_metrics,
 		false, NULL, NULL
@@ -3293,6 +3295,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&verify_gpfdists_cert,
 		true, assign_verify_gpfdists_cert, NULL
+	},
+
+	{
+		{"enable_filter_pushdown", PGC_USERSET, EXTERNAL_TABLES,
+			gettext_noop("Enable passing of query constraints to external table providers"),
+			NULL,
+			GUC_GPDB_ADDOPT
+		},
+		&enable_filter_pushdown,
+		true, NULL, NULL
 	},
 
 	/* End-of-list marker */
@@ -5346,7 +5358,7 @@ struct config_string ConfigureNamesString_gp[] =
 		{"pljava_classpath", PGC_SUSET, CUSTOM_OPTIONS,
 			gettext_noop("classpath used by the the JVM"),
 			NULL,
-			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE 
+			GUC_GPDB_ADDOPT | GUC_NOT_IN_SAMPLE
 		},
 		&pljava_classpath,
 		"", NULL, NULL

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -600,7 +600,7 @@ char	   *gp_default_storage_options = NULL;
 
 int			writable_external_table_bufsize = 64;
 
-bool		enable_filter_pushdown = true;
+bool		enable_filter_pushdown = false;
 
 IndexCheckType gp_indexcheck_insert = INDEX_CHECK_NONE;
 IndexCheckType gp_indexcheck_vacuum = INDEX_CHECK_NONE;

--- a/src/include/access/extprotocol.h
+++ b/src/include/access/extprotocol.h
@@ -8,7 +8,7 @@
  *
  *
  * IDENTIFICATION
- *	    src/include/access/extprotocol.h
+ *		src/include/access/extprotocol.h
  *
  *-------------------------------------------------------------------------
  */
@@ -29,15 +29,14 @@
  */
 typedef struct ExtProtocolData
 {
-	NodeTag			type;                 /* see T_ExtProtocolData */
-	Relation    	prot_relation;
+	NodeTag			type;				  /* see T_ExtProtocolData */
+	Relation		prot_relation;
 	char*			prot_url;
 	char*			prot_databuf;
 	int				prot_maxbytes;
 	void*			prot_user_ctx;
-	List*			filter_quals;
 	bool			prot_last_call;
-
+	List*			filter_quals;
 } ExtProtocolData;
 
 typedef ExtProtocolData *ExtProtocol;
@@ -45,7 +44,7 @@ typedef ExtProtocolData *ExtProtocol;
 #define CALLED_AS_EXTPROTOCOL(fcinfo) \
 	((fcinfo->context != NULL && IsA((fcinfo)->context, ExtProtocolData)))
 
-#define EXTPROTOCOL_GET_URL(fcinfo)    	   (((ExtProtocolData*) fcinfo->context)->prot_url)
+#define EXTPROTOCOL_GET_URL(fcinfo)		   (((ExtProtocolData*) fcinfo->context)->prot_url)
 #define EXTPROTOCOL_GET_RELATION(fcinfo)   (((ExtProtocolData*) fcinfo->context)->prot_relation)
 #define EXTPROTOCOL_GET_DATABUF(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_databuf)
 #define EXTPROTOCOL_GET_DATALEN(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_maxbytes)
@@ -72,9 +71,9 @@ typedef enum ValidatorDirection
  */
 typedef struct ExtProtocolValidatorData
 {
-	NodeTag				 type;            /* see T_ExtProtocolValidatorData */
-	List 		  		*url_list;
-	ValidatorDirection 	 direction;  /* validating read or write? */
+	NodeTag				 type;			  /* see T_ExtProtocolValidatorData */
+	List				*url_list;
+	ValidatorDirection	 direction;  /* validating read or write? */
 	char				*errmsg;		  /* the validation error upon return, if any */
 
 } ExtProtocolValidatorData;
@@ -88,7 +87,7 @@ typedef ExtProtocolValidatorData *ExtProtocolValidator;
 #define EXTPROTOCOL_VALIDATOR_GET_NUM_URLS(fcinfo)	(list_length(((ExtProtocolValidatorData*) fcinfo->context)->url_list))
 
 #define EXTPROTOCOL_VALIDATOR_GET_NTH_URL(fcinfo, n) (((Value *)(list_nth(EXTPROTOCOL_VALIDATOR_GET_URL_LIST(fcinfo),(n - 1))))->val.str)
-#define EXTPROTOCOL_VALIDATOR_GET_DIRECTION(fcinfo)	(((ExtProtocolValidatorData*) fcinfo->context)->direction)
+#define EXTPROTOCOL_VALIDATOR_GET_DIRECTION(fcinfo) (((ExtProtocolValidatorData*) fcinfo->context)->direction)
 
 
-#endif /* EXTPROTOCOL_H */
+#endif   /* EXTPROTOCOL_H */

--- a/src/include/access/extprotocol.h
+++ b/src/include/access/extprotocol.h
@@ -35,8 +35,9 @@ typedef struct ExtProtocolData
 	char*			prot_databuf;
 	int				prot_maxbytes;
 	void*			prot_user_ctx;
+	List*			filter_quals;
 	bool			prot_last_call;
-		
+
 } ExtProtocolData;
 
 typedef ExtProtocolData *ExtProtocol;
@@ -49,6 +50,7 @@ typedef ExtProtocolData *ExtProtocol;
 #define EXTPROTOCOL_GET_DATABUF(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_databuf)
 #define EXTPROTOCOL_GET_DATALEN(fcinfo)    (((ExtProtocolData*) fcinfo->context)->prot_maxbytes)
 #define EXTPROTOCOL_GET_USER_CTX(fcinfo)   (((ExtProtocolData*) fcinfo->context)->prot_user_ctx)
+#define EXTPROTOCOL_GET_FILTER_QUALS(fcinfo) (((ExtProtocolData*) fcinfo->context)->filter_quals)
 #define EXTPROTOCOL_IS_LAST_CALL(fcinfo)   (((ExtProtocolData*) fcinfo->context)->prot_last_call)
 
 #define EXTPROTOCOL_SET_LAST_CALL(fcinfo)  (((ExtProtocolData*) fcinfo->context)->prot_last_call = true)
@@ -74,7 +76,7 @@ typedef struct ExtProtocolValidatorData
 	List 		  		*url_list;
 	ValidatorDirection 	 direction;  /* validating read or write? */
 	char				*errmsg;		  /* the validation error upon return, if any */
-	
+
 } ExtProtocolValidatorData;
 
 typedef ExtProtocolValidatorData *ExtProtocolValidator;

--- a/src/include/access/fileam.h
+++ b/src/include/access/fileam.h
@@ -61,7 +61,7 @@ extern FileScanDesc external_beginscan(Relation relation, Index scanrelid,
 extern void external_rescan(FileScanDesc scan);
 extern void external_endscan(FileScanDesc scan);
 extern void external_stopscan(FileScanDesc scan);
-extern HeapTuple external_getnext(FileScanDesc scan, ScanDirection direction);
+extern HeapTuple external_getnext(FileScanDesc scan, ScanDirection direction, List* filter_quals);
 extern ExternalInsertDesc external_insert_init(Relation rel);
 extern Oid	external_insert(ExternalInsertDesc extInsertDesc, HeapTuple instup);
 extern void external_insert_finish(ExternalInsertDesc extInsertDesc);

--- a/src/include/access/url.h
+++ b/src/include/access/url.h
@@ -19,13 +19,13 @@
 /*
  * Different "flavors", or implementations, of external tables.
  */
-enum fcurl_type_e 
-{ 
-	CFTYPE_NONE = 0, 
-	CFTYPE_FILE = 1, 
-	CFTYPE_CURL = 2, 
-	CFTYPE_EXEC = 3, 
-	CFTYPE_CUSTOM = 4 
+enum fcurl_type_e
+{
+	CFTYPE_NONE = 0,
+	CFTYPE_FILE = 1,
+	CFTYPE_CURL = 2,
+	CFTYPE_EXEC = 3,
+	CFTYPE_CUSTOM = 4
 };
 
 /*
@@ -76,7 +76,7 @@ typedef struct extvar_t
 #define EXEC_URL_PREFIX "execute:"
 
 /* exported functions */
-extern URL_FILE *url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate);
+extern URL_FILE *url_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals);
 extern void url_fclose(URL_FILE *file, bool failOnError, const char *relname);
 extern bool url_feof(URL_FILE *file, int bytesread);
 extern bool url_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen);
@@ -106,7 +106,7 @@ extern bool url_execute_ferror(URL_FILE *file, int bytesread, char *ebuf, int eb
 extern size_t url_execute_fread(void *ptr, size_t size, URL_FILE *file, CopyState pstate);
 extern size_t url_execute_fwrite(void *ptr, size_t size, URL_FILE *file, CopyState pstate);
 
-extern URL_FILE *url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate);
+extern URL_FILE *url_custom_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate, List* filter_quals);
 extern void url_custom_fclose(URL_FILE *file, bool failOnError, const char *relname);
 extern bool url_custom_feof(URL_FILE *file, int bytesread);
 extern bool url_custom_ferror(URL_FILE *file, int bytesread, char *ebuf, int ebuflen);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -194,7 +194,7 @@ extern bool gp_appendonly_compaction;
  * 0 indicates compact whenever there is hidden data.
  * 10 indicates that a segment should be compacted when more than
  * 10% of the tuples are hidden.
- */ 
+ */
 extern int  gp_appendonly_compaction_threshold;
 extern bool gp_heap_verify_checksums_on_mirror;
 extern bool gp_heap_require_relhasoids_match;
@@ -517,7 +517,7 @@ extern char  *gp_email_from;
 extern char  *gp_email_to;
 extern int   gp_email_connect_timeout;
 extern int   gp_email_connect_failures;
-extern int   gp_email_connect_avoid_duration; 
+extern int   gp_email_connect_avoid_duration;
 
 #if USE_SNMP
 extern char   *gp_snmp_community;
@@ -550,6 +550,9 @@ extern bool gp_enable_segment_copy_checking;
 extern int log_count_recovered_files_batch;
 
 extern int writable_external_table_bufsize;
+
+/* Enable passing of query constraints to external table providers */
+extern bool enable_filter_pushdown;
 
 typedef enum
 {


### PR DESCRIPTION
Implement filter pushdown for external sources accessible by PXF protocol.

Pushdown can be implemented for other custom protocols, too, and the changes will reside in the code of GPDB extension for that protocol, not in GPDB core.

The feature is disabled by default and can be enabled by setting a GUC parameter enable_filter_pushdown to on.

### Principle
The filter quals are extracted from a query in ExternalNext(), passed (as a List*) to url_custom_fopen(), and pushed into ExtProtocolData located in URL_CUSTOM_FILE. The latter is then provided to an accessor of external data source (in case of PXF the entrypoint is pxfprotocol_import()).

The external data source accessor retrieves the constraints from ExtProtocolData and processes them properly (in case of PXF the processing is a custom constraints serialization and encoding; the code is in pxffilters.c (the file comes from Apache HAWQ, with minor modifications), and the rules can be found in pxf_serialize_filter_list()).

Finally, the accessor makes a request to the external data source with the constraints from GPDB included.

When the data is returned to GPDB, the same constraints are applied to the result again. This keeps the output consistent in case constraints were not processed properly by PXF (or some other) extension or PXF (or other external data source) was unable to process them properly.

### PXF accessor
PXF external source accessor has certain limitations. When they are not met, no constraints will be passed to PXF. The limitations are as follows:

Multiple constraints must be ANDed (OR is not allowed);
Only >, <, =, <>, BETWEEN, IN and LIKE constraint operators are supported;
Only INT, FLOAT, REAL, TEXT, CHAR, DATE and TIMESTAMP constraint data types are supported. All constraints (except for those of type INT) should be explicitly cast to the type of field they are applied to;
If any of the limitations is not met, a query will be executed properly, but pushdown will be disabled for it.

Also, every PXF plugin has its own set of supported operators and data types for pushdown, thus, even if the constraints were properly processed by GPDB PXF extension, PXF may not pass them to the external data source.