### PR TITLE
Implement two-stage sampling for AO/AOC analyze

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -543,7 +543,7 @@ aocs_beginscan_internal(Relation relation,
 	scan->columnScanInfo.scanCtx = CurrentMemoryContext;
 
 	/* block size for analyze scan */
-	scan->analyze_block_size = APPENDONLY_ANALYZE_BLOCK_SIZE;
+	scan->analyze_block_size = gp_appendonly_analyze_block_size;
 
 	/* relationTupleDesc will be inited by the slot when needed */
 	scan->columnScanInfo.relationTupleDesc = NULL;

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -518,13 +518,36 @@ aoco_beginscan(Relation relation,
                uint32 flags)
 {
 	AOCSScanDesc	aoscan;
+	AttrNumber		natts;
+	AttrNumber		attr;
+	bool			*proj;
 
 	/* Parallel scan not supported for AO_COLUMN tables */
 	Assert(pscan == NULL);
 
+	/*
+	 * At the moment we project all columns for analyze scan.
+	 *
+	 * TODO: we need a way to project only subset of columns from
+	 * "analyze t(col1, ..., colN)"" command.
+	 */
+	if ((flags & SO_TYPE_ANALYZE) != 0)
+	{
+		natts = RelationGetNumberOfAttributes(relation);
+		proj = palloc(sizeof(bool *) * natts);
+		for (attr = 0; attr < natts; attr++)
+		{
+			proj[attr] = true;
+		}
+	}
+	else
+	{
+		proj = NULL;
+	}
+
 	aoscan = aocs_beginscan(relation,
 							snapshot,
-							NULL,
+							proj,
 							flags);
 
 	return (TableScanDesc) aoscan;
@@ -1222,12 +1245,208 @@ aoco_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	aocs_insert_finish(idesc);
 }
 
+/* Loop over an ordered sequence of appendonly segments in a scan to find a target row. */
+static bool
+aoco_analyze_find_segment(AOCSScanDesc scan, int64 targetrow)
+{
+	AOCSFileSegInfo *seginfo;
+	int	segno;
+	int64	rows_prev_segments; /* row count from prevoius segments (except current segment) */
+
+	/* Need to open a new segment file. */
+	if (scan->cur_seg < 0)
+	{
+		if (open_next_scan_seg(scan) < 0)
+		{
+			elog(DEBUG2, "Failed to open a new segment.");
+			scan->cur_seg = -1;
+			return false;
+		}
+		scan->cur_seg_row = 0;
+	}
+
+	/* No more segments left. */
+	if (scan->cur_seg >= scan->total_seg)
+	{
+		elog(DEBUG2, "No more segments left.");
+		return false;
+	}
+
+	if (scan->total_row > targetrow)
+	{
+		elog(ERROR, "Analyze block inconsistency: total rows scanned %lu, target row %lu",
+			scan->total_row, targetrow);
+	}
+
+	/* Look up for the target row in a current segment. */
+	seginfo = scan->seginfo[scan->cur_seg];
+	rows_prev_segments = scan->total_row - scan->cur_seg_row;
+	if (targetrow <= rows_prev_segments + seginfo->total_tupcount)
+	{
+		return true;
+	}
+
+	/* Look up for the target row among other segments */
+	while (true)
+	{
+		scan->total_row += seginfo->total_tupcount - scan->cur_seg_row;
+		scan->cur_seg_row = 0;
+
+		close_cur_scan_seg(scan);
+		elog(DEBUG2, "Skipping current segment: segno %d", scan->cur_seg);
+		segno = open_next_scan_seg(scan);
+		if ((segno < 0) || (segno >= scan->total_seg))
+		{
+			elog(DEBUG3, "No more varblocks left in a current segment.");
+			return false;
+		}
+
+		/* Skip a segment if it doesn't contain the target row. */
+		seginfo = scan->seginfo[scan->cur_seg];
+		if (scan->total_row + seginfo->total_tupcount >= targetrow)
+		{
+			break;
+		}
+	}
+
+	return true;
+}
+
 static bool
 aoco_scan_analyze_next_block(TableScanDesc scan, BlockNumber blockno,
                                    BufferAccessStrategy bstrategy)
 {
+	AttrNumber proj;
+	int64 targetrow;
+	int64 varblockFirstRow;	/* var block row position with respect to previous segments */
+	int64 varblockRemainingRows;
+	AOCSFileSegInfo *seginfo;
+	DatumStreamRead *ds;
+	TupleTableSlot *slot;
+	bool found;
+	int segno;
+	int64 totalrows;
+	int64 totalRemainingRows;
+
 	AOCSScanDesc aoscan = (AOCSScanDesc) scan;
-	aoscan->targetTupleId = blockno;
+
+	/* Convert block number to a target row in an ordered sequence of appendonly segments. */
+	targetrow = blockno * aoscan->analyze_block_size;
+
+	/* This should never happen */
+	if (targetrow > INT64_MAX)
+	{
+		elog(ERROR, "Target row is out on range");
+	}
+
+	/* Initialize AOC scan. */
+	if (aoscan->columnScanInfo.relationTupleDesc == NULL)
+	{
+		aoscan->columnScanInfo.relationTupleDesc = RelationGetDescr(aoscan->rs_base.rs_rd);
+		PinTupleDesc(aoscan->columnScanInfo.relationTupleDesc);
+		aocs_initscan(aoscan);
+	}
+
+	/* Find a segment with a target row (skip other ones without scan and increment counters) */
+	if (!aoco_analyze_find_segment(aoscan, targetrow))
+	{
+		elog(DEBUG3, "No segment exists for the target row %lu", targetrow);
+		return false;
+	}
+
+	/* Calculate rows to scan in a current block. */
+	totalrows = 0;
+	for (segno = 0; segno < aoscan->total_seg; segno++)
+	{
+		totalrows += aoscan->seginfo[segno]->total_tupcount;
+	}
+	totalRemainingRows = totalrows - aoscan->total_row;
+	aoscan->rows_to_scan = aoscan->analyze_block_size < totalRemainingRows ?
+								aoscan->analyze_block_size :
+								totalRemainingRows;
+
+	/* Look for a target row in all scanned projections. */
+	for (proj = 0; proj < aoscan->columnScanInfo.num_proj_atts; proj++)
+	{
+		AttrNumber attno;
+
+		attno = aoscan->columnScanInfo.proj_atts[proj];
+		ds = aoscan->columnScanInfo.ds[attno];
+
+		/* Check the target row in a current varblock. */
+		found = false;
+		varblockFirstRow = aoscan->total_row - DatumStreamBlockRead_Nth(&ds->blockRead);
+		seginfo = aoscan->seginfo[aoscan->cur_seg];
+		if (varblockFirstRow + ds->blockRowCount >= targetrow)
+		{
+			elog(DEBUG2, "Target row %lu have been found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (projection %d, segno %d). Rows scanned: total %lu, segment %lu, varblock %d",
+				targetrow, ds->blockFirstRowNum, varblockFirstRow, ds->blockFileOffset, ds->blockRowCount, attno,
+				seginfo->segno, aoscan->total_row, aoscan->cur_seg_row, DatumStreamBlockRead_Nth(&ds->blockRead));
+			found = true;
+		}
+
+		/* Check other varblock headers for the target row. */
+		if (!found)
+		{
+			/* Store remaining rows in a varblock for the first step in a skip loop. */
+			varblockRemainingRows = ds->blockRowCount - DatumStreamBlockRead_Nth(&ds->blockRead);
+
+			/* Iterate over varblock headers in a current segment. */
+			while (datumstreamread_block_info(ds))
+			{
+				/* Increment counters. */
+				elog(DEBUG2, "Incrementing total (%lu) and segment (%lu) scanned rows with %lu",
+					aoscan->total_row, aoscan->cur_seg_row, varblockRemainingRows);
+				aoscan->total_row += varblockRemainingRows;
+				aoscan->cur_seg_row += varblockRemainingRows;
+				ds->blockRead.nth = 0;
+
+				/* Does current header have enough rows to reach the target row? */
+				if (aoscan->total_row + ds->blockRowCount >= targetrow)
+				{
+					/* Read current block data. */
+					datumstreamread_block_content(ds);
+					varblockFirstRow = aoscan->total_row - DatumStreamBlockRead_Nth(&ds->blockRead);
+					elog(DEBUG2, "Target row %lu have been found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (projection %d, segno %d). Rows scanned: total %lu, segment %lu, varblock %d",
+						targetrow, ds->blockFirstRowNum, varblockFirstRow, ds->blockFileOffset, ds->blockRowCount, attno,
+						seginfo->segno, aoscan->total_row, aoscan->cur_seg_row, DatumStreamBlockRead_Nth(&ds->blockRead));
+					found = true;
+					break;
+				}
+
+				/* Store remaining rows in a varblock for the next loop iteration. */
+				varblockRemainingRows = ds->blockRowCount - DatumStreamBlockRead_Nth(&ds->blockRead);
+
+				/* Skip current block without decompression. */
+				elog(DEBUG2, "Target row %lu can't be found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (projection %d, segno %d) - skipping. Rows scanned: total %lu, segment %lu, varblock %d",
+					targetrow, ds->blockFirstRowNum, varblockFirstRow, ds->blockFileOffset, ds->blockRowCount, attno,
+					seginfo->segno, aoscan->total_row, aoscan->cur_seg_row, DatumStreamBlockRead_Nth(&ds->blockRead));
+				AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+			}
+
+			if (!found)
+			{
+				elog(DEBUG2, "Target row  %lu can't be found among varblocks in projection %d.",
+					targetrow, attno);
+				return false;
+			}
+		}
+
+		if (!found)
+		{
+			elog(ERROR, "Target row can't be found among varblock headers");
+		}
+	}
+
+	/* Set block reader position to the target row. */
+	slot = table_slot_create(aoscan->rs_base.rs_rd, NULL);
+	while (aoscan->total_row < targetrow)
+	{
+		aoco_getnextslot(scan, ForwardScanDirection, slot);
+		elog(DEBUG3, "Move scan position to the target row %lu. Rows scanned: total %lu, segment %lu",
+			targetrow, aoscan->total_row, aoscan->cur_seg_row);
+	}
+	ExecDropSingleTupleTableSlot(slot);
 
 	return true;
 }
@@ -1237,28 +1456,44 @@ aoco_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
                                    double *liverows, double *deadrows,
                                    TupleTableSlot *slot)
 {
+	bool ret;
+	AOTupleId *tupleId;
 	AOCSScanDesc aoscan = (AOCSScanDesc) scan;
-	bool		ret = false;
 
-	/* skip several tuples if they are not sampling target */
-	while (aoscan->targetTupleId > aoscan->nextTupleId)
-	{
-		aoco_getnextslot(scan, ForwardScanDirection, slot);
-		aoscan->nextTupleId++;
-	}
+	elog(DEBUG3, "Remaining rows to scan %lu", aoscan->rows_to_scan);
 
-	if (aoscan->targetTupleId == aoscan->nextTupleId)
+	/* Inner loop over all tuples of the analyze block. */
+	while (--aoscan->rows_to_scan >= 0)
 	{
 		ret = aoco_getnextslot(scan, ForwardScanDirection, slot);
-		aoscan->nextTupleId++;
-
 		if (ret)
+		{
+			if (aoscan->rows_to_scan < 0)
+			{
+				return false;
+			}
+
+			tupleId = (AOTupleId *) &slot->tts_tid;
+			elog(DEBUG3, "Row number %lu", AOTupleIdGet_rowNum(tupleId));
+			if (AOTupleIdGet_segmentFileNum(tupleId) != aoscan->cur_seg + 1)
+			{
+				elog(ERROR, "Inconsistency in AOC analyze scan: tuple segment %d, block reader segment %d",
+					AOTupleIdGet_segmentFileNum(tupleId), aoscan->cur_seg + 1);
+			}
 			*liverows += 1;
+
+			return true;
+		}
 		else
+		{
+			elog(DEBUG3, "Dead row");
 			*deadrows += 1; /* if return an invisible tuple */
+
+			continue;
+		}
 	}
 
-	return ret;
+	return false;
 }
 
 static double

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -525,12 +525,7 @@ aoco_beginscan(Relation relation,
 	/* Parallel scan not supported for AO_COLUMN tables */
 	Assert(pscan == NULL);
 
-	/*
-	 * At the moment we project all columns for analyze scan.
-	 *
-	 * TODO: we need a way to project only subset of columns from
-	 * "analyze t(col1, ..., colN)"" command.
-	 */
+	/* At the moment we project all columns for analyze scan. */
 	if ((flags & SO_TYPE_ANALYZE) != 0)
 	{
 		natts = RelationGetNumberOfAttributes(relation);

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -140,6 +140,9 @@ static void AppendOnlyExecutorReadBlock_Init(
 static void AppendOnlyExecutorReadBlock_Finish(
 								   AppendOnlyExecutorReadBlock *executorReadBlock);
 
+static void AppendOnlyExecutorReadBlock_NewSegmentCounts(
+										AppendOnlyExecutorReadBlock *executorReadBlock);
+
 static void AppendOnlyExecutorReadBlock_ResetCounts(
 										AppendOnlyExecutorReadBlock *executorReadBlock);
 
@@ -174,7 +177,7 @@ initscan(AppendOnlyScanDesc scan, ScanKey key)
 /*
  * Open the next file segment to scan and allocate all resources needed for it.
  */
-static bool
+bool
 SetNextFileSegForRead(AppendOnlyScanDesc scan)
 {
 	Relation	reln = scan->aos_rd;
@@ -342,6 +345,8 @@ SetNextFileSegForRead(AppendOnlyScanDesc scan)
 												 &scan->executorReadBlock,
 												  /* blockFirstRowNum */ 1);
 
+	AppendOnlyExecutorReadBlock_NewSegmentCounts(&scan->executorReadBlock);
+
 	/* ready to go! */
 	scan->aos_need_new_segfile = false;
 
@@ -505,7 +510,7 @@ SetCurrentFileSegForWrite(AppendOnlyInsertDesc aoInsertDesc)
 /*
  * Finished scanning this file segment. Close it.
  */
-static void
+void
 CloseScannedFileSeg(AppendOnlyScanDesc scan)
 {
 	AppendOnlyStorageRead_CloseFile(&scan->storageRead);
@@ -554,7 +559,7 @@ CloseWritableFileSeg(AppendOnlyInsertDesc aoInsertDesc)
 
 /* ------------------------------------------------------------------------------ */
 
-static void
+void
 AppendOnlyExecutorReadBlock_GetContents(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
 	VarBlockCheckError varBlockCheckError;
@@ -745,7 +750,7 @@ AppendOnlyExecutorReadBlock_GetContents(AppendOnlyExecutorReadBlock *executorRea
 	}
 }
 
-static bool
+bool
 AppendOnlyExecutorReadBlock_GetBlockInfo(AppendOnlyStorageRead *storageRead,
 										 AppendOnlyExecutorReadBlock *executorReadBlock)
 {
@@ -797,7 +802,7 @@ AppendOnlyExecutionReadBlock_SetPositionInfo(AppendOnlyExecutorReadBlock *execut
 	executorReadBlock->blockFirstRowNum = blockFirstRowNum;
 }
 
-static void
+void
 AppendOnlyExecutionReadBlock_FinishedScanBlock(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
 	executorReadBlock->blockFirstRowNum += executorReadBlock->rowCount;
@@ -852,9 +857,17 @@ AppendOnlyExecutorReadBlock_Finish(AppendOnlyExecutorReadBlock *executorReadBloc
 }
 
 static void
+AppendOnlyExecutorReadBlock_NewSegmentCounts(AppendOnlyExecutorReadBlock *executorReadBlock)
+{
+	executorReadBlock->segmentRowsScanned = 0;
+}
+
+static void
 AppendOnlyExecutorReadBlock_ResetCounts(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
-	executorReadBlock->totalRowsScannned = 0;
+	executorReadBlock->totalRowsScanned = 0;
+	executorReadBlock->rows_to_scan = 0;
+	AppendOnlyExecutorReadBlock_NewSegmentCounts(executorReadBlock);
 }
 
 /*
@@ -1124,7 +1137,9 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 
 				executorReadBlock->currentItemCount++;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->segmentRowsScanned++;
+
+				executorReadBlock->totalRowsScanned++;
 
 				if (itemLen > 0)
 				{
@@ -1177,7 +1192,9 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 				executorReadBlock->singleRow = NULL;
 				executorReadBlock->singleRowLen = 0;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->segmentRowsScanned++;
+
+				executorReadBlock->totalRowsScanned++;
 
 				if (AppendOnlyExecutorReadBlock_ProcessTuple(
 															 executorReadBlock,
@@ -1286,7 +1303,7 @@ AppendOnlyExecutorReadBlock_FetchTuple(AppendOnlyExecutorReadBlock *executorRead
 /*
  * You can think of this scan routine as get next "executor" AO block.
  */
-static bool
+bool
 getNextBlock(AppendOnlyScanDesc scan)
 {
 	if (scan->aos_need_new_segfile)
@@ -1644,6 +1661,9 @@ appendonly_beginrangescan_internal(Relation relation,
 	scan->snapshot = snapshot;
 	scan->aos_nkeys = nkeys;
 	scan->aoScanInitContext = CurrentMemoryContext;
+
+	/* block size for analyze scan */
+	scan->analyze_block_size = APPENDONLY_ANALYZE_BLOCK_SIZE;
 
 	initStringInfo(&titleBuf);
 	appendStringInfo(&titleBuf, "Scan of Append-Only Row-Oriented relation '%s'",

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1663,7 +1663,7 @@ appendonly_beginrangescan_internal(Relation relation,
 	scan->aoScanInitContext = CurrentMemoryContext;
 
 	/* block size for analyze scan */
-	scan->analyze_block_size = APPENDONLY_ANALYZE_BLOCK_SIZE;
+	scan->analyze_block_size = gp_appendonly_analyze_block_size;
 
 	initStringInfo(&titleBuf);
 	appendStringInfo(&titleBuf, "Scan of Append-Only Row-Oriented relation '%s'",

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1050,12 +1050,184 @@ appendonly_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 	appendonly_insert_finish(aoInsertDesc);
 }
 
+/* Loop over an ordered sequence of appendonly segments in a scan to find a target row. */
+static bool
+appendonly_analyze_find_segment(AppendOnlyScanDesc scan, int64 targetrow)
+{
+	AppendOnlyExecutorReadBlock	*readblock;
+	FileSegInfo	*seginfo;
+	int64	rows_prev_segments; /* row count from prevoius segments (except current segment) */
+
+	readblock = &scan->executorReadBlock;
+
+	/* Need to open a new segment file. */
+	if (scan->aos_need_new_segfile)
+	{
+		if (!SetNextFileSegForRead(scan))
+			return false;
+		readblock->segmentRowsScanned = 0;
+	}
+
+	/* No more segments left. */
+	if (scan->aos_done_all_segfiles)
+	{
+		elog(DEBUG2, "No more segments left.");
+		return false;
+	}
+
+	if (readblock->totalRowsScanned > targetrow)
+	{
+		elog(ERROR, "Analyze block inconsistency: total rows scanned %lu, target row %lu",
+			readblock->totalRowsScanned, targetrow);
+	}
+
+	/* Look up for the target row in a current segment. */
+	seginfo = scan->aos_segfile_arr[scan->aos_segfiles_processed - 1];
+	rows_prev_segments = readblock->totalRowsScanned - readblock->segmentRowsScanned;
+	if (targetrow <= rows_prev_segments + seginfo->total_tupcount)
+	{
+		return true;
+	}
+
+	/* Look up for the target row among other segments. */
+	while (true)
+	{
+		readblock->totalRowsScanned += seginfo->total_tupcount - readblock->segmentRowsScanned;
+
+		scan->aos_need_new_segfile = true;
+		CloseScannedFileSeg(scan);
+		elog(DEBUG2, "Skipping current segment: segno %d", readblock->segmentFileNum);
+		if (!getNextBlock(scan))
+		{
+			elog(DEBUG3, "No more varblocks left in a current segment.");
+			return false;
+		}
+
+		/* Skip a segment until it contains the target row. */
+		seginfo = scan->aos_segfile_arr[scan->aos_segfiles_processed - 1];
+		if (readblock->totalRowsScanned + seginfo->total_tupcount >= targetrow)
+		{
+			break;
+		}
+	}
+
+	return true;
+}
+
 static bool
 appendonly_scan_analyze_next_block(TableScanDesc scan, BlockNumber blockno,
 							   BufferAccessStrategy bstrategy)
 {
+	int64 targetrow;
+	int64 varblockFirstRow;	/* var block row position with respect to previous segments */
+	int64 varblockRemainingRows;
+	FileSegInfo *seginfo;
+	AppendOnlyExecutorReadBlock *readblock;
+	TupleTableSlot *slot;
+	bool found;
+	int segno;
+	int64 totalrows;
+	int64 totalRemainingRows;
+
 	AppendOnlyScanDesc aoscan = (AppendOnlyScanDesc) scan;
-	aoscan->targetTupleId = blockno;
+
+	/* Convert block number to a target row in an ordered sequence of appendonly segments. */
+	targetrow = blockno * aoscan->analyze_block_size;
+
+	/* This should never happen */
+	if (targetrow > INT64_MAX)
+	{
+		elog(ERROR, "Target row is out on range");
+	}
+
+	/* Find a segment with a target row (skip other ones without scan and increment counters) */
+	if (!appendonly_analyze_find_segment(aoscan, targetrow))
+	{
+		elog(DEBUG3, "No segment exists for the target row %lu", targetrow);
+		return false;
+	}
+
+	/* Calculate rows to scan in a current block. */
+	readblock = &aoscan->executorReadBlock;
+	totalrows = 0;
+	for (segno = 0; segno < aoscan->aos_total_segfiles; segno++)
+	{
+		totalrows += aoscan->aos_segfile_arr[segno]->total_tupcount;
+	}
+	totalRemainingRows = totalrows - readblock->totalRowsScanned;
+	readblock->rows_to_scan = aoscan->analyze_block_size < totalRemainingRows ?
+								aoscan->analyze_block_size :
+								totalRemainingRows;
+
+	/* Check the target row in a current varblock. */
+	found = false;
+	varblockFirstRow = readblock->totalRowsScanned - readblock->currentItemCount;
+	seginfo = aoscan->aos_segfile_arr[aoscan->aos_segfiles_processed - 1];
+	if (varblockFirstRow + readblock->rowCount >= targetrow)
+	{
+		elog(DEBUG2, "Target row %lu have been found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (segno %d). Rows scanned: total %lu, segment %lu, varblock %d",
+			targetrow, readblock->blockFirstRowNum, varblockFirstRow, readblock->headerOffsetInFile, readblock->rowCount,
+			seginfo->segno, readblock->totalRowsScanned, readblock->segmentRowsScanned, readblock->currentItemCount);
+		found = true;
+	}
+
+	/* Check other varblock headers for the target row. */
+	if (!found)
+	{
+		/* Store remaining rows in a varblock for the first step in a skip loop. */
+		varblockRemainingRows = readblock->rowCount - readblock->currentItemCount;
+
+		/* Iterate over varblock headers in a current segment. */
+		while(AppendOnlyExecutorReadBlock_GetBlockInfo(&aoscan->storageRead, &aoscan->executorReadBlock))
+		{
+			/* Increment counters. */
+			elog(DEBUG2, "Incrementing total (%lu) and segment (%lu) scanned rows with %lu",
+				readblock->totalRowsScanned, readblock->segmentRowsScanned,
+				varblockRemainingRows);
+			readblock->totalRowsScanned += varblockRemainingRows;
+			readblock->segmentRowsScanned += varblockRemainingRows;
+			readblock->currentItemCount = 0;
+
+			/* Does current header have enough rows to reach the target row? */
+			if (readblock->totalRowsScanned + readblock->rowCount >= targetrow)
+			{
+				/* Read current block data. */
+				AppendOnlyExecutorReadBlock_GetContents(readblock);
+				varblockFirstRow = readblock->totalRowsScanned - readblock->currentItemCount;
+				elog(DEBUG2, "Target row %lu have been found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (segno %d). Rows scanned: total %lu, segment %lu, varblock %d",
+					targetrow, readblock->blockFirstRowNum, varblockFirstRow, readblock->headerOffsetInFile, readblock->rowCount,
+					seginfo->segno, readblock->totalRowsScanned, readblock->segmentRowsScanned, readblock->currentItemCount);
+				found = true;
+				break;
+			}
+
+			/* Store remaining rows in a varblock for the next loop iteration. */
+			varblockRemainingRows = readblock->rowCount - readblock->currentItemCount;
+
+			/* Skip current block without decompression. */
+			elog(DEBUG2, "Target row %lu can't be found in varblock (first row [header value %lu / order count %lu], header offset %lu) of size %d (segno %d) - skipping. Rows scanned: total %lu, segment %lu, varblock %d",
+				targetrow, readblock->blockFirstRowNum, varblockFirstRow, readblock->headerOffsetInFile, readblock->rowCount,
+				seginfo->segno, readblock->totalRowsScanned, readblock->segmentRowsScanned, readblock->currentItemCount);
+			AppendOnlyExecutionReadBlock_FinishedScanBlock(readblock);
+			AppendOnlyStorageRead_SkipCurrentBlock(&aoscan->storageRead);
+		}
+
+		if (!found)
+		{
+			elog(DEBUG2, "Target row  %lu can't be found among varblocks.", targetrow);
+			return false;
+		}
+	}
+
+	/* Set block reader position to the target row. */
+	slot = table_slot_create(aoscan->aos_rd, NULL);
+	while (readblock->totalRowsScanned < targetrow)
+	{
+		appendonly_getnextslot(scan, ForwardScanDirection, slot);
+		elog(DEBUG3, "Move scan position to the target row %lu. Rows scanned: total %lu, segment %lu, varblock %d",
+			targetrow, readblock->totalRowsScanned, readblock->segmentRowsScanned, readblock->currentItemCount);
+	}
+	ExecDropSingleTupleTableSlot(slot);
 
 	return true;
 }
@@ -1065,30 +1237,40 @@ appendonly_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 							   double *liverows, double *deadrows,
 							   TupleTableSlot *slot)
 {
+	bool ret;
+	AOTupleId *tupleId;
 	AppendOnlyScanDesc aoscan = (AppendOnlyScanDesc) scan;
-	bool		ret = false;
 
-	/* skip several tuples if they are not sampling target */
-	while (!aoscan->aos_done_all_segfiles
-		   && aoscan->targetTupleId > aoscan->nextTupleId)
-	{
-		appendonly_getnextslot(scan, ForwardScanDirection, slot);
-		aoscan->nextTupleId++;
-	}
+	elog(DEBUG3, "Remaining rows to scan %lu. Varblock first row: %lu",
+		aoscan->executorReadBlock.rows_to_scan, aoscan->executorReadBlock.blockFirstRowNum);
 
-	if (!aoscan->aos_done_all_segfiles
-		&& aoscan->targetTupleId == aoscan->nextTupleId)
+	/* Inner loop over all tuples of the analyze block. */
+	while (--aoscan->executorReadBlock.rows_to_scan >= 0)
 	{
 		ret = appendonly_getnextslot(scan, ForwardScanDirection, slot);
-		aoscan->nextTupleId++;
-
 		if (ret)
+		{
+			tupleId = (AOTupleId *) &slot->tts_tid;
+			elog(DEBUG3, "Row number %lu", AOTupleIdGet_rowNum(tupleId));
+			if (AOTupleIdGet_segmentFileNum(tupleId) != aoscan->executorReadBlock.segmentFileNum)
+			{
+				elog(ERROR, "Inconsistency in AO analyze scan: tuple segment %d, block reader segment %d",
+					AOTupleIdGet_segmentFileNum(tupleId), aoscan->executorReadBlock.segmentFileNum);
+			}
 			*liverows += 1;
+
+			return true;
+		}
 		else
+		{
+			elog(DEBUG3, "Dead row");
 			*deadrows += 1; /* if return an invisible tuple */
+
+			continue;
+		}
 	}
 
-	return ret;
+	return false;
 }
 
 static double

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1388,32 +1388,7 @@ acquire_sample_rows(Relation onerel, int elevel,
 											  totalrows, totaldeadrows);
 	}
 
-	/*
-	 * GPDB: Analyze does make a lot of assumptions regarding the file layout of a
-	 * relation. These assumptions are heap specific and do not hold for AO/AOCO
-	 * relations. In the case of AO/AOCO, what is actually needed and used instead
-	 * of number of blocks, is number of tuples.
-	 *
-	 * GPDB_12_MERGE_FIXME: BlockNumber is uint32 and Number of tuples is uint64.
-	 * That means that after row number UINT_MAX we will never analyze the table.
-	 */
-	if (RelationIsAppendOptimized(onerel))
-	{
-		BlockNumber pages;
-		double		tuples;
-		double		allvisfrac;
-		int32		attr_widths;
-
-		table_relation_estimate_size(onerel,	&attr_widths, &pages,
-									&tuples, &allvisfrac);
-
-		if (tuples > UINT_MAX)
-			tuples = UINT_MAX;
-
-		totalblocks = (BlockNumber)tuples;
-	}
-	else
-		totalblocks = RelationGetNumberOfBlocks(onerel);
+	totalblocks = RelationGetNumberOfBlocks(onerel);
 
 	/* Need a cutoff xmin for HeapTupleSatisfiesVacuum */
 	OldestXmin = GetOldestXmin(onerel, PROCARRAY_FLAGS_VACUUM);

--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -2964,7 +2964,7 @@ RelationGetNumberOfBlocksInFork(Relation relation, ForkNumber forkNum)
 					Snapshot snapshot;
 					FileSegTotals *fileSegTotals;
 					double tuples;
-					BlockNumber blocks;
+					double blocks;
 
 					/* Get total number of rows among all segment files. */
 					snapshot = RegisterSnapshot(GetLatestSnapshot());
@@ -2974,10 +2974,13 @@ RelationGetNumberOfBlocksInFork(Relation relation, ForkNumber forkNum)
 					tuples = (double) fileSegTotals->totaltuples;
 					UnregisterSnapshot(snapshot);
 
-					/* Analyze skips blocks starting from about 2 billion rows on GP's segment instance. */
-					blocks = (BlockNumber) ceil(tuples / APPENDONLY_ANALYZE_BLOCK_SIZE);
+					blocks = ceil(tuples / gp_appendonly_analyze_block_size);
+					if (blocks > APPENDONLY_ANALYZE_BLOCK_MAX)
+					{
+						blocks = APPENDONLY_ANALYZE_BLOCK_MAX;
+					}
 
-					return blocks;
+					return (BlockNumber) blocks;
 				}
 			}
 		case RELKIND_TOASTVALUE:

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1083,7 +1083,7 @@ datumstreamwrite_lob(DatumStreamWrite * acc,
 	return varLen;
 }
 
-static bool
+bool
 datumstreamread_block_info(DatumStreamRead * acc)
 {
 	bool		readOK = false;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -137,6 +137,7 @@ bool        Test_print_prefetch_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
+int			gp_appendonly_analyze_block_size = 0;
 bool		gp_appendonly_verify_block_checksums = true;
 bool		gp_appendonly_verify_write_block = false;
 bool		gp_appendonly_compaction = true;
@@ -2961,6 +2962,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_plan_size,
 		0, 0, MAX_KILOBYTES,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_appendonly_analyze_block_size", PGC_USERSET, APPENDONLY_TABLES,
+			gettext_noop("AO/AOC relation logical block size we try to use during analyze."
+						 "We can use a larger block size if the resulting block number is too big."),
+			NULL
+		},
+		&gp_appendonly_analyze_block_size,
+		100, 1, APPENDONLY_ANALYZE_BLOCK_SIZE > INT_MAX ? INT_MAX : (int) APPENDONLY_ANALYZE_BLOCK_SIZE,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -108,14 +108,14 @@ typedef struct AOCSScanDescData
 
 	/* synthetic system attributes */
 	ItemPointerData cdb_fake_ctid;
-	int64 total_row;
-	int64 cur_seg_row;
+	int64 total_row;	/* row count behind current position among all scanned segments */
+	int64 cur_seg_row;	/* row count behind current position in a current segment */
 
 	/*
 	 * Only used by `analyze`
 	 */
-	int64		nextTupleId;
-	int64		targetTupleId;
+	int64		analyze_block_size;
+	int64		rows_to_scan;	/* row count left to scan during analyze */
 
 	/*
 	 * Part of the struct to be used only inside aocsam.c
@@ -297,8 +297,11 @@ extern AOCSScanDesc aocs_beginrangescan(Relation relation, Snapshot snapshot,
 
 extern void aocs_rescan(AOCSScanDesc scan);
 extern void aocs_endscan(AOCSScanDesc scan);
+extern void aocs_initscan(AOCSScanDesc scan);
 
 extern bool aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot);
+extern int open_next_scan_seg(AOCSScanDesc scan);
+extern void close_cur_scan_seg(AOCSScanDesc scan);
 extern AOCSInsertDesc aocs_insert_init(Relation rel, int segno);
 extern void aocs_insert_values(AOCSInsertDesc idesc, Datum *d, bool *null, AOTupleId *aoTupleId);
 static inline void aocs_insert(AOCSInsertDesc idesc, TupleTableSlot *slot)

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -315,6 +315,7 @@ extern void datumstreamread_rewind_block(DatumStreamRead * datumStream);
 extern bool datumstreamread_find_block(DatumStreamRead * datumStream,
 						   DatumStreamFetchDesc datumStreamFetchDesc,
 						   int64 rowNum);
+extern bool datumstreamread_block_info(DatumStreamRead * acc);
 extern void *datumstreamread_get_upgrade_space(DatumStreamRead *datumStream,
 											   size_t len);
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -293,6 +293,7 @@ extern bool Debug_bitmap_print_insert;
 extern bool enable_checksum_on_tables;
 extern int  gp_max_local_distributed_cache;
 extern bool gp_local_distributed_cache_stats;
+extern int	gp_appendonly_analyze_block_size;
 extern bool gp_appendonly_verify_block_checksums;
 extern bool gp_appendonly_verify_write_block;
 extern bool gp_appendonly_compaction;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -150,6 +150,7 @@
 		"gp_adjust_selectivity_for_outerjoins",
 		"gp_allow_non_uniform_partitioning_ddl",
 		"gp_allow_rename_relation_without_lock",
+		"gp_appendonly_analyze_block_size",
 		"gp_appendonly_compaction",
 		"gp_appendonly_compaction_threshold",
 		"gp_appendonly_verify_block_checksums",


### PR DESCRIPTION
To calculate statistics at first we have to retrieve in reservoir some
representative sample from relation. PostgreSQL uses two stage sampling
to avoid sequential scan of the whole relation:

* at first it samples blocks with algorithm S from Knuth
* for each block it samples tuples with algorithm Z from Vitter

To make it work every AM has to know how to estimate block number for
any relation. These blocks should be of the fix size to make algorithm
S from Knuth work correctly. Previously, AO/AOC relations didn't use two
stage sampling and sequentially scanned the whole relation. The main
reason for it was the fact that segment files are constructed from variable
sized blocks (that are not suitable for algorithm S from Knuth).

Current implementation treats AO/AOC relations as a collection of segment
files with a global sequence of rows among them:

* segno 1 with 100 rows - its rows are treated as global positions 0-99
* segno 2 with 200 rows - its rows are treated as global positions 100-299

This global sequence of rows is divided on some arbitrary number of "logical"
analyze blocks fitting BlockNumber (uint32). These blocks are not
interconnected with variable sized physical blocks of segment files -
it is simply a range of global row positions. So block sampling by
algorithm S from Knuth gives us the starting global position of a target
block (the size of the block is fixed and known). We get a benefit of this
schema when the number of blocks is more that 300 * statistics target.
So if we are lucky enough there would be several physical variable
sized blocks between logical blocks and we can just read their headers
without decompressing data. This is the main idea of speeding up AO/AOC
analyze. After that we simply iterate among all rows in a logical analyze
block and fill reservoir with samples.

Current implementation is suboptimal in getting relation's analyze block count.
To always fit BlockNumber (uint32) we use a fix sized block of 65536 rows. But
as far as we should collect 300 * statistic target (default = 100) blocks
of 65536 rows, we get benefit from two stage sampling starting from ~2 billion
rows per GP instance. It is made just to simplify the code but in fact we
can use any logic to get block count for AO/AOC relation (not so straightforward
as we do now).

Another suboptimal thing is AOC projections - I didn't find a way to get columns
required for current analyze and project all of them at the moment.