### PR TITLE
ADBDEV-1145. pg_partitions_nolock: pg_partitions without locks on relations

### DIFF
--- a/gpcontrib/pg_partitions_nolock/Makefile
+++ b/gpcontrib/pg_partitions_nolock/Makefile
@@ -1,0 +1,23 @@
+EXTENSION = pg_partitions_nolock
+MODULES = pg_partitions_nolock
+
+EXTENSION_VERSION = 1.0
+
+
+DATA = pg_partitions_nolock--1.0.sql
+
+OBJS = pg_get_expr_nolock.o
+
+MODULE_big = pg_partitions_nolock
+
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/gp_inject_fault
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/pg_partitions_nolock/README.md
+++ b/gpcontrib/pg_partitions_nolock/README.md
@@ -1,0 +1,26 @@
+# `pg_partitions_nolock`: Modify `pg_catalog.pg_partitions` so that it does not require `AccessShareLock`
+
+`pg_catalog.pg_partitions` uses `pg_get_expr()`, which holds an `AccessShareLock` on every relation whose OID is provided to it as its second argument. However, this lock is actually useless, as the values passed to `pg_get_expr()` by `pg_catalog.pg_partitions` do not contain `Var` nodes. The presence of the mentioned lock slows down queries significantly when accesses to `pg_catalog.pg_partitions` are combined with `ALTER PARTITION` queries. This is an exotic workload, but it turns out to be possible.
+
+The `pg_partitions_nolock` extension fixes this using the following approach:
+1. `pg_catalog.pg_partitions` is renamed to `pg_catalog.pg_partitions_lock`
+2. A new `VIEW` with the name `pg_catalog.pg_partitions` is created, which uses a different version of `pg_get_expr()`, not requiring locks.
+
+
+## Install
+```shell script
+make install
+```
+```sql
+CREATE EXTENSION pg_partitions_nolock;
+```
+
+
+## Uninstall
+PostgreSQL extensions do not provide a capability to set a custom `DROP EXTENSION` script. As a result, it is the uninstalling user's responsibility to rename `pg_catalog.pg_partitions_lock` back to `pg_catalog.pg_partitions`.
+
+```sql
+DROP EXTENSION pg_partitions_nolock;
+SET allow_system_table_mods = true;
+ALTER VIEW pg_catalog.pg_partitions_lock RENAME TO pg_catalog.pg_partitions;
+```

--- a/gpcontrib/pg_partitions_nolock/README.md
+++ b/gpcontrib/pg_partitions_nolock/README.md
@@ -22,5 +22,5 @@ PostgreSQL extensions do not provide a capability to set a custom `DROP EXTENSIO
 ```sql
 DROP EXTENSION pg_partitions_nolock;
 SET allow_system_table_mods = true;
-ALTER VIEW pg_catalog.pg_partitions_lock RENAME TO pg_catalog.pg_partitions;
+ALTER VIEW pg_catalog.pg_partitions_lock RENAME TO pg_partitions;
 ```

--- a/gpcontrib/pg_partitions_nolock/pg_get_expr_nolock.c
+++ b/gpcontrib/pg_partitions_nolock/pg_get_expr_nolock.c
@@ -1,0 +1,34 @@
+/*
+ * Implementation of pg_get_expr without locks.
+ */
+
+/* .c include is intentional */
+#include "../../src/backend/utils/adt/ruleutils.c"
+
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+
+PG_FUNCTION_INFO_V1(pg_get_expr_nolock);
+/*
+ * This method is the same as the original 'pg_get_expr', but does not accept
+ * relation ID, and uses 'InvalidOid' in pg_get_expr_worker instead.
+ * 
+ * As a result, it does not take locks on any tables. This is the origin of its
+ * name.
+ */
+Datum
+pg_get_expr_nolock(PG_FUNCTION_ARGS)
+{
+	text	   *expr = PG_GETARG_TEXT_P(0);
+	int			prettyFlags;
+	text		*result;
+
+	prettyFlags = PRETTYFLAG_INDENT;
+
+	result = pg_get_expr_worker(expr, InvalidOid, NULL, prettyFlags);
+
+	PG_RETURN_TEXT_P(result);
+}

--- a/gpcontrib/pg_partitions_nolock/pg_partitions_nolock--1.0.sql
+++ b/gpcontrib/pg_partitions_nolock/pg_partitions_nolock--1.0.sql
@@ -1,0 +1,115 @@
+\echo Use "CREATE EXTENSION pg_partitions_nolock" to load this file. \quit
+
+
+CREATE FUNCTION pg_get_expr_nolock(TEXT)
+RETURNS TEXT
+AS '$libdir/pg_partitions_nolock', 'pg_get_expr_nolock'
+LANGUAGE C STRICT;
+
+
+SET allow_system_table_mods = true;
+
+ALTER VIEW pg_catalog.pg_partitions RENAME TO pg_partitions_lock;
+
+create view pg_catalog.pg_partitions as
+  select 
+      schemaname, 
+      tablename, 
+      partitionschemaname, 
+      partitiontablename, 
+      partitionname, 
+      parentpartitiontablename, 
+      parentpartitionname, 
+      partitiontype, 
+      partitionlevel, 
+      -- Only the non-default parts of range partitions have 
+      -- a non-null partition rank.  For these the rank is
+      -- from (1, 2, ...) in keeping with the use of RANK(n)
+      -- to identify the parts of a range partition in the 
+      -- ALTER statement.
+      case
+          when partitiontype <> 'range'::text then null::bigint
+          when partitionnodefault > 0 then partitionrank
+          when partitionrank = 0 then null::bigint
+          else partitionrank
+          end as partitionrank, 
+      partitionposition, 
+      partitionlistvalues, 
+      partitionrangestart, 
+      case
+          when partitiontype = 'range'::text then partitionstartinclusive
+          else null::boolean
+          end as partitionstartinclusive, partitionrangeend, 
+      case
+          when partitiontype = 'range'::text then partitionendinclusive
+          else null::boolean
+          end as partitionendinclusive, 
+      partitioneveryclause, 
+      parisdefault as partitionisdefault, 
+      partitionboundary,
+      parentspace as parenttablespace,
+      partspace as partitiontablespace
+  from 
+      ( 
+          select 
+              n.nspname as schemaname, 
+              cl.relname as tablename, 
+              n2.nspname as partitionschemaname, 
+              cl2.relname as partitiontablename, 
+              pr1.parname as partitionname, 
+              cl3.relname as parentpartitiontablename, 
+              pr2.parname as parentpartitionname, 
+              case
+                  when pp.parkind = 'h'::"char" then 'hash'::text
+                  when pp.parkind = 'r'::"char" then 'range'::text
+                  when pp.parkind = 'l'::"char" then 'list'::text
+                  else null::text
+                  end as partitiontype, 
+              pp.parlevel as partitionlevel, 
+              pr1.parruleord as partitionposition, 
+              case
+                  when pp.parkind != 'r'::"char" or pr1.parisdefault then null::bigint
+                  else
+                      rank() over(
+                      partition by pp.oid, cl.relname, pp.parlevel, cl3.relname
+                      order by pr1.parisdefault, pr1.parruleord) 
+                  end as partitionrank, 
+              pg_get_expr_nolock(pr1.parlistvalues) as partitionlistvalues, 
+              pg_get_expr_nolock(pr1.parrangestart) as partitionrangestart, 
+              pr1.parrangestartincl as partitionstartinclusive, 
+              pg_get_expr_nolock(pr1.parrangeend) as partitionrangeend, 
+              pr1.parrangeendincl as partitionendinclusive, 
+              pg_get_expr_nolock(pr1.parrangeevery) as partitioneveryclause, 
+              min(pr1.parruleord) over(
+                  partition by pp.oid, cl.relname, pp.parlevel, cl3.relname
+                  order by pr1.parruleord) as partitionnodefault, 
+              pr1.parisdefault, 
+              pg_get_partition_rule_def(pr1.oid, true) as partitionboundary,
+              coalesce(sp.spcname, dfltspcname) as parentspace,
+              coalesce(sp3.spcname, dfltspcname) as partspace
+          from 
+              pg_namespace n, 
+              pg_namespace n2, 
+              pg_class cl
+                  left join
+              pg_tablespace sp on cl.reltablespace = sp.oid, 
+              pg_class cl2
+                  left join
+              pg_tablespace sp3 on cl2.reltablespace = sp3.oid,
+              pg_partition pp, 
+              pg_partition_rule pr1
+                  left join 
+              pg_partition_rule pr2 on pr1.parparentrule = pr2.oid
+                  left join 
+              pg_class cl3 on pr2.parchildrelid = cl3.oid,
+              (select s.spcname
+               from pg_database, pg_tablespace s
+               where datname = current_database()
+                 and dattablespace = s.oid) d(dfltspcname)
+      where 
+          pp.paristemplate = false and 
+          pp.parrelid = cl.oid and 
+          pr1.paroid = pp.oid and 
+          cl2.oid = pr1.parchildrelid and 
+          cl.relnamespace = n.oid and 
+          cl2.relnamespace = n2.oid) p1;

--- a/gpcontrib/pg_partitions_nolock/pg_partitions_nolock.control
+++ b/gpcontrib/pg_partitions_nolock/pg_partitions_nolock.control
@@ -1,0 +1,3 @@
+comment = 'Implementation of pg_partitions without locks'
+default_version = '1.0'
+relocatable = false


### PR DESCRIPTION
Implement a different version of `pg_get_expr` which does not process `Var` nodes, but also does not require relation OID. Its purpose is to deparse expressions when called by `pg_partitions` `VIEW` which do not contain `Var` nodes.

The method is packed into an extension, which renames the original GPDB view `pg_partitions` to `pg_partitions_lock` and recreates `pg_partitions`, attaching the non-locking version of `pg_get_expr` to it.