### PR TITLE
Revalidate plan in SPI taking params into account

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1128,7 +1128,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	/*
 	 * Prepare to copy stuff into the portal's memory context.  We do all this
 	 * copying first, because it could possibly fail (out-of-memory) and we
-	 * don't want a failure to occur between RevalidateCachedPlan and
+	 * don't want a failure to occur between RevalidateCachedPlanWithParams and
 	 * PortalDefineQuery; that would result in leaking our plancache refcount.
 	 */
 	oldcontext = MemoryContextSwitchTo(PortalGetHeapMemory(portal));
@@ -1178,7 +1178,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	if (plan->saved)
 	{
 		/* Replan if needed, and increment plan refcount for portal */
-		cplan = RevalidateCachedPlan(plansource, false);
+		cplan = RevalidateCachedPlanWithParams(plansource, false, paramLI, NULL);
 		stmt_list = cplan->stmt_list;
 	}
 	else
@@ -1242,8 +1242,8 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	 * If told to be read-only, we'd better check for read-only queries. This
 	 * can't be done earlier because we need to look at the finished, planned
 	 * queries.  (In particular, we don't want to do it between
-	 * RevalidateCachedPlan and PortalDefineQuery, because throwing an error
-	 * between those steps would result in leaking our plancache refcount.)
+	 * RevalidateCachedPlanWithParams and PortalDefineQuery, because throwing an
+	 * error between those steps would result in leaking our plancache refcount.)
 	 */
 	if (read_only)
 	{
@@ -1415,7 +1415,6 @@ bool
 SPI_is_cursor_plan(SPIPlanPtr plan)
 {
 	CachedPlanSource *plansource;
-	CachedPlan *cplan;
 
 	if (plan == NULL || plan->magic != _SPI_PLAN_MAGIC)
 	{
@@ -1430,19 +1429,6 @@ SPI_is_cursor_plan(SPIPlanPtr plan)
 	}
 	plansource = (CachedPlanSource *) linitial(plan->plancache_list);
 
-	/* Need _SPI_begin_call in case replanning invokes SPI-using functions */
-	SPI_result = _SPI_begin_call(false);
-	if (SPI_result < 0)
-		return false;
-
-	if (plan->saved)
-	{
-		/* Make sure the plan is up to date */
-		cplan = RevalidateCachedPlan(plansource, true);
-		ReleaseCachedPlan(cplan, true);
-	}
-
-	_SPI_end_call(false);
 	SPI_result = 0;
 
 	/* Does it return tuples? */
@@ -1810,7 +1796,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			if (plan->saved)
 			{
 				/* Replan if needed, and increment plan refcount locally */
-				cplan = RevalidateCachedPlan(plansource, true);
+				cplan = RevalidateCachedPlanWithParams(plansource, true, paramLI, NULL);
 				stmt_list = cplan->stmt_list;
 			}
 			else

--- a/src/test/regress/expected/plpgsql_cache.out
+++ b/src/test/regress/expected/plpgsql_cache.out
@@ -787,3 +787,63 @@ select cache_test(t) from cache_tab;
 
 drop function get_dummy_string(text);
 drop function cache_test(text);
+-- ************************************************************
+-- * Test partition elimination inside plpgsql
+-- ************************************************************
+drop table if exists t_part;
+NOTICE:  table "t_part" does not exist, skipping
+create table t_part (a date, b int) distributed by (b)
+partition by range (a)
+(start ('2019-01-01') end ('2020-01-01') every (interval '1 month'));
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_1" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_2" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_3" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_4" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_5" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_6" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_7" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_8" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_9" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_10" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_11" for table "t_part"
+NOTICE:  CREATE TABLE will create partition "t_part_1_prt_12" for table "t_part"
+-- f_pe() is a plpgsql function, so its internal expression is planned
+-- and executed via SPI. A plan for the expression would be generated
+-- twice.
+-- 1. General plan without any parameters in predicate. It produces a
+--    seqscan for all 12 partitions.
+-- 2. Revalidated plan with a parameter in predicate, eliminating
+--    partitions (plan contains exactly 1 partition seqscan).
+-- So, the total printed seqscans with `debug_print_plan` is 13.
+create or replace function f_pe(d date)
+returns void as $$
+begin
+	perform * from t_part where a = d;
+end;
+$$ language plpgsql
+	set optimizer = off
+	set client_min_messages = debug1
+	set debug_print_plan = on
+	set debug_pretty_print = on;
+-- start_ignore
+create language plpythonu;
+-- end_ignore
+create or replace function f_plan(db text)
+returns text as $$
+import subprocess
+cmd = '''psql %s -c "select f_pe('2019-11-17')"''' % (db,)
+cmd_output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
+return cmd_output.stdout.read()
+$$ language plpythonu;
+-- Expect to have 13 seqscans: 12 from the first general without partition elimination
+-- and 1 from the final revalidated plan.
+select count(*) from regexp_matches(f_plan(current_database()), 'SEQSCAN', 'g');
+ count 
+-------
+    13
+(1 row)
+
+reset optimizer;
+drop function if exists f_pe(date);
+drop function if exists f_plan(text);
+drop table if exists t_part;


### PR DESCRIPTION
The problem was detected when we found out that partition
elimination didn't work inside plpgsql functions. The root of
the problem was in SPI exec_run_select() call (used by plpgsql
to evaluate SQL queries). It reevaluated the plan for prepared
queries (that is how plpqsql works with parameters) but didn't
take parameters into account - only cached plan. GPDB 6X_STABLE
uses both cached plan and parameter to reevaluated the plan. This
commit synchronizes behavior with 6X_STABLE.