### PR TITLE
Disable strxfrm for mk_sort at compile time

### DIFF
--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -732,6 +732,11 @@ create_mksort_context(
 
 			if (sinfo->scanKey.sk_func.fn_addr == btint4cmp)
 				sinfo->lvtype = MKLV_TYPE_INT32;
+/*
+ * Users who are certain that their glibc is not affected by strcoll() and strxfrm()
+ * inconsistency can speed up mk sort defining TRUST_STRXFRM_MK_SORT at compile time.
+ */
+#ifdef TRUST_STRXFRM_MK_SORT
 			if (!lc_collate_is_c())
 			{
 				if (sinfo->scanKey.sk_func.fn_addr == bpcharcmp)
@@ -739,6 +744,7 @@ create_mksort_context(
 				else if (sinfo->scanKey.sk_func.fn_addr == bttextcmp)
 					sinfo->lvtype = MKLV_TYPE_TEXT;
 			}
+#endif
 		}
 		else
 		{

--- a/src/test/regress/expected/sort.out
+++ b/src/test/regress/expected/sort.out
@@ -587,4 +587,23 @@ select col1, col2, col3, col4, col5 from gpsort_alltypes order by col5 desc, col
     122223333333366 | 423402340240234 | 1    | 0100 | f
   99999999999999999 |       312394234 | 1    | 0000 | f
  (4 rows)
- 
+
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+ count 
+-------
+     2
+(1 row)
+
+reset gp_enable_mk_sort;
+reset enable_hashjoin;

--- a/src/test/regress/sql/sort.sql
+++ b/src/test/regress/sql/sort.sql
@@ -110,3 +110,20 @@ select col1, col2, col3, col4, col5 from gpsort_alltypes order by col1, col2, co
 select col1, col2, col3, col4, col5 from gpsort_alltypes order by col3 desc, col2 asc, col1, col4, col5;
 select col1, col2, col3, col4, col5 from gpsort_alltypes order by col5 desc, col3 asc, col2 desc, col4 asc, col1 desc;
 
+
+--
+-- Test strxfrm()/strcoll() sort order inconsistency in a
+-- merge join with russian characters and default collation
+--
+set gp_enable_mk_sort = on;
+set enable_hashjoin = off;
+
+with t as (
+    select * from (values ('б б'), ('бб ')) as t1(b)
+    full join (values ('б б'), ('бб ')) as t2(b)
+    using (b)
+)
+select count(*) from t;
+
+reset gp_enable_mk_sort;
+reset enable_hashjoin;


### PR DESCRIPTION
Glibc implementations are known to return inconsistent results for
strcoll() and strxfrm() on many platforms that can cause
unpredictable bugs. Because of that PostgreSQL disabled strxfrm()
by default since 9.5 at compile time by TRUST_STRXFRM definition.
Greenplum has its own mk sort implementation that can also use
strxfrm(). Hence mk sort can also be affected by strcoll() and
strxfrm() inconsistency (breaks merge joins). That is why strxfrm()
should be disabled by default with TRUST_STRXFRM_MK_SORT definition
for mk sort as well.

Reviewed-by: Asim R P <pasim@vmware.com>
Reviewed-by: Heikki Linnakangas <linnakangash@vmware.com>
Reviewed-by: Hubert Zhang <hzhang@pivotal.io>

(cherry picked from commit 2d523e9e864b863abe29a389fc8e9ff960fa5596)