### PR TITLE
ADBDEV-697. Fix null transition for non-strict aggregate functions

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -3109,7 +3109,11 @@ numeric_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3200,7 +3204,11 @@ numeric_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (NumericAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3712,7 +3720,11 @@ numeric_poly_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)
@@ -3952,7 +3964,11 @@ int8_avg_combine(PG_FUNCTION_ARGS)
 	state2 = PG_ARGISNULL(1) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(1);
 
 	if (state2 == NULL)
+	{
+		if (state1 == NULL)
+			PG_RETURN_NULL();
 		PG_RETURN_POINTER(state1);
+	}
 
 	/* manually copy all fields from state2 to state1 */
 	if (state1 == NULL)

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -156,6 +156,31 @@ SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') 
  t
 (1 row)
 
+-- Test the spilling aggregates for pergroupstate inconsistency
+create table spill_pgs1(a bigint, b bigint, c text, d bigint) distributed randomly;
+insert into spill_pgs1 select g, null::bigint, 'aaaaaa', g from generate_series(1, 500000) as g;
+insert into spill_pgs1 select g, g, 'aaaaaa', g from generate_series(1, 500000) as g;
+create index spill_pgs1_idx on spill_pgs1(a) where c = 'aaaaaa' or c = 'bbbbbb';
+create table spill_pgs2(a bigint) distributed randomly;
+insert into spill_pgs2 select generate_series(1, 500000);
+create table spill_pgs3(d bigint, f integer) distributed randomly;
+insert into spill_pgs3 select g, 1 from generate_series(300000, 1000000) as g;
+set statement_mem='2MB';
+set optimizer=off;
+select count(q.*) as num from (
+    select
+        spill_pgs1.a, spill_pgs3.f,
+        sum(spill_pgs1.b) filter (where spill_pgs1.c in ('bbbbbb'))
+    from spill_pgs1 join spill_pgs2 using(a)
+    left join spill_pgs3 using(d)
+    where spill_pgs1.c in ('aaaaaa', 'bbbbbb')
+    group by 1, 2  
+) as q;
+  num   
+--------
+ 500000
+(1 row)
+
 -- check spilling to a temp tablespace
 CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
 SET temp_tablespaces=pg_default;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -114,6 +114,27 @@ SET gp_workfile_compression = ON;
 select overflows >= 1 from hashagg_spill.num_hashagg_overflows('explain analyze
 SELECT avg(col2) col2 FROM hashagg_spill GROUP BY col1 HAVING(sum(col1)) < 0;') overflows;
 
+-- Test the spilling aggregates for pergroupstate inconsistency
+create table spill_pgs1(a bigint, b bigint, c text, d bigint) distributed randomly;
+insert into spill_pgs1 select g, null::bigint, 'aaaaaa', g from generate_series(1, 500000) as g;
+insert into spill_pgs1 select g, g, 'aaaaaa', g from generate_series(1, 500000) as g;
+create index spill_pgs1_idx on spill_pgs1(a) where c = 'aaaaaa' or c = 'bbbbbb';
+create table spill_pgs2(a bigint) distributed randomly;
+insert into spill_pgs2 select generate_series(1, 500000);
+create table spill_pgs3(d bigint, f integer) distributed randomly;
+insert into spill_pgs3 select g, 1 from generate_series(300000, 1000000) as g;
+set statement_mem='2MB';
+set optimizer=off;
+select count(q.*) as num from (
+    select
+        spill_pgs1.a, spill_pgs3.f,
+        sum(spill_pgs1.b) filter (where spill_pgs1.c in ('bbbbbb'))
+    from spill_pgs1 join spill_pgs2 using(a)
+    left join spill_pgs3 using(d)
+    where spill_pgs1.c in ('aaaaaa', 'bbbbbb')
+    group by 1, 2  
+) as q;
+
 -- check spilling to a temp tablespace
 CREATE TABLE spill_temptblspace (a numeric) DISTRIBUTED BY (a);
 SET temp_tablespaces=pg_default;


### PR DESCRIPTION
The bug was indeed related to the case when pergroupstate->transValueIsNull is false, but pergroupstate->transValue = 0.
These fields correspond to an aggregate group and updated on HashAggTable insert:
agg_hash_initial_pass -> advance_aggregates -> advance_transition_function -> invoke_agg_trans_func

As can be seen new transValue is returned from int8_avg_combine(fcinfo) and transValueIsNull is set to fcinfo->isnull that is set to false by default. The problem that int8_avg_combinei() can return immediately the old transValue and not touch fcinfo->isnull at all if increment is null. So we can end up with transValueIsNull is false and transValue = 0. This is possible, because int8_avg_combine() is defined as strict function (transfn->fn_strict = true) and accept nulls. As another approach it is good to check if this flag is really required for this function.
