### PR TITLE
Add ORCA fallback for replicated tables with volatile fuctions

### DIFF
--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -28,7 +28,9 @@ CContextQueryToDXL::CContextQueryToDXL
   :
   m_mp(mp),
   m_has_distributed_tables(false),
-  m_distribution_hashops(DistrHashOpsNotDeterminedYet)
+  m_distribution_hashops(DistrHashOpsNotDeterminedYet),
+  m_has_replicated_tables(false),
+  m_has_volatile_functions(false)
 {
 	// map that stores gpdb att to optimizer col mapping
 	m_colid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1345,6 +1345,9 @@ CTranslatorScalarToDXL::TranslateFuncExprToDXL
 	const IMDFunction *md_func = m_md_accessor->RetrieveFunc(mdid_func);
 	if (IMDFunction::EfsVolatile == md_func->GetFuncStability())
 	{
+		if (m_context)
+			m_context->m_has_volatile_functions = true;
+
 		ListCell *lc = NULL;
 		ForEach (lc, func_expr->args)
 		{

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -121,7 +121,8 @@ CTranslatorUtils::GetTableDescr
 	CMDAccessor *md_accessor,
 	CIdGenerator *id_generator,
 	const RangeTblEntry *rte,
-	BOOL *is_distributed_table // output
+	BOOL *is_distributed_table,	// output
+	BOOL *is_replicated_table	// output
 	)
 {
 	// generate an MDId for the table desc.
@@ -148,6 +149,10 @@ CTranslatorUtils::GetTableDescr
 
 	IMDRelation::Ereldistrpolicy distribution_policy = rel->GetRelDistribution();
 
+	if (NULL != is_replicated_table && IMDRelation::EreldistrReplicated == distribution_policy)
+	{
+		*is_replicated_table = true;
+	}
 	if (NULL != is_distributed_table &&
 		(IMDRelation::EreldistrHash == distribution_policy || IMDRelation::EreldistrRandom == distribution_policy || IMDRelation::EreldistrReplicated == distribution_policy))
 	{

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -60,6 +60,12 @@ namespace gpdxl
 			// What operator classes are used in the distribution keys?
 			DistributionHashOpsKind m_distribution_hashops;
 
+			// does the query have any replicated tables?
+			BOOL m_has_replicated_tables;
+
+			// does the query have any volatile functions?
+			BOOL m_has_volatile_functions;
+
 		public:
 			// ctor
 			CContextQueryToDXL

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -157,7 +157,8 @@ namespace gpdxl
 								CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
-								BOOL *is_distributed_table = NULL
+								BOOL *is_distributed_table = NULL,
+								BOOL *is_replicated_table = NULL
 								);
 
 			// translate a RangeTableEntry into a CDXLLogicalTVF


### PR DESCRIPTION
ORCA can't produce correct plans for replicated tables with volatile functions in a query - https://github.com/greenplum-db/gpdb/issues/9737#issuecomment-662423967. As far as Pivotal is still working on ORCA patch it was decided with @Stolb27 that we should simply fallback to Postgres planner if we find out such queries during query to DXL translation. When Pivotal creates a solution for ORCA (it is quit a complicated task) we would revert this patch and use upstream solution.