### PR TITLE
Add missed NULL checks for XLogReaderAllocate

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1401,6 +1401,11 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 	 * file descriptor here.
 	 */
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
+	if (!xlogreader)
+		ereport(ERROR,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("out of memory"),
+			 errdetail("Failed while allocating an XLog reading processor.")));
 
 	tfRecord = XLogReadRecord(xlogreader, tfXLogRecPtr, &errormsg);
 	if (tfRecord == NULL)
@@ -1687,6 +1692,11 @@ PrescanPreparedTransactions(TransactionId **xids_p, int *nxids_p)
 	}
 
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
+	if (!xlogreader)
+		ereport(ERROR,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("out of memory"),
+			 errdetail("Failed while allocating an XLog reading processor.")));
 
 	while (tfXLogRecPtr != InvalidXLogRecPtr)
 	{
@@ -1913,6 +1923,11 @@ RecoverPreparedTransactions(void)
 	char	   *errormsg;
 
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
+	if (!xlogreader)
+		ereport(ERROR,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("out of memory"),
+			 errdetail("Failed while allocating an XLog reading processor.")));
 
 	if (crashRecoverPostCheckpointPreparedTransactions_map_ht != NULL)
 	{

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -442,6 +442,11 @@ check_ao_record_present(unsigned char type, char *buf, Size len,
 	test_PrintLog("wal end record", walEnd, sendTime);
 
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
+	if (!xlogreader)
+		ereport(ERROR,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("out of memory"),
+			 errdetail("Failed while allocating an XLog reading processor.")));
 
 	/*
 	 * Find the first valid record at or after the given starting point.


### PR DESCRIPTION
`XLogReaderAllocate` returns `NULL` if the `xlogreader` couldn't be allocated. This `NULL` checks were forgotten in several places of `twophase.c` and caused segmentation faults under heavy workloads.

This problem affects only `6X_STABLE`.
Current PR was cherry-picked from https://github.com/greenplum-db/gpdb/pull/10416