### PR TITLE
ADBDEV-1153

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -96,6 +96,7 @@ static void
 libpqrcv_connect(char *conninfo)
 {
 	char		conninfo_repl[MAXCONNINFO + 75];
+	PostgresPollingStatusType status;
 
 	/*
 	 * Connect using deliberately undocumented parameter: replication. The
@@ -106,7 +107,45 @@ libpqrcv_connect(char *conninfo)
 			 "%s dbname=replication replication=true fallback_application_name=walreceiver",
 			 conninfo);
 
-	streamConn = PQconnectdb(conninfo_repl);
+	streamConn =  PQconnectStart(conninfo_repl);
+	if (PQstatus(streamConn) == CONNECTION_BAD)
+		ereport(ERROR,
+				(errmsg("could not connect to the primary server: %s",
+						PQerrorMessage(streamConn))));
+
+	/*
+	 * Poll connection until we have OK or FAILED status.
+	 *
+	 * Per spec for PQconnectPoll, first wait till socket is write-ready.
+	 */
+	status = PGRES_POLLING_WRITING;
+	do
+	{
+		int			io_flag;
+		int			rc;
+
+		if (status == PGRES_POLLING_READING)
+			io_flag = WL_SOCKET_READABLE;
+		else
+			io_flag = WL_SOCKET_WRITEABLE;
+
+		rc = WaitLatchOrSocket(&MyProc->procLatch,
+							   WL_POSTMASTER_DEATH | WL_LATCH_SET | io_flag,
+							   PQsocket(streamConn),
+							   0);
+
+		/* Interrupted? */
+		if (rc & WL_LATCH_SET)
+		{
+			ResetLatch(&MyProc->procLatch);
+			ProcessWalRcvInterrupts();
+		}
+
+		/* If socket is ready, advance the libpq state machine */
+		if (rc & io_flag)
+			status = PQconnectPoll(streamConn);
+	} while (status != PGRES_POLLING_OK && status != PGRES_POLLING_FAILED);
+
 	if (PQstatus(streamConn) != CONNECTION_OK)
 		ereport(ERROR,
 				(errmsg("could not connect to the primary server: %s",

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -56,6 +56,7 @@
 #include "replication/walsender.h"
 #include "storage/ipc.h"
 #include "storage/pmsignal.h"
+#include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/guc.h"
 #include "utils/ps_status.h"
@@ -240,12 +241,12 @@ WalReceiverMain(void)
 	walrcv->lastMsgSendTime =
 		walrcv->lastMsgReceiptTime = walrcv->latestWalEndTime = now;
 
+	walrcv->latch = &MyProc->procLatch;
+
 	SpinLockRelease(&walrcv->mutex);
 
 	/* Arrange to clean up at walreceiver exit */
 	on_shmem_exit(WalRcvDie, 0);
-
-	OwnLatch(&walrcv->latch);
 
 	/*
 	 * If possible, make this process a group leader, so that the postmaster
@@ -609,7 +610,7 @@ WalRcvWaitForStartPosition(XLogRecPtr *startpoint, TimeLineID *startpointTLI)
 	WakeupRecovery();
 	for (;;)
 	{
-		ResetLatch(&walrcv->latch);
+		ResetLatch(walrcv->latch);
 
 		/*
 		 * Emergency bailout if postmaster has died.  This is to avoid the
@@ -644,7 +645,7 @@ WalRcvWaitForStartPosition(XLogRecPtr *startpoint, TimeLineID *startpointTLI)
 		}
 		SpinLockRelease(&walrcv->mutex);
 
-		WaitLatch(&walrcv->latch, WL_LATCH_SET | WL_POSTMASTER_DEATH, 0);
+		WaitLatch(walrcv->latch, WL_LATCH_SET | WL_POSTMASTER_DEATH, 0);
 	}
 
 	if (update_process_title)
@@ -718,8 +719,6 @@ WalRcvDie(int code, Datum arg)
 	/* Ensure that all WAL records received are flushed to disk */
 	XLogWalRcvFlush(true);
 
-	DisownLatch(&walrcv->latch);
-
 	SpinLockAcquire(&walrcv->mutex);
 	Assert(walrcv->walRcvState == WALRCV_STREAMING ||
 		   walrcv->walRcvState == WALRCV_RESTARTING ||
@@ -729,6 +728,7 @@ WalRcvDie(int code, Datum arg)
 	Assert(walrcv->pid == MyProcPid);
 	walrcv->walRcvState = WALRCV_STOPPED;
 	walrcv->pid = 0;
+	walrcv->latch = NULL;
 	SpinLockRelease(&walrcv->mutex);
 
 	/* Terminate the connection gracefully. */
@@ -765,7 +765,7 @@ WalRcvShutdownHandler(SIGNAL_ARGS)
 
 	got_SIGTERM = true;
 
-	SetLatch(&WalRcv->latch);
+	SetLatch(&MyProc->procLatch);
 
 	errno = save_errno;
 }

--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -65,7 +65,7 @@ WalRcvShmemInit(void)
 		MemSet(WalRcv, 0, WalRcvShmemSize());
 		WalRcv->walRcvState = WALRCV_STOPPED;
 		SpinLockInit(&WalRcv->mutex);
-		InitSharedLatch(&WalRcv->latch);
+		WalRcv->latch = NULL;
 	}
 }
 
@@ -247,6 +247,7 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	volatile WalRcvData *walrcv = WalRcv;
 	bool		launch = false;
 	pg_time_t	now = (pg_time_t) time(NULL);
+	Latch	   *latch;
 
 	/*
 	 * We always start at the beginning of the segment. That prevents a broken
@@ -295,12 +296,14 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	walrcv->receiveStart = recptr;
 	walrcv->receiveStartTLI = tli;
 
+	latch = walrcv->latch;
+
 	SpinLockRelease(&walrcv->mutex);
 
 	if (launch)
 		SendPostmasterSignal(PMSIGNAL_START_WALRECEIVER);
-	else
-		SetLatch(&walrcv->latch);
+	else if (latch)
+		SetLatch(latch);
 }
 
 /*

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -109,14 +109,14 @@ typedef struct
 	 */
 	char		slotname[NAMEDATALEN];
 
-	slock_t		mutex;			/* locks shared variables shown above */
-
 	/*
 	 * Latch used by startup process to wake up walreceiver after telling it
-	 * where to start streaming (after setting receiveStart and
-	 * receiveStartTLI).
+	 * where to start streaming (after setting receiveStart and receiveStartTLI).
+	 * This is normally mapped to procLatch when walreceiver is running.
 	 */
-	Latch		latch;
+	Latch		*latch;
+
+	slock_t		mutex;			/* locks shared variables shown above */
 } WalRcvData;
 
 extern WalRcvData *WalRcv;

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -1,8 +1,8 @@
 -- negative cases
 SELECT test_receive();
-ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:561)
+ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:600)
 SELECT test_send();
-ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:580)
+ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:619)
 SELECT test_disconnect();
  test_disconnect 
 -----------------


### PR DESCRIPTION
When the master host becomes unavailable, walreceiver is trying to open a connection with the master. After an unsuccessful attempt, it dies and reborns again. 

During the attempt, the system call poll() (or select) is called, where walreceiver is for a long time (on my cluster about 2 minutes).

When we call gpactivatestandby, the promote signal is sent. postmaster tries to stop the walreceiver and sends a `SIGTERM` to it. `SIGTERM` doesn't stop `poll()`. After the signals have arrived the `poll()` continues its work. You can check this by looking 
at the `pqSocketCheck` function in the `fe-misc.c` file. 

gpactivatestandby tries to connect to new master and by making 50 attempts in 50 seconds. If the connection fails, this error is displayed
```
[CRITICAL]:-Error activating standby master: Either the set port is incorrect or the postmaster could not come up.
```
Since `poll()` may run for several minutes, gpactivatestandby may never connect to the new master.
  
To fix this, we fixed the `libpqrcv_connect` function. The implementation logic is taken from newer versions of postgres.

Here's an stack trace for walreceiver's `poll()` call: 
```
#0  0x00007f0778556a20 in __poll_nocancel () from /lib64/libc.so.6
#1  0x000000000093957d in pqSocketPoll (end_time=-1, forWrite=0, forRead=0, sock=<optimized out>) at fe-misc.c:1236
#2  pqSocketCheck (conn=conn@entry=0x36a9590, forRead=forRead@entry=0, forWrite=forWrite@entry=1, end_time=end_time@entry=-1) at fe-misc.c:1178
#3  0x000000000093aa90 in pqWaitTimed (forRead=forRead@entry=0, forWrite=forWrite@entry=1, conn=conn@entry=0x36a9590, finish_time=finish_time@entry=-1)
    at fe-misc.c:1088
#4  0x000000000092ee35 in connectDBComplete (conn=0x36a9590) at fe-connect.c:1745
#5  0x000000000092fb4c in PQconnectdb (
    conninfo=conninfo@entry=0x7fff104d03e0 "user=gpadmin host=10.92.6.102 port=5432 sslmode=prefer sslcompression=1 krbsrvname=postgres application_name=gp_walreceiver dbname=replication replication=true fallback_application_name=walreceiver") at fe-connect.c:686
#6  0x0000000000a4abf6 in libpqrcv_connect (conninfo=<optimized out>) at libpqwalreceiver/libpqwalreceiver.c:109
#7  0x0000000000a40152 in WalReceiverMain () at walreceiver.c:326
#8  0x000000000079c792 in AuxiliaryProcessMain (argc=argc@entry=2, argv=argv@entry=0x7fff104d0e90) at bootstrap.c:459
#9  0x0000000000a1290d in StartChildProcess (type=WalReceiverProcess) at postmaster.c:5832
#10 MaybeStartWalReceiver () at postmaster.c:5987
#11 0x00000000006cc109 in ServerLoop () at postmaster.c:2017
#12 0x0000000000a15d17 in PostmasterMain (argc=argc@entry=6, argv=argv@entry=0x36870d0) at postmaster.c:1518
#13 0x00000000006d167b in main (argc=6, argv=0x36870d0) at main.c:245
```