### PR TITLE
ADBDEV-246 Fix gpexpand to deal with database, schema, table with special char

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1992,9 +1992,9 @@ Set PGDATABASE or use the -D option to specify the correct database to use.""" %
             all other table types.
         """
 
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(n.nspname) || '.' || quote_ident(c.relname))"
+        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(c.oid)"
         sql = """SELECT
-    n.nspname || '.' || c.relname as fq_name,
+    pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) as fq_name,
     n.oid as schemaoid,
     c.oid as tableoid,
     p.attrnums as distribution_policy,
@@ -2041,7 +2041,7 @@ WHERE
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
                 fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, schema_oid, table_oid,
+                    dbname.replace('\\', '\\\\'), fqname.replace('\\', '\\\\'), schema_oid, table_oid,
                     dist_policy, policy_name, policy_oids,
                     rank, undone_status, rel_bytes))
         except Exception, e:
@@ -2064,10 +2064,10 @@ WHERE
 
     def _populate_partitioned_tables(self, dbname):
         """population of status_detail for partitioned tables. """
-        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(quote_ident(p.partitionschemaname) || '.' || quote_ident(p.partitiontablename))"
+        src_bytes_str = "0" if self.options.simple_progress else "pg_relation_size(c2.oid)"
         sql = """
 SELECT
-    p.partitionschemaname || '.' || p.partitiontablename as fq_name,
+    pg_catalog.quote_ident(p.partitionschemaname) || '.' || pg_catalog.quote_ident(p.partitiontablename) as fq_name,
     n.oid as schemaoid,
     c2.oid as tableoid,
     d.attrnums as distributed_policy,
@@ -2123,7 +2123,7 @@ ORDER BY tablename, c2.oid desc;
                 rank = 1 if self.unique_index_tables.has_key(full_name) else 2
 
                 fp.write("""%s\t%s\t%s\t%s\t%s\t%s\t%s\tNULL\t%d\t%s\tNULL\tNULL\t%d\n""" % (
-                    dbname, fqname, schema_oid, table_oid,
+                    dbname.replace('\\', '\\\\'), fqname.replace('\\', '\\\\'), schema_oid, table_oid,
                     dist_policy, policy_name, policy_oids,
                     rank, undone_status, rel_bytes))
         except Exception:
@@ -2532,7 +2532,7 @@ class ExpandTable():
                             VALUES ('%s','%s',%s,%s,
                                     '%s','%s','%s','%s',%d,'%s','%s','%s',%d)
                     """ % (gpexpand_schema, status_detail_table,
-                           self.dbname, self.fq_name, self.schema_oid, self.table_oid,
+                           self.dbname.replace("'", "''"), self.fq_name.replace("'", "''"), self.schema_oid, self.table_oid,
                            self.distrib_policy, self.distrib_policy_names, self.distrib_policy_coloids,
                            self.storage_options, self.rank, self.status,
                            self.expansion_started, self.expansion_finished,
@@ -2544,8 +2544,7 @@ class ExpandTable():
     def mark_started(self, status_conn, table_conn, start_time, cancel_flag):
         if cancel_flag:
             return
-        (schema_name, table_name) = self.fq_name.split('.')
-        sql = "SELECT pg_relation_size(quote_ident('%s') || '.' || quote_ident('%s'))" % (schema_name, table_name)
+        sql = "SELECT pg_relation_size(%s)" % (self.table_oid)
         cursor = dbconn.execSQL(table_conn, sql)
         row = cursor.fetchone()
         src_bytes = int(row[0])
@@ -2557,7 +2556,7 @@ class ExpandTable():
                   WHERE dbname = '%s' AND schema_oid = %s
                         AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
                                                   start_status, start_time,
-                                                  src_bytes, self.dbname,
+                                                  src_bytes, self.dbname.replace("'", "''"),
                                                   self.schema_oid, self.table_oid)
 
         logger.debug("Mark Started: " + sql.decode('utf-8'))
@@ -2569,7 +2568,7 @@ class ExpandTable():
                  SET status = '%s', expansion_started=NULL, expansion_finished=NULL
                  WHERE dbname = '%s' AND schema_oid = %s
                  AND table_oid = %s """ % (gpexpand_schema, status_detail_table, undone_status,
-                                           self.dbname, self.schema_oid, self.table_oid)
+                                           self.dbname.replace("'", "''"), self.schema_oid, self.table_oid)
 
         logger.debug('Reseting detailed_status: %s' % sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
@@ -2581,20 +2580,19 @@ class ExpandTable():
         if self.storage_options:
             new_storage_options = ',' + self.storage_options
 
-        (schema_name, table_name) = self.fq_name.split('.')
 
         logger.info("Distribution policy for table %s is '%s' " % (self.fq_name.decode('utf-8'), foo.decode('utf-8')))
         # logger.info("Storage options for table %s is %s" % (self.fq_name, self.storage_options))
 
         if foo == "" or foo == "None" or foo is None:
-            sql = 'ALTER TABLE ONLY "%s"."%s" SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED RANDOMLY' % (
-                schema_name, table_name, new_storage_options)
+            sql = 'ALTER TABLE ONLY %s SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED RANDOMLY' % (
+                self.fq_name, new_storage_options)
         else:
             dist_cols = foo.split(',')
             dist_cols = ['"%s"' % x.strip() for x in dist_cols]
             dist_cols = ','.join(dist_cols)
-            sql = 'ALTER TABLE ONLY "%s"."%s" SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED BY (%s)' % (
-                schema_name, table_name, new_storage_options, dist_cols)
+            sql = 'ALTER TABLE ONLY %s SET WITH(REORGANIZE=TRUE%s) DISTRIBUTED BY (%s)' % (
+                self.fq_name, new_storage_options, dist_cols)
 
         logger.info('Expanding %s.%s' % (self.dbname.decode('utf-8'), self.fq_name.decode('utf-8')))
         logger.debug("Expand SQL: %s" % sql.decode('utf-8'))
@@ -2604,8 +2602,8 @@ class ExpandTable():
             dbconn.execSQL(table_conn, sql)
             table_conn.commit()
             if self.options.analyze:
-                sql = 'ANALYZE "%s"."%s"' % (schema_name, table_name)
-                logger.info('Analyzing %s.%s' % (schema_name.decode('utf-8'), table_name.decode('utf-8')))
+                sql = 'ANALYZE %s' % (self.fq_name)
+                logger.info('Analyzing %s' % (self.fq_name.decode('utf-8')))
                 dbconn.execSQL(table_conn, sql)
                 table_conn.commit()
 
@@ -2620,7 +2618,7 @@ class ExpandTable():
                   WHERE dbname = '%s' AND schema_oid = %s
                   AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
                                             done_status, start_time, finish_time,
-                                            self.dbname, self.schema_oid, self.table_oid)
+                                            self.dbname.replace("'", "''") , self.schema_oid, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
@@ -2631,7 +2629,7 @@ class ExpandTable():
                   WHERE dbname = '%s' AND schema_oid = %s
                   AND table_oid = %s """ % (gpexpand_schema, status_detail_table,
                                             does_not_exist_status, finish_time,
-                                            self.dbname, self.schema_oid, self.table_oid)
+                                            self.dbname.replace("'", "''"), self.schema_oid, self.table_oid)
         logger.debug(sql.decode('utf-8'))
         dbconn.execSQL(status_conn, sql)
         status_conn.commit()
@@ -2766,16 +2764,13 @@ class ExpandCommand(SQLCommand):
         # validate table hasn't been dropped
         start_time = None
         try:
-            (schema_name, table_name) = self.table.fq_name.split('.')
-            sql = """select * from pg_class c, pg_namespace n
-            where c.relname = '%s' and n.oid = c.relnamespace and n.nspname='%s'""" % (table_name, schema_name)
+            sql = """select * from pg_class c where c.oid = %d """ % (self.table.table_oid)
 
             cursor = dbconn.execSQL(table_conn, sql)
 
             if cursor.rowcount == 0:
-                logger.info('%s.%s no longer exists in database %s' % (schema_name.decode('utf-8'),
-                                                                       table_name.decode('utf-8'),
-                                                                       self.table.dbname.decode('utf-8')))
+                logger.info('%s no longer exists in database %s' % (self.table.fq_name.decode('utf-8'),
+                                                                    self.table.dbname.decode('utf-8')))
 
                 self.table.mark_does_not_exist(status_conn, datetime.datetime.now())
                 status_conn.close()

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -189,3 +189,24 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand with the latest gpexpand_inputfile
         Then gpexpand should return a return code of 0
         And verify that the cluster has 14 new segments
+
+    @gpexpand_no_mirrors
+    @gpexpand_with_special_character
+    Scenario: create database,schema,table with special character
+        Given a working directory of the test as '/tmp/gpexpand_behave'
+        And the database is killed on hosts "mdw,sdw1"
+        And the user runs command "rm -rf /tmp/gpexpand_behave/*"
+        And a temporary directory to expand into
+        And the database is not running
+        And a cluster is created with no mirrors on "mdw" and "sdw1"
+        And database "gptest" exists
+        And create database schema table with special character
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "mdw,sdw1"
+        And the number of segments have been saved
+        And the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        When the user runs gpexpand with the latest gpexpand_inputfile
+        Then gpexpand should return a return code of 0
+        And verify that the cluster has 1 new segments
+        When the user runs gpexpand to redistribute
+        Then the tables have finished expanding

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -5786,6 +5786,17 @@ def impl(context):
 
         return
 
+@then('the tables have finished expanding')
+def impl(context):
+    dbname = 'gptest'
+    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        query = """select fq_name from gpexpand.status_detail WHERE expansion_finished IS NULL"""
+        cursor = dbconn.execSQL(conn, query)
+
+        row = cursor.fetchone()
+        if row:
+            raise Exception("table %s has not finished expanding" % row[0])
+
 @given('an FTS probe is triggered')
 def impl(context):
     with dbconn.connect(dbconn.DbURL(dbname='postgres')) as conn:
@@ -5875,3 +5886,51 @@ def step_impl(context):
     run_command(context, cmd)
 
     wait_for_unblocked_transactions(context)
+
+@given('create database schema table with special character')
+@then('create database schema table with special character')
+def impl(context):
+    dbname = ' a b."\'\\\\'
+    escape_dbname = dbname.replace('\\', '\\\\').replace('"', '\\"')
+    createdb_cmd = "createdb \"%s\"" % escape_dbname
+    run_command(context, createdb_cmd)
+
+    with dbconn.connect(dbconn.DbURL(dbname=dbname)) as conn:
+        #special char table
+        query = 'create table " a b.""\'\\\\"(c1 int);'
+        dbconn.execSQL(conn, query)
+        query = 'create schema " a b.""\'\\\\";'
+        dbconn.execSQL(conn, query)
+        #special char schema and table
+        query = 'create table " a b.""\'\\\\"." a b.""\'\\\\"(c1 int);'
+        dbconn.execSQL(conn, query)
+
+        #special char partition table
+        query = """
+CREATE TABLE \" a b.'\"\"\\\\\" (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+  SUBPARTITION BY RANGE (month)
+    SUBPARTITION TEMPLATE (
+       START (1) END (13) EVERY (4),
+       DEFAULT SUBPARTITION other_months )
+( START (2008) END (2016) EVERY (1),
+  DEFAULT PARTITION outlying_years);
+"""
+        dbconn.execSQL(conn, query)
+        #special char schema and partition table
+        query = """
+CREATE TABLE \" a b.\"\"'\\\\\".\" a b.'\"\"\\\\\" (id int, year int, month int, day int,
+region text)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+  SUBPARTITION BY RANGE (month)
+    SUBPARTITION TEMPLATE (
+       START (1) END (13) EVERY (4),
+       DEFAULT SUBPARTITION other_months )
+( START (2008) END (2016) EVERY (1),
+  DEFAULT PARTITION outlying_years);
+"""
+        dbconn.execSQL(conn, query)
+        conn.commit()

--- a/gpMgmt/test/behave_utils/cluster_expand.py
+++ b/gpMgmt/test/behave_utils/cluster_expand.py
@@ -81,7 +81,7 @@ class Gpexpand:
         else:
             flags = ""
 
-        run_gpcommand(self.context, "gpexpand %s" % flags)
+        run_gpcommand(self.context, "gpexpand -D %s %s" % (self.database, flags))
 
 
 if __name__ == '__main__':

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -489,7 +489,7 @@ pg_relation_size_oid(PG_FUNCTION_ARGS)
 
 		initStringInfo(&buffer);
 
-		appendStringInfo(&buffer, "select sum(pg_relation_size('%s.%s'))::int8 from gp_dist_random('gp_id');", quote_identifier(schemaName), quote_identifier(relName));
+		appendStringInfo(&buffer, "select sum(pg_relation_size(%u))::int8 from gp_dist_random('gp_id');", relOid);
 
 		size += get_size_from_segDBs(buffer.data);
 	}


### PR DESCRIPTION
Currently gpexpand fails when a provided database, schema or table name
contains a special character. This PR is a partitial backport of
multiple commits: a490e50f and cc0bf0ab.
Along with a test from the second commit, these changes also contain some
necessary behave tests improvements (already present in 6x).

To run behave tests see [comment](https://arenadata.atlassian.net/browse/ADBDEV-1170?focusedCommentId=17995)