### PR TITLE
[Backport to 6X] pgstattuple: support auxiliary AO relations in bloat estimation function

### DIFF
--- a/contrib/pgstattuple/expected/pgstattuple.out
+++ b/contrib/pgstattuple/expected/pgstattuple.out
@@ -130,3 +130,36 @@ select * from pgstatginindex('test_ginidx');
        2 |             0 |              0
 (1 row)
 
+--
+-- Test cases for auxiliary system relations of appendonly table
+--
+create table ao_table
+(id int,
+ fname text,
+ lname text,
+ address1 text,
+ address2 text,
+ city text,
+ state text,
+ zip text)
+with (appendonly=true)
+distributed by (id);
+create index ao_table_fname_idx on ao_table (fname);
+select pgstattuple(blkdirrelid) from pg_appendonly where relid = 'ao_table'::regclass;
+     pgstattuple     
+---------------------
+ (0,0,0,0,0,0,0,0,0)
+(1 row)
+
+select pgstattuple(segrelid) from pg_appendonly where relid = 'ao_table'::regclass;
+     pgstattuple     
+---------------------
+ (0,0,0,0,0,0,0,0,0)
+(1 row)
+
+select pgstattuple(visimaprelid) from pg_appendonly where relid = 'ao_table'::regclass;
+     pgstattuple     
+---------------------
+ (0,0,0,0,0,0,0,0,0)
+(1 row)
+

--- a/contrib/pgstattuple/pgstattuple.c
+++ b/contrib/pgstattuple/pgstattuple.c
@@ -216,6 +216,9 @@ pgstat_relation(Relation rel, FunctionCallInfo fcinfo)
 		case RELKIND_MATVIEW:
 		case RELKIND_TOASTVALUE:
 		case RELKIND_SEQUENCE:
+		case RELKIND_AOSEGMENTS:
+		case RELKIND_AOBLOCKDIR:
+		case RELKIND_AOVISIMAP:
 			return pgstat_heap(rel, fcinfo);
 		case RELKIND_INDEX:
 			switch (rel->rd_rel->relam)

--- a/contrib/pgstattuple/sql/pgstattuple.sql
+++ b/contrib/pgstattuple/sql/pgstattuple.sql
@@ -47,3 +47,23 @@ select pg_relpages(relname) from pg_class where relname = 'test_pkey';
 create index test_ginidx on test using gin (b);
 
 select * from pgstatginindex('test_ginidx');
+
+--
+-- Test cases for auxiliary system relations of appendonly table
+--
+create table ao_table
+(id int,
+ fname text,
+ lname text,
+ address1 text,
+ address2 text,
+ city text,
+ state text,
+ zip text)
+with (appendonly=true)
+distributed by (id);
+create index ao_table_fname_idx on ao_table (fname);
+
+select pgstattuple(blkdirrelid) from pg_appendonly where relid = 'ao_table'::regclass;
+select pgstattuple(segrelid) from pg_appendonly where relid = 'ao_table'::regclass;
+select pgstattuple(visimaprelid) from pg_appendonly where relid = 'ao_table'::regclass;


### PR DESCRIPTION
By now auxiliary system relations of appendonly table such as block
directory, aosegments and visibility map are not supported by bloat
estimation function pgstattuple() of pgstattuple extension despite of
they are regular heap relations. This is because those relations have
relkind value different from regular RELKIND_RELATION. Situation also
deteriorates by the fact that planner statistics isn't gathered for
auxiliary system relations of AO table that makes it impossible to
estimate their bloating via gp_toolkit.gp_bloat_expected_pages view.

The current fix eliminates this defect.