### PR TITLE
Enable to use column-wise statistics setting for partitioned tables

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -4558,8 +4558,8 @@ merge_leaf_stats(VacAttrStatsP stats,
 
 		mcvpairArray = aggregate_leaf_partition_MCVs(
 			stats->attr->attrelid, stats->attr->attnum, heaptupleStats,
-			relTuples, default_statistics_target, ndistinct, &num_mcv, &rem_mcv,
-			resultMCV);
+			relTuples, stats->attr->attstattarget, ndistinct, &num_mcv,
+			&rem_mcv, resultMCV);
 		MemoryContextSwitchTo(old_context);
 
 		if (num_mcv > 0)
@@ -4582,7 +4582,7 @@ merge_leaf_stats(VacAttrStatsP stats,
 		void *resultHistogram[1];
 		int num_hist = aggregate_leaf_partition_histograms(
 			stats->attr->attrelid, stats->attr->attnum, heaptupleStats,
-			relTuples, default_statistics_target, mcvpairArray + num_mcv,
+			relTuples, stats->attr->attstattarget, mcvpairArray + num_mcv,
 			rem_mcv, resultHistogram);
 		MemoryContextSwitchTo(old_context);
 		if (num_hist > 0)

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1968,3 +1968,18 @@ select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
          0 |        1
 (1 row)
 
+-- Test application of column-wise statistics setting to the number of MCVs and histogram bounds on partitioned table
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int) PARTITION BY RANGE (a) (START (0) END (10) EVERY (5));
+-- fill foo with even numbers twice as large than odd ones to avoid fully even distribution of 'a' attribute and hence empty MCV/MCF
+INSERT INTO foo SELECT i%10 FROM generate_series(0, 100) i;
+INSERT INTO foo SELECT i%10 FROM generate_series(0, 100) i WHERE i%2 = 0;
+-- default_statistics_target is 4
+ALTER TABLE foo ALTER COLUMN a SET STATISTICS 5;
+ANALYZE foo;
+SELECT array_length(most_common_vals, 1), array_length(most_common_freqs, 1), array_length(histogram_bounds, 1) FROM pg_stats WHERE tablename = 'foo' AND attname = 'a';
+ array_length | array_length | array_length 
+--------------+--------------+--------------
+            5 |            5 |            5
+(1 row)
+

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -811,3 +811,13 @@ analyze verbose rootpartition foo;
 -- ensure relpages is correctly set after analyzing
 analyze foo_1_prt_2;
 select reltuples, relpages from pg_class where relname ='foo_1_prt_2';
+-- Test application of column-wise statistics setting to the number of MCVs and histogram bounds on partitioned table
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (a int) PARTITION BY RANGE (a) (START (0) END (10) EVERY (5));
+-- fill foo with even numbers twice as large than odd ones to avoid fully even distribution of 'a' attribute and hence empty MCV/MCF
+INSERT INTO foo SELECT i%10 FROM generate_series(0, 100) i;
+INSERT INTO foo SELECT i%10 FROM generate_series(0, 100) i WHERE i%2 = 0;
+-- default_statistics_target is 4
+ALTER TABLE foo ALTER COLUMN a SET STATISTICS 5;
+ANALYZE foo;
+SELECT array_length(most_common_vals, 1), array_length(most_common_freqs, 1), array_length(histogram_bounds, 1) FROM pg_stats WHERE tablename = 'foo' AND attname = 'a';


### PR DESCRIPTION
## Problem description
The analyze routine for partitioned table is based on merging statistics from its child tables. And building routines for MCV and histogram bounds collections explicitly use the `default_statistics_target` value as the number of slots for these structures ignoring the similar higher priority column-wise setting assigned via `ALTER TABLE ... ALTER COLUMN ... SET STATISTICS ...` statement. 

## Steps to reproduce
```sql
-- create partitioned table with 2 partitions
CREATE TABLE foo (a int) PARTITION BY RANGE (a) (START (0) END (1000) EVERY (500));
-- fill in foo with evenly distributed values but twice as large even numbers
-- to avoid fully even distribution of 'a' attribute and hence empty MCV/MCF
INSERT INTO foo SELECT i%1000 FROM generate_series(0, 10000) i;
INSERT INTO foo SELECT i%1000 FROM generate_series(0, 10000) i WHERE i%2 = 0;
-- default_statistics_target is 100 by default
ALTER TABLE foo ALTER COLUMN a SET STATISTICS 50;
ANALYZE foo;
-- the lengths of MCV, MCF and histogram bounds are 50, 50 and 51 correspondingly,
-- not 100, 100 and 101 as were before this fix
SELECT
    array_length(most_common_vals, 1),
    array_length(most_common_freqs, 1),
    array_length(histogram_bounds, 1)
FROM pg_stats
WHERE tablename = 'foo' AND attname = 'a';
```

## Patch details
Besides of main fix of upper function calls (`aggregate_leaf_partition_MCVs` and `aggregate_leaf_partition_histograms`) there was fixed the definition of upper bound of minimal frequency (expressed in terms of estimated count of rows having target value of attribute) for MCV values gotten from partitions.
The minimal frequency is defined as average frequency over all distinct values plus 25% from its value. The upper bound of this minimal frequency is average over distinct values whose number equals to the statistics target. Fun fact: if we have on some attribute the evenly distributed values the number of distinct of which is greater then statistics target (the number of MCV/MCF slots) then their frequencies would be less then average one + 25% and less then average one over statistics target number and hence we would get empty MCV and MCF. To fill in MCV/MCF in such case you have to increase statistics target no less than the number of distinct values in attribute.