### PR TITLE
Disable strxfrm for mk_sort at compile time

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -742,6 +742,11 @@ create_mksort_context(MKContext *mkctxt,
 			if (sinfo->scanKey.sk_func.fn_addr == btint4cmp)
 				sinfo->lvtype = MKLV_TYPE_INT32;
 
+/*
+* Users who are certain that their glibc is not affected by strcoll() and strxfrm()
+* inconsistency can speed up mk sort defining TRUST_STRXFRM_MK_SORT at compile time.
+*/
+#ifdef TRUST_STRXFRM_MK_SORT
 			/* GPDB_91_MERGE_FIXME: these MKLV_TYPE_CHAR and MKLV_TYPE_TEXT
 			 * fastpaths only work with the default collation of the database.
 			 */
@@ -753,6 +758,7 @@ create_mksort_context(MKContext *mkctxt,
 				else if (sinfo->scanKey.sk_func.fn_addr == bttextcmp)
 					sinfo->lvtype = MKLV_TYPE_TEXT;
 			}
+#endif
 		}
 		else
 		{

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -650,3 +650,22 @@ select * from colltest order by t COLLATE "C" NULLS FIRST;
  d
 (9 rows)
 
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+ count 
+-------
+     2
+(1 row)
+
+reset gp_enable_mk_sort;
+reset enable_hashjoin;

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -124,3 +124,21 @@ select * from colltest order by t COLLATE "C" NULLS FIRST;
 set gp_enable_motion_mk_sort=off;
 select * from colltest order by t COLLATE "C";
 select * from colltest order by t COLLATE "C" NULLS FIRST;
+
+
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+
+reset gp_enable_mk_sort;
+reset enable_hashjoin;


### PR DESCRIPTION
Glibc implementations are known to return inconsistent results for
strcoll() and strxfrm() on many platforms that can cause
unpredictable bugs. Because of that PostgreSQL disabled strxfrm()
by default since 9.5 at compile time by TRUST_STRXFRM definition.
Greenplum has its own mk sort implementation that can also use
strxfrm(). Hence mk sort can also be affected by strcoll() and
strxfrm() inconsistency (breaks merge joins). That is why strxfrm()
should be disabled by default with TRUST_STRXFRM_MK_SORT definition
for mk sort as well.

Reviewed-by: Asim R P <pasim@vmware.com>
Reviewed-by: Heikki Linnakangas <linnakangash@vmware.com>
Reviewed-by: Hubert Zhang <hzhang@pivotal.io>

(cherry picked from commit 2d523e9e864b863abe29a389fc8e9ff960fa5596)