### PR TITLE
Revert pr 25

### DIFF
--- a/concourse/pipelines/5X_STABLE-generated.yml
+++ b/concourse/pipelines/5X_STABLE-generated.yml
@@ -534,7 +534,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_centos6/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_centos6/gpdb5/bin_gpdb.tar.gz
 
 - name: bin_gpdb_centos7_rc
   type: s3
@@ -543,7 +543,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_centos7/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_centos7/gpdb5/bin_gpdb.tar.gz
 
 - name: bin_gpdb_sles11_rc
   type: s3
@@ -552,7 +552,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_sles11/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_sles11/gpdb5/bin_gpdb.tar.gz
 
 - name: compiled_bits_ubuntu16
   type: s3

--- a/concourse/pipelines/5X_STABLE-generated.yml
+++ b/concourse/pipelines/5X_STABLE-generated.yml
@@ -716,21 +716,22 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: {{deb_package_open_source_ubuntu16_versioned_file}}
 
-# - name: nightly-trigger
-#   type: time
-#   source:
-#     location: America/Los_Angeles
-#     days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
-#     start: 6:00 AM
-#     stop: 7:00 AM
+- name: nightly-trigger
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    start: 6:00 AM
+    stop: 7:00 AM
 
-# - name: nightly-trigger-aix
-#   type: time
-#   source:
-#     location: America/Los_Angeles
-#     days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
-#     start: 8:00 AM
-#     stop: 9:00 AM
+- name: nightly-trigger-aix
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    start: 8:00 AM
+    stop: 9:00 AM
+
 - name: madlib_ci
   type: git
   source:
@@ -1419,10 +1420,9 @@ jobs:
   # We need to serialize this job to avoid overwhelming workload
   # on remote machine.
   - aggregate:
-    # - get: nightly-trigger-aix
-      # trigger: true
-    - get: gpdb_src
+    - get: nightly-trigger-aix
       trigger: true
+    - get: gpdb_src
       passed: [gate_compile_start]
     - get: gpaddon_src
       passed: [gate_compile_start]
@@ -3149,8 +3149,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part1
   plan:
-  # - get: nightly-trigger
-    # trigger: true
+  - get: nightly-trigger
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3159,7 +3159,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3228,8 +3227,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part2
   plan:
-  # - get: nightly-trigger
-    # trigger: true
+  - get: nightly-trigger
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3238,7 +3237,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3307,8 +3305,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part3
   plan:
-  # - get: nightly-trigger
-    # trigger: true
+  - get: nightly-trigger
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3317,7 +3315,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3386,9 +3383,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part1
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: true
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3397,7 +3394,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3445,9 +3441,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part2
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: true
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3456,7 +3452,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3504,9 +3499,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part3
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: true
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: true
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3515,7 +3510,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3571,7 +3565,6 @@ jobs:
         - gpMgmt/bin/pythonSrc/ext
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
       trigger: true
@@ -3618,7 +3611,6 @@ jobs:
     - get: gpdb_src
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
       trigger: true

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -752,22 +752,22 @@ resources:
     versioned_file: {{deb_package_open_source_ubuntu16_versioned_file}}
 
 {% if "DPM" in test_sections %}
-# - name: nightly-trigger
-#   type: time
-#   source:
-#     location: America/Los_Angeles
-#     days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
-#     start: 6:00 AM
-#     stop: 7:00 AM
+- name: nightly-trigger
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    start: 6:00 AM
+    stop: 7:00 AM
 
 {% endif %}
-# - name: nightly-trigger-aix
-#   type: time
-#   source:
-#     location: America/Los_Angeles
-#     days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
-#     start: 8:00 AM
-#     stop: 9:00 AM
+- name: nightly-trigger-aix
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday]
+    start: 8:00 AM
+    stop: 9:00 AM
 
 {% if "AA" in test_sections %}
 - name: madlib_ci
@@ -1463,10 +1463,9 @@ jobs:
   # We need to serialize this job to avoid overwhelming workload
   # on remote machine.
   - aggregate:
-    # - get: nightly-trigger-aix
-      # trigger: true
-    - get: gpdb_src
+    - get: nightly-trigger-aix
       trigger: true
+    - get: gpdb_src
       passed: [gate_compile_start]
     - get: gpaddon_src
       passed: [gate_compile_start]
@@ -2773,8 +2772,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part1
   plan:
-  # - get: nightly-trigger
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -2783,7 +2782,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -2852,8 +2850,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part2
   plan:
-  # - get: nightly-trigger
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -2862,7 +2860,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -2931,8 +2928,8 @@ jobs:
 
 - name: DPM_backup-restore_ddboost_part3
   plan:
-  # - get: nightly-trigger
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -2941,7 +2938,6 @@ jobs:
       tags: ["ddboost"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["ddboost"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3010,9 +3006,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part1
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3021,7 +3017,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3069,9 +3064,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part2
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3080,7 +3075,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3128,9 +3122,9 @@ jobs:
 
 - name: DPM_backup-restore_netbackup_part3
   plan:
-  # - get: nightly-trigger
-    # tags: ["netbackup"]
-    # trigger: [[ test_trigger ]]
+  - get: nightly-trigger
+    tags: ["netbackup"]
+    trigger: [[ test_trigger ]]
   - *ccp_jitter_delay
   - aggregate:
     - get: ccp_src
@@ -3139,7 +3133,6 @@ jobs:
       tags: ["netbackup"]
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       tags: ["netbackup"]
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
@@ -3195,7 +3188,6 @@ jobs:
         - gpMgmt/bin/pythonSrc/ext
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
       trigger: [[ test_trigger ]]
@@ -3242,7 +3234,6 @@ jobs:
     - get: gpdb_src
       passed: [gate_dpm_start]
     - get: gpdb_binary
-      trigger: true
       resource: bin_gpdb_centos6
       passed: [gate_dpm_start]
       trigger: [[ test_trigger ]]

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -566,7 +566,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_centos6/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_centos6/gpdb5/bin_gpdb.tar.gz
 
 - name: bin_gpdb_centos7_rc
   type: s3
@@ -575,7 +575,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_centos7/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_centos7/gpdb5/bin_gpdb.tar.gz
 
 - name: bin_gpdb_sles11_rc
   type: s3
@@ -584,7 +584,7 @@ resources:
     bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release_candidates/bin_gpdb_sles11/gpdb511X/bin_gpdb.tar.gz
+    versioned_file: release_candidates/bin_gpdb_sles11/gpdb5/bin_gpdb.tar.gz
 
 {% endif %}
 - name: compiled_bits_ubuntu16


### PR DESCRIPTION
Originally this PR was inspired by https://github.com/arenadata/gpdb/pull/127#issuecomment-722789846 where @Stolb27 found out that `adb-5.x` contains some Pivotal commits that are not present in `5X_STABLE`. And these commits caused conflicts in concourse pipeline with https://github.com/arenadata/gpdb/pull/127 . 

So current PR reverts two commits: https://github.com/arenadata/gpdb/commit/eb1cfd6f5147c0a4bfed78aeb81a2417ed4da946 and https://github.com/arenadata/gpdb/commit/0d5f032845f822095a688e6f605d200cb7a6ffb6 as other ones in @Stolb27 list don't affect anything (their changes were totally overwritten and there is nothing to revert).

After this PR concourse pipeline becomes equal with Pivotal's `5.28.1`. Pay attention that https://github.com/arenadata/gpdb/commit/88928c0f2b6a9c6c38096f86bfec8f3b688117bc also changed some additional triggers not touched by original commit - I have no idea where and when we got this inconsistency (may be in previous merges).