### PR TITLE
Fix type of stack depth variable in Backtrace routine

### DIFF
--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -34,7 +34,7 @@ CStackDescriptor::BackTrace
 {
 	// get base pointer of current frame
 
-	int gpos_stack_trace_depth_actual;
+	ULONG gpos_stack_trace_depth_actual;
 	#ifdef GPOS_GET_FRAME_POINTER
 	ULONG_PTR current_frame;
 	GPOS_GET_FRAME_POINTER(current_frame);


### PR DESCRIPTION
Commit 70e444e3f53 had brought special variable to denote stack depth.
Signed type of this variable caused error under its comparison with
unsigned iterable frame counter when compile option
[-Werror=sign-compare] was specified (it's so by default).

As stack depth value defined by backtrace(3) function can not be
negative it's safe to define unsigned type for variable that stores that
value.