### PR TITLE
ADBDEV-824 Fix concourse script to run in our CI

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -80,7 +80,7 @@ EOF
 
 function run_test() {
   # is this particular python version giving us trouble?
-  ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel6_x86_64/python-2.7.12" /opt
+  # ln -s "$(pwd)/gpdb_src/gpAux/ext/rhel6_x86_64/python-2.7.12" /opt
   su gpadmin -c "bash /opt/run_test.sh $(pwd)"
 }
 

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -275,8 +275,8 @@ function _main() {
       prep_env
       build_xerces
       test_orca
-      install_deps
-      link_python
+      #install_deps
+      #link_python
       ;;
     win32)
         export BLD_ARCH=win32
@@ -309,7 +309,7 @@ function _main() {
       unittest_check_gpdb
   fi
   include_zstd
-  include_quicklz
+  #include_quicklz
   include_libstdcxx
   include_libuv
   export_gpdb

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -129,11 +129,11 @@ APR_CONFIG=--with-apr-config=$(BLD_THIRDPARTY_BIN_DIR)/apr-1-config
 endif
 
 aix7_ppc_64_CONFIGFLAGS=--disable-gpcloud --without-readline --without-libcurl --disable-orca --without-zstd $(APR_CONFIG)
-rhel6_x86_64_CONFIGFLAGS=--with-quicklz  --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
-rhel7_x86_64_CONFIGFLAGS=--with-quicklz  --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
+rhel6_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
+rhel7_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml $(APU_CONFIG)
 linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml $(APR_CONFIG)
-ubuntu18.04_x86_64_CONFIGFLAGS=--with-quicklz --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
-sles12_x86_64_CONFIGFLAGS=--with-quicklz --enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
+ubuntu18.04_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
+sles12_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 BLD_CONFIGFLAGS=$($(BLD_ARCH)_CONFIGFLAGS)
 
 CONFIGFLAGS=$(strip $(BLD_CONFIGFLAGS) --with-pgport=$(DEFPORT) $(BLD_DEPLOYMENT_SETTING))

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -695,7 +695,7 @@ copylibs : thirdparty-dist
 
 greenplum_path:
 	mkdir -p $(INSTLOC)
-	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh yes > $(INSTLOC)/greenplum_path.sh
+	$(BUILDDIR)/gpMgmt/bin/generate-greenplum-path.sh no > $(INSTLOC)/greenplum_path.sh
 
 copylicense:
 	for proddir in $(INSTLOC) $(CLIENTSINSTLOC); do \

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -56,11 +56,11 @@ endif
 export BLD_LD_LIBRARY_PATH_FIXED=true
 
 # specify python version to use for build-time and run-time
-aix7_ppc_64_PYTHONHOME=/opt/freeware
-rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-ubuntu18.04_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
-sles12_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
+# aix7_ppc_64_PYTHONHOME=/opt/freeware
+# rhel6_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
+# rhel7_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
+# ubuntu18.04_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
+# sles12_x86_64_PYTHONHOME=$(BLD_THIRDPARTY_DIR)/python-2.7.12
 
 ifneq "$($(BLD_ARCH)_PYTHONHOME)" ""
 export PYTHONHOME=$($(BLD_ARCH)_PYTHONHOME)

--- a/gpcontrib/zstd/expected/compression_zstd.out
+++ b/gpcontrib/zstd/expected/compression_zstd.out
@@ -23,7 +23,7 @@ INSERT INTO zstdtest SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
 SELECT get_ao_compression_ratio('zstdtest');
  get_ao_compression_ratio 
 --------------------------
-                     2.62
+                     2.66
 (1 row)
 
 -- Check contents, at the beginning of the table and at the end.


### PR DESCRIPTION
We need to run regression tests for each our commit/PR.
I think it is a good idea to use Pivotal scripts to achieve
this target because we don't want to support our separate
pipelines.
But concourse scripts are quite tight with the Pivotal build process.
They use tarballs with proprietary components like quicklz library 
during the build process. So I suggest:

* disable python vendoring. We use gpdb with system python in production
* remove steps which required proprietary quicklz library
* provide build dependencies in the build environment (sigar, libuv)
* use actual zstd library which provides higher compress ratio

Obviously, we will periodically get conflicts when we merge upstream changes.