### PR TITLE
Replace list() with set() validation in analyzedb

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -23,6 +23,7 @@ import time
 from datetime import datetime
 import pipes  # for shell-quoting, pipes.quote()
 import fcntl
+import itertools
 
 try:
     from gppylib import gplog, pgconf, userinput
@@ -537,12 +538,12 @@ class AnalyzeDb(Operation):
         3. skip views and external tables
         """
         qresult = run_sql(self.conn, GET_MID_LEVEL_PARTITIONS_SQL)
-        mid_level_partitions = []
+        mid_level_partitions = set()
         for schema_tbl in qresult:
             tup = (schema_tbl[0], schema_tbl[1])
-            mid_level_partitions.append(tup)
+            mid_level_partitions.add(tup)
 
-        ret = []
+        ret = set()
         for can in candidates:
             schema = can[0]
             table = can[1]
@@ -553,16 +554,16 @@ class AnalyzeDb(Operation):
             if can in mid_level_partitions:
                 logger.warning("Skipping mid-level partition %s.%s" % (schema, table))
             else:
-                ret.append(can)
+                ret.add(can)
 
         if self.config_file is not None or self.single_table is not None:
-            valid_tables = []
+            valid_tables = set()
             if len(ret) > 0:
                 oid_str = get_oid_str(ret)
                 qresult = run_sql(self.conn, GET_VALID_DATA_TABLES_SQL % oid_str)
                 for schema_tbl in qresult:
                     tup = (schema_tbl[0], schema_tbl[1])
-                    valid_tables.append(tup)
+                    valid_tables.add(tup)
             return valid_tables
 
         return ret
@@ -777,7 +778,7 @@ class AnalyzeDb(Operation):
         2. The leaf partitions (if range partitioned, especially by date) will be ordered in descending
            order of the partition key, so that newer partitions can be analyzed first.
         """
-        candidate_regclass_str = get_oid_str(candidates + root_partition_col_dict.keys())
+        candidate_regclass_str = get_oid_str(itertools.chain(candidates, root_partition_col_dict.keys()))
         qresult = run_sql(self.conn, ORDER_CANDIDATES_BY_OID_SQL % candidate_regclass_str)
         ordered_candidates = []
         for schema_tbl in qresult:


### PR DESCRIPTION
After testing `analyzedb` on a huge database with 170k tables we have found a bottleneck while printing candidate list to `analyze`. It took about 45 minutes to print all tables. The bottleneck was in `O(n^2)` complexity when we validated candidates in a loop with a `list()` instead of `set()`. The same `O(n^2)` validation is made while running `analyze` commands on executor pool.
This commit change candidate type from list() to set() to reduce complexity from `O(n^2)` to `O(n)`.

The problem can be explained with a benchmark below. For 50k items with a `list()` validation we spend 29.4 sec while with a `set()` one - only 0.2 sec.
```python
import time


if __name__ == "__main__":
    size = 50000
    source_list = [("schema" + str(i), "table" + str(i)) for i in range(0, size)]
    target_list = []
    validation_list = source_list
    validation_set = set(source_list)

    start = time.time()
    for item in source_list:
        if item in validation_list:
            target = '%s.%s' % (item[0], item[1])
        target_list.append(target)
    end =  time.time()
    print("Execution time with list O(n^2) validation: %s sec" % str(end - start))

    start = time.time()
    for item in source_list:
        if item in validation_set:
            target = '%s.%s' % (item[0], item[1])
        target_list.append(target)
    end =  time.time()
    print("Execution time with set O(n) validation: %s sec" % str(end - start))

```

Backport 1ca428ef1e24628b8f2e5accb374be6f949525b3