### PR TITLE
Fix zero plan_node_id for BitmapOr/And in ORCA

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5369,6 +5369,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapBoolOp
 	if (CDXLScalarBitmapBoolOp::EdxlbitmapAnd == sc_bitmap_boolop_dxlop->GetDXLBitmapOpType())
 	{
 		BitmapAnd *bitmapand = MakeNode(BitmapAnd);
+		bitmapand->plan.plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 		bitmapand->bitmapplans = child_plan_list;
 		bitmapand->plan.targetlist = NULL;
 		bitmapand->plan.qual = NULL;
@@ -5377,6 +5378,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapBoolOp
 	else
 	{
 		BitmapOr *bitmapor = MakeNode(BitmapOr);
+		bitmapor->plan.plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 		bitmapor->bitmapplans = child_plan_list;
 		bitmapor->plan.targetlist = NULL;
 		bitmapor->plan.qual = NULL;


### PR DESCRIPTION
According to `plannode.h` `plan_node_id` should be unique across entire final plan tree. But `ORCA DXL` to `PlanStatement` translator returns uninitialized zero values for `BitmapOr` and `BitmapAnd` nodes. This behaviour differs from Postgres planner and from all other node translations in this class. It was fixed.

There are no regression tests in this PR as GP doesn't seem to have a SQL infrastructure to retrieve `plan_node_id` from a generated plan. I made some experiments with
```sql
create table t(a int);
insert into t select generate_series(1, 10000);
create index t_idx on t(a);

set debug_print_plan = on;
set client_min_messages = log;
set optimizer_enable_bitmapscan = on;
explain select * from t where (a < 10 or a > 9999) and (a > 0 or a < 10000);
```
but the result contained too much per-run specific information like OIDs and exact costs. So this method doesn't suit us for a current task.

Also there is no sense to use ORCA mini dump infrastructure as plans are constructed correctly. The problem is in post-plan translation outside of `ORCA` in `gpopt` module.