### PR TITLE
[Backport to ADB-5.x] Fix computing of final agg GROUPING value for not distributed queries

### DIFF
--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -933,11 +933,6 @@ typedef struct Agg
 	 * The GROUPING value of input tuples for Agg(a,b,c) is 0, and the values
 	 * for Agg(a,b), Agg(a), Agg() are 0, 1, 3, respectively.
 	 *
-	 * We also use the value "-1" to indicate an Agg node is the final
-	 * one that brings back all rollup results from different segments. This final
-	 * Agg node is very similar to the non-rollup Agg node, except that we need
-	 * a way to know this to properly set GROUPING value during execution.
-	 *
 	 * For a non-rollup Agg node, this value is 0.
 	 */
 	uint64 inputGrouping;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6076,7 +6076,7 @@ select x,y,count(*), grouping(x), grouping(y),grouping(x,y) from generate_series
 ---+---+-------+----------+----------+----------
  1 | 1 |     1 |        0 |        0 |        0
    | 1 |     1 |        1 |        0 |        2
-   |   |     1 |        1 |        0 |        2
+   |   |     1 |        1 |        1 |        3
  1 |   |     1 |        0 |        1 |        1
 (4 rows)
 
@@ -6085,7 +6085,7 @@ select x,y,count(*), grouping(x,y) from generate_series(1,1) x, generate_series(
 ---+---+-------+----------
  1 | 1 |     1 |        0
    | 1 |     1 |        2
-   |   |     1 |        2
+   |   |     1 |        3
  1 |   |     1 |        1
 (4 rows)
 
@@ -6098,7 +6098,7 @@ select x,y,count(*), grouping(x,y) from generate_series(1,2) x, generate_series(
  1 | 2 |     1 |        0
  2 | 2 |     1 |        0
    | 2 |     2 |        2
-   |   |     4 |        2
+   |   |     4 |        3
  1 |   |     2 |        1
  2 |   |     2 |        1
 (9 rows)


### PR DESCRIPTION
Backport from ADBDEV-1103, commit cf3e46d