### PR TITLE
ADBDEV-88. Fix ZSTD compression error "dst buffer too small"

### DIFF
--- a/configure
+++ b/configure
@@ -12661,13 +12661,21 @@ fi
 
 fi
 
-# Check for zstd.h
+# Check for zstd.h and zstd_errors.h
 if test "$with_zstd" = yes; then
   ac_fn_c_check_header_mongrel "$LINENO" "zstd.h" "ac_cv_header_zstd_h" "$ac_includes_default"
 if test "x$ac_cv_header_zstd_h" = xyes; then :
 
 else
   as_fn_error $? "header file <zstd.h> is required for zstd support" "$LINENO" 5
+fi
+
+
+  ac_fn_c_check_header_mongrel "$LINENO" "zstd_errors.h" "ac_cv_header_zstd_errors_h" "$ac_includes_default"
+if test "x$ac_cv_header_zstd_errors_h" = xyes; then :
+
+else
+  as_fn_error $? "header file <zstd_errors.h> is required for zstd support" "$LINENO" 5
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -1365,6 +1365,7 @@ fi
 # Check for zstd.h
 if test "$with_zstd" = yes; then
   AC_CHECK_HEADER(zstd.h, [], [AC_MSG_ERROR([header file <zstd.h> is required for zstd support])])
+  AC_CHECK_HEADER(zstd_errors.h, [], [AC_MSG_ERROR([header file <zstd_errors.h> is required for zstd support])])
 fi
 
 # On BSD, cpp test for net/if.h will fail unless sys/socket.h


### PR DESCRIPTION
This closes https://jira.arenadata.io/browse/ADBDEV-88.

When ZSTD compression is used for AO CO tables, insertion of data may cause an error "Destination buffer is too small". This happens when compressed data is larger than uncompressed input data.

This commit adds correct handling of this situation: do not change output buffer and return size used equal to source size. The caller (e.g., 'cdbappendonlystoragewrite.c') is able to handle such output; in this case, it copies data from input to output itself.