### PR TITLE
Init gpmon packet for dynamic scan states

### DIFF
--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -122,6 +122,9 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	if (node->ss.ps.instrument)
 		InstrStopNode(node->ss.ps.instrument, 1 /* nTuples */);
 
+	/* Increment gpmon packet too */
+	Gpmon_Incr_Rows_Out(&node->ss.ps.gpmon_pkt);
+
 	return (Node *) bitmap;
 }
 

--- a/src/backend/executor/nodeDynamicBitmapHeapscan.c
+++ b/src/backend/executor/nodeDynamicBitmapHeapscan.c
@@ -112,6 +112,7 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 	Oid			currentPartitionOid;
 	Oid		   *pid;
 	Relation	currentRelation;
+	PlanState  *bhsPlanState;
 
 	pid = hash_seq_search(&node->pidStatus);
 	if (pid == NULL)
@@ -176,6 +177,16 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 	DynamicScan_SetTableOid(&node->ss, currentPartitionOid);
 	node->bhsState = ExecInitBitmapHeapScanForPartition(&plan->bitmapheapscan, estate, node->eflags,
 													 currentRelation);
+
+	/*
+	 * Setup gpmon counters for BitmapHeapScan. Rows count for sidecar partition scan should
+	 * be consistent with a parent dynamic scan as they share the same plan_node_id. Otherwise
+	 * partition sends zero row number while dynamic scan sends an actual value and this is
+	 * confusing.
+	 */
+	bhsPlanState = &node->bhsState->ss.ps;
+	InitPlanNodeGpmonPkt(bhsPlanState->plan, &bhsPlanState->gpmon_pkt, estate);
+	bhsPlanState->gpmon_pkt.u.qexec.rowsout = node->ss.ps.gpmon_pkt.u.qexec.rowsout;
 
 	/*
 	 * Rescan the child node, and attach it to the sidecar BitmapHeapScan.
@@ -248,7 +259,15 @@ ExecDynamicBitmapHeapScan(DynamicBitmapHeapScanState *node)
 		slot = ExecBitmapHeapScan(node->bhsState);
 
 		if (!TupIsNull(slot))
+		{
+			/*
+			 * Increment sidecar's partition scan tuples count.
+			 * It should be incremented consistently with a
+			 * dynamic scan to avoid gpperfmon anomalies.
+			 */
+			Gpmon_Incr_Rows_Out(&node->bhsState->ss.ps.gpmon_pkt);
 			break;
+		}
 
 		/* No more tuples from this partition. Move to next one. */
 		CleanupOnePartition(node);

--- a/src/backend/executor/nodeDynamicBitmapIndexscan.c
+++ b/src/backend/executor/nodeDynamicBitmapIndexscan.c
@@ -115,6 +115,7 @@ beginCurrentBitmapIndexScan(DynamicBitmapIndexScanState *node, EState *estate,
 	Relation	currentRelation;
 	Oid			indexOid;
 	MemoryContext oldCxt;
+	PlanState	*bisPlanState;
 
 	oldCxt = MemoryContextSwitchTo(node->partitionMemoryContext);
 
@@ -151,6 +152,16 @@ beginCurrentBitmapIndexScan(DynamicBitmapIndexScanState *node, EState *estate,
 														 estate,
 														 node->eflags);
 
+	/*
+	 * Setup gpmon counters for BitmapIndexScan. Bitmaps count for sidecar index scan
+	 * should be consistent with a parent dynamic scan as they share the same plan_node_id.
+	 * Otherwise index sends zero bitmap number while dynamic scan sends an actual value
+	 * and this is confusing.
+	 */
+	bisPlanState = &node->bitmapIndexScanState->ss.ps;
+	InitPlanNodeGpmonPkt(bisPlanState->plan, &bisPlanState->gpmon_pkt, estate);
+	bisPlanState->gpmon_pkt.u.qexec.rowsout = node->ss.ps.gpmon_pkt.u.qexec.rowsout;
+
 	if (node->ss.ps.instrument)
 	{
 		/* Let the BitmapIndexScan share our Instrument node */
@@ -184,6 +195,7 @@ MultiExecDynamicBitmapIndexScan(DynamicBitmapIndexScanState *node)
 {
 	EState	   *estate = node->ss.ps.state;
 	Oid			tableOid;
+	Node	   *bitmap = NULL;
 
 	/* close previously open scan, if any. */
 	endCurrentBitmapIndexScan(node);
@@ -205,7 +217,16 @@ MultiExecDynamicBitmapIndexScan(DynamicBitmapIndexScanState *node)
 	 */
 	beginCurrentBitmapIndexScan(node, estate, tableOid);
 
-	return MultiExecBitmapIndexScan(node->bitmapIndexScanState);
+	node = MultiExecBitmapIndexScan(node->bitmapIndexScanState);
+
+	/*
+	 * Increment dynamic index scan bitmap count.
+	 * It should be incremented consistently with a
+	 * sidecar index scan to avoid gpperfmon anomalies.
+	 */
+	Gpmon_Incr_Rows_Out(&node->ss.ps.gpmon_pkt);
+
+	return node;
 }
 
 /*

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -141,6 +141,7 @@ beginCurrentIndexScan(DynamicIndexScanState *node, EState *estate,
 	Oid			indexOid;
 	List	   *save_tupletable;
 	MemoryContext oldCxt;
+	PlanState  *isPlanState;
 
 	/*
 	 * open the base relation and acquire appropriate lock on it.
@@ -173,6 +174,17 @@ beginCurrentIndexScan(DynamicIndexScanState *node, EState *estate,
 	node->indexScanState = ExecInitIndexScanForPartition(&dynamicIndexScan->indexscan, estate,
 														 node->eflags,
 														 currentRelation, indexOid);
+
+	/*
+	 * Setup gpmon counters for IndexScan. Rows count for sidecar index scan should
+	 * be consistent with a parent dynamic scan as they share the same plan_node_id.
+	 * Otherwise index sends zero row number while dynamic scan sends an actual value
+	 * and this is confusing.
+	 */
+	isPlanState = &node->indexScanState->ss.ps;
+	InitPlanNodeGpmonPkt(isPlanState->plan, &isPlanState->gpmon_pkt, estate);
+	isPlanState->gpmon_pkt.u.qexec.rowsout = node->ss.ps.gpmon_pkt.u.qexec.rowsout;
+
 	/* The IndexScan node takes ownership of currentRelation, and will close it when done */
 	node->tuptable = estate->es_tupleTable;
 	estate->es_tupleTable = save_tupletable;
@@ -291,6 +303,13 @@ ExecDynamicIndexScan(DynamicIndexScanState *node)
 		   initNextIndexToScan(node))
 	{
 		slot = ExecIndexScan(node->indexScanState);
+
+		/*
+		 * Increment sidecar's index scan tuples count.
+		 * It should be incremented consistently with a
+		 * dynamic scan to avoid gpperfmon anomalies.
+		 */
+		Gpmon_Incr_Rows_Out(&node->indexScanState->ss.ps.gpmon_pkt);
 
 		if (TupIsNull(slot))
 		{

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -105,6 +105,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	AttrNumber *attMap;
 	Oid		   *pid;
 	Relation	currentRelation;
+	PlanState  *ssPlanState;
 
 	pid = hash_seq_search(&node->pidStatus);
 	if (pid == NULL)
@@ -168,6 +169,17 @@ initNextTableToScan(DynamicSeqScanState *node)
 	DynamicScan_SetTableOid(&node->ss, *pid);
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate, node->eflags,
 													 currentRelation);
+
+	/*
+	 * Setup gpmon counters for SeqScan. Rows count for sidecar partition scan should
+	 * be consistent with a parent dynamic scan as they share the same plan_node_id.
+	 * Otherwise partition sends zero row number while dynamic scan sends an actual
+	 * value and this is confusing.
+	 */
+	ssPlanState = &node->seqScanState->ss.ps;
+	InitPlanNodeGpmonPkt(ssPlanState->plan, &ssPlanState->gpmon_pkt, estate);
+	ssPlanState->gpmon_pkt.u.qexec.rowsout = node->ss.ps.gpmon_pkt.u.qexec.rowsout;
+
 	return true;
 }
 
@@ -232,7 +244,15 @@ ExecDynamicSeqScan(DynamicSeqScanState *node)
 		slot = ExecSeqScan(node->seqScanState);
 
 		if (!TupIsNull(slot))
+		{
+			/*
+			 * Increment sidecar's partition scan tuples count.
+			 * It should be incremented consistently with a
+			 * dynamic scan to avoid gpperfmon anomalies.
+			 */
+			Gpmon_Incr_Rows_Out(&node->seqScanState->ss.ps.gpmon_pkt);
 			break;
+		}
 
 		/* No more tuples from this partition. Move to next one. */
 		CleanupOnePartition(node);


### PR DESCRIPTION
Dynamic scans use scan states to initialize and keep sidecar nodes. It is done bypassing `ExecInitNode` that normally does `gpmon` packet initialization. As a result `gpmon` is not initialized for all dynamic sidecar nodes that causes `bad magic 0` warnings. Here is an example to reproduce a problem (`gp_enable_gpperfmon` should be `on`):
```sql
create table t(a int, b date, c int) distributed by (a)
partition by range (b) subpartition by list (c)
subpartition template
(subpartition s1 values (1), subpartition s2 values(2))
(start ('2020-04-01') end('2020-05-01') every(interval '1 day'));
create index t_idx on t using bitmap (b);

select count(*) from t where b = '2020-04-02';

WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg1 slice1 10.92.6.98:6006 pid=7727)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
WARNING:  gpmon - bad magic 0  (seg0 slice1 10.92.6.98:6005 pid=7726)
WARNING:  gpmon - bad magic 0  (seg2 slice1 10.92.6.98:6007 pid=7728)
 count 
-------
     0
(1 row)
```
We should keep in mind that rows count for sidecar partition scan should be consistent with a parent dynamic scan as they share the same plan_node_id. Otherwise partition sends zero row number while dynamic scan sends an actual value and this is confusing.

There are no tests in a PR as I haven't found any existing `gpperfmon` tests in GP code.