### PR TITLE
Fix explain analyze error handling

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -700,7 +700,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 			ctx.nStatInst = hdr->nInst;
 		else
 		{
-			/* MPP-2140: what causes this ? */
+			/* Check for a stats corruption */
 			if (ctx.nStatInst != hdr->nInst)
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 								errmsg("Invalid execution statistics "

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -876,25 +876,6 @@ standard_ExecutorRun(QueryDesc *queryDesc,
     }
 	PG_CATCH();
 	{
-        /* If EXPLAIN ANALYZE, let qExec try to return stats to qDisp. */
-        if (estate->es_sliceTable &&
-            estate->es_sliceTable->instrument_options &&
-            (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
-            Gp_role == GP_ROLE_EXECUTE)
-        {
-            PG_TRY();
-            {
-                cdbexplain_sendExecStats(queryDesc);
-            }
-            PG_CATCH();
-            {
-                /* Close down interconnect etc. */
-				mppExecutorCleanup(queryDesc);
-		        PG_RE_THROW();
-            }
-            PG_END_TRY();
-        }
-
         /* Close down interconnect etc. */
 		mppExecutorCleanup(queryDesc);
 		PG_RE_THROW();


### PR DESCRIPTION
Error handling for explain analyze differs from a regular query. When we execute a plan slice and get an error in a case on a simple query we just cleanup and rethrow an exception out of PG_TRY block. But for explain analyze we tried to return stats to QD though it is possibly incorrect or even broken. It can cause different errors with stats packets during:

- serialization on QE (`InstrEndLoop called on running node`)
-  deserialization on QD (`Invalid execution statistics received stats node-count mismatch`)

Also in a case of a double fault an original error was overridden by a new one. It hid an original error from a user and this behavior differed from a simple query plan processing.