### PR TITLE
gpperfmon: fix some timeout characteristics under nonstandart quantum

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1273,9 +1273,6 @@ static int read_conf_file(char *conffile)
 		}
 	}
 
-	smon_terminate_timeout = opt.quantum * smon_terminate_safe_factor;
-	recv_timeout = opt.quantum * recv_timeout_factor;
-
 	/* check for valid entries */
 	if (!section_found)
 		fprintf(stderr, "Performance Monitor - Failed to find [gpmmon] section in the "
@@ -1347,6 +1344,8 @@ static int read_conf_file(char *conffile)
 		opt.tail_buffer_max = (1LL << 31); /* 2GB */
 	}
 
+	smon_terminate_timeout = opt.quantum * smon_terminate_safe_factor;
+	recv_timeout = opt.quantum * recv_timeout_factor;
 	verbose = opt.v;
 	min_query_time = opt.min_query_time;
 	quantum = opt.quantum;

--- a/gpAux/gpperfmon/src/gpmon/gpsmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpsmon.c
@@ -861,7 +861,7 @@ static void gx_gettcpcmd(SOCKET sock, short event, void* arg)
 	struct timeval tv;
 	tv.tv_sec = opt.terminate_timeout;
 	tv.tv_usec = 0;
-	if (event_add(&gx.tcp_event, &tv)) //reset timeout
+	if (event_add(&gx.tcp_event, opt.terminate_timeout ? &tv : NULL)) //reset timeout
         {
 		gpmon_warningx(FLINE, APR_FROM_OS_ERROR(errno), "event_add failed");
         }
@@ -950,7 +950,7 @@ static void gx_accept(SOCKET sock, short event, void* arg)
 	tv.tv_sec = opt.terminate_timeout;
 	tv.tv_usec = 0;
 	event_set(&gx.tcp_event, nsock, EV_READ | EV_PERSIST | EV_TIMEOUT, gx_gettcpcmd, 0);
-	if (event_add(&gx.tcp_event, &tv))
+	if (event_add(&gx.tcp_event, opt.terminate_timeout ? &tv : NULL))
 	{
 		gpmon_warningx(FLINE, APR_FROM_OS_ERROR(errno), "event_add failed");
 		close(nsock);


### PR DESCRIPTION
## Problem description
The terminate_timeout and recv_timeout parameters are defined based on
incoming quantum value before its invalidation/normalization phase. As a
consequence those parameters can take on values that lead to unstable
interaction between gpmmon and gpsmon.

Current fix move the assignment of terminate_timeout and recv_timeout
parameters after invalidation/normalization phase on gpmmon side.
Furthermore, as terminate_timeout is passed to gpsmon as startup option,
there is added guard to not allow zero timeout on tcp_event on gpsmon
side.

## Step to reproduce

1. Set `quantum` parameter inside `gpperfmon.conf` to zero or one.
2. Reload `gpperfmon.conf` via sending of SIGHUP to `gpmmon` daemon.
3. Kill `gpsmon` so that `gpmmon` will restart it with new `terminate_timeout`
4. `gpmmon` log will show periodic connection/disconnection phases with `gpsmon`.