### PR TITLE
ADBDEV-271

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1599,26 +1599,7 @@ MergeAttributes(List *schema, List *supers, bool istemp, bool isPartitioned,
 				/* Default and other constraints are handled below */
 				newattno[parent_attno - 1] = exist_attno;
 
-				/*
-				 * Update GpPolicy
-				 */
-				if (policy != NULL)
-				{
-					int attr_ofst = 0;
-
-					Assert(policy->nattrs >= 0 && "the number of distribution attributes is not negative");
-
-					/* Iterate over all distribution attribute offsets */
-					for (attr_ofst = 0; attr_ofst < policy->nattrs; attr_ofst++)
-					{
-						/* Check if any distribution attribute has higher offset than the current */
-						if (policy->attrs[attr_ofst] > child_attno)
-						{
-							Assert(policy->attrs[attr_ofst] > 0 && "index should not become negative");
-							policy->attrs[attr_ofst]--;
-						}
-					}
-				}
+				Assert(policy->nattrs >= 0 && "the number of distribution attributes is not negative");
 
 			}
 			else

--- a/src/test/regress/expected/create_table_distpol.out
+++ b/src/test/regress/expected/create_table_distpol.out
@@ -161,3 +161,35 @@ select localoid::regclass, attrnums from gp_distribution_policy where localoid::
  distpol_ctas4 | {2,3}
 (4 rows)
 
+-- Check distribution keys for inherited tables with the same columns as in a parent table
+CREATE TABLE points (
+    p     point
+) distributed randomly;
+CREATE TABLE a_points (
+    p     point,
+    a     int
+) INHERITS (points) distributed by (a);
+NOTICE:  merging column "p" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'a_points'::regclass;
+ attrnums 
+----------
+ {2}
+(1 row)
+
+CREATE TABLE b_points (
+    b     int,
+    p     point,
+    c     int
+) INHERITS (points) distributed by (b, c);
+NOTICE:  merging column "p" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'b_points'::regclass;
+ attrnums 
+----------
+ {2,3}
+(1 row)
+
+-- Check distribution on non-hashable column in a parent table
+CREATE TABLE c_points (
+    c     int
+) INHERITS (points) distributed by (p);
+ERROR:  type "point" can't be a part of a distribution key

--- a/src/test/regress/expected/create_table_distpol.out
+++ b/src/test/regress/expected/create_table_distpol.out
@@ -188,6 +188,23 @@ select attrnums from gp_distribution_policy where localoid = 'b_points'::regclas
  {2,3}
 (1 row)
 
+CREATE TABLE c_points (
+    b     int,
+    p     point,
+    d     int,
+    c     int
+) INHERITS (points, b_points, a_points) distributed by (b, c);
+NOTICE:  merging multiple inherited definitions of column "p"
+NOTICE:  merging multiple inherited definitions of column "p"
+NOTICE:  merging column "b" with inherited definition
+NOTICE:  merging column "p" with inherited definition
+NOTICE:  merging column "c" with inherited definition
+select attrnums from gp_distribution_policy where localoid = 'c_points'::regclass;
+ attrnums 
+----------
+ {2,3}
+  (1 row)
+
 -- Check distribution on non-hashable column in a parent table
 CREATE TABLE c_points (
     c     int

--- a/src/test/regress/sql/create_table_distpol.sql
+++ b/src/test/regress/sql/create_table_distpol.sql
@@ -129,6 +129,14 @@ CREATE TABLE b_points (
 ) INHERITS (points) distributed by (b, c);
 select attrnums from gp_distribution_policy where localoid = 'b_points'::regclass;
 
+CREATE TABLE c_points (
+    b     int,
+    p     point,
+    d     int,
+    c     int
+) INHERITS (points, b_points, a_points) distributed by (b, c);
+select attrnums from gp_distribution_policy where localoid = 'c_points'::regclass;
+
 -- Check distribution on non-hashable column in a parent table
 CREATE TABLE c_points (
     c     int

--- a/src/test/regress/sql/create_table_distpol.sql
+++ b/src/test/regress/sql/create_table_distpol.sql
@@ -110,3 +110,26 @@ create table distpol_ctas4 as select 1 as col1, i, j from (select i, j from foo)
 
 -- Check the results.
 select localoid::regclass, attrnums from gp_distribution_policy where localoid::regclass::text like 'distpol_ctas%';
+
+-- Check distribution keys for inherited tables with the same columns as in a parent table
+CREATE TABLE points (
+    p     point
+) distributed randomly;
+
+CREATE TABLE a_points (
+    p     point,
+    a     int
+) INHERITS (points) distributed by (a);
+select attrnums from gp_distribution_policy where localoid = 'a_points'::regclass;
+
+CREATE TABLE b_points (
+    b     int,
+    p     point,
+    c     int
+) INHERITS (points) distributed by (b, c);
+select attrnums from gp_distribution_policy where localoid = 'b_points'::regclass;
+
+-- Check distribution on non-hashable column in a parent table
+CREATE TABLE c_points (
+    c     int
+) INHERITS (points) distributed by (p);


### PR DESCRIPTION
Fix parser algorithm for setting distribution key column numbers
in gp_distribution_policy relation for inherited tables in GP5X
(GP6X is ok).
Query planes with ORCA caused segmentation faults because of
out of range column numbers and legacy optimizer simply
returned error before current patch. For example:
```
create table ta (a int) distributed randomly;
create table tb (a int, b int) inherits (ta) distributed by (b);

set optimizer=on;
insert into tb values(0, 0);
-- Segmentation fault

set optimizer=off;
insert into tb values(0, 0);
-- ERROR: no tlist entry for key 3 (cdbmutate.c:1484)

select attrnums from gp_distribution_policy where localoid = 'tb'::regclass;
 attrnums
----------
{3}
(1 row)
```

Also a check for setting non-hashable distribution key from a
parent table in an inherited one didn't work.
```
create table tc (a point) distributed randomly;
create table td (b int) inherits (tc) distributed by (a);

select * from td;
ERROR:  could not find mergejoinable = operator for type 600 (pathkeys.c:1174)
```