### PR TITLE
5X: Fix query string truncation while dispatching to QE

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -35,6 +35,7 @@
 #include "utils/session_state.h"
 #include "utils/typcache.h"
 #include "miscadmin.h"
+#include "mb/pg_wchar.h"
 
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbdisp_query.h"
@@ -941,11 +942,14 @@ buildGpQueryString(struct CdbDispatcherState *ds,
 	 *
 	 * Here we only need to determine the truncated size, the actual work is
 	 * done later when copying it to the result buffer.
+	 *
+	 * The +1 and -1 below are adjustments to accommodate terminating null
+	 * character.
 	 */
-	if (querytree || plantree)
-		command_len = strnlen(command, QUERY_STRING_TRUNCATE_SIZE - 1) + 1;
-	else
-		command_len = strlen(command) + 1;
+	command_len = strlen(command) + 1;
+	if ((querytree || plantree) && command_len > QUERY_STRING_TRUNCATE_SIZE)
+		command_len = pg_mbcliplen(command, command_len,
+								   QUERY_STRING_TRUNCATE_SIZE-1) + 1;
 
 	initStringInfo(&resgroupInfo);
 	if (IsResGroupActivated())

--- a/src/test/regress/expected/dispatch_encoding.out
+++ b/src/test/regress/expected/dispatch_encoding.out
@@ -1,0 +1,27 @@
+--
+-- Test buildGpQueryString of cdbdisp_query.c truncates a query longer than QUERY_STRING_TRUNCATE_SIZE and containing
+-- multi-byte symbols properly
+--
+set log_min_duration_statement to 0;
+create table truncate_test ("колонка 1" int, "колонка 2" int, "колонка 3" int, "колонка 4" int, "колонка 5" int,
+"колонка 6" int, "колонка 7" int, "колонка 8" int, "колонка 9" int, "колонка 10" int, "колонка 11" int,
+"колонка 12" int, "колонка 13" int, "колонка 14" int, "колонка 15" int, "колонка 16" int, "колонка 17" int,
+"колонка 18" int, "колонка 19" int, "колонка 20" int, "колонка 21" int, "колонка 22" int, "колонка 23" int,
+"колонка 24" int, "колонка 25" int, "колонка 26" int, "колонка 27" int, "колонка 28" int, "колонка 29" int,
+"колонка 30" int, "колонка 31" int, "колонка 32" int, "колонка 33" int, "колонка 34" int, "колонка 35" int,
+"колонка 36" int, "колонка 37" int, "колонка 38" int, "колонка 39" int, "колонка 40" int, "особая колонка" int);
+select logdebug from gp_toolkit.__gp_log_segment_ext where logdebug ilike
+'%create table truncate_test%' and logdebug not ilike '%gp_toolkit.__gp_log_segment_ext%' order by logtime desc limit 1;
+                                                     logdebug                                                     
+------------------------------------------------------------------------------------------------------------------
+ create table truncate_test ("колонка 1" int, "колонка 2" int, "колонка 3" int, "колонка 4" int, "колонка 5" int, 
+ "колонка 6" int, "колонка 7" int, "колонка 8" int, "колонка 9" int, "колонка 10" int, "колонка 11" int,          
+ "колонка 12" int, "колонка 13" int, "колонка 14" int, "колонка 15" int, "колонка 16" int, "колонка 17" int,      
+ "колонка 18" int, "колонка 19" int, "колонка 20" int, "колонка 21" int, "колонка 22" int, "колонка 23" int,      
+ "колонка 24" int, "колонка 25" int, "колонка 26" int, "колонка 27" int, "колонка 28" int, "колонка 29" int,      
+ "колонка 30" int, "колонка 31" int, "колонка 32" int, "колонка 33" int, "колонка 34" int, "колонка 35" int,      
+ "колонка 36" int, "колонка 37" int, "колонка 38" int, "колонка 39" int, "колонка 40" int, "о
+(1 row)
+
+drop table truncate_test;
+reset log_min_duration_statement;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -20,7 +20,7 @@ test: gp_metadata variadic_parameters default_parameters function_extensions spi
 test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp limit_gp notin percentile join_gp union_gp gpcopy gp_create_table gp_create_view resource_queue_with_rule
 test: filter gpctas gpdist matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var guc_gp gp_explain distributed_transactions
 test: bitmap_index gp_dump_query_oids analyze gp_owner_permission incremental_analyze gang_reuse
-test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules motion_gp
+test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding motion_gp
 # dispatch should always run seperately from other cases.
 test: dispatch
 

--- a/src/test/regress/sql/dispatch_encoding.sql
+++ b/src/test/regress/sql/dispatch_encoding.sql
@@ -1,0 +1,16 @@
+--
+-- Test buildGpQueryString of cdbdisp_query.c truncates a query longer than QUERY_STRING_TRUNCATE_SIZE and containing
+-- multi-byte symbols properly
+--
+set log_min_duration_statement to 0;
+create table truncate_test ("колонка 1" int, "колонка 2" int, "колонка 3" int, "колонка 4" int, "колонка 5" int,
+"колонка 6" int, "колонка 7" int, "колонка 8" int, "колонка 9" int, "колонка 10" int, "колонка 11" int,
+"колонка 12" int, "колонка 13" int, "колонка 14" int, "колонка 15" int, "колонка 16" int, "колонка 17" int,
+"колонка 18" int, "колонка 19" int, "колонка 20" int, "колонка 21" int, "колонка 22" int, "колонка 23" int,
+"колонка 24" int, "колонка 25" int, "колонка 26" int, "колонка 27" int, "колонка 28" int, "колонка 29" int,
+"колонка 30" int, "колонка 31" int, "колонка 32" int, "колонка 33" int, "колонка 34" int, "колонка 35" int,
+"колонка 36" int, "колонка 37" int, "колонка 38" int, "колонка 39" int, "колонка 40" int, "особая колонка" int);
+select logdebug from gp_toolkit.__gp_log_segment_ext where logdebug ilike
+'%create table truncate_test%' and logdebug not ilike '%gp_toolkit.__gp_log_segment_ext%' order by logtime desc limit 1;
+drop table truncate_test;
+reset log_min_duration_statement;


### PR DESCRIPTION
Execution of a long enough query containing multi-byte characters can
cause incorrect truncation of the query string. Incorrect truncation
implies an occasional cut of a multi-byte character and (with
log_min_duration_statement set to 0 ) subsequent write of an invalid
symbol to segment logs. Such broken character present in logs produces
problems when trying to fetch logs info from
gp_toolkit.__gp_log_segment_ext  table - queries fail with the following
error: «ERROR: invalid byte sequence for encoding…».
This is caused by buildGpQueryString function in `cdbdisp_query.c`,
which prepares query text for dispatch to QE. It does not take into
account character length when truncation is necessary (text is longer
than QUERY_STRING_TRUNCATE_SIZE).

Cherry picked from 889ba39 and ef09a3a