### PR TITLE
Init gpmon packet for dynamic scan states

### DIFF
--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -122,6 +122,10 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	if (node->ss.ps.instrument)
 		InstrStopNode(node->ss.ps.instrument, 1 /* nTuples */);
 
+	/* Increment gpmon packet too */
+	if (&node->ss.ps.gpmon_pkt)
+		Gpmon_Incr_Rows_Out(&node->ss.ps.gpmon_pkt);
+
 	return (Node *) bitmap;
 }
 


### PR DESCRIPTION
Dynamic scans use scan states to initialize and keep sidecar nodes.
It is done bypassing ExecInitNode that normally does gpmon packet
initialization. As a result gpmon is not initialized for all
dynamic sidecar nodes that causes "bad magic 0" warnings.