### PR TITLE
ADBDEV-1133. Fix ExecInitWindowAgg failure

### DIFF
--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2259,10 +2259,6 @@ ExecInitWindowAgg(WindowAgg *node, EState *estate, int eflags)
 		AclResult	aclresult;
 		int			i;
 
-		if (wfunc->winref != node->winref)		/* planner screwed up? */
-			elog(ERROR, "WindowFunc with winref %u assigned to WindowAgg with winref %u",
-				 wfunc->winref, node->winref);
-
 		/* Look for a previous duplicate window function */
 		for (i = 0; i <= wfuncno; i++)
 		{


### PR DESCRIPTION
## The problem
`WindowAgg.winref` is not equal to `WindowFunc.winref` in a special case of `GROUPING SET` usage.

## Current solution
Remove the check of equality of the mentioned values. It prevents execution of a correctly planned query.

Without a check, the results are the same as ones obtained from PostgreSQL 13.