### PR TITLE
Cleanup new segments in parallel for gpexpand

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1799,10 +1799,10 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
                                                          , sqlCommandList=statements
                                                          )
                 self.pool.addCommand(execSQLCmd)
-                self.pool.join()
-                ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
-                self.pool.check_results()
-                self.pool.getCompletedItems()
+        self.pool.join()
+        ### need to fix self.pool.check_results(). Call getCompletedItems to clear the queue for now.
+        self.pool.check_results()
+        self.pool.getCompletedItems()
 
         """
         Stop all the new segments.


### PR DESCRIPTION
Jobs on cleaning up the master-only files on the new segments used to
be done one by one. It can be very slow in the case of a big number of
segments.
Now jobs are performed in parallel.

Cherry-pick from #9551