### PR TITLE
Explicitly handle on QE side zero value parameter incoming from QD

### DIFF
--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -268,6 +268,9 @@ TRRemapDatum(TupleRemapper *remapper, Oid typeid, Datum value)
 	TupleRemapInfo *remapinfo;
 	bool		changed;
 
+	if (value == 0)
+		return value;
+
 	remapinfo = BuildTupleRemapInfo(typeid, remapper->mycontext);
 
 	if (!remapinfo)

--- a/src/test/regress/expected/gpparams.out
+++ b/src/test/regress/expected/gpparams.out
@@ -1,5 +1,5 @@
 --
--- All derived from MPP-3613: use of incorrect parameters in queries
+-- Derived from MPP-3613: use of incorrect parameters in queries
 -- which intermix initPlans with "internal" parameters.
 --
 --
@@ -260,3 +260,30 @@ select * from create_target_list_sql(30);
 --select * from create_target_list(30, 1);
 --truncate module_targets;
 --select * from create_target_list_sql(30);
+--
+-- Test case on using initPlan with internal not-evaluated parameter of RECORD
+-- type that have to be transmited to QEs from master node
+--
+CREATE TABLE users_unmasked (
+    user_id bigint NOT NULL,
+    params text
+) DISTRIBUTED BY (user_id);
+ALTER TABLE ONLY users_unmasked
+ADD CONSTRAINT users_20171219_pkey PRIMARY KEY (user_id);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "users_unmasked_pkey" for table "users_unmasked"
+-- query that on segment side deserializes not-evaluated zero parameter
+-- corresponding to returning 'row(u.user_id)' tuple from subquery inside WHERE
+-- stmt
+SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
+    SELECT
+        row(u.user_id)
+    FROM
+        users_unmasked u
+    WHERE
+        u.user_id = 7
+) IS NOT NULL;
+ userId 
+--------
+(0 rows)
+
+DROP TABLE users_unmasked;


### PR DESCRIPTION
The master node dispatches external and internal (gathered from plan
tree) parameters along with query plan. Internal parameters might
include not initialized zero values, e.g., used for storing results of
not yet evaluated initPlans. Those parameters are trasmitted as zero
values that cases segfault on segments under deserialization of complex
type value.

The current fix intercepts on QE side handling of zero value parameter
before further deserialization process.