### PR TITLE
Fix explain analyze error handling

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -586,6 +586,11 @@ cdbexplain_sendExecStats(QueryDesc *queryDesc)
 	 */
 	memcpy(ctx.buf.data + hoff, (char *) &ctx.hdr, sizeof(ctx.hdr) - sizeof(ctx.hdr.inst));
 
+#ifdef FAULT_INJECTOR
+	/* Inject a fault before sending a message to qDisp process */
+	SIMPLE_FAULT_INJECTOR("send_exec_stats");
+#endif /* FAULT_INJECTOR */
+
 	/* Send message to qDisp process. */
 	pq_endmessage(&ctx.buf);
 }								/* cdbexplain_sendExecStats */
@@ -734,7 +739,7 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 			ctx.nStatInst = hdr->nInst;
 		else
 		{
-			/* MPP-2140: what causes this ? */
+			/* Check for stats corruption */
 			if (ctx.nStatInst != hdr->nInst)
 				ereport(ERROR, (errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 								errmsg("Invalid execution statistics "

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -965,25 +965,6 @@ standard_ExecutorRun(QueryDesc *queryDesc,
     }
 	PG_CATCH();
 	{
-        /* If EXPLAIN ANALYZE, let qExec try to return stats to qDisp. */
-        if (estate->es_sliceTable &&
-            estate->es_sliceTable->instrument_options &&
-            (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
-            Gp_role == GP_ROLE_EXECUTE)
-        {
-            PG_TRY();
-            {
-                cdbexplain_sendExecStats(queryDesc);
-            }
-            PG_CATCH();
-            {
-                /* Close down interconnect etc. */
-				mppExecutorCleanup(queryDesc);
-		        PG_RE_THROW();
-            }
-            PG_END_TRY();
-        }
-
         /* Close down interconnect etc. */
 		mppExecutorCleanup(queryDesc);
 		PG_RE_THROW();
@@ -2976,6 +2957,11 @@ ExecutePlan(EState *estate,
 	 * Make sure slice dependencies are met
 	 */
 	ExecSliceDependencyNode(planstate);
+
+#ifdef FAULT_INJECTOR
+	/* Inject a fault before tuple processing started */
+	SIMPLE_FAULT_INJECTOR("executor_pre_tuple_processed");
+#endif /* FAULT_INJECTOR */
 
 	/*
 	 * Loop until we've processed the proper number of tuples from the plan.

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -502,5 +502,49 @@ create view show_fast_database_size_view as
 select count((pg_database_size(oid) - dbsize) / dbsize) < 0
   from pg_database, show_fast_database_size_view;
 
+--
+-- Test executor double fault
+-- check PG_TRY/PG_CATCH - we should always return an original error
+-- (for a query and its explain analyze)
+--
+drop table if exists double_fault;
+create table double_fault(a int) distributed by (a);
+insert into double_fault select generate_series(1, 10);
+create or replace function fault_exec_plan(explain_analyze bool default true) returns void as $_$
+declare
+    query text;
+begin
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+    perform gp_inject_fault('send_exec_stats', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+
+    if explain_analyze then
+        query := 'explain analyze select count(*) from double_fault';
+    else
+        query := 'select count(*) from double_fault';
+    end if;
+    execute query;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+exception when fault_inject then
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    raise exception $$'%' fault triggered$$, case
+        when coalesce(substring(sqlerrm from 'send_exec_stats'), '') != '' then 'send_exec_stats'
+        when coalesce(substring(sqlerrm from 'executor_pre_tuple_processed'), '') != '' then 'executor_pre_tuple_processed'
+    end;
+end;
+$_$ language plpgsql;
+-- Query raising 'executor_pre_tuple_processed' error
+select fault_exec_plan(false);
+-- Same query with explain analyze (should raise
+-- 'executor_pre_tuple_processed' not 'send_exec_stats')
+select fault_exec_plan(true);
 \c regression
 DROP DATABASE dispatch_test_db;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -841,5 +841,51 @@ select count((pg_database_size(oid) - dbsize) / dbsize) < 0
  f
 (1 row)
 
+--
+-- Test executor double fault
+-- check PG_TRY/PG_CATCH - we should always return an original error
+-- (for a query and its explain analyze)
+--
+drop table if exists double_fault;
+create table double_fault(a int) distributed by (a);
+insert into double_fault select generate_series(1, 10);
+create or replace function fault_exec_plan(explain_analyze bool default true) returns void as $_$
+declare
+    query text;
+begin
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+    perform gp_inject_fault('send_exec_stats', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+
+    if explain_analyze then
+        query := 'explain analyze select count(*) from double_fault';
+    else
+        query := 'select count(*) from double_fault';
+    end if;
+    execute query;
+
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+exception when fault_inject then
+    perform gp_inject_fault('executor_pre_tuple_processed', 'reset', dbid) from gp_segment_configuration;
+    perform gp_inject_fault('send_exec_stats', 'reset', dbid) from gp_segment_configuration;
+
+    raise exception $$'%' fault triggered$$, case
+        when coalesce(substring(sqlerrm from 'send_exec_stats'), '') != '' then 'send_exec_stats'
+        when coalesce(substring(sqlerrm from 'executor_pre_tuple_processed'), '') != '' then 'executor_pre_tuple_processed'
+    end;
+end;
+$_$ language plpgsql;
+-- Query raising 'executor_pre_tuple_processed' error
+select fault_exec_plan(false);
+ERROR:  'executor_pre_tuple_processed' fault triggered
+-- Same query with explain analyze (should raise
+-- 'executor_pre_tuple_processed' not 'send_exec_stats')
+select fault_exec_plan(true);
+ERROR:  'executor_pre_tuple_processed' fault triggered
 \c regression
 DROP DATABASE dispatch_test_db;


### PR DESCRIPTION
A backport of https://github.com/greenplum-db/gpdb/pull/10197

Error handling for explain analyze differs from a regular query. When we execute a plan slice and get an error in a case on a simple query we just cleanup and rethrow an exception out of PG_TRY block. But for explain analyze we tried to return stats to QD though it is possibly incorrect or even broken. It can cause different errors with stats packets during:

- serialization on QE ("InstrEndLoop called on running node")
- deserialization on QD ("Invalid execution statistics received stats node-count mismatch")

Also in a case of a double fault an original error was overridden by a new one. It hid an original error from a user and this behavior differed from a simple query plan processing.