### PR TITLE
Fix bitmap segfault while portal clean

### DIFF
--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -914,14 +914,14 @@ ExecEndBitmapHeapScan(BitmapHeapScanState *node)
 	ExecClearTuple(node->ss.ss_ScanTupleSlot);
 
 	/*
+	 * release bitmap iterator if any
+	 */
+	ExecEagerFreeBitmapHeapScan(node);
+
+	/*
 	 * close down subplans
 	 */
 	ExecEndNode(outerPlanState(node));
-
-	/*
-	 * release bitmap if any
-	 */
-	ExecEagerFreeBitmapHeapScan(node);
 
 	/*
 	 * close heap scan


### PR DESCRIPTION
Currently when we finish a query with a bitmap index scan and destroy its portal, we release bitmap resources in a wrong order. First of all we should release bitmap iterator (a bitmap wrapper) and only after that close down subplans (bitmap index scan with an allocated bitmap). Before current commit this operations were done in a reverse order that causes access to a freed bitmap in a iterator closing function (`ExecEndBitmapHeapScan`):
1. `ExecEndNode -> ExecEndBitmapIndexScan -> tbm_generic_free` - deallocate bitmap
2. `ExecEagerFreeBitmapHeapScan -> freeBitmapState -> tbm_generic_end_iterate` - access `bm->type` to close a bitmap iterator correctly according to its type (use deallocated bitmap)

Underhood `pfree()` is a malloc's `free()` wrapper. `Free()` doesn't return memory to OS in most cases or even doesn't immediately corrupt data in a freed chunk, so it is possible to access freed chunk data right after its deallocation. That is why we can get segfault only under concurrent workloads when malloc's arena returns memory to OS.

This problem also affects `6X_STABLE` and `5X_STABLE` branches and need to be backported there.