### PR TITLE
ADBDEV-796: Fix gporca stacktrace on architectures other than x86-64 - to correct branch

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/utils.h
+++ b/src/backend/gporca/libgpos/include/gpos/utils.h
@@ -21,8 +21,16 @@
 #include "gpos/error/CException.h"
 #include "gpos/io/COstreamBasic.h"
 
+// These fallback is similar to the one used in Postgres 'elog.c'
+#if defined(__x86_64__)
 #define GPOS_ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
-#define GPOS_ASMSP asm volatile ("movq %%rsp, %0" : "=g" (ulp));
+#define GPOS_GET_FRAME_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMFP; x = ulp; } while (0)
+#elif defined(__i386)
+#define GPOS_ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
+#define GPOS_GET_FRAME_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMFP; x = ulp; } while (0)
+#else
+#include <execinfo.h>
+#endif
 
 #define ALIGNED_16(x) (((ULONG_PTR) x >> 1) << 1 == (ULONG_PTR) x)	// checks 16-bit alignment
 #define ALIGNED_32(x) (((ULONG_PTR) x >> 2) << 2 == (ULONG_PTR) x)	// checks 32-bit alignment
@@ -31,9 +39,6 @@
 #define MAX_ALIGNED(x) ALIGNED_64(x)
 
 #define	ALIGN_STORAGE __attribute__((aligned (8)))
-
-#define GPOS_GET_FRAME_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMFP; x = ulp; } while (0)
-#define GPOS_GET_STACK_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMSP; x = ulp; } while (0)
 
 #define GPOS_MSEC_IN_SEC	((ULLONG) 1000)
 #define GPOS_USEC_IN_MSEC	((ULLONG) 1000)

--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -33,8 +33,16 @@ CStackDescriptor::BackTrace
 	)
 {
 	// get base pointer of current frame
+
+	int gpos_stack_trace_depth_actual;
+	#ifdef GPOS_GET_FRAME_POINTER
 	ULONG_PTR current_frame;
 	GPOS_GET_FRAME_POINTER(current_frame);
+	gpos_stack_trace_depth_actual = GPOS_STACK_TRACE_DEPTH;
+	#else
+	void *current_frame[GPOS_STACK_TRACE_DEPTH];
+	gpos_stack_trace_depth_actual = backtrace(current_frame, GPOS_STACK_TRACE_DEPTH);
+	#endif
 
 	// reset stack depth
 	Reset();
@@ -55,7 +63,7 @@ CStackDescriptor::BackTrace
 	stack_start = worker->GetStackStart();
 
 	// consider the first GPOS_STACK_TRACE_DEPTH frames below worker object
-	for (ULONG frame_counter = 0; frame_counter < GPOS_STACK_TRACE_DEPTH; frame_counter++)
+	for (ULONG frame_counter = 0; frame_counter < gpos_stack_trace_depth_actual; frame_counter++)
 	{
 		// check if the frame pointer is after stack start and before previous frame
 		if ((ULONG_PTR) *next_frame > stack_start ||


### PR DESCRIPTION
* gporca provides its own backtrace method which has a definition
different from the one used in 'elog.c'. This definition suites only
x86-64 architecture (as it uses assembly instructions). Change this and
use library method 'backtrace()' when the architecture is not the one
where the required assembly calls are supported