### PR TITLE
Fix desc context for  dynamic index scan tuples

### DIFF
--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -318,6 +318,18 @@ ExecDynamicIndexScan(DynamicIndexScanState *node)
 
 			node->scan_state = SCAN_INIT;
 		}
+		else
+		{
+			/*
+			 * Tuples should use dynamic index scan descriptor rather than
+			 * an auxiliary index scan one to avoid free memory context
+			 * problems in parent plan nodes (indexScanState is cleaned at
+			 * the end of partition index scan).
+			 */
+			ReleaseTupleDesc(slot->tts_tupleDescriptor);
+			slot->tts_tupleDescriptor = node->ss.ps.ps_ResultTupleSlot->tts_tupleDescriptor;
+			PinTupleDesc(slot->tts_tupleDescriptor);
+		}
 	}
 	return slot;
 }

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -4160,6 +4160,36 @@ select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 (0 rows)
 
 drop table ti;
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+NOTICE:  table "dis_tupdesc" does not exist, skipping
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p1" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p2" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_junk_data" for table "dis_tupdesc"
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+ b 
+---
+ 0
+ 1
+ 2
+(3 rows)
+
+reset gp_segments_for_planner;
+reset optimizer_segments;
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -4173,6 +4173,36 @@ select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 (0 rows)
 
 drop table ti;
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+NOTICE:  table "dis_tupdesc" does not exist, skipping
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p1" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_p2" for table "dis_tupdesc"
+NOTICE:  CREATE TABLE will create partition "dis_tupdesc_1_prt_junk_data" for table "dis_tupdesc"
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+ b 
+---
+ 0
+ 1
+ 2
+(3 rows)
+
+reset gp_segments_for_planner;
+reset optimizer_segments;
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -2141,6 +2141,26 @@ drop index ti_j_idx;
 select * from pg_indexes where schemaname = 'public' and tablename like 'ti%';
 drop table ti;
 
+-- Partitioned table with btree index and hash aggregate should use a correct
+-- memory context for its tuples` descriptor
+drop table if exists dis_tupdesc;
+create table dis_tupdesc (a int, b int, c int)
+distributed by (a)
+partition by list (b)
+(
+    partition p1 values (1),
+    partition p2 values (2),
+    default partition junk_data
+);
+create index dis_tupdesc_idx on dis_tupdesc using btree (c);
+insert into dis_tupdesc select i, i % 3, i % 4 from generate_series (1, 240) as i;
+analyze dis_tupdesc;
+set gp_segments_for_planner = 2;
+set optimizer_segments = 2;
+select distinct b from dis_tupdesc where c >= 2;
+reset gp_segments_for_planner;
+reset optimizer_segments;
+
 -- MPP-6611, make sure rename works with default partitions
 create table it (i int, j int) partition by range(i) 
 subpartition by range(j) subpartition template(start(1) end(10) every(5))


### PR DESCRIPTION
This problem manifests itself with HashAgg node on the top of
Dynamic Index node and causes a segmentation fault.

Previously dynamic index scan tuples had a tuple descriptor with a
partition index scan context. It caused dangling pointer segfaults
in hash aggregates on the top of dynamic index scan. Hash aggregate
used tuple descriptor from the first tuple it received and expected
that this descriptor would live until the aggregate node end. But as
tuples returned descriptor from partition index scan context, this
descriptor was valid only until the end of a first partition scan.
Next partition returned a new tuple with a new descriptor (it is ok),
but a hash aggregate still tried to use a tuple descriptor of the
first partition causing a segfault.

The fix is to use dynamic index scan tuple descriptor in every tuple
instead of partition index scan ones.