### PR TITLE
ADBDEV-869

### DIFF
--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -36,7 +36,7 @@ POSTMASTER_MIRROR_VERSION_DETAIL_MSG = "- VERSION:"
 
 def _get_segment_status(segment):
     cmd = base.Command('pg_isready for segment',
-                       "PGOPTIONS='-c gp_session_role=utility' pg_isready -q -h %s -p %d --dbname=postgres" % (segment.hostname, segment.port))
+                       "PGOPTIONS='-c gp_session_role=utility' pg_isready -q -h %s -p %d -d template1" % (segment.hostname, segment.port))
     cmd.run()
 
     rc = cmd.get_return_code()

--- a/gpMgmt/sbin/gpgetstatususingtransition.py
+++ b/gpMgmt/sbin/gpgetstatususingtransition.py
@@ -36,7 +36,7 @@ POSTMASTER_MIRROR_VERSION_DETAIL_MSG = "- VERSION:"
 
 def _get_segment_status(segment):
     cmd = base.Command('pg_isready for segment',
-                       "pg_isready -q -h %s -p %d" % (segment.hostname, segment.port))
+                       "PGOPTIONS='-c gp_session_role=utility' pg_isready -q -h %s -p %d --dbname=postgres" % (segment.hostname, segment.port))
     cmd.run()
 
     rc = cmd.get_return_code()


### PR DESCRIPTION
When calling `gpsgate`, an error appears in the segment logs:
```
"FATAL","3D000","database ""t1mursadykov"" does not exist",,,,,,,0,,"postinit.c",955,
```
To get the segment statuses, `gpstate` calls `pg_isready`, which pings the desired host and port and returns the code that the server sent . 

To get the server state, `pg_isready` uses the `PQpingParams` function of the libpq library. Which connects to the server and returns the received return code. The documentation says thats it is not necessary to pass correct user name, password, or database name values to obtain the server status. However, if incorrect values are provided, the server logs an unsuccessful connection attempt. 

To fix this, parameters in the `pg_isready` call was added.