### PR TITLE
GPORCA: Fix cardinality estimation for plan nodes with predicates of the form: date_attribute = constant_value

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -2234,7 +2234,8 @@ CTranslatorScalarToDXL::ExtractLintValueFromDatum(const IMDType *md_type,
 		return lint_value;
 	}
 
-	if (mdid->Equals(&CMDIdGPDB::m_mdid_cash))
+	if (mdid->Equals(&CMDIdGPDB::m_mdid_cash) ||
+		mdid->Equals(&CMDIdGPDB::m_mdid_date))
 	{
 		// cash is a pass-by-ref type
 		Datum datumConstVal = (Datum) 0;

--- a/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
+++ b/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
@@ -402,34 +402,34 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.33051926.1.1.3" Name="i_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.666007" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166502" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166502" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.33051926.1.1.2" Name="i_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.499505" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166502" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166502" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166502" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:RelationStatistics Mdid="2.33052616.1.1" Name="store_sales" Rows="2880377.000000" EmptyRelation="false"/>

--- a/src/backend/gporca/data/dxl/minidump/106-way-join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/106-way-join.mdp
@@ -903,598 +903,598 @@ group by	pa11.dcal_month_id,
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.40" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.33" Name="dcal_pay_period_to" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.017801" DistinctValues="58.783817">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZnH//w==" DoubleValue="-3154118400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oHT//w==" DoubleValue="-3082752000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZnH//w==" LintValue="-36506"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oHT//w==" LintValue="-35680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oHT//w==" DoubleValue="-3082752000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oHT//w==" DoubleValue="-3082752000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oHT//w==" LintValue="-35680"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oHT//w==" LintValue="-35680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021724" DistinctValues="71.736183">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oHT//w==" DoubleValue="-3082752000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kHj//w==" DoubleValue="-2995660800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oHT//w==" LintValue="-35680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kHj//w==" LintValue="-34672"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008470" DistinctValues="27.754286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kHj//w==" DoubleValue="-2995660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cnr//w==" DoubleValue="-2963001600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kHj//w==" LintValue="-34672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cnr//w==" LintValue="-34294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cnr//w==" DoubleValue="-2963001600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cnr//w==" DoubleValue="-2963001600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cnr//w==" LintValue="-34294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cnr//w==" LintValue="-34294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025095" DistinctValues="82.234921">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cnr//w==" DoubleValue="-2963001600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="an7//w==" DoubleValue="-2866233600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cnr//w==" LintValue="-34294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="an7//w==" LintValue="-33174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="an7//w==" DoubleValue="-2866233600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="an7//w==" DoubleValue="-2866233600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="an7//w==" LintValue="-33174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="an7//w==" LintValue="-33174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005960" DistinctValues="19.530794">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="an7//w==" DoubleValue="-2866233600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dH///w==" DoubleValue="-2843251200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="an7//w==" LintValue="-33174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dH///w==" LintValue="-32908"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dH///w==" DoubleValue="-2843251200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nob//w==" DoubleValue="-2684793600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dH///w==" LintValue="-32908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nob//w==" LintValue="-31074"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nob//w==" DoubleValue="-2684793600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Do7//w==" DoubleValue="-2520288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nob//w==" LintValue="-31074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Do7//w==" LintValue="-29170"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016518" DistinctValues="54.545672">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Do7//w==" DoubleValue="-2520288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HpH//w==" DoubleValue="-2452550400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Do7//w==" LintValue="-29170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HpH//w==" LintValue="-28386"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HpH//w==" DoubleValue="-2452550400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HpH//w==" DoubleValue="-2452550400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HpH//w==" LintValue="-28386"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HpH//w==" LintValue="-28386"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="75.974328">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HpH//w==" DoubleValue="-2452550400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YpX//w==" DoubleValue="-2358201600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HpH//w==" LintValue="-28386"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YpX//w==" LintValue="-27294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011204" DistinctValues="36.997795">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YpX//w==" DoubleValue="-2358201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wpf//w==" DoubleValue="-2314656000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YpX//w==" LintValue="-27294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wpf//w==" LintValue="-26790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wpf//w==" DoubleValue="-2314656000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wpf//w==" DoubleValue="-2314656000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wpf//w==" LintValue="-26790"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wpf//w==" LintValue="-26790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028321" DistinctValues="93.522205">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wpf//w==" DoubleValue="-2314656000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VJz//w==" DoubleValue="-2204582400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wpf//w==" LintValue="-26790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VJz//w==" LintValue="-25516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000309" DistinctValues="1.011875">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VJz//w==" DoubleValue="-2204582400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ypz//w==" DoubleValue="-2203372800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VJz//w==" LintValue="-25516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ypz//w==" LintValue="-25502"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ypz//w==" DoubleValue="-2203372800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ypz//w==" DoubleValue="-2203372800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ypz//w==" LintValue="-25502"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ypz//w==" LintValue="-25502"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031496" DistinctValues="103.211250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ypz//w==" DoubleValue="-2203372800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9qH//w==" DoubleValue="-2079993600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ypz//w==" LintValue="-25502"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9qH//w==" LintValue="-24074"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9qH//w==" DoubleValue="-2079993600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9qH//w==" DoubleValue="-2079993600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9qH//w==" LintValue="-24074"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9qH//w==" LintValue="-24074"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007720" DistinctValues="25.296875">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9qH//w==" DoubleValue="-2079993600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VKP//w==" DoubleValue="-2049753600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9qH//w==" LintValue="-24074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VKP//w==" LintValue="-23724"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024323" DistinctValues="80.320000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VKP//w==" DoubleValue="-2049753600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tKf//w==" DoubleValue="-1952985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VKP//w==" LintValue="-23724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tKf//w==" LintValue="-22604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tKf//w==" DoubleValue="-1952985600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tKf//w==" DoubleValue="-1952985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tKf//w==" LintValue="-22604"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tKf//w==" LintValue="-22604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015202" DistinctValues="50.200000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tKf//w==" DoubleValue="-1952985600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cKr//w==" DoubleValue="-1892505600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tKf//w==" LintValue="-22604"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cKr//w==" LintValue="-21904"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009213" DistinctValues="29.955789">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cKr//w==" DoubleValue="-1892505600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iqz//w==" DoubleValue="-1855008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cKr//w==" LintValue="-21904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iqz//w==" LintValue="-21470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iqz//w==" DoubleValue="-1855008000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Iqz//w==" DoubleValue="-1855008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iqz//w==" LintValue="-21470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Iqz//w==" LintValue="-21470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002972" DistinctValues="9.663158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Iqz//w==" DoubleValue="-1855008000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rqz//w==" DoubleValue="-1842912000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Iqz//w==" LintValue="-21470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rqz//w==" LintValue="-21330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rqz//w==" DoubleValue="-1842912000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rqz//w==" DoubleValue="-1842912000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rqz//w==" LintValue="-21330"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rqz//w==" LintValue="-21330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011887" DistinctValues="38.652632">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rqz//w==" DoubleValue="-1842912000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3q7//w==" DoubleValue="-1794528000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rqz//w==" LintValue="-21330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3q7//w==" LintValue="-20770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3q7//w==" DoubleValue="-1794528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3q7//w==" DoubleValue="-1794528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3q7//w==" LintValue="-20770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3q7//w==" LintValue="-20770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015453" DistinctValues="50.248421">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3q7//w==" DoubleValue="-1794528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="trH//w==" DoubleValue="-1731628800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3q7//w==" LintValue="-20770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="trH//w==" LintValue="-20042"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006081" DistinctValues="19.926154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="trH//w==" DoubleValue="-1731628800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zrL//w==" DoubleValue="-1707436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="trH//w==" LintValue="-20042"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zrL//w==" LintValue="-19762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zrL//w==" DoubleValue="-1707436800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zrL//w==" DoubleValue="-1707436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zrL//w==" LintValue="-19762"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zrL//w==" LintValue="-19762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008209" DistinctValues="26.900308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zrL//w==" DoubleValue="-1707436800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SLT//w==" DoubleValue="-1674777600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zrL//w==" LintValue="-19762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SLT//w==" LintValue="-19384"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SLT//w==" DoubleValue="-1674777600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SLT//w==" DoubleValue="-1674777600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SLT//w==" LintValue="-19384"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SLT//w==" LintValue="-19384"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025235" DistinctValues="82.693538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SLT//w==" DoubleValue="-1674777600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0rj//w==" DoubleValue="-1574380800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SLT//w==" LintValue="-19384"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0rj//w==" LintValue="-18222"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035133" DistinctValues="116.017778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0rj//w==" DoubleValue="-1574380800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yr///w==" DoubleValue="-1429228800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0rj//w==" LintValue="-18222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yr///w==" LintValue="-16542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yr///w==" DoubleValue="-1429228800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yr///w==" DoubleValue="-1429228800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yr///w==" LintValue="-16542"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yr///w==" LintValue="-16542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004392" DistinctValues="14.502222">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yr///w==" DoubleValue="-1429228800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NMD//w==" DoubleValue="-1411084800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yr///w==" LintValue="-16542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NMD//w==" LintValue="-16332"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029568" DistinctValues="97.640916">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NMD//w==" DoubleValue="-1411084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kMX//w==" DoubleValue="-1292544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NMD//w==" LintValue="-16332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kMX//w==" LintValue="-14960"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kMX//w==" DoubleValue="-1292544000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kMX//w==" DoubleValue="-1292544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kMX//w==" LintValue="-14960"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kMX//w==" LintValue="-14960"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009957" DistinctValues="32.879084">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kMX//w==" DoubleValue="-1292544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xsf//w==" DoubleValue="-1252627200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kMX//w==" LintValue="-14960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xsf//w==" LintValue="-14498"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017292" DistinctValues="56.665000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xsf//w==" DoubleValue="-1252627200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bsr//w==" DoubleValue="-1184889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xsf//w==" LintValue="-14498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bsr//w==" LintValue="-13714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bsr//w==" DoubleValue="-1184889600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bsr//w==" DoubleValue="-1184889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bsr//w==" LintValue="-13714"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bsr//w==" LintValue="-13714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001235" DistinctValues="4.047500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bsr//w==" DoubleValue="-1184889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="psr//w==" DoubleValue="-1180051200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bsr//w==" LintValue="-13714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="psr//w==" LintValue="-13658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="psr//w==" DoubleValue="-1180051200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="psr//w==" DoubleValue="-1180051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="psr//w==" LintValue="-13658"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="psr//w==" LintValue="-13658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020998" DistinctValues="68.807500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="psr//w==" DoubleValue="-1180051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xs7//w==" DoubleValue="-1097798400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="psr//w==" LintValue="-13658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xs7//w==" LintValue="-12706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xs7//w==" DoubleValue="-1097798400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3NX//w==" DoubleValue="-932083200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xs7//w==" LintValue="-12706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3NX//w==" LintValue="-10788"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035364" DistinctValues="116.781053">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3NX//w==" DoubleValue="-932083200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xtz//w==" DoubleValue="-788140800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3NX//w==" LintValue="-10788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xtz//w==" LintValue="-9122"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xtz//w==" DoubleValue="-788140800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xtz//w==" DoubleValue="-788140800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xtz//w==" LintValue="-9122"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xtz//w==" LintValue="-9122"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004160" DistinctValues="13.738947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xtz//w==" DoubleValue="-788140800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="It3//w==" DoubleValue="-771206400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xtz//w==" LintValue="-9122"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="It3//w==" LintValue="-8926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003648" DistinctValues="11.863385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="It3//w==" DoubleValue="-771206400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yt3//w==" DoubleValue="-756691200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="It3//w==" LintValue="-8926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yt3//w==" LintValue="-8758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yt3//w==" DoubleValue="-756691200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yt3//w==" DoubleValue="-756691200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yt3//w==" LintValue="-8758"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yt3//w==" LintValue="-8758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001216" DistinctValues="3.954462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yt3//w==" DoubleValue="-756691200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="At7//w==" DoubleValue="-751852800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yt3//w==" LintValue="-8758"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="At7//w==" LintValue="-8702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="At7//w==" DoubleValue="-751852800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="At7//w==" DoubleValue="-751852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="At7//w==" LintValue="-8702"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="At7//w==" LintValue="-8702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033748" DistinctValues="109.736308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="At7//w==" DoubleValue="-751852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FOT//w==" DoubleValue="-617587200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="At7//w==" LintValue="-8702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FOT//w==" LintValue="-7148"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FOT//w==" DoubleValue="-617587200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FOT//w==" DoubleValue="-617587200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FOT//w==" LintValue="-7148"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FOT//w==" LintValue="-7148"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000912" DistinctValues="2.965846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FOT//w==" DoubleValue="-617587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PuT//w==" DoubleValue="-613958400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FOT//w==" LintValue="-7148"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PuT//w==" LintValue="-7106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027340" DistinctValues="90.284511">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PuT//w==" DoubleValue="-613958400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Run//w==" DoubleValue="-502675200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PuT//w==" LintValue="-7106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Run//w==" LintValue="-5818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Run//w==" DoubleValue="-502675200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Run//w==" DoubleValue="-502675200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Run//w==" LintValue="-5818"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Run//w==" LintValue="-5818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012184" DistinctValues="40.235489">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Run//w==" DoubleValue="-502675200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hOv//w==" DoubleValue="-453081600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Run//w==" LintValue="-5818"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hOv//w==" LintValue="-5244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hOv//w==" DoubleValue="-453081600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvL//w==" DoubleValue="-294624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hOv//w==" LintValue="-5244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvL//w==" LintValue="-3410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013074" DistinctValues="43.172000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvL//w==" DoubleValue="-294624000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CPX//w==" DoubleValue="-242611200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvL//w==" LintValue="-3410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CPX//w==" LintValue="-2808"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CPX//w==" DoubleValue="-242611200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CPX//w==" DoubleValue="-242611200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CPX//w==" LintValue="-2808"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CPX//w==" LintValue="-2808"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026451" DistinctValues="87.348000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="CPX//w==" DoubleValue="-242611200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="CPX//w==" LintValue="-2808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HgEAAA==" DoubleValue="24710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HgEAAA==" LintValue="286"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012370" DistinctValues="40.849771">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HgEAAA==" DoubleValue="24710400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XAMAAA==" DoubleValue="74304000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HgEAAA==" LintValue="286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XAMAAA==" LintValue="860"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XAMAAA==" DoubleValue="74304000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XAMAAA==" DoubleValue="74304000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XAMAAA==" LintValue="860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XAMAAA==" LintValue="860"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027154" DistinctValues="89.670229">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XAMAAA==" DoubleValue="74304000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SAgAAA==" DoubleValue="183168000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XAMAAA==" LintValue="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SAgAAA==" LintValue="2120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAgAAA==" DoubleValue="183168000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg8AAA==" DoubleValue="341625600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAgAAA==" LintValue="2120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg8AAA==" LintValue="3954"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg8AAA==" DoubleValue="341625600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jhYAAA==" DoubleValue="498873600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg8AAA==" LintValue="3954"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jhYAAA==" LintValue="5774"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jhYAAA==" DoubleValue="498873600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4h0AAA==" DoubleValue="660960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jhYAAA==" LintValue="5774"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4h0AAA==" LintValue="7650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4h0AAA==" DoubleValue="660960000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4h0AAA==" DoubleValue="660960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4h0AAA==" LintValue="7650"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4h0AAA==" LintValue="7650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="130.520000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4h0AAA==" DoubleValue="660960000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GiUAAA==" DoubleValue="820627200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4h0AAA==" LintValue="7650"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GiUAAA==" LintValue="9498"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.32" Name="dcal_pay_period_from" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.002112" DistinctValues="6.974351">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WXH//w==" DoubleValue="-3155241600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u3H//w==" DoubleValue="-3146774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WXH//w==" LintValue="-36519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u3H//w==" LintValue="-36421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u3H//w==" DoubleValue="-3146774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u3H//w==" DoubleValue="-3146774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u3H//w==" LintValue="-36421"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u3H//w==" LintValue="-36421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037413" DistinctValues="123.545649">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u3H//w==" DoubleValue="-3146774400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g3j//w==" DoubleValue="-2996784000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u3H//w==" LintValue="-36421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g3j//w==" LintValue="-34685"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008470" DistinctValues="27.754286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g3j//w==" DoubleValue="-2996784000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/Xn//w==" DoubleValue="-2964124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g3j//w==" LintValue="-34685"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/Xn//w==" LintValue="-34307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/Xn//w==" DoubleValue="-2964124800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/Xn//w==" DoubleValue="-2964124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/Xn//w==" LintValue="-34307"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/Xn//w==" LintValue="-34307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025095" DistinctValues="82.234921">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/Xn//w==" DoubleValue="-2964124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XX7//w==" DoubleValue="-2867356800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/Xn//w==" LintValue="-34307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XX7//w==" LintValue="-33187"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XX7//w==" DoubleValue="-2867356800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XX7//w==" DoubleValue="-2867356800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XX7//w==" LintValue="-33187"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XX7//w==" LintValue="-33187"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005960" DistinctValues="19.530794">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XX7//w==" DoubleValue="-2867356800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z3///w==" DoubleValue="-2844374400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XX7//w==" LintValue="-33187"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z3///w==" LintValue="-32921"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z3///w==" DoubleValue="-2844374400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kYb//w==" DoubleValue="-2685916800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z3///w==" LintValue="-32921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kYb//w==" LintValue="-31087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kYb//w==" DoubleValue="-2685916800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AY7//w==" DoubleValue="-2521411200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kYb//w==" LintValue="-31087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AY7//w==" LintValue="-29183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016518" DistinctValues="54.545672">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AY7//w==" DoubleValue="-2521411200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AY7//w==" LintValue="-29183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="75.974328">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VZX//w==" DoubleValue="-2359324800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VZX//w==" LintValue="-27307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009959" DistinctValues="32.634961">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VZX//w==" DoubleValue="-2359324800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FZf//w==" DoubleValue="-2320617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VZX//w==" LintValue="-27307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FZf//w==" LintValue="-26859"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FZf//w==" DoubleValue="-2320617600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FZf//w==" DoubleValue="-2320617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FZf//w==" LintValue="-26859"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FZf//w==" LintValue="-26859"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001245" DistinctValues="4.079370">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FZf//w==" DoubleValue="-2320617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TZf//w==" DoubleValue="-2315779200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FZf//w==" LintValue="-26859"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TZf//w==" LintValue="-26803"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TZf//w==" DoubleValue="-2315779200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TZf//w==" DoubleValue="-2315779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TZf//w==" LintValue="-26803"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TZf//w==" LintValue="-26803"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028321" DistinctValues="92.805669">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TZf//w==" DoubleValue="-2315779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R5z//w==" DoubleValue="-2205705600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TZf//w==" LintValue="-26803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R5z//w==" LintValue="-25529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000309" DistinctValues="1.011875">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R5z//w==" DoubleValue="-2205705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VZz//w==" DoubleValue="-2204496000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R5z//w==" LintValue="-25529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VZz//w==" LintValue="-25515"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VZz//w==" DoubleValue="-2204496000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VZz//w==" DoubleValue="-2204496000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VZz//w==" LintValue="-25515"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VZz//w==" LintValue="-25515"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031496" DistinctValues="103.211250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VZz//w==" DoubleValue="-2204496000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6aH//w==" DoubleValue="-2081116800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VZz//w==" LintValue="-25515"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6aH//w==" LintValue="-24087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6aH//w==" DoubleValue="-2081116800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6aH//w==" DoubleValue="-2081116800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6aH//w==" LintValue="-24087"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6aH//w==" LintValue="-24087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007720" DistinctValues="25.296875">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6aH//w==" DoubleValue="-2081116800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R6P//w==" DoubleValue="-2050876800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6aH//w==" LintValue="-24087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R6P//w==" LintValue="-23737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024323" DistinctValues="79.704615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R6P//w==" DoubleValue="-2050876800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p6f//w==" DoubleValue="-1954108800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R6P//w==" LintValue="-23737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p6f//w==" LintValue="-22617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p6f//w==" DoubleValue="-1954108800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p6f//w==" DoubleValue="-1954108800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p6f//w==" LintValue="-22617"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p6f//w==" LintValue="-22617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014898" DistinctValues="48.819077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p6f//w==" DoubleValue="-1954108800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Var//w==" DoubleValue="-1894838400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p6f//w==" LintValue="-22617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Var//w==" LintValue="-21931"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Var//w==" DoubleValue="-1894838400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Var//w==" DoubleValue="-1894838400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Var//w==" LintValue="-21931"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Var//w==" LintValue="-21931"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="0.996308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Var//w==" DoubleValue="-1894838400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y6r//w==" DoubleValue="-1893628800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Var//w==" LintValue="-21931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y6r//w==" LintValue="-21917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009213" DistinctValues="30.421955">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y6r//w==" DoubleValue="-1893628800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Faz//w==" DoubleValue="-1856131200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y6r//w==" LintValue="-21917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Faz//w==" LintValue="-21483"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Faz//w==" DoubleValue="-1856131200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Faz//w==" DoubleValue="-1856131200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Faz//w==" LintValue="-21483"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Faz//w==" LintValue="-21483"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030312" DistinctValues="100.098045">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Faz//w==" DoubleValue="-1856131200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qbH//w==" DoubleValue="-1732752000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Faz//w==" LintValue="-21483"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qbH//w==" LintValue="-20055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006081" DistinctValues="19.926154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qbH//w==" DoubleValue="-1732752000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wbL//w==" DoubleValue="-1708560000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qbH//w==" LintValue="-20055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wbL//w==" LintValue="-19775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wbL//w==" DoubleValue="-1708560000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wbL//w==" DoubleValue="-1708560000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wbL//w==" LintValue="-19775"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wbL//w==" LintValue="-19775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008209" DistinctValues="26.900308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wbL//w==" DoubleValue="-1708560000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O7T//w==" DoubleValue="-1675900800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wbL//w==" LintValue="-19775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O7T//w==" LintValue="-19397"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O7T//w==" DoubleValue="-1675900800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O7T//w==" DoubleValue="-1675900800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O7T//w==" LintValue="-19397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O7T//w==" LintValue="-19397"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025235" DistinctValues="82.693538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O7T//w==" DoubleValue="-1675900800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xbj//w==" DoubleValue="-1575504000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O7T//w==" LintValue="-19397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xbj//w==" LintValue="-18235"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xbj//w==" DoubleValue="-1575504000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J8D//w==" DoubleValue="-1412208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xbj//w==" LintValue="-18235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J8D//w==" LintValue="-16345"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J8D//w==" DoubleValue="-1412208000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ucf//w==" DoubleValue="-1253750400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J8D//w==" LintValue="-16345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ucf//w==" LintValue="-14511"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017292" DistinctValues="56.665000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ucf//w==" DoubleValue="-1253750400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ycr//w==" DoubleValue="-1186012800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ucf//w==" LintValue="-14511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ycr//w==" LintValue="-13727"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ycr//w==" DoubleValue="-1186012800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ycr//w==" DoubleValue="-1186012800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ycr//w==" LintValue="-13727"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ycr//w==" LintValue="-13727"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001235" DistinctValues="4.047500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ycr//w==" DoubleValue="-1186012800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mcr//w==" DoubleValue="-1181174400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ycr//w==" LintValue="-13727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mcr//w==" LintValue="-13671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mcr//w==" DoubleValue="-1181174400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mcr//w==" DoubleValue="-1181174400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mcr//w==" LintValue="-13671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mcr//w==" LintValue="-13671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020998" DistinctValues="68.807500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mcr//w==" DoubleValue="-1181174400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uc7//w==" DoubleValue="-1098921600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mcr//w==" LintValue="-13671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uc7//w==" LintValue="-12719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uc7//w==" DoubleValue="-1098921600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z9X//w==" DoubleValue="-933206400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uc7//w==" LintValue="-12719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z9X//w==" LintValue="-10801"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035364" DistinctValues="116.781053">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z9X//w==" DoubleValue="-933206400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Udz//w==" DoubleValue="-789264000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z9X//w==" LintValue="-10801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Udz//w==" LintValue="-9135"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Udz//w==" DoubleValue="-789264000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Udz//w==" DoubleValue="-789264000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Udz//w==" LintValue="-9135"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Udz//w==" LintValue="-9135"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004160" DistinctValues="13.738947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Udz//w==" DoubleValue="-789264000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fd3//w==" DoubleValue="-772329600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Udz//w==" LintValue="-9135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fd3//w==" LintValue="-8939"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004865" DistinctValues="16.064000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fd3//w==" DoubleValue="-772329600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9d3//w==" DoubleValue="-752976000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fd3//w==" LintValue="-8939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9d3//w==" LintValue="-8715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9d3//w==" DoubleValue="-752976000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9d3//w==" DoubleValue="-752976000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9d3//w==" LintValue="-8715"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9d3//w==" LintValue="-8715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034660" DistinctValues="114.456000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9d3//w==" DoubleValue="-752976000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MeT//w==" DoubleValue="-615081600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9d3//w==" LintValue="-8715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MeT//w==" LintValue="-7119"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027340" DistinctValues="90.284511">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MeT//w==" DoubleValue="-615081600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Oen//w==" DoubleValue="-503798400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MeT//w==" LintValue="-7119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Oen//w==" LintValue="-5831"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Oen//w==" DoubleValue="-503798400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Oen//w==" DoubleValue="-503798400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Oen//w==" LintValue="-5831"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Oen//w==" LintValue="-5831"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012184" DistinctValues="40.235489">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Oen//w==" DoubleValue="-503798400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d+v//w==" DoubleValue="-454204800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Oen//w==" LintValue="-5831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d+v//w==" LintValue="-5257"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d+v//w==" DoubleValue="-454204800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofL//w==" DoubleValue="-295747200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d+v//w==" LintValue="-5257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofL//w==" LintValue="-3423"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013074" DistinctValues="43.172000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofL//w==" DoubleValue="-295747200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/T//w==" DoubleValue="-243734400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofL//w==" LintValue="-3423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/T//w==" LintValue="-2821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/T//w==" DoubleValue="-243734400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/T//w==" DoubleValue="-243734400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/T//w==" LintValue="-2821"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/T//w==" LintValue="-2821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026451" DistinctValues="87.348000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+/T//w==" DoubleValue="-243734400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfn//w==" DoubleValue="-138499200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+/T//w==" LintValue="-2821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfn//w==" LintValue="-1603"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021827" DistinctValues="72.078209">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfn//w==" DoubleValue="-138499200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yf3//w==" DoubleValue="-48988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfn//w==" LintValue="-1603"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yf3//w==" LintValue="-567"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yf3//w==" DoubleValue="-48988800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yf3//w==" DoubleValue="-48988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yf3//w==" LintValue="-567"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yf3//w==" LintValue="-567"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017698" DistinctValues="58.441791">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yf3//w==" DoubleValue="-48988800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EQEAAA==" DoubleValue="23587200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yf3//w==" LintValue="-567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EQEAAA==" LintValue="273"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012370" DistinctValues="40.536794">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EQEAAA==" DoubleValue="23587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TwMAAA==" DoubleValue="73180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EQEAAA==" LintValue="273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TwMAAA==" LintValue="847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TwMAAA==" DoubleValue="73180800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TwMAAA==" DoubleValue="73180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TwMAAA==" LintValue="847"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TwMAAA==" LintValue="847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008448" DistinctValues="27.683664">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TwMAAA==" DoubleValue="73180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1wQAAA==" DoubleValue="107049600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TwMAAA==" LintValue="847"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1wQAAA==" LintValue="1239"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1wQAAA==" DoubleValue="107049600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1wQAAA==" DoubleValue="107049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1wQAAA==" LintValue="1239"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1wQAAA==" LintValue="1239"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018706" DistinctValues="61.299542">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1wQAAA==" DoubleValue="107049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OwgAAA==" DoubleValue="182044800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1wQAAA==" LintValue="1239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OwgAAA==" LintValue="2107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026853" DistinctValues="88.673893">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OwgAAA==" DoubleValue="182044800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQ0AAA==" DoubleValue="289699200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OwgAAA==" LintValue="2107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQ0AAA==" LintValue="3353"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQ0AAA==" DoubleValue="289699200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GQ0AAA==" DoubleValue="289699200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQ0AAA==" LintValue="3353"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GQ0AAA==" LintValue="3353"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012672" DistinctValues="41.846107">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GQ0AAA==" DoubleValue="289699200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZQ8AAA==" DoubleValue="340502400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GQ0AAA==" LintValue="3353"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZQ8AAA==" LintValue="3941"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008817" DistinctValues="29.116000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZQ8AAA==" DoubleValue="340502400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+xAAAA==" DoubleValue="375580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZQ8AAA==" LintValue="3941"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+xAAAA==" LintValue="4347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+xAAAA==" DoubleValue="375580800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+xAAAA==" DoubleValue="375580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+xAAAA==" LintValue="4347"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+xAAAA==" LintValue="4347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030708" DistinctValues="101.404000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+xAAAA==" DoubleValue="375580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gRYAAA==" DoubleValue="497750400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+xAAAA==" LintValue="4347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gRYAAA==" LintValue="5761"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gRYAAA==" DoubleValue="497750400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1R0AAA==" DoubleValue="659836800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gRYAAA==" LintValue="5761"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1R0AAA==" LintValue="7637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1R0AAA==" DoubleValue="659836800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1R0AAA==" DoubleValue="659836800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1R0AAA==" LintValue="7637"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1R0AAA==" LintValue="7637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="130.520000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1R0AAA==" DoubleValue="659836800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DSUAAA==" DoubleValue="819504000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1R0AAA==" LintValue="7637"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DSUAAA==" LintValue="9485"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.25" Name="dcal_day_in_week" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -1859,696 +1859,696 @@ group by	pa11.dcal_month_id,
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.9" Name="dcal_quarter_end" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.016926" DistinctValues="8.614655">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rXH//w==" DoubleValue="-3147984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4nT//w==" DoubleValue="-3077049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rXH//w==" LintValue="-36435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4nT//w==" LintValue="-35614"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4nT//w==" DoubleValue="-3077049600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4nT//w==" DoubleValue="-3077049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4nT//w==" LintValue="-35614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4nT//w==" LintValue="-35614"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020719" DistinctValues="10.545345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4nT//w==" DoubleValue="-3077049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z3j//w==" DoubleValue="-2990217600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4nT//w==" LintValue="-35614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z3j//w==" LintValue="-34609"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025740" DistinctValues="13.100760">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z3j//w==" DoubleValue="-2990217600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cn3//w==" DoubleValue="-2887660800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z3j//w==" LintValue="-34609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cn3//w==" LintValue="-33422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cn3//w==" DoubleValue="-2887660800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cn3//w==" DoubleValue="-2887660800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cn3//w==" LintValue="-33422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cn3//w==" LintValue="-33422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011905" DistinctValues="6.059240">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cn3//w==" DoubleValue="-2887660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l3///w==" DoubleValue="-2840227200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cn3//w==" LintValue="-33422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l3///w==" LintValue="-32873"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l3///w==" DoubleValue="-2840227200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uYb//w==" DoubleValue="-2682460800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l3///w==" LintValue="-32873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uYb//w==" LintValue="-31047"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uYb//w==" DoubleValue="-2682460800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="No7//w==" DoubleValue="-2516832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uYb//w==" LintValue="-31047"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="No7//w==" LintValue="-29130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016123" DistinctValues="7.777444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="No7//w==" DoubleValue="-2516832000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a5H//w==" DoubleValue="-2445897600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="No7//w==" LintValue="-29130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a5H//w==" LintValue="-28309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a5H//w==" DoubleValue="-2445897600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a5H//w==" DoubleValue="-2445897600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a5H//w==" LintValue="-28309"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a5H//w==" LintValue="-28309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007168" DistinctValues="3.457694">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a5H//w==" DoubleValue="-2445897600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2JL//w==" DoubleValue="-2414361600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a5H//w==" LintValue="-28309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2JL//w==" LintValue="-27944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2JL//w==" DoubleValue="-2414361600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2JL//w==" DoubleValue="-2414361600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2JL//w==" LintValue="-27944"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2JL//w==" LintValue="-27944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014355" DistinctValues="6.924862">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2JL//w==" DoubleValue="-2414361600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s5X//w==" DoubleValue="-2351203200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2JL//w==" LintValue="-27944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s5X//w==" LintValue="-27213"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s5X//w==" DoubleValue="-2351203200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="epz//w==" DoubleValue="-2201299200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s5X//w==" LintValue="-27213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="epz//w==" LintValue="-25478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007525" DistinctValues="3.630011">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="epz//w==" DoubleValue="-2201299200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="553//w==" DoubleValue="-2169763200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="epz//w==" LintValue="-25478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="553//w==" LintValue="-25113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="553//w==" DoubleValue="-2169763200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="553//w==" DoubleValue="-2169763200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="553//w==" LintValue="-25113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="553//w==" LintValue="-25113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003773" DistinctValues="1.819978">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="553//w==" DoubleValue="-2169763200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="np7//w==" DoubleValue="-2153952000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="553//w==" LintValue="-25113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="np7//w==" LintValue="-24930"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="np7//w==" DoubleValue="-2153952000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="np7//w==" DoubleValue="-2153952000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="np7//w==" LintValue="-24930"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="np7//w==" LintValue="-24930"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026348" DistinctValues="12.710011">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="np7//w==" DoubleValue="-2153952000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nKP//w==" DoubleValue="-2043532800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="np7//w==" LintValue="-24930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nKP//w==" LintValue="-23652"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028250" DistinctValues="14.377865">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nKP//w==" DoubleValue="-2043532800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="96j//w==" DoubleValue="-1925078400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nKP//w==" LintValue="-23652"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="96j//w==" LintValue="-22281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="96j//w==" DoubleValue="-1925078400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="96j//w==" DoubleValue="-1925078400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="96j//w==" LintValue="-22281"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="96j//w==" LintValue="-22281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009396" DistinctValues="4.782135">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="96j//w==" DoubleValue="-1925078400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v6r//w==" DoubleValue="-1885680000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="96j//w==" LintValue="-22281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v6r//w==" LintValue="-21825"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005670" DistinctValues="2.734940">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v6r//w==" DoubleValue="-1885680000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0qv//w==" DoubleValue="-1861920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v6r//w==" LintValue="-21825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0qv//w==" LintValue="-21550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0qv//w==" DoubleValue="-1861920000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0qv//w==" DoubleValue="-1861920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0qv//w==" LintValue="-21550"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0qv//w==" LintValue="-21550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015050" DistinctValues="7.260022">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0qv//w==" DoubleValue="-1861920000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0qv//w==" LintValue="-21550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016926" DistinctValues="8.165038">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4bH//w==" DoubleValue="-1727913600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4bH//w==" LintValue="-19999"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013194" DistinctValues="6.715444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4bH//w==" DoubleValue="-1727913600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YbT//w==" DoubleValue="-1672617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4bH//w==" LintValue="-19999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YbT//w==" LintValue="-19359"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YbT//w==" DoubleValue="-1672617600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YbT//w==" DoubleValue="-1672617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YbT//w==" LintValue="-19359"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YbT//w==" LintValue="-19359"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024451" DistinctValues="12.444556">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YbT//w==" DoubleValue="-1672617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A7n//w==" DoubleValue="-1570147200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YbT//w==" LintValue="-19359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A7n//w==" LintValue="-18173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A7n//w==" DoubleValue="-1570147200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gMD//w==" DoubleValue="-1404518400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A7n//w==" LintValue="-18173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gMD//w==" LintValue="-16256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gMD//w==" DoubleValue="-1404518400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o8f//w==" DoubleValue="-1246665600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gMD//w==" LintValue="-16256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o8f//w==" LintValue="-14429"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011912" DistinctValues="4.480599">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o8f//w==" DoubleValue="-1246665600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yMn//w==" DoubleValue="-1199232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o8f//w==" LintValue="-14429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yMn//w==" LintValue="-13880"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yMn//w==" DoubleValue="-1199232000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yMn//w==" DoubleValue="-1199232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yMn//w==" LintValue="-13880"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yMn//w==" LintValue="-13880"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001953" DistinctValues="0.734524">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yMn//w==" DoubleValue="-1199232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Isr//w==" DoubleValue="-1191456000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yMn//w==" LintValue="-13880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Isr//w==" LintValue="-13790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Isr//w==" DoubleValue="-1191456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Isr//w==" DoubleValue="-1191456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Isr//w==" LintValue="-13790"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Isr//w==" LintValue="-13790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001974" DistinctValues="0.742686">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Isr//w==" DoubleValue="-1191456000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Isr//w==" LintValue="-13790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001996" DistinctValues="0.750847">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2cr//w==" DoubleValue="-1175644800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2cr//w==" LintValue="-13607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2cr//w==" DoubleValue="-1175644800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2cr//w==" DoubleValue="-1175644800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2cr//w==" LintValue="-13607"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2cr//w==" LintValue="-13607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009916" DistinctValues="3.729752">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2cr//w==" DoubleValue="-1175644800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="osz//w==" DoubleValue="-1136160000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2cr//w==" LintValue="-13607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="osz//w==" LintValue="-13150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="osz//w==" DoubleValue="-1136160000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="osz//w==" DoubleValue="-1136160000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="osz//w==" LintValue="-13150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="osz//w==" LintValue="-13150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005945" DistinctValues="2.236219">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="osz//w==" DoubleValue="-1136160000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tM3//w==" DoubleValue="-1112486400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="osz//w==" LintValue="-13150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tM3//w==" LintValue="-12876"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tM3//w==" DoubleValue="-1112486400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tM3//w==" DoubleValue="-1112486400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tM3//w==" LintValue="-12876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tM3//w==" LintValue="-12876"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003949" DistinctValues="1.485372">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tM3//w==" DoubleValue="-1112486400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="as7//w==" DoubleValue="-1096761600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tM3//w==" LintValue="-12876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="as7//w==" LintValue="-12694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="as7//w==" DoubleValue="-1096761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="as7//w==" LintValue="-12694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="19.160000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zd3//w==" DoubleValue="-765417600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zd3//w==" LintValue="-8859"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003771" DistinctValues="1.818982">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zd3//w==" DoubleValue="-765417600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zd3//w==" LintValue="-8859"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002392" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011292" DistinctValues="5.447006">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QOD//w==" DoubleValue="-702259200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QOD//w==" LintValue="-8128"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QOD//w==" DoubleValue="-702259200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QOD//w==" DoubleValue="-702259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QOD//w==" LintValue="-8128"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QOD//w==" LintValue="-8128"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022583" DistinctValues="10.894012">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QOD//w==" DoubleValue="-702259200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QOD//w==" LintValue="-8128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015050" DistinctValues="7.659803">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yuf//w==" DoubleValue="-544492800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yuf//w==" LintValue="-6302"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yuf//w==" DoubleValue="-544492800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yuf//w==" DoubleValue="-544492800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yuf//w==" LintValue="-6302"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yuf//w==" LintValue="-6302"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022596" DistinctValues="11.500197">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yuf//w==" DoubleValue="-544492800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yuf//w==" LintValue="-6302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPL//w==" DoubleValue="-292032000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPL//w==" LintValue="-3380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020699" DistinctValues="10.534852">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPL//w==" DoubleValue="-292032000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPL//w==" LintValue="-3380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016947" DistinctValues="8.625148">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vn//w==" DoubleValue="-134265600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vn//w==" LintValue="-1554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vn//w==" DoubleValue="-134265600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bQEAAA==" DoubleValue="31536000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vn//w==" LintValue="-1554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bQEAAA==" LintValue="365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035749" DistinctValues="18.194655">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bQEAAA==" DoubleValue="31536000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MwgAAA==" DoubleValue="181353600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bQEAAA==" LintValue="365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MwgAAA==" LintValue="2099"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MwgAAA==" DoubleValue="181353600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MwgAAA==" DoubleValue="181353600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MwgAAA==" LintValue="2099"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MwgAAA==" LintValue="2099"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001897" DistinctValues="0.965345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MwgAAA==" DoubleValue="181353600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jwgAAA==" DoubleValue="189302400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MwgAAA==" LintValue="2099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jwgAAA==" LintValue="2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024451" DistinctValues="12.444556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jwgAAA==" DoubleValue="189302400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jwgAAA==" LintValue="2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013194" DistinctValues="6.715444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sQ8AAA==" DoubleValue="347068800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sQ8AAA==" LintValue="4017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007525" DistinctValues="3.829901">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sQ8AAA==" DoubleValue="347068800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhEAAA==" DoubleValue="378604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sQ8AAA==" LintValue="4017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhEAAA==" LintValue="4382"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhEAAA==" DoubleValue="378604800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhEAAA==" DoubleValue="378604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhEAAA==" LintValue="4382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhEAAA==" LintValue="4382"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030121" DistinctValues="15.330099">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhEAAA==" DoubleValue="378604800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xYAAA==" DoubleValue="504835200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhEAAA==" LintValue="4382"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xYAAA==" LintValue="5843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xYAAA==" DoubleValue="504835200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9h0AAA==" DoubleValue="662688000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xYAAA==" LintValue="5843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9h0AAA==" LintValue="7670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024451" DistinctValues="12.444556">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9h0AAA==" DoubleValue="662688000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mCIAAA==" DoubleValue="765158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9h0AAA==" LintValue="7670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mCIAAA==" LintValue="8856"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mCIAAA==" DoubleValue="765158400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mCIAAA==" DoubleValue="765158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mCIAAA==" LintValue="8856"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mCIAAA==" LintValue="8856"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013194" DistinctValues="6.715444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mCIAAA==" DoubleValue="765158400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" DoubleValue="820454400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mCIAAA==" LintValue="8856"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" LintValue="9496"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.8" Name="dcal_quarter_begin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.016905" DistinctValues="8.604162">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" DoubleValue="-3155673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iHT//w==" DoubleValue="-3084825600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" LintValue="-36524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iHT//w==" LintValue="-35704"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iHT//w==" DoubleValue="-3084825600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iHT//w==" DoubleValue="-3084825600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iHT//w==" LintValue="-35704"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iHT//w==" LintValue="-35704"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020740" DistinctValues="10.555838">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iHT//w==" DoubleValue="-3084825600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dnj//w==" DoubleValue="-2997907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iHT//w==" LintValue="-35704"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dnj//w==" LintValue="-34698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025748" DistinctValues="12.420854">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dnj//w==" DoubleValue="-2997907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GH3//w==" DoubleValue="-2895436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dnj//w==" LintValue="-34698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GH3//w==" LintValue="-33512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GH3//w==" DoubleValue="-2895436800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GH3//w==" DoubleValue="-2895436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GH3//w==" LintValue="-33512"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GH3//w==" LintValue="-33512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005970" DistinctValues="2.880046">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GH3//w==" DoubleValue="-2895436800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K37//w==" DoubleValue="-2871676800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GH3//w==" LintValue="-33512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K37//w==" LintValue="-33237"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K37//w==" DoubleValue="-2871676800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K37//w==" DoubleValue="-2871676800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K37//w==" LintValue="-33237"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K37//w==" LintValue="-33237"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005927" DistinctValues="2.859100">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K37//w==" DoubleValue="-2871676800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PH///w==" DoubleValue="-2848089600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K37//w==" LintValue="-33237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PH///w==" LintValue="-32964"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PH///w==" DoubleValue="-2848089600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xob//w==" DoubleValue="-2690323200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PH///w==" LintValue="-32964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xob//w==" LintValue="-31138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xob//w==" DoubleValue="-2690323200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3I3//w==" DoubleValue="-2524608000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xob//w==" LintValue="-31138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3I3//w==" LintValue="-29220"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016123" DistinctValues="8.205717">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3I3//w==" DoubleValue="-2524608000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3I3//w==" LintValue="-29220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021523" DistinctValues="10.954283">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WZX//w==" DoubleValue="-2358979200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WZX//w==" LintValue="-27303"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WZX//w==" DoubleValue="-2358979200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IZz//w==" DoubleValue="-2208988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WZX//w==" LintValue="-27303"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IZz//w==" LintValue="-25567"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007525" DistinctValues="3.630011">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IZz//w==" DoubleValue="-2208988800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jp3//w==" DoubleValue="-2177452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IZz//w==" LintValue="-25567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jp3//w==" LintValue="-25202"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jp3//w==" DoubleValue="-2177452800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jp3//w==" DoubleValue="-2177452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jp3//w==" LintValue="-25202"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jp3//w==" LintValue="-25202"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003732" DistinctValues="1.800088">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jp3//w==" DoubleValue="-2177452800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q57//w==" DoubleValue="-2161814400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jp3//w==" LintValue="-25202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q57//w==" LintValue="-25021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q57//w==" DoubleValue="-2161814400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q57//w==" DoubleValue="-2161814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q57//w==" LintValue="-25021"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q57//w==" LintValue="-25021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026389" DistinctValues="12.729901">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q57//w==" DoubleValue="-2161814400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q6P//w==" DoubleValue="-2051222400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q57//w==" LintValue="-25021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q6P//w==" LintValue="-23741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028224" DistinctValues="14.364754">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q6P//w==" DoubleValue="-2051222400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nKj//w==" DoubleValue="-1932940800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q6P//w==" LintValue="-23741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nKj//w==" LintValue="-22372"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nKj//w==" DoubleValue="-1932940800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nKj//w==" DoubleValue="-1932940800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nKj//w==" LintValue="-22372"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nKj//w==" LintValue="-22372"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009422" DistinctValues="4.795246">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nKj//w==" DoubleValue="-1932940800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zar//w==" DoubleValue="-1893456000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nKj//w==" LintValue="-22372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zar//w==" LintValue="-21915"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005646" DistinctValues="2.723503">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zar//w==" DoubleValue="-1893456000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d6v//w==" DoubleValue="-1869782400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zar//w==" LintValue="-21915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d6v//w==" LintValue="-21641"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d6v//w==" DoubleValue="-1869782400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d6v//w==" DoubleValue="-1869782400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d6v//w==" LintValue="-21641"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d6v//w==" LintValue="-21641"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015042" DistinctValues="7.256048">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d6v//w==" DoubleValue="-1869782400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ua7//w==" DoubleValue="-1806710400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d6v//w==" LintValue="-21641"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ua7//w==" LintValue="-20911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ua7//w==" DoubleValue="-1806710400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ua7//w==" DoubleValue="-1806710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ua7//w==" LintValue="-20911"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ua7//w==" LintValue="-20911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016958" DistinctValues="8.180449">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ua7//w==" DoubleValue="-1806710400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iLH//w==" DoubleValue="-1735603200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ua7//w==" LintValue="-20911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iLH//w==" LintValue="-20088"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013153" DistinctValues="6.694458">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iLH//w==" DoubleValue="-1735603200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BrT//w==" DoubleValue="-1680480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iLH//w==" LintValue="-20088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BrT//w==" LintValue="-19450"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BrT//w==" DoubleValue="-1680480000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BrT//w==" DoubleValue="-1680480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BrT//w==" LintValue="-19450"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BrT//w==" LintValue="-19450"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024492" DistinctValues="12.465542">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BrT//w==" DoubleValue="-1680480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qrj//w==" DoubleValue="-1577836800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BrT//w==" LintValue="-19450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qrj//w==" LintValue="-18262"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qrj//w==" DoubleValue="-1577836800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JsD//w==" DoubleValue="-1412294400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qrj//w==" LintValue="-18262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JsD//w==" LintValue="-16346"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JsD//w==" DoubleValue="-1412294400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Scf//w==" DoubleValue="-1254441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JsD//w==" LintValue="-16346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Scf//w==" LintValue="-14519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011883" DistinctValues="4.469862">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Scf//w==" DoubleValue="-1254441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bcn//w==" DoubleValue="-1207094400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Scf//w==" LintValue="-14519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bcn//w==" LintValue="-13971"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bcn//w==" DoubleValue="-1207094400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bcn//w==" DoubleValue="-1207094400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bcn//w==" LintValue="-13971"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bcn//w==" LintValue="-13971"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001995" DistinctValues="0.750415">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bcn//w==" DoubleValue="-1207094400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ycn//w==" DoubleValue="-1199145600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bcn//w==" LintValue="-13971"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ycn//w==" LintValue="-13879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ycn//w==" DoubleValue="-1199145600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ycn//w==" DoubleValue="-1199145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ycn//w==" LintValue="-13879"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ycn//w==" LintValue="-13879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001952" DistinctValues="0.734101">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ycn//w==" DoubleValue="-1199145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I8r//w==" DoubleValue="-1191369600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ycn//w==" LintValue="-13879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I8r//w==" LintValue="-13789"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I8r//w==" DoubleValue="-1191369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="I8r//w==" DoubleValue="-1191369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I8r//w==" LintValue="-13789"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="I8r//w==" LintValue="-13789"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001973" DistinctValues="0.742258">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="I8r//w==" DoubleValue="-1191369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fsr//w==" DoubleValue="-1183507200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="I8r//w==" LintValue="-13789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fsr//w==" LintValue="-13698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fsr//w==" DoubleValue="-1183507200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fsr//w==" DoubleValue="-1183507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fsr//w==" LintValue="-13698"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fsr//w==" LintValue="-13698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009910" DistinctValues="3.727604">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fsr//w==" DoubleValue="-1183507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R8z//w==" DoubleValue="-1144022400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fsr//w==" LintValue="-13698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R8z//w==" LintValue="-13241"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R8z//w==" DoubleValue="-1144022400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R8z//w==" DoubleValue="-1144022400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R8z//w==" LintValue="-13241"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R8z//w==" LintValue="-13241"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005942" DistinctValues="2.234931">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R8z//w==" DoubleValue="-1144022400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wc3//w==" DoubleValue="-1120348800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R8z//w==" LintValue="-13241"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wc3//w==" LintValue="-12967"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wc3//w==" DoubleValue="-1120348800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wc3//w==" DoubleValue="-1120348800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wc3//w==" LintValue="-12967"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wc3//w==" LintValue="-12967"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003990" DistinctValues="1.500829">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wc3//w==" DoubleValue="-1120348800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ec7//w==" DoubleValue="-1104451200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wc3//w==" LintValue="-12967"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ec7//w==" LintValue="-12783"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ec7//w==" DoubleValue="-1104451200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jdX//w==" DoubleValue="-938908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ec7//w==" LintValue="-12783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jdX//w==" LintValue="-10867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jdX//w==" DoubleValue="-938908800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jdX//w==" DoubleValue="-938908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jdX//w==" LintValue="-10867"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jdX//w==" LintValue="-10867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="19.160000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jdX//w==" DoubleValue="-938908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ct3//w==" DoubleValue="-773280000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jdX//w==" LintValue="-10867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ct3//w==" LintValue="-8950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003791" DistinctValues="1.828922">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ct3//w==" DoubleValue="-773280000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wt3//w==" DoubleValue="-757382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ct3//w==" LintValue="-8950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wt3//w==" LintValue="-8766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002392" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wt3//w==" DoubleValue="-757382400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wt3//w==" DoubleValue="-757382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wt3//w==" LintValue="-8766"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wt3//w==" LintValue="-8766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011271" DistinctValues="5.437066">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wt3//w==" DoubleValue="-757382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5d///w==" DoubleValue="-710121600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wt3//w==" LintValue="-8766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5d///w==" LintValue="-8219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002353" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5d///w==" DoubleValue="-710121600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5d///w==" DoubleValue="-710121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5d///w==" LintValue="-8219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5d///w==" LintValue="-8219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022583" DistinctValues="10.894012">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5d///w==" DoubleValue="-710121600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5d///w==" LintValue="-8219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015050" DistinctValues="7.260022">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B+f//w==" DoubleValue="-552355200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B+f//w==" LintValue="-6393"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B+f//w==" DoubleValue="-552355200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B+f//w==" DoubleValue="-552355200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B+f//w==" LintValue="-6393"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B+f//w==" LintValue="-6393"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022596" DistinctValues="10.899978">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B+f//w==" DoubleValue="-552355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T+v//w==" DoubleValue="-457660800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B+f//w==" LintValue="-6393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T+v//w==" LintValue="-5297"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T+v//w==" DoubleValue="-457660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfL//w==" DoubleValue="-299894400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T+v//w==" LintValue="-5297"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfL//w==" LintValue="-3471"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020719" DistinctValues="10.545345">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfL//w==" DoubleValue="-299894400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfL//w==" LintValue="-3471"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016926" DistinctValues="8.614655">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/n//w==" DoubleValue="-142128000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/n//w==" LintValue="-1645"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/n//w==" DoubleValue="-142128000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/n//w==" LintValue="-1645"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035749" DistinctValues="18.194655">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AcAAA==" DoubleValue="173491200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AcAAA==" LintValue="2008"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AcAAA==" DoubleValue="173491200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AcAAA==" DoubleValue="173491200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AcAAA==" LintValue="2008"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AcAAA==" LintValue="2008"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001897" DistinctValues="0.965345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AcAAA==" DoubleValue="173491200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NAgAAA==" DoubleValue="181440000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AcAAA==" LintValue="2008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NAgAAA==" LintValue="2100"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024492" DistinctValues="12.465542">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NAgAAA==" DoubleValue="181440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NAgAAA==" LintValue="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002431" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013153" DistinctValues="6.694458">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg8AAA==" DoubleValue="339206400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg8AAA==" LintValue="3926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007525" DistinctValues="3.829901">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg8AAA==" DoubleValue="339206400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wxAAAA==" DoubleValue="370742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg8AAA==" LintValue="3926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wxAAAA==" LintValue="4291"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002314" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wxAAAA==" DoubleValue="370742400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wxAAAA==" DoubleValue="370742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wxAAAA==" LintValue="4291"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wxAAAA==" LintValue="4291"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030121" DistinctValues="15.330099">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wxAAAA==" DoubleValue="370742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBYAAA==" DoubleValue="496972800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wxAAAA==" LintValue="4291"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBYAAA==" LintValue="5752"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBYAAA==" DoubleValue="496972800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mx0AAA==" DoubleValue="654825600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBYAAA==" LintValue="5752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mx0AAA==" LintValue="7579"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037645" DistinctValues="20.160000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mx0AAA==" DoubleValue="654825600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vSQAAA==" DoubleValue="812592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mx0AAA==" LintValue="7579"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vSQAAA==" LintValue="9405"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.1" Name="dcal_calendar_dt" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" DoubleValue="-3155673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iHj//w==" DoubleValue="-2996352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" LintValue="-36524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iHj//w==" LintValue="-34680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iHj//w==" DoubleValue="-2996352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aH///w==" DoubleValue="-2844288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iHj//w==" LintValue="-34680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aH///w==" LintValue="-32920"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aH///w==" DoubleValue="-2844288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k4b//w==" DoubleValue="-2685744000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aH///w==" LintValue="-32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k4b//w==" LintValue="-31085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k4b//w==" DoubleValue="-2685744000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C47//w==" DoubleValue="-2520547200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k4b//w==" LintValue="-31085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C47//w==" LintValue="-29173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C47//w==" DoubleValue="-2520547200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YpX//w==" DoubleValue="-2358201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C47//w==" LintValue="-29173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YpX//w==" LintValue="-27294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YpX//w==" DoubleValue="-2358201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SJz//w==" DoubleValue="-2205619200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YpX//w==" LintValue="-27294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SJz//w==" LintValue="-25528"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SJz//w==" DoubleValue="-2205619200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SKP//w==" DoubleValue="-2050790400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SJz//w==" LintValue="-25528"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SKP//w==" LintValue="-23736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SKP//w==" DoubleValue="-2050790400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aKr//w==" DoubleValue="-1893196800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SKP//w==" LintValue="-23736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aKr//w==" LintValue="-21912"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aKr//w==" DoubleValue="-1893196800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rLH//w==" DoubleValue="-1732492800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aKr//w==" LintValue="-21912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rLH//w==" LintValue="-20052"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rLH//w==" DoubleValue="-1732492800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yrj//w==" DoubleValue="-1575072000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rLH//w==" LintValue="-20052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yrj//w==" LintValue="-18230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yrj//w==" DoubleValue="-1575072000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MsD//w==" DoubleValue="-1411257600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yrj//w==" LintValue="-18230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MsD//w==" LintValue="-16334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MsD//w==" DoubleValue="-1411257600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XMf//w==" DoubleValue="-1252800000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MsD//w==" LintValue="-16334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XMf//w==" LintValue="-14500"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XMf//w==" DoubleValue="-1252800000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vs7//w==" DoubleValue="-1098489600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XMf//w==" LintValue="-14500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vs7//w==" LintValue="-12714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vs7//w==" DoubleValue="-1098489600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1dX//w==" DoubleValue="-932688000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vs7//w==" LintValue="-12714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1dX//w==" LintValue="-10795"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1dX//w==" DoubleValue="-932688000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GN3//w==" DoubleValue="-772070400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1dX//w==" LintValue="-10795"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GN3//w==" LintValue="-8936"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GN3//w==" DoubleValue="-772070400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PeT//w==" DoubleValue="-614044800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GN3//w==" LintValue="-8936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PeT//w==" LintValue="-7107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PeT//w==" DoubleValue="-614044800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PeT//w==" LintValue="-7107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/L//w==" DoubleValue="-295574400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/L//w==" LintValue="-3421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/L//w==" DoubleValue="-295574400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvn//w==" DoubleValue="-137721600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/L//w==" LintValue="-3421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvn//w==" LintValue="-1594"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvn//w==" DoubleValue="-137721600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GAEAAA==" DoubleValue="24192000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvn//w==" LintValue="-1594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GAEAAA==" LintValue="280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GAEAAA==" DoubleValue="24192000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QQgAAA==" DoubleValue="182563200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GAEAAA==" LintValue="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QQgAAA==" LintValue="2113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QQgAAA==" DoubleValue="182563200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bw8AAA==" DoubleValue="341366400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QQgAAA==" LintValue="2113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bw8AAA==" LintValue="3951"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bw8AAA==" DoubleValue="341366400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxYAAA==" DoubleValue="498268800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bw8AAA==" LintValue="3951"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxYAAA==" LintValue="5767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxYAAA==" DoubleValue="498268800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3R0AAA==" DoubleValue="660528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxYAAA==" LintValue="5767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3R0AAA==" LintValue="7645"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3R0AAA==" DoubleValue="660528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FyUAAA==" DoubleValue="820368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3R0AAA==" LintValue="7645"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FyUAAA==" LintValue="9495"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.0" Name="dcal_date_key" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -4214,806 +4214,806 @@ group by	pa11.dcal_month_id,
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.34" Name="dcal_pay_period_paid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.002112" DistinctValues="6.974351">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bXH//w==" DoubleValue="-3153513600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z3H//w==" DoubleValue="-3145046400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bXH//w==" LintValue="-36499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z3H//w==" LintValue="-36401"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z3H//w==" DoubleValue="-3145046400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="z3H//w==" DoubleValue="-3145046400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z3H//w==" LintValue="-36401"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="z3H//w==" LintValue="-36401"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037413" DistinctValues="123.545649">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="z3H//w==" DoubleValue="-3145046400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l3j//w==" DoubleValue="-2995056000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="z3H//w==" LintValue="-36401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l3j//w==" LintValue="-34665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013489" DistinctValues="44.542540">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l3j//w==" DoubleValue="-2995056000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Xr//w==" DoubleValue="-2943043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l3j//w==" LintValue="-34665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Xr//w==" LintValue="-34063"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Xr//w==" DoubleValue="-2943043200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8Xr//w==" DoubleValue="-2943043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Xr//w==" LintValue="-34063"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8Xr//w==" LintValue="-34063"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026036" DistinctValues="85.977460">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8Xr//w==" DoubleValue="-2943043200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e3///w==" DoubleValue="-2842646400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8Xr//w==" LintValue="-34063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e3///w==" LintValue="-32901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e3///w==" DoubleValue="-2842646400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pYb//w==" DoubleValue="-2684188800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e3///w==" LintValue="-32901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pYb//w==" LintValue="-31067"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pYb//w==" DoubleValue="-2684188800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FY7//w==" DoubleValue="-2519683200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pYb//w==" LintValue="-31067"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FY7//w==" LintValue="-29163"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016518" DistinctValues="54.545672">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FY7//w==" DoubleValue="-2519683200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JZH//w==" DoubleValue="-2451945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FY7//w==" LintValue="-29163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JZH//w==" LintValue="-28379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JZH//w==" DoubleValue="-2451945600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JZH//w==" DoubleValue="-2451945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JZH//w==" LintValue="-28379"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JZH//w==" LintValue="-28379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="75.974328">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JZH//w==" DoubleValue="-2451945600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aZX//w==" DoubleValue="-2357596800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JZH//w==" LintValue="-28379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aZX//w==" LintValue="-27287"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001867" DistinctValues="6.166299">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aZX//w==" DoubleValue="-2357596800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vZX//w==" DoubleValue="-2350339200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aZX//w==" LintValue="-27287"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vZX//w==" LintValue="-27203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vZX//w==" DoubleValue="-2350339200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vZX//w==" DoubleValue="-2350339200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vZX//w==" LintValue="-27203"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vZX//w==" LintValue="-27203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037657" DistinctValues="124.353701">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vZX//w==" DoubleValue="-2350339200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W5z//w==" DoubleValue="-2203977600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vZX//w==" LintValue="-27203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W5z//w==" LintValue="-25509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007411" DistinctValues="24.472500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W5z//w==" DoubleValue="-2203977600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q53//w==" DoubleValue="-2174947200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W5z//w==" LintValue="-25509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q53//w==" LintValue="-25173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q53//w==" DoubleValue="-2174947200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q53//w==" DoubleValue="-2174947200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q53//w==" LintValue="-25173"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q53//w==" LintValue="-25173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032114" DistinctValues="106.047500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q53//w==" DoubleValue="-2174947200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W6P//w==" DoubleValue="-2049148800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q53//w==" LintValue="-25173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W6P//w==" LintValue="-23717"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024323" DistinctValues="79.704615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W6P//w==" DoubleValue="-2049148800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u6f//w==" DoubleValue="-1952380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W6P//w==" LintValue="-23717"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u6f//w==" LintValue="-22597"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u6f//w==" DoubleValue="-1952380800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u6f//w==" DoubleValue="-1952380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u6f//w==" LintValue="-22597"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u6f//w==" LintValue="-22597"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014898" DistinctValues="48.819077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u6f//w==" DoubleValue="-1952380800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u6f//w==" LintValue="-22597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="0.996308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d6r//w==" DoubleValue="-1891900800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d6r//w==" LintValue="-21897"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012184" DistinctValues="40.235489">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d6r//w==" DoubleValue="-1891900800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="taz//w==" DoubleValue="-1842307200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d6r//w==" LintValue="-21897"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="taz//w==" LintValue="-21323"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="taz//w==" DoubleValue="-1842307200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="taz//w==" DoubleValue="-1842307200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="taz//w==" LintValue="-21323"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="taz//w==" LintValue="-21323"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027340" DistinctValues="90.284511">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="taz//w==" DoubleValue="-1842307200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vbH//w==" DoubleValue="-1731024000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="taz//w==" LintValue="-21323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vbH//w==" LintValue="-20035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006081" DistinctValues="19.926154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vbH//w==" DoubleValue="-1731024000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1bL//w==" DoubleValue="-1706832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vbH//w==" LintValue="-20035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1bL//w==" LintValue="-19755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1bL//w==" DoubleValue="-1706832000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1bL//w==" DoubleValue="-1706832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1bL//w==" LintValue="-19755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1bL//w==" LintValue="-19755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008209" DistinctValues="26.900308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1bL//w==" DoubleValue="-1706832000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T7T//w==" DoubleValue="-1674172800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1bL//w==" LintValue="-19755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T7T//w==" LintValue="-19377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T7T//w==" DoubleValue="-1674172800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T7T//w==" DoubleValue="-1674172800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T7T//w==" LintValue="-19377"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T7T//w==" LintValue="-19377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025235" DistinctValues="82.693538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T7T//w==" DoubleValue="-1674172800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2bj//w==" DoubleValue="-1573776000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T7T//w==" LintValue="-19377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2bj//w==" LintValue="-18215"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035133" DistinctValues="116.017778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2bj//w==" DoubleValue="-1573776000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ab///w==" DoubleValue="-1428624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2bj//w==" LintValue="-18215"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ab///w==" LintValue="-16535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ab///w==" DoubleValue="-1428624000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ab///w==" DoubleValue="-1428624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ab///w==" LintValue="-16535"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ab///w==" LintValue="-16535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004392" DistinctValues="14.502222">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ab///w==" DoubleValue="-1428624000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O8D//w==" DoubleValue="-1410480000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ab///w==" LintValue="-16535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O8D//w==" LintValue="-16325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029568" DistinctValues="97.640916">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O8D//w==" DoubleValue="-1410480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l8X//w==" DoubleValue="-1291939200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O8D//w==" LintValue="-16325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l8X//w==" LintValue="-14953"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l8X//w==" DoubleValue="-1291939200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l8X//w==" DoubleValue="-1291939200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l8X//w==" LintValue="-14953"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l8X//w==" LintValue="-14953"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009957" DistinctValues="32.879084">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l8X//w==" DoubleValue="-1291939200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zcf//w==" DoubleValue="-1252022400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l8X//w==" LintValue="-14953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zcf//w==" LintValue="-14491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017292" DistinctValues="56.665000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zcf//w==" DoubleValue="-1252022400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dcr//w==" DoubleValue="-1184284800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zcf//w==" LintValue="-14491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dcr//w==" LintValue="-13707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dcr//w==" DoubleValue="-1184284800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dcr//w==" DoubleValue="-1184284800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dcr//w==" LintValue="-13707"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dcr//w==" LintValue="-13707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001235" DistinctValues="4.047500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dcr//w==" DoubleValue="-1184284800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rcr//w==" DoubleValue="-1179446400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dcr//w==" LintValue="-13707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rcr//w==" LintValue="-13651"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rcr//w==" DoubleValue="-1179446400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rcr//w==" DoubleValue="-1179446400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rcr//w==" LintValue="-13651"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rcr//w==" LintValue="-13651"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020998" DistinctValues="68.807500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rcr//w==" DoubleValue="-1179446400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zc7//w==" DoubleValue="-1097193600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rcr//w==" LintValue="-13651"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zc7//w==" LintValue="-12699"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010963" DistinctValues="35.925255">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zc7//w==" DoubleValue="-1097193600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="edD//w==" DoubleValue="-1051228800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zc7//w==" LintValue="-12699"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="edD//w==" LintValue="-12167"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="edD//w==" DoubleValue="-1051228800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="edD//w==" DoubleValue="-1051228800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="edD//w==" LintValue="-12167"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="edD//w==" LintValue="-12167"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004328" DistinctValues="14.181022">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="edD//w==" DoubleValue="-1051228800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S9H//w==" DoubleValue="-1033084800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="edD//w==" LintValue="-12167"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S9H//w==" LintValue="-11957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S9H//w==" DoubleValue="-1033084800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S9H//w==" DoubleValue="-1033084800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S9H//w==" LintValue="-11957"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S9H//w==" LintValue="-11957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024234" DistinctValues="79.413723">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S9H//w==" DoubleValue="-1033084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="49X//w==" DoubleValue="-931478400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S9H//w==" LintValue="-11957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="49X//w==" LintValue="-10781"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031204" DistinctValues="102.252632">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="49X//w==" DoubleValue="-931478400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="odv//w==" DoubleValue="-804470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="49X//w==" LintValue="-10781"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="odv//w==" LintValue="-9311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="odv//w==" DoubleValue="-804470400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="odv//w==" DoubleValue="-804470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="odv//w==" LintValue="-9311"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="odv//w==" LintValue="-9311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004160" DistinctValues="13.633684">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="odv//w==" DoubleValue="-804470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zdz//w==" DoubleValue="-787536000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="odv//w==" LintValue="-9311"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zdz//w==" LintValue="-9115"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zdz//w==" DoubleValue="-787536000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zdz//w==" DoubleValue="-787536000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zdz//w==" LintValue="-9115"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zdz//w==" LintValue="-9115"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004160" DistinctValues="13.633684">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zdz//w==" DoubleValue="-787536000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kd3//w==" DoubleValue="-770601600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zdz//w==" LintValue="-9115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kd3//w==" LintValue="-8919"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038613" DistinctValues="127.508000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kd3//w==" DoubleValue="-770601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G+T//w==" DoubleValue="-616982400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kd3//w==" LintValue="-8919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G+T//w==" LintValue="-7141"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G+T//w==" DoubleValue="-616982400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G+T//w==" DoubleValue="-616982400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G+T//w==" LintValue="-7141"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G+T//w==" LintValue="-7141"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000912" DistinctValues="3.012000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G+T//w==" DoubleValue="-616982400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ReT//w==" DoubleValue="-613353600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G+T//w==" LintValue="-7141"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ReT//w==" LintValue="-7099"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027340" DistinctValues="90.284511">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ReT//w==" DoubleValue="-613353600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ten//w==" DoubleValue="-502070400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ReT//w==" LintValue="-7099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ten//w==" LintValue="-5811"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ten//w==" DoubleValue="-502070400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ten//w==" DoubleValue="-502070400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ten//w==" LintValue="-5811"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ten//w==" LintValue="-5811"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012184" DistinctValues="40.235489">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ten//w==" DoubleValue="-502070400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i+v//w==" DoubleValue="-452476800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ten//w==" LintValue="-5811"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i+v//w==" LintValue="-5237"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i+v//w==" DoubleValue="-452476800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfL//w==" DoubleValue="-294019200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i+v//w==" LintValue="-5237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfL//w==" LintValue="-3403"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003040" DistinctValues="9.963077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfL//w==" DoubleValue="-294019200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QfP//w==" DoubleValue="-281923200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfL//w==" LintValue="-3403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QfP//w==" LintValue="-3263"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QfP//w==" DoubleValue="-281923200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QfP//w==" DoubleValue="-281923200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QfP//w==" LintValue="-3263"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QfP//w==" LintValue="-3263"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010033" DistinctValues="32.878154">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QfP//w==" DoubleValue="-281923200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QfP//w==" LintValue="-3263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000510" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026451" DistinctValues="86.678769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JQEAAA==" DoubleValue="25315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JQEAAA==" LintValue="293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012370" DistinctValues="40.536794">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JQEAAA==" DoubleValue="25315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YwMAAA==" DoubleValue="74908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JQEAAA==" LintValue="293"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YwMAAA==" LintValue="867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YwMAAA==" DoubleValue="74908800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YwMAAA==" DoubleValue="74908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YwMAAA==" LintValue="867"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YwMAAA==" LintValue="867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008448" DistinctValues="27.683664">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YwMAAA==" DoubleValue="74908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YwMAAA==" LintValue="867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6wQAAA==" LintValue="1259"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6wQAAA==" LintValue="1259"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6wQAAA==" LintValue="1259"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018706" DistinctValues="61.299542">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TwgAAA==" DoubleValue="183772800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6wQAAA==" LintValue="1259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TwgAAA==" LintValue="2127"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TwgAAA==" DoubleValue="183772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eQ8AAA==" DoubleValue="342230400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TwgAAA==" LintValue="2127"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eQ8AAA==" LintValue="3961"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008817" DistinctValues="29.116000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eQ8AAA==" DoubleValue="342230400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DxEAAA==" DoubleValue="377308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eQ8AAA==" LintValue="3961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DxEAAA==" LintValue="4367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000471" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DxEAAA==" DoubleValue="377308800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DxEAAA==" DoubleValue="377308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DxEAAA==" LintValue="4367"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DxEAAA==" LintValue="4367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030708" DistinctValues="101.404000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DxEAAA==" DoubleValue="377308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lRYAAA==" DoubleValue="499478400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DxEAAA==" LintValue="4367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lRYAAA==" LintValue="5781"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lRYAAA==" DoubleValue="499478400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6R0AAA==" DoubleValue="661564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lRYAAA==" LintValue="5781"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6R0AAA==" LintValue="7657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039525" DistinctValues="131.520000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6R0AAA==" DoubleValue="661564800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ISUAAA==" DoubleValue="821232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6R0AAA==" LintValue="7657"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ISUAAA==" LintValue="9505"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.27" Name="dcal_next_day" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VXH//w==" DoubleValue="-3155587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iXj//w==" DoubleValue="-2996265600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VXH//w==" LintValue="-36523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iXj//w==" LintValue="-34679"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iXj//w==" DoubleValue="-2996265600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aX///w==" DoubleValue="-2844201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iXj//w==" LintValue="-34679"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aX///w==" LintValue="-32919"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aX///w==" DoubleValue="-2844201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lIb//w==" DoubleValue="-2685657600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aX///w==" LintValue="-32919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lIb//w==" LintValue="-31084"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lIb//w==" DoubleValue="-2685657600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DI7//w==" DoubleValue="-2520460800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lIb//w==" LintValue="-31084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DI7//w==" LintValue="-29172"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DI7//w==" DoubleValue="-2520460800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y5X//w==" DoubleValue="-2358115200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DI7//w==" LintValue="-29172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y5X//w==" LintValue="-27293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y5X//w==" DoubleValue="-2358115200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SZz//w==" DoubleValue="-2205532800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y5X//w==" LintValue="-27293"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SZz//w==" LintValue="-25527"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SZz//w==" DoubleValue="-2205532800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SaP//w==" DoubleValue="-2050704000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SZz//w==" LintValue="-25527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SaP//w==" LintValue="-23735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SaP//w==" DoubleValue="-2050704000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SaP//w==" LintValue="-23735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" DoubleValue="-1893110400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rbH//w==" DoubleValue="-1732406400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aar//w==" LintValue="-21911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rbH//w==" LintValue="-20051"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rbH//w==" DoubleValue="-1732406400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y7j//w==" DoubleValue="-1574985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rbH//w==" LintValue="-20051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y7j//w==" LintValue="-18229"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y7j//w==" DoubleValue="-1574985600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M8D//w==" DoubleValue="-1411171200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y7j//w==" LintValue="-18229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M8D//w==" LintValue="-16333"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M8D//w==" DoubleValue="-1411171200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xcf//w==" DoubleValue="-1252713600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M8D//w==" LintValue="-16333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xcf//w==" LintValue="-14499"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xcf//w==" DoubleValue="-1252713600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V87//w==" DoubleValue="-1098403200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xcf//w==" LintValue="-14499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V87//w==" LintValue="-12713"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V87//w==" DoubleValue="-1098403200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1tX//w==" DoubleValue="-932601600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V87//w==" LintValue="-12713"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1tX//w==" LintValue="-10794"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1tX//w==" DoubleValue="-932601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gd3//w==" DoubleValue="-771984000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1tX//w==" LintValue="-10794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gd3//w==" LintValue="-8935"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gd3//w==" DoubleValue="-771984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PuT//w==" DoubleValue="-613958400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gd3//w==" LintValue="-8935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PuT//w==" LintValue="-7106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PuT//w==" DoubleValue="-613958400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f+v//w==" DoubleValue="-453513600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PuT//w==" LintValue="-7106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f+v//w==" LintValue="-5249"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f+v//w==" DoubleValue="-453513600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPL//w==" DoubleValue="-295488000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f+v//w==" LintValue="-5249"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPL//w==" LintValue="-3420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPL//w==" DoubleValue="-295488000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPL//w==" LintValue="-3420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQEAAA==" DoubleValue="24278400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQEAAA==" LintValue="281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQEAAA==" DoubleValue="24278400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QggAAA==" DoubleValue="182649600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQEAAA==" LintValue="281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QggAAA==" LintValue="2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QggAAA==" DoubleValue="182649600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cA8AAA==" DoubleValue="341452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QggAAA==" LintValue="2114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cA8AAA==" LintValue="3952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cA8AAA==" DoubleValue="341452800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBYAAA==" DoubleValue="498355200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cA8AAA==" LintValue="3952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBYAAA==" LintValue="5768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBYAAA==" DoubleValue="498355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3h0AAA==" DoubleValue="660614400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBYAAA==" LintValue="5768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3h0AAA==" LintValue="7646"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3h0AAA==" DoubleValue="660614400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" DoubleValue="820454400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3h0AAA==" LintValue="7646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" LintValue="9496"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.26" Name="dcal_prev_day" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U3H//w==" DoubleValue="-3155760000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h3j//w==" DoubleValue="-2996438400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U3H//w==" LintValue="-36525"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h3j//w==" LintValue="-34681"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h3j//w==" DoubleValue="-2996438400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z3///w==" DoubleValue="-2844374400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h3j//w==" LintValue="-34681"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z3///w==" LintValue="-32921"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z3///w==" DoubleValue="-2844374400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kob//w==" DoubleValue="-2685830400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z3///w==" LintValue="-32921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kob//w==" LintValue="-31086"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kob//w==" DoubleValue="-2685830400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Co7//w==" DoubleValue="-2520633600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kob//w==" LintValue="-31086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Co7//w==" LintValue="-29174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Co7//w==" DoubleValue="-2520633600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YZX//w==" DoubleValue="-2358288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Co7//w==" LintValue="-29174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YZX//w==" LintValue="-27295"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YZX//w==" DoubleValue="-2358288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R5z//w==" DoubleValue="-2205705600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YZX//w==" LintValue="-27295"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R5z//w==" LintValue="-25529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R5z//w==" DoubleValue="-2205705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R6P//w==" DoubleValue="-2050876800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R5z//w==" LintValue="-25529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R6P//w==" LintValue="-23737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R6P//w==" DoubleValue="-2050876800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z6r//w==" DoubleValue="-1893283200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R6P//w==" LintValue="-23737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z6r//w==" LintValue="-21913"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z6r//w==" DoubleValue="-1893283200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q7H//w==" DoubleValue="-1732579200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z6r//w==" LintValue="-21913"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q7H//w==" LintValue="-20053"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q7H//w==" DoubleValue="-1732579200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ybj//w==" DoubleValue="-1575158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q7H//w==" LintValue="-20053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ybj//w==" LintValue="-18231"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ybj//w==" DoubleValue="-1575158400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="McD//w==" DoubleValue="-1411344000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ybj//w==" LintValue="-18231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="McD//w==" LintValue="-16335"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="McD//w==" DoubleValue="-1411344000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W8f//w==" DoubleValue="-1252886400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="McD//w==" LintValue="-16335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W8f//w==" LintValue="-14501"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W8f//w==" DoubleValue="-1252886400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vc7//w==" DoubleValue="-1098576000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W8f//w==" LintValue="-14501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vc7//w==" LintValue="-12715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vc7//w==" DoubleValue="-1098576000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1NX//w==" DoubleValue="-932774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vc7//w==" LintValue="-12715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1NX//w==" LintValue="-10796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1NX//w==" DoubleValue="-932774400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F93//w==" DoubleValue="-772156800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1NX//w==" LintValue="-10796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F93//w==" LintValue="-8937"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F93//w==" DoubleValue="-772156800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="POT//w==" DoubleValue="-614131200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F93//w==" LintValue="-8937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="POT//w==" LintValue="-7108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="POT//w==" DoubleValue="-614131200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fev//w==" DoubleValue="-453686400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="POT//w==" LintValue="-7108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fev//w==" LintValue="-5251"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fev//w==" DoubleValue="-453686400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovL//w==" DoubleValue="-295660800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fev//w==" LintValue="-5251"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovL//w==" LintValue="-3422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovL//w==" DoubleValue="-295660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovL//w==" LintValue="-3422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FwEAAA==" DoubleValue="24105600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FwEAAA==" LintValue="279"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FwEAAA==" DoubleValue="24105600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QAgAAA==" DoubleValue="182476800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FwEAAA==" LintValue="279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QAgAAA==" LintValue="2112"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QAgAAA==" DoubleValue="182476800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg8AAA==" DoubleValue="341280000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QAgAAA==" LintValue="2112"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg8AAA==" LintValue="3950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg8AAA==" DoubleValue="341280000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hhYAAA==" DoubleValue="498182400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg8AAA==" LintValue="3950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hhYAAA==" LintValue="5766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hhYAAA==" DoubleValue="498182400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3B0AAA==" DoubleValue="660441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hhYAAA==" LintValue="5766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3B0AAA==" LintValue="7644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="1840.880000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3B0AAA==" DoubleValue="660441600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FiUAAA==" DoubleValue="820281600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3B0AAA==" LintValue="7644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FiUAAA==" LintValue="9494"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.19" Name="dcal_week_start" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.002115" DistinctValues="13.951027">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U3H//w==" DoubleValue="-3155760000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tXH//w==" DoubleValue="-3147292800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U3H//w==" LintValue="-36525"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tXH//w==" LintValue="-36427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tXH//w==" DoubleValue="-3147292800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tXH//w==" DoubleValue="-3147292800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tXH//w==" LintValue="-36427"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tXH//w==" LintValue="-36427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037611" DistinctValues="248.128973">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tXH//w==" DoubleValue="-3147292800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hHj//w==" DoubleValue="-2996697600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tXH//w==" LintValue="-36427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hHj//w==" LintValue="-34684"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hHj//w==" DoubleValue="-2996697600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aH///w==" DoubleValue="-2844288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hHj//w==" LintValue="-34684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aH///w==" LintValue="-32920"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aH///w==" DoubleValue="-2844288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kob//w==" DoubleValue="-2685830400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aH///w==" LintValue="-32920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kob//w==" LintValue="-31086"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032013" DistinctValues="211.200000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kob//w==" DoubleValue="-2685830400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="loz//w==" DoubleValue="-2552774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kob//w==" LintValue="-31086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="loz//w==" LintValue="-29546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="loz//w==" DoubleValue="-2552774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="loz//w==" DoubleValue="-2552774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="loz//w==" LintValue="-29546"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="loz//w==" LintValue="-29546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007712" DistinctValues="50.880000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="loz//w==" DoubleValue="-2552774400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CY7//w==" DoubleValue="-2520720000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="loz//w==" LintValue="-29546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CY7//w==" LintValue="-29175"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019566" DistinctValues="129.084179">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CY7//w==" DoubleValue="-2520720000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pZH//w==" DoubleValue="-2440886400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CY7//w==" LintValue="-29175"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pZH//w==" LintValue="-28251"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pZH//w==" DoubleValue="-2440886400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pZH//w==" DoubleValue="-2440886400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pZH//w==" LintValue="-28251"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pZH//w==" LintValue="-28251"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020159" DistinctValues="132.995821">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pZH//w==" DoubleValue="-2440886400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XZX//w==" DoubleValue="-2358633600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pZH//w==" LintValue="-28251"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XZX//w==" LintValue="-27299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XZX//w==" DoubleValue="-2358633600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SJz//w==" DoubleValue="-2205619200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XZX//w==" LintValue="-27299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SJz//w==" LintValue="-25528"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011949" DistinctValues="78.828750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SJz//w==" DoubleValue="-2205619200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y57//w==" DoubleValue="-2159049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SJz//w==" LintValue="-25528"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y57//w==" LintValue="-24989"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y57//w==" DoubleValue="-2159049600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Y57//w==" DoubleValue="-2159049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y57//w==" LintValue="-24989"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Y57//w==" LintValue="-24989"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027777" DistinctValues="183.251250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Y57//w==" DoubleValue="-2159049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SKP//w==" DoubleValue="-2050790400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Y57//w==" LintValue="-24989"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SKP//w==" LintValue="-23736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SKP//w==" DoubleValue="-2050790400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZKr//w==" DoubleValue="-1893542400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SKP//w==" LintValue="-23736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZKr//w==" LintValue="-21916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKr//w==" DoubleValue="-1893542400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qrH//w==" DoubleValue="-1732665600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKr//w==" LintValue="-21916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qrH//w==" LintValue="-20054"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014515" DistinctValues="95.760000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qrH//w==" DoubleValue="-1732665600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q7T//w==" DoubleValue="-1675209600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qrH//w==" LintValue="-20054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q7T//w==" LintValue="-19389"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q7T//w==" DoubleValue="-1675209600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q7T//w==" DoubleValue="-1675209600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q7T//w==" LintValue="-19389"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q7T//w==" LintValue="-19389"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025210" DistinctValues="166.320000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q7T//w==" DoubleValue="-1675209600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xrj//w==" DoubleValue="-1575417600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q7T//w==" LintValue="-19389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xrj//w==" LintValue="-18234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024187" DistinctValues="159.569004">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xrj//w==" DoubleValue="-1575417600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sb3//w==" DoubleValue="-1475625600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xrj//w==" LintValue="-18234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sb3//w==" LintValue="-17079"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sb3//w==" DoubleValue="-1475625600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sb3//w==" DoubleValue="-1475625600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sb3//w==" LintValue="-17079"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sb3//w==" LintValue="-17079"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015538" DistinctValues="102.510996">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sb3//w==" DoubleValue="-1475625600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L8D//w==" DoubleValue="-1411516800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sb3//w==" LintValue="-17079"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L8D//w==" LintValue="-16337"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L8D//w==" DoubleValue="-1411516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wcf//w==" DoubleValue="-1253059200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L8D//w==" LintValue="-16337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wcf//w==" LintValue="-14503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018694" DistinctValues="122.390588">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wcf//w==" DoubleValue="-1253059200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ocr//w==" DoubleValue="-1180483200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wcf//w==" LintValue="-14503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ocr//w==" LintValue="-13663"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ocr//w==" DoubleValue="-1180483200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ocr//w==" DoubleValue="-1180483200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ocr//w==" LintValue="-13663"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ocr//w==" LintValue="-13663"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010593" DistinctValues="69.354667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ocr//w==" DoubleValue="-1180483200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcz//w==" DoubleValue="-1139356800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ocr//w==" LintValue="-13663"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcz//w==" LintValue="-13187"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcz//w==" DoubleValue="-1139356800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcz//w==" DoubleValue="-1139356800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcz//w==" LintValue="-13187"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcz//w==" LintValue="-13187"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004362" DistinctValues="28.557804">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcz//w==" DoubleValue="-1139356800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qc3//w==" DoubleValue="-1122422400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcz//w==" LintValue="-13187"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qc3//w==" LintValue="-12991"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qc3//w==" DoubleValue="-1122422400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qc3//w==" DoubleValue="-1122422400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qc3//w==" LintValue="-12991"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qc3//w==" LintValue="-12991"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006076" DistinctValues="39.776941">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qc3//w==" DoubleValue="-1122422400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Us7//w==" DoubleValue="-1098835200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qc3//w==" LintValue="-12991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Us7//w==" LintValue="-12718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011019" DistinctValues="72.416350">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Us7//w==" DoubleValue="-1098835200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZtD//w==" DoubleValue="-1052870400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Us7//w==" LintValue="-12718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZtD//w==" LintValue="-12186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZtD//w==" DoubleValue="-1052870400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZtD//w==" DoubleValue="-1052870400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZtD//w==" LintValue="-12186"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZtD//w==" LintValue="-12186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027402" DistinctValues="180.088029">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZtD//w==" DoubleValue="-1052870400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kdX//w==" DoubleValue="-938563200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZtD//w==" LintValue="-12186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kdX//w==" LintValue="-10863"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kdX//w==" DoubleValue="-938563200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kdX//w==" DoubleValue="-938563200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kdX//w==" LintValue="-10863"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kdX//w==" LintValue="-10863"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001305" DistinctValues="8.575620">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kdX//w==" DoubleValue="-938563200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0NX//w==" DoubleValue="-933120000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kdX//w==" LintValue="-10863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0NX//w==" LintValue="-10800"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0NX//w==" DoubleValue="-933120000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ft3//w==" DoubleValue="-772243200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0NX//w==" LintValue="-10800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ft3//w==" LintValue="-8938"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003653" DistinctValues="24.099310">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ft3//w==" DoubleValue="-772243200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vt3//w==" DoubleValue="-757728000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ft3//w==" LintValue="-8938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vt3//w==" LintValue="-8770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vt3//w==" DoubleValue="-757728000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vt3//w==" DoubleValue="-757728000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vt3//w==" LintValue="-8770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vt3//w==" LintValue="-8770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036073" DistinctValues="237.980690">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vt3//w==" DoubleValue="-757728000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OeT//w==" DoubleValue="-614390400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vt3//w==" LintValue="-8770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OeT//w==" LintValue="-7111"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000600" DistinctValues="3.940830">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OeT//w==" DoubleValue="-614390400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VeT//w==" DoubleValue="-611971200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OeT//w==" LintValue="-7111"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VeT//w==" LintValue="-7083"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VeT//w==" DoubleValue="-611971200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VeT//w==" DoubleValue="-611971200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VeT//w==" LintValue="-7083"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VeT//w==" LintValue="-7083"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005247" DistinctValues="34.482264">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VeT//w==" DoubleValue="-611971200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SuX//w==" DoubleValue="-590803200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VeT//w==" LintValue="-7083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SuX//w==" LintValue="-6838"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SuX//w==" DoubleValue="-590803200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SuX//w==" DoubleValue="-590803200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SuX//w==" LintValue="-6838"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SuX//w==" LintValue="-6838"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033879" DistinctValues="222.656906">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SuX//w==" DoubleValue="-590803200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eOv//w==" DoubleValue="-454118400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SuX//w==" LintValue="-6838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eOv//w==" LintValue="-5256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eOv//w==" DoubleValue="-454118400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eOv//w==" DoubleValue="-454118400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eOv//w==" LintValue="-5256"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eOv//w==" LintValue="-5256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003942" DistinctValues="25.809466">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eOv//w==" DoubleValue="-454118400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Luz//w==" DoubleValue="-438393600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eOv//w==" LintValue="-5256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Luz//w==" LintValue="-5074"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Luz//w==" DoubleValue="-438393600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Luz//w==" DoubleValue="-438393600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Luz//w==" LintValue="-5074"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Luz//w==" LintValue="-5074"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004549" DistinctValues="29.780153">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Luz//w==" DoubleValue="-438393600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AO3//w==" DoubleValue="-420249600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Luz//w==" LintValue="-5074"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AO3//w==" LintValue="-4864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AO3//w==" DoubleValue="-420249600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AO3//w==" DoubleValue="-420249600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AO3//w==" LintValue="-4864"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AO3//w==" LintValue="-4864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031235" DistinctValues="204.490382">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AO3//w==" DoubleValue="-420249600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovL//w==" DoubleValue="-295660800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AO3//w==" LintValue="-4864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovL//w==" LintValue="-3422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001674" DistinctValues="11.045517">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovL//w==" DoubleValue="-295660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/L//w==" DoubleValue="-289008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovL//w==" LintValue="-3422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/L//w==" LintValue="-3345"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/L//w==" DoubleValue="-289008000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/L//w==" DoubleValue="-289008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/L//w==" LintValue="-3345"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/L//w==" LintValue="-3345"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038051" DistinctValues="251.034483">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/L//w==" DoubleValue="-289008000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/L//w==" LintValue="-3345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000149" DistinctValues="0.974082">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002976" DistinctValues="19.481648">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012647" DistinctValues="82.797004">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023954" DistinctValues="156.827266">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003942" DistinctValues="26.007939">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yAEAAA==" DoubleValue="39398400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yAEAAA==" LintValue="456"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yAEAAA==" DoubleValue="39398400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yAEAAA==" DoubleValue="39398400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yAEAAA==" LintValue="456"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yAEAAA==" LintValue="456"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035783" DistinctValues="236.072061">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yAEAAA==" DoubleValue="39398400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PAgAAA==" DoubleValue="182131200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yAEAAA==" LintValue="456"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PAgAAA==" LintValue="2108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PAgAAA==" DoubleValue="182131200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bQ8AAA==" DoubleValue="341193600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PAgAAA==" LintValue="2108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bQ8AAA==" LintValue="3949"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005062" DistinctValues="33.392432">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bQ8AAA==" DoubleValue="341193600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VBAAAA==" DoubleValue="361152000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bQ8AAA==" LintValue="3949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VBAAAA==" LintValue="4180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VBAAAA==" DoubleValue="361152000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VBAAAA==" DoubleValue="361152000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VBAAAA==" LintValue="4180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VBAAAA==" LintValue="4180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034664" DistinctValues="228.687568">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VBAAAA==" DoubleValue="361152000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ghYAAA==" DoubleValue="497836800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VBAAAA==" LintValue="4180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ghYAAA==" LintValue="5762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022890" DistinctValues="151.012639">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ghYAAA==" DoubleValue="497836800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vxoAAA==" DoubleValue="591580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ghYAAA==" LintValue="5762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vxoAAA==" LintValue="6847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vxoAAA==" DoubleValue="591580800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vxoAAA==" DoubleValue="591580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vxoAAA==" LintValue="6847"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vxoAAA==" LintValue="6847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016835" DistinctValues="111.067361">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vxoAAA==" DoubleValue="591580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3R0AAA==" DoubleValue="660528000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vxoAAA==" LintValue="6847"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3R0AAA==" LintValue="7645"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012790" DistinctValues="84.381818">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3R0AAA==" DoubleValue="660528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MCAAAA==" DoubleValue="711936000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3R0AAA==" LintValue="7645"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MCAAAA==" LintValue="8240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MCAAAA==" DoubleValue="711936000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MCAAAA==" DoubleValue="711936000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MCAAAA==" LintValue="8240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MCAAAA==" LintValue="8240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026935" DistinctValues="177.698182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MCAAAA==" DoubleValue="711936000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FSUAAA==" DoubleValue="820195200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MCAAAA==" LintValue="8240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FSUAAA==" LintValue="9493"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.18" Name="dcal_week_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -7258,300 +7258,300 @@ group by	pa11.dcal_month_id,
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.20" Name="dcal_week_end" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WXH//w==" DoubleValue="-3155241600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="inj//w==" DoubleValue="-2996179200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WXH//w==" LintValue="-36519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="inj//w==" LintValue="-34678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="inj//w==" DoubleValue="-2996179200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bn///w==" DoubleValue="-2843769600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="inj//w==" LintValue="-34678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bn///w==" LintValue="-32914"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004397" DistinctValues="29.008855">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bn///w==" DoubleValue="-2843769600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OYD//w==" DoubleValue="-2826230400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bn///w==" LintValue="-32914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OYD//w==" LintValue="-32711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OYD//w==" DoubleValue="-2826230400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OYD//w==" DoubleValue="-2826230400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OYD//w==" LintValue="-32711"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OYD//w==" LintValue="-32711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035328" DistinctValues="233.071145">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OYD//w==" DoubleValue="-2826230400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mIb//w==" DoubleValue="-2685312000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OYD//w==" LintValue="-32711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mIb//w==" LintValue="-31080"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mIb//w==" DoubleValue="-2685312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D47//w==" DoubleValue="-2520201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mIb//w==" LintValue="-31080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D47//w==" LintValue="-29169"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021197" DistinctValues="139.841194">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D47//w==" DoubleValue="-2520201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+JH//w==" DoubleValue="-2433715200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D47//w==" LintValue="-29169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+JH//w==" LintValue="-28168"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+JH//w==" DoubleValue="-2433715200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+JH//w==" DoubleValue="-2433715200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+JH//w==" LintValue="-28168"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+JH//w==" LintValue="-28168"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018529" DistinctValues="122.238806">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+JH//w==" DoubleValue="-2433715200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y5X//w==" DoubleValue="-2358115200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+JH//w==" LintValue="-28168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y5X//w==" LintValue="-27293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008793" DistinctValues="58.009802">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y5X//w==" DoubleValue="-2358115200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="65b//w==" DoubleValue="-2324246400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y5X//w==" LintValue="-27293"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="65b//w==" LintValue="-26901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="65b//w==" DoubleValue="-2324246400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="65b//w==" DoubleValue="-2324246400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="65b//w==" LintValue="-26901"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="65b//w==" LintValue="-26901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030932" DistinctValues="204.070198">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="65b//w==" DoubleValue="-2324246400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tpz//w==" DoubleValue="-2205100800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="65b//w==" LintValue="-26901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tpz//w==" LintValue="-25522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tpz//w==" DoubleValue="-2205100800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TqP//w==" DoubleValue="-2050272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tpz//w==" LintValue="-25522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TqP//w==" LintValue="-23730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026433" DistinctValues="174.384000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TqP//w==" DoubleValue="-2050272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Caj//w==" DoubleValue="-1945641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TqP//w==" LintValue="-23730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Caj//w==" LintValue="-22519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Caj//w==" DoubleValue="-1945641600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Caj//w==" DoubleValue="-1945641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Caj//w==" LintValue="-22519"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Caj//w==" LintValue="-22519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013293" DistinctValues="87.696000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Caj//w==" DoubleValue="-1945641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aqr//w==" DoubleValue="-1893024000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Caj//w==" LintValue="-22519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aqr//w==" LintValue="-21910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024194" DistinctValues="159.003609">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aqr//w==" DoubleValue="-1893024000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2K7//w==" DoubleValue="-1795046400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aqr//w==" LintValue="-21910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2K7//w==" LintValue="-20776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2K7//w==" DoubleValue="-1795046400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2K7//w==" DoubleValue="-1795046400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2K7//w==" LintValue="-20776"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2K7//w==" LintValue="-20776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002539" DistinctValues="16.685564">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2K7//w==" DoubleValue="-1795046400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T6///w==" DoubleValue="-1784764800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2K7//w==" LintValue="-20776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T6///w==" LintValue="-20657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T6///w==" DoubleValue="-1784764800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T6///w==" DoubleValue="-1784764800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T6///w==" LintValue="-20657"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T6///w==" LintValue="-20657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012993" DistinctValues="85.390827">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T6///w==" DoubleValue="-1784764800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sLH//w==" DoubleValue="-1732147200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T6///w==" LintValue="-20657"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sLH//w==" LintValue="-20048"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027044" DistinctValues="178.416000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sLH//w==" DoubleValue="-1732147200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h7b//w==" DoubleValue="-1625097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sLH//w==" LintValue="-20048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h7b//w==" LintValue="-18809"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h7b//w==" DoubleValue="-1625097600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h7b//w==" DoubleValue="-1625097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h7b//w==" LintValue="-18809"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h7b//w==" LintValue="-18809"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012682" DistinctValues="83.664000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h7b//w==" DoubleValue="-1625097600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zLj//w==" DoubleValue="-1574899200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h7b//w==" LintValue="-18809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zLj//w==" LintValue="-18228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017884" DistinctValues="117.984354">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zLj//w==" DoubleValue="-1574899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Irz//w==" DoubleValue="-1501113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zLj//w==" LintValue="-18228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Irz//w==" LintValue="-17374"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Irz//w==" DoubleValue="-1501113600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Irz//w==" DoubleValue="-1501113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Irz//w==" LintValue="-17374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Irz//w==" LintValue="-17374"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021842" DistinctValues="144.095646">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Irz//w==" DoubleValue="-1501113600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NcD//w==" DoubleValue="-1410998400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Irz//w==" LintValue="-17374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NcD//w==" LintValue="-16331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NcD//w==" DoubleValue="-1410998400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X8f//w==" DoubleValue="-1252540800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NcD//w==" LintValue="-16331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X8f//w==" LintValue="-14497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X8f//w==" DoubleValue="-1252540800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WM7//w==" DoubleValue="-1098316800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X8f//w==" LintValue="-14497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WM7//w==" LintValue="-12712"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013773" DistinctValues="90.520438">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WM7//w==" DoubleValue="-1098316800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8dD//w==" DoubleValue="-1040860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WM7//w==" LintValue="-12712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8dD//w==" LintValue="-12047"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8dD//w==" DoubleValue="-1040860800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8dD//w==" DoubleValue="-1040860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8dD//w==" LintValue="-12047"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8dD//w==" LintValue="-12047"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001740" DistinctValues="11.434161">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8dD//w==" DoubleValue="-1040860800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RdH//w==" DoubleValue="-1033603200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8dD//w==" LintValue="-12047"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RdH//w==" LintValue="-11963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RdH//w==" DoubleValue="-1033603200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RdH//w==" DoubleValue="-1033603200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RdH//w==" LintValue="-11963"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RdH//w==" LintValue="-11963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024212" DistinctValues="159.125401">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RdH//w==" DoubleValue="-1033603200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1tX//w==" DoubleValue="-932601600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RdH//w==" LintValue="-11963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1tX//w==" LintValue="-10794"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005078" DistinctValues="33.371128">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1tX//w==" DoubleValue="-932601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xNb//w==" DoubleValue="-912038400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1tX//w==" LintValue="-10794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xNb//w==" LintValue="-10556"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xNb//w==" DoubleValue="-912038400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xNb//w==" DoubleValue="-912038400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xNb//w==" LintValue="-10556"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xNb//w==" LintValue="-10556"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026285" DistinctValues="172.744662">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xNb//w==" DoubleValue="-912038400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lNv//w==" DoubleValue="-805593600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xNb//w==" LintValue="-10556"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lNv//w==" LintValue="-9324"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lNv//w==" DoubleValue="-805593600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lNv//w==" DoubleValue="-805593600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lNv//w==" LintValue="-9324"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lNv//w==" LintValue="-9324"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008363" DistinctValues="54.964211">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lNv//w==" DoubleValue="-805593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN3//w==" DoubleValue="-771724800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lNv//w==" LintValue="-9324"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN3//w==" LintValue="-8932"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038660" DistinctValues="255.051034">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN3//w==" DoubleValue="-771724800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DuT//w==" DoubleValue="-618105600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN3//w==" LintValue="-8932"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DuT//w==" LintValue="-7154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DuT//w==" DoubleValue="-618105600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DuT//w==" DoubleValue="-618105600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DuT//w==" LintValue="-7154"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DuT//w==" LintValue="-7154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001065" DistinctValues="7.028966">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DuT//w==" DoubleValue="-618105600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P+T//w==" DoubleValue="-613872000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DuT//w==" LintValue="-7154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P+T//w==" LintValue="-7105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000600" DistinctValues="3.910642">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P+T//w==" DoubleValue="-613872000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W+T//w==" DoubleValue="-611452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P+T//w==" LintValue="-7105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W+T//w==" LintValue="-7077"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+T//w==" DoubleValue="-611452800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="W+T//w==" DoubleValue="-611452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+T//w==" LintValue="-7077"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="W+T//w==" LintValue="-7077"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005247" DistinctValues="34.218113">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="W+T//w==" DoubleValue="-611452800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UOX//w==" DoubleValue="-590284800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="W+T//w==" LintValue="-7077"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UOX//w==" LintValue="-6832"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UOX//w==" DoubleValue="-590284800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UOX//w==" DoubleValue="-590284800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UOX//w==" LintValue="-6832"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UOX//w==" LintValue="-6832"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015440" DistinctValues="100.699019">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UOX//w==" DoubleValue="-590284800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iej//w==" DoubleValue="-527990400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UOX//w==" LintValue="-6832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iej//w==" LintValue="-6111"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iej//w==" DoubleValue="-527990400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Iej//w==" DoubleValue="-527990400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iej//w==" LintValue="-6111"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Iej//w==" LintValue="-6111"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006146" DistinctValues="40.084075">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Iej//w==" DoubleValue="-527990400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QOn//w==" DoubleValue="-503193600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Iej//w==" LintValue="-6111"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QOn//w==" LintValue="-5824"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QOn//w==" DoubleValue="-503193600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QOn//w==" DoubleValue="-503193600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QOn//w==" LintValue="-5824"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QOn//w==" LintValue="-5824"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012292" DistinctValues="80.168151">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QOn//w==" DoubleValue="-503193600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QOn//w==" LintValue="-5824"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="262.080000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" DoubleValue="-453600000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPL//w==" DoubleValue="-295142400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fuv//w==" LintValue="-5250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPL//w==" LintValue="-3416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003196" DistinctValues="21.086897">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPL//w==" DoubleValue="-295142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/P//w==" DoubleValue="-282441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPL//w==" LintValue="-3416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/P//w==" LintValue="-3269"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/P//w==" DoubleValue="-282441600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/P//w==" DoubleValue="-282441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/P//w==" LintValue="-3269"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/P//w==" LintValue="-3269"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036529" DistinctValues="240.993103">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/P//w==" DoubleValue="-282441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/P//w==" LintValue="-3269"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GAEAAA==" DoubleValue="24192000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GAEAAA==" LintValue="280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008643" DistinctValues="56.364733">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GAEAAA==" DoubleValue="24192000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pwIAAA==" DoubleValue="58665600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GAEAAA==" LintValue="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pwIAAA==" LintValue="679"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pwIAAA==" DoubleValue="58665600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pwIAAA==" DoubleValue="58665600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pwIAAA==" LintValue="679"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pwIAAA==" LintValue="679"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000758" DistinctValues="4.944275">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pwIAAA==" DoubleValue="58665600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ygIAAA==" DoubleValue="61689600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pwIAAA==" LintValue="679"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ygIAAA==" LintValue="714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ygIAAA==" DoubleValue="61689600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ygIAAA==" DoubleValue="61689600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ygIAAA==" LintValue="714"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ygIAAA==" LintValue="714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001365" DistinctValues="8.899695">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ygIAAA==" DoubleValue="61689600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CQMAAA==" DoubleValue="67132800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ygIAAA==" LintValue="714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CQMAAA==" LintValue="777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CQMAAA==" DoubleValue="67132800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CQMAAA==" DoubleValue="67132800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CQMAAA==" LintValue="777"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CQMAAA==" LintValue="777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016982" DistinctValues="110.751756">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="CQMAAA==" DoubleValue="67132800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQYAAA==" DoubleValue="134870400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="CQMAAA==" LintValue="777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GQYAAA==" LintValue="1561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQYAAA==" DoubleValue="134870400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GQYAAA==" DoubleValue="134870400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GQYAAA==" LintValue="1561"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GQYAAA==" LintValue="1561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011978" DistinctValues="78.119542">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GQYAAA==" DoubleValue="134870400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QggAAA==" DoubleValue="182649600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GQYAAA==" LintValue="1561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QggAAA==" LintValue="2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QggAAA==" DoubleValue="182649600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cw8AAA==" DoubleValue="341712000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QggAAA==" LintValue="2114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cw8AAA==" LintValue="3955"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036658" DistinctValues="241.842162">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cw8AAA==" DoubleValue="341712000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/BUAAA==" DoubleValue="486259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cw8AAA==" LintValue="3955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/BUAAA==" LintValue="5628"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/BUAAA==" DoubleValue="486259200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/BUAAA==" DoubleValue="486259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/BUAAA==" LintValue="5628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/BUAAA==" LintValue="5628"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003068" DistinctValues="20.237838">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/BUAAA==" DoubleValue="486259200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBYAAA==" DoubleValue="498355200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/BUAAA==" LintValue="5628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBYAAA==" LintValue="5768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009747" DistinctValues="64.302156">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBYAAA==" DoubleValue="498355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VhgAAA==" DoubleValue="538272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBYAAA==" LintValue="5768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VhgAAA==" LintValue="6230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000275" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VhgAAA==" DoubleValue="538272000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VhgAAA==" DoubleValue="538272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VhgAAA==" LintValue="6230"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VhgAAA==" LintValue="6230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029979" DistinctValues="197.777844">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VhgAAA==" DoubleValue="538272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4x0AAA==" DoubleValue="661046400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VhgAAA==" LintValue="6230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4x0AAA==" LintValue="7651"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039725" DistinctValues="263.080000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4x0AAA==" DoubleValue="661046400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GyUAAA==" DoubleValue="820713600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4x0AAA==" LintValue="7651"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GyUAAA==" LintValue="9499"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.12" Name="dcal_month_num" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -9878,606 +9878,606 @@ group by	pa11.dcal_month_id,
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.15" Name="dcal_month_end" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.018193" DistinctValues="27.687842">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cnH//w==" DoubleValue="-3153081600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xHT//w==" DoubleValue="-3079641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cnH//w==" LintValue="-36494"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xHT//w==" LintValue="-35644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xHT//w==" DoubleValue="-3079641600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xHT//w==" DoubleValue="-3079641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xHT//w==" LintValue="-35644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xHT//w==" LintValue="-35644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020890" DistinctValues="31.792158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xHT//w==" DoubleValue="-3079641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lHj//w==" DoubleValue="-2995315200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xHT//w==" LintValue="-35644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lHj//w==" LintValue="-34668"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007400" DistinctValues="11.072744">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lHj//w==" DoubleValue="-2995315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4nn//w==" DoubleValue="-2966457600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lHj//w==" LintValue="-34668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4nn//w==" LintValue="-34334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4nn//w==" DoubleValue="-2966457600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4nn//w==" DoubleValue="-2966457600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4nn//w==" LintValue="-34334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4nn//w==" LintValue="-34334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012784" DistinctValues="19.128662">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4nn//w==" DoubleValue="-2966457600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I3z//w==" DoubleValue="-2916604800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4nn//w==" LintValue="-34334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I3z//w==" LintValue="-33757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I3z//w==" DoubleValue="-2916604800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="I3z//w==" DoubleValue="-2916604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I3z//w==" LintValue="-33757"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="I3z//w==" LintValue="-33757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018899" DistinctValues="28.278594">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="I3z//w==" DoubleValue="-2916604800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eH///w==" DoubleValue="-2842905600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="I3z//w==" LintValue="-33757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eH///w==" LintValue="-32904"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eH///w==" DoubleValue="-2842905600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mob//w==" DoubleValue="-2685139200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eH///w==" LintValue="-32904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mob//w==" LintValue="-31078"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mob//w==" DoubleValue="-2685139200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F47//w==" DoubleValue="-2519510400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mob//w==" LintValue="-31078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F47//w==" LintValue="-29161"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016383" DistinctValues="24.513874">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F47//w==" DoubleValue="-2519510400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LpH//w==" DoubleValue="-2451168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F47//w==" LintValue="-29161"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LpH//w==" LintValue="-28370"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LpH//w==" DoubleValue="-2451168000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LpH//w==" DoubleValue="-2451168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LpH//w==" LintValue="-28370"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LpH//w==" LintValue="-28370"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010728" DistinctValues="16.053333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LpH//w==" DoubleValue="-2451168000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NJP//w==" DoubleValue="-2406412800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LpH//w==" LintValue="-28370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NJP//w==" LintValue="-27852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NJP//w==" DoubleValue="-2406412800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NJP//w==" DoubleValue="-2406412800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NJP//w==" LintValue="-27852"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NJP//w==" LintValue="-27852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011971" DistinctValues="17.912793">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NJP//w==" DoubleValue="-2406412800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dpX//w==" DoubleValue="-2356473600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NJP//w==" LintValue="-27852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dpX//w==" LintValue="-27274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dpX//w==" DoubleValue="-2356473600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W5z//w==" DoubleValue="-2203977600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dpX//w==" LintValue="-27274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W5z//w==" LintValue="-25509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031149" DistinctValues="47.405362">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W5z//w==" DoubleValue="-2203977600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9KH//w==" DoubleValue="-2080166400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W5z//w==" LintValue="-25509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9KH//w==" LintValue="-24076"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9KH//w==" DoubleValue="-2080166400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9KH//w==" DoubleValue="-2080166400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9KH//w==" LintValue="-24076"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9KH//w==" LintValue="-24076"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007934" DistinctValues="12.074638">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9KH//w==" DoubleValue="-2080166400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YaP//w==" DoubleValue="-2048630400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9KH//w==" LintValue="-24076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YaP//w==" LintValue="-23711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005843" DistinctValues="8.892683">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YaP//w==" DoubleValue="-2048630400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cqT//w==" DoubleValue="-2025043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YaP//w==" LintValue="-23711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cqT//w==" LintValue="-23438"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cqT//w==" DoubleValue="-2025043200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cqT//w==" DoubleValue="-2025043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cqT//w==" LintValue="-23438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cqT//w==" LintValue="-23438"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033239" DistinctValues="50.587317">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cqT//w==" DoubleValue="-2025043200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g6r//w==" DoubleValue="-1890864000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cqT//w==" LintValue="-23438"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g6r//w==" LintValue="-21885"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022438" DistinctValues="34.148895">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g6r//w==" DoubleValue="-1890864000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g6r//w==" LintValue="-21885"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016644" DistinctValues="25.331105">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" DoubleValue="-1798848000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wrH//w==" DoubleValue="-1730592000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rK7//w==" LintValue="-20820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wrH//w==" LintValue="-20030"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wrH//w==" DoubleValue="-1730592000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Lj//w==" DoubleValue="-1572825600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wrH//w==" LintValue="-20030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Lj//w==" LintValue="-18204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017667" DistinctValues="26.887356">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Lj//w==" DoubleValue="-1572825600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Obz//w==" DoubleValue="-1499126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Lj//w==" LintValue="-18204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Obz//w==" LintValue="-17351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Obz//w==" DoubleValue="-1499126400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Obz//w==" DoubleValue="-1499126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Obz//w==" LintValue="-17351"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Obz//w==" LintValue="-17351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021416" DistinctValues="32.592644">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Obz//w==" DoubleValue="-1499126400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q8D//w==" DoubleValue="-1409788800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Obz//w==" LintValue="-17351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q8D//w==" LintValue="-16317"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q8D//w==" DoubleValue="-1409788800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsf//w==" DoubleValue="-1251936000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q8D//w==" LintValue="-16317"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsf//w==" LintValue="-14490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017213" DistinctValues="25.315523">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsf//w==" DoubleValue="-1251936000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsf//w==" LintValue="-14490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001349" DistinctValues="1.984276">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" DoubleValue="-1183593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u8r//w==" DoubleValue="-1178236800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fcr//w==" LintValue="-13699"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u8r//w==" LintValue="-13637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u8r//w==" DoubleValue="-1178236800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u8r//w==" DoubleValue="-1178236800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u8r//w==" LintValue="-13637"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u8r//w==" LintValue="-13637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009923" DistinctValues="14.594031">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u8r//w==" DoubleValue="-1178236800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g8z//w==" DoubleValue="-1138838400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u8r//w==" LintValue="-13637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g8z//w==" LintValue="-13181"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g8z//w==" DoubleValue="-1138838400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g8z//w==" DoubleValue="-1138838400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g8z//w==" LintValue="-13181"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g8z//w==" LintValue="-13181"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010597" DistinctValues="15.586169">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g8z//w==" DoubleValue="-1138838400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="as7//w==" DoubleValue="-1096761600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g8z//w==" LintValue="-13181"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="as7//w==" LintValue="-12694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014883" DistinctValues="22.650183">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="as7//w==" DoubleValue="-1096761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RNH//w==" DoubleValue="-1033689600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="as7//w==" LintValue="-12694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RNH//w==" LintValue="-11964"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RNH//w==" DoubleValue="-1033689600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RNH//w==" DoubleValue="-1033689600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RNH//w==" LintValue="-11964"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RNH//w==" LintValue="-11964"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024200" DistinctValues="36.829817">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RNH//w==" DoubleValue="-1033689600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RNH//w==" LintValue="-11964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" DoubleValue="-931132800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KN3//w==" DoubleValue="-770688000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="59X//w==" LintValue="-10777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KN3//w==" LintValue="-8920"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005220" DistinctValues="7.943689">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KN3//w==" DoubleValue="-770688000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KN3//w==" LintValue="-8920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033863" DistinctValues="51.536311">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" DoubleValue="-749606400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S+T//w==" DoubleValue="-612835200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HN7//w==" LintValue="-8676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S+T//w==" LintValue="-7093"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001284" DistinctValues="1.953840">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S+T//w==" DoubleValue="-612835200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S+T//w==" LintValue="-7093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037799" DistinctValues="57.526160">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" DoubleValue="-607564800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jOv//w==" DoubleValue="-452390400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iOT//w==" LintValue="-7032"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jOv//w==" LintValue="-5236"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jOv//w==" DoubleValue="-452390400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvL//w==" DoubleValue="-294624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jOv//w==" LintValue="-5236"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvL//w==" LintValue="-3410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013013" DistinctValues="19.471982">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvL//w==" DoubleValue="-294624000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvL//w==" LintValue="-3410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007812" DistinctValues="11.689595">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/b//w==" DoubleValue="-210556800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/b//w==" LintValue="-2437"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/b//w==" DoubleValue="-210556800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/b//w==" DoubleValue="-210556800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/b//w==" LintValue="-2437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/b//w==" LintValue="-2437"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018257" DistinctValues="27.318423">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/b//w==" DoubleValue="-210556800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pn//w==" DoubleValue="-136857600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/b//w==" LintValue="-2437"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pn//w==" LintValue="-1584"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033410" DistinctValues="50.847839">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pn//w==" DoubleValue="-136857600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HgAAAA==" DoubleValue="2592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pn//w==" LintValue="-1584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HgAAAA==" LintValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000980" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HgAAAA==" DoubleValue="2592000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HgAAAA==" DoubleValue="2592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HgAAAA==" LintValue="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HgAAAA==" LintValue="30"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005672" DistinctValues="8.632161">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HgAAAA==" DoubleValue="2592000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MAEAAA==" DoubleValue="26265600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HgAAAA==" LintValue="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MAEAAA==" LintValue="304"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024742" DistinctValues="37.655465">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MAEAAA==" DoubleValue="26265600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tAUAAA==" DoubleValue="126144000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MAEAAA==" LintValue="304"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tAUAAA==" LintValue="1460"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAUAAA==" DoubleValue="126144000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAUAAA==" DoubleValue="126144000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAUAAA==" LintValue="1460"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAUAAA==" LintValue="1460"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014340" DistinctValues="21.824535">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tAUAAA==" DoubleValue="126144000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UggAAA==" DoubleValue="184032000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tAUAAA==" LintValue="1460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UggAAA==" LintValue="2130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024764" DistinctValues="37.054414">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UggAAA==" DoubleValue="184032000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1wwAAA==" DoubleValue="283996800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UggAAA==" LintValue="2130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1wwAAA==" LintValue="3287"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1wwAAA==" DoubleValue="283996800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1wwAAA==" DoubleValue="283996800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1wwAAA==" LintValue="3287"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1wwAAA==" LintValue="3287"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001926" DistinctValues="2.882366">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1wwAAA==" DoubleValue="283996800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1wwAAA==" LintValue="3287"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012392" DistinctValues="18.543220">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" DoubleValue="291772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dA8AAA==" DoubleValue="341798400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MQ0AAA==" LintValue="3377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dA8AAA==" LintValue="3956"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dA8AAA==" DoubleValue="341798400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lhYAAA==" DoubleValue="499564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dA8AAA==" LintValue="3956"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lhYAAA==" LintValue="5782"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028339" DistinctValues="42.404195">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lhYAAA==" DoubleValue="499564800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7xsAAA==" DoubleValue="617846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lhYAAA==" LintValue="5782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7xsAAA==" LintValue="7151"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7xsAAA==" DoubleValue="617846400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7xsAAA==" DoubleValue="617846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7xsAAA==" LintValue="7151"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7xsAAA==" LintValue="7151"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003167" DistinctValues="4.739110">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7xsAAA==" DoubleValue="617846400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7xsAAA==" LintValue="7151"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007576" DistinctValues="11.336695">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9h0AAA==" DoubleValue="662688000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9h0AAA==" LintValue="7670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012350" DistinctValues="18.479168">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9h0AAA==" DoubleValue="662688000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NyAAAA==" DoubleValue="712540800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9h0AAA==" LintValue="7670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NyAAAA==" LintValue="8247"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NyAAAA==" DoubleValue="712540800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NyAAAA==" DoubleValue="712540800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NyAAAA==" LintValue="8247"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NyAAAA==" LintValue="8247"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009781" DistinctValues="14.636013">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NyAAAA==" DoubleValue="712540800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ACIAAA==" DoubleValue="752025600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NyAAAA==" LintValue="8247"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ACIAAA==" LintValue="8704"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ACIAAA==" DoubleValue="752025600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ACIAAA==" DoubleValue="752025600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ACIAAA==" LintValue="8704"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ACIAAA==" LintValue="8704"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016951" DistinctValues="25.364819">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ACIAAA==" DoubleValue="752025600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" DoubleValue="820454400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ACIAAA==" LintValue="8704"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GCUAAA==" LintValue="9496"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.14" Name="dcal_month_begin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.018193" DistinctValues="27.687842">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" DoubleValue="-3155673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pnT//w==" DoubleValue="-3082233600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" LintValue="-36524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pnT//w==" LintValue="-35674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pnT//w==" DoubleValue="-3082233600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pnT//w==" DoubleValue="-3082233600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pnT//w==" LintValue="-35674"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pnT//w==" LintValue="-35674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020890" DistinctValues="31.792158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pnT//w==" DoubleValue="-3082233600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dnj//w==" DoubleValue="-2997907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pnT//w==" LintValue="-35674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dnj//w==" LintValue="-34698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007396" DistinctValues="11.066470">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dnj//w==" DoubleValue="-2997907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xHn//w==" DoubleValue="-2969049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dnj//w==" LintValue="-34698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xHn//w==" LintValue="-34364"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xHn//w==" DoubleValue="-2969049600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xHn//w==" DoubleValue="-2969049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xHn//w==" LintValue="-34364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xHn//w==" LintValue="-34364"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012776" DistinctValues="19.117824">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xHn//w==" DoubleValue="-2969049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BXz//w==" DoubleValue="-2919196800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xHn//w==" LintValue="-34364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BXz//w==" LintValue="-33787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BXz//w==" DoubleValue="-2919196800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BXz//w==" DoubleValue="-2919196800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BXz//w==" LintValue="-33787"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BXz//w==" LintValue="-33787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018910" DistinctValues="28.295705">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BXz//w==" DoubleValue="-2919196800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W3///w==" DoubleValue="-2845411200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BXz//w==" LintValue="-33787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W3///w==" LintValue="-32933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W3///w==" DoubleValue="-2845411200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fYb//w==" DoubleValue="-2687644800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W3///w==" LintValue="-32933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fYb//w==" LintValue="-31107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fYb//w==" DoubleValue="-2687644800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+43//w==" DoubleValue="-2521929600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fYb//w==" LintValue="-31107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+43//w==" LintValue="-29189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016371" DistinctValues="24.495864">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+43//w==" DoubleValue="-2521929600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+43//w==" LintValue="-29189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010734" DistinctValues="16.061845">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" DoubleValue="-2453673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F5P//w==" DoubleValue="-2408918400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EZH//w==" LintValue="-28399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F5P//w==" LintValue="-27881"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F5P//w==" DoubleValue="-2408918400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F5P//w==" DoubleValue="-2408918400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F5P//w==" LintValue="-27881"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F5P//w==" LintValue="-27881"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011978" DistinctValues="17.922291">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F5P//w==" DoubleValue="-2408918400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WZX//w==" DoubleValue="-2358979200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F5P//w==" LintValue="-27881"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WZX//w==" LintValue="-27303"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WZX//w==" DoubleValue="-2358979200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QJz//w==" DoubleValue="-2206310400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WZX//w==" LintValue="-27303"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QJz//w==" LintValue="-25536"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031135" DistinctValues="47.385181">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QJz//w==" DoubleValue="-2206310400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1qH//w==" DoubleValue="-2082758400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QJz//w==" LintValue="-25536"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1qH//w==" LintValue="-24106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1qH//w==" DoubleValue="-2082758400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1qH//w==" DoubleValue="-2082758400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1qH//w==" LintValue="-24106"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1qH//w==" LintValue="-24106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007947" DistinctValues="12.094819">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1qH//w==" DoubleValue="-2082758400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q6P//w==" DoubleValue="-2051222400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1qH//w==" LintValue="-24106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q6P//w==" LintValue="-23741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q6P//w==" DoubleValue="-2051222400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zar//w==" DoubleValue="-1893456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q6P//w==" LintValue="-23741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zar//w==" LintValue="-21915"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022402" DistinctValues="34.093757">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zar//w==" DoubleValue="-1893456000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jq7//w==" DoubleValue="-1801440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zar//w==" LintValue="-21915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jq7//w==" LintValue="-20850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jq7//w==" DoubleValue="-1801440000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jq7//w==" DoubleValue="-1801440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jq7//w==" LintValue="-20850"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jq7//w==" LintValue="-20850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016680" DistinctValues="25.386243">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jq7//w==" DoubleValue="-1801440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p7H//w==" DoubleValue="-1732924800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jq7//w==" LintValue="-20850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p7H//w==" LintValue="-20057"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p7H//w==" DoubleValue="-1732924800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ybj//w==" DoubleValue="-1575158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p7H//w==" LintValue="-20057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ybj//w==" LintValue="-18231"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017644" DistinctValues="26.852775">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ybj//w==" DoubleValue="-1575158400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HLz//w==" DoubleValue="-1501632000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ybj//w==" LintValue="-18231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HLz//w==" LintValue="-17380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HLz//w==" DoubleValue="-1501632000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HLz//w==" DoubleValue="-1501632000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HLz//w==" LintValue="-17380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HLz//w==" LintValue="-17380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021438" DistinctValues="32.627225">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HLz//w==" DoubleValue="-1501632000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JsD//w==" DoubleValue="-1412294400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HLz//w==" LintValue="-17380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JsD//w==" LintValue="-16346"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JsD//w==" DoubleValue="-1412294400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Scf//w==" DoubleValue="-1254441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JsD//w==" LintValue="-16346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Scf//w==" LintValue="-14519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017222" DistinctValues="25.329627">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Scf//w==" DoubleValue="-1254441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YMr//w==" DoubleValue="-1186099200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Scf//w==" LintValue="-14519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YMr//w==" LintValue="-13728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YMr//w==" DoubleValue="-1186099200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YMr//w==" DoubleValue="-1186099200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YMr//w==" LintValue="-13728"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YMr//w==" LintValue="-13728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001328" DistinctValues="1.953359">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YMr//w==" DoubleValue="-1186099200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ncr//w==" DoubleValue="-1180828800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YMr//w==" LintValue="-13728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ncr//w==" LintValue="-13667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ncr//w==" DoubleValue="-1180828800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ncr//w==" DoubleValue="-1180828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ncr//w==" LintValue="-13667"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ncr//w==" LintValue="-13667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009950" DistinctValues="14.634184">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ncr//w==" DoubleValue="-1180828800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsz//w==" DoubleValue="-1141344000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ncr//w==" LintValue="-13667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsz//w==" LintValue="-13210"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsz//w==" DoubleValue="-1141344000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsz//w==" DoubleValue="-1141344000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsz//w==" LintValue="-13210"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zsz//w==" LintValue="-13210"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010582" DistinctValues="15.562830">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsz//w==" DoubleValue="-1141344000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TM7//w==" DoubleValue="-1099353600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zsz//w==" LintValue="-13210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TM7//w==" LintValue="-12724"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014875" DistinctValues="22.257769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TM7//w==" DoubleValue="-1099353600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JtH//w==" DoubleValue="-1036281600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TM7//w==" LintValue="-12724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JtH//w==" LintValue="-11994"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JtH//w==" DoubleValue="-1036281600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JtH//w==" DoubleValue="-1036281600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JtH//w==" LintValue="-11994"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JtH//w==" LintValue="-11994"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023576" DistinctValues="35.277039">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JtH//w==" DoubleValue="-1036281600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q9X//w==" DoubleValue="-936316800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JtH//w==" LintValue="-11994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q9X//w==" LintValue="-10837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q9X//w==" DoubleValue="-936316800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q9X//w==" DoubleValue="-936316800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q9X//w==" LintValue="-10837"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q9X//w==" LintValue="-10837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000632" DistinctValues="0.945193">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q9X//w==" DoubleValue="-936316800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ytX//w==" DoubleValue="-933638400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q9X//w==" LintValue="-10837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ytX//w==" LintValue="-10806"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ytX//w==" DoubleValue="-933638400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ct3//w==" DoubleValue="-773280000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ytX//w==" LintValue="-10806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ct3//w==" LintValue="-8950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ct3//w==" DoubleValue="-773280000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ct3//w==" LintValue="-8950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001305" DistinctValues="1.985870">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" DoubleValue="-615427200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a+T//w==" DoubleValue="-610070400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LeT//w==" LintValue="-7123"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a+T//w==" LintValue="-7061"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a+T//w==" DoubleValue="-610070400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a+T//w==" DoubleValue="-610070400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a+T//w==" LintValue="-7061"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a+T//w==" LintValue="-7061"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037778" DistinctValues="57.494130">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a+T//w==" DoubleValue="-610070400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="buv//w==" DoubleValue="-454982400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a+T//w==" LintValue="-7061"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="buv//w==" LintValue="-5266"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039082" DistinctValues="60.480000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="buv//w==" DoubleValue="-454982400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPL//w==" DoubleValue="-297216000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="buv//w==" LintValue="-5266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPL//w==" LintValue="-3440"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020847" DistinctValues="31.727010">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPL//w==" DoubleValue="-297216000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPL//w==" LintValue="-3440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018236" DistinctValues="27.752990">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svn//w==" DoubleValue="-139449600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svn//w==" LintValue="-1614"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033410" DistinctValues="50.847839">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svn//w==" DoubleValue="-139449600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AAAAAA==" DoubleValue="0.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svn//w==" LintValue="-1614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AAAAAA==" LintValue="0"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000980" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AAAAAA==" DoubleValue="0.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AAAAAA==" DoubleValue="0.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AAAAAA==" LintValue="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AAAAAA==" LintValue="0"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005672" DistinctValues="8.632161">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AAAAAA==" DoubleValue="0.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AAAAAA==" LintValue="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024742" DistinctValues="37.655465">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" DoubleValue="23673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lgUAAA==" DoubleValue="123552000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EgEAAA==" LintValue="274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lgUAAA==" LintValue="1430"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lgUAAA==" DoubleValue="123552000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lgUAAA==" DoubleValue="123552000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lgUAAA==" LintValue="1430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lgUAAA==" LintValue="1430"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014340" DistinctValues="21.824535">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lgUAAA==" DoubleValue="123552000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NAgAAA==" DoubleValue="181440000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lgUAAA==" LintValue="1430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NAgAAA==" LintValue="2100"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009118" DistinctValues="13.409901">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NAgAAA==" DoubleValue="181440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3gkAAA==" DoubleValue="218246400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NAgAAA==" LintValue="2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3gkAAA==" LintValue="2526"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3gkAAA==" DoubleValue="218246400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3gkAAA==" DoubleValue="218246400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3gkAAA==" LintValue="2526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3gkAAA==" LintValue="2526"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015646" DistinctValues="23.010887">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3gkAAA==" DoubleValue="218246400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uQwAAA==" DoubleValue="281404800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3gkAAA==" LintValue="2526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uQwAAA==" LintValue="3257"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uQwAAA==" DoubleValue="281404800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uQwAAA==" DoubleValue="281404800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uQwAAA==" LintValue="3257"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uQwAAA==" LintValue="3257"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001926" DistinctValues="2.833078">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uQwAAA==" DoubleValue="281404800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ew0AAA==" DoubleValue="289180800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uQwAAA==" LintValue="3257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ew0AAA==" LintValue="3347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ew0AAA==" DoubleValue="289180800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ew0AAA==" DoubleValue="289180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ew0AAA==" LintValue="3347"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ew0AAA==" LintValue="3347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012392" DistinctValues="18.226134">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ew0AAA==" DoubleValue="289180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg8AAA==" DoubleValue="339206400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ew0AAA==" LintValue="3347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg8AAA==" LintValue="3926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020847" DistinctValues="31.727010">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg8AAA==" DoubleValue="339206400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg8AAA==" LintValue="3926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018236" DistinctValues="27.752990">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBYAAA==" DoubleValue="496972800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBYAAA==" LintValue="5752"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028339" DistinctValues="42.404195">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBYAAA==" DoubleValue="496972800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0RsAAA==" DoubleValue="615254400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBYAAA==" LintValue="5752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0RsAAA==" LintValue="7121"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0RsAAA==" DoubleValue="615254400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0RsAAA==" DoubleValue="615254400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0RsAAA==" LintValue="7121"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0RsAAA==" LintValue="7121"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003167" DistinctValues="4.739110">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0RsAAA==" DoubleValue="615254400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ahwAAA==" DoubleValue="628473600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0RsAAA==" LintValue="7121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ahwAAA==" LintValue="7274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ahwAAA==" DoubleValue="628473600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ahwAAA==" DoubleValue="628473600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ahwAAA==" LintValue="7274"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ahwAAA==" LintValue="7274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007576" DistinctValues="11.336695">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ahwAAA==" DoubleValue="628473600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2B0AAA==" DoubleValue="660096000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ahwAAA==" LintValue="7274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2B0AAA==" LintValue="7640"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012350" DistinctValues="18.479168">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2B0AAA==" DoubleValue="660096000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSAAAA==" DoubleValue="709948800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2B0AAA==" LintValue="7640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSAAAA==" LintValue="8217"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000941" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSAAAA==" DoubleValue="709948800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GSAAAA==" DoubleValue="709948800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSAAAA==" LintValue="8217"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GSAAAA==" LintValue="8217"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009781" DistinctValues="14.636013">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GSAAAA==" DoubleValue="709948800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4iEAAA==" DoubleValue="749433600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GSAAAA==" LintValue="8217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4iEAAA==" LintValue="8674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4iEAAA==" DoubleValue="749433600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4iEAAA==" DoubleValue="749433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4iEAAA==" LintValue="8674"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4iEAAA==" LintValue="8674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016951" DistinctValues="25.364819">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4iEAAA==" DoubleValue="749433600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+iQAAA==" DoubleValue="817862400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4iEAAA==" LintValue="8674"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+iQAAA==" LintValue="9466"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.3726598.1.1.7" Name="dcal_quarter_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpAll.mdp
@@ -401,214 +401,214 @@
       <dxl:ColumnStatistics Mdid="1.17165.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" DoubleValue="-249696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KfX//w==" DoubleValue="-239760000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" LintValue="-2890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KfX//w==" LintValue="-2775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KfX//w==" DoubleValue="-239760000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvX//w==" DoubleValue="-231724800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KfX//w==" LintValue="-2775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvX//w==" LintValue="-2682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvX//w==" DoubleValue="-231724800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvX//w==" LintValue="-2682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivj//w==" DoubleValue="-174009600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivj//w==" LintValue="-2014"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivj//w==" DoubleValue="-174009600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivj//w==" LintValue="-2014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvv//w==" DoubleValue="-97977600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvv//w==" LintValue="-1134"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvv//w==" DoubleValue="-97977600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vv//w==" DoubleValue="-89683200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvv//w==" LintValue="-1134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vv//w==" LintValue="-1038"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vv//w==" DoubleValue="-89683200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vv//w==" LintValue="-1038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dv3//w==" DoubleValue="-65145600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dv3//w==" LintValue="-754"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dv3//w==" DoubleValue="-65145600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv3//w==" DoubleValue="-56505600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dv3//w==" LintValue="-754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv3//w==" LintValue="-654"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv3//w==" DoubleValue="-56505600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv3//w==" LintValue="-654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP7//w==" DoubleValue="-37670400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP7//w==" LintValue="-436"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP7//w==" DoubleValue="-37670400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP7//w==" LintValue="-436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" DoubleValue="-251856000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/X//w==" DoubleValue="-239587200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" LintValue="-2915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/X//w==" LintValue="-2773"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/X//w==" DoubleValue="-239587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/X//w==" LintValue="-2773"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvn//w==" DoubleValue="-148089600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvn//w==" LintValue="-1714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvn//w==" DoubleValue="-148089600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvn//w==" LintValue="-1714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pr//w==" DoubleValue="-114393600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pr//w==" LintValue="-1324"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pr//w==" DoubleValue="-114393600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/v//w==" DoubleValue="-106185600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pr//w==" LintValue="-1324"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/v//w==" LintValue="-1229"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/v//w==" DoubleValue="-106185600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/v//w==" LintValue="-1229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvz//w==" DoubleValue="-81734400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvz//w==" LintValue="-946"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvz//w==" DoubleValue="-81734400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvz//w==" LintValue="-946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv7//w==" DoubleValue="-34732800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv7//w==" LintValue="-402"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" DoubleValue="-34732800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" LintValue="-402"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -765,108 +765,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" DoubleValue="-251769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" LintValue="-2914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fX//w==" DoubleValue="-221788800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fX//w==" LintValue="-2567"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fX//w==" DoubleValue="-221788800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fX//w==" LintValue="-2567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPb//w==" DoubleValue="-203904000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPb//w==" LintValue="-2360"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPb//w==" DoubleValue="-203904000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPb//w==" LintValue="-2360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfj//w==" DoubleValue="-172713600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfj//w==" LintValue="-1999"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfj//w==" DoubleValue="-172713600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfj//w==" LintValue="-1999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/n//w==" DoubleValue="-138326400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/n//w==" LintValue="-1601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/n//w==" DoubleValue="-138326400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvr//w==" DoubleValue="-129427200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/n//w==" LintValue="-1601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvr//w==" LintValue="-1498"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvr//w==" DoubleValue="-129427200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvr//w==" LintValue="-1498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPv//w==" DoubleValue="-104716800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPv//w==" LintValue="-1212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPv//w==" DoubleValue="-104716800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/v//w==" DoubleValue="-96508800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPv//w==" LintValue="-1212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/v//w==" LintValue="-1117"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/v//w==" DoubleValue="-96508800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/v//w==" LintValue="-1117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvz//w==" DoubleValue="-80352000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvz//w==" LintValue="-930"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvz//w==" DoubleValue="-80352000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvz//w==" LintValue="-930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="If3//w==" DoubleValue="-63504000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="If3//w==" LintValue="-735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="If3//w==" DoubleValue="-63504000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="If3//w==" LintValue="-735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hP7//w==" DoubleValue="-32832000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hP7//w==" LintValue="-380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hP7//w==" DoubleValue="-32832000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hP7//w==" LintValue="-380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.5" Name="l_extendedprice" Width="10.000000">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
@@ -290,104 +290,104 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1632545.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
@@ -303,104 +303,104 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1632545.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
@@ -142,104 +142,104 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
       <dxl:ColumnStatistics Mdid="1.21849009.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.21849009.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.21849009.1.1.3" Name="c4" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
@@ -219,8 +219,8 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
       <dxl:ColumnStatistics Mdid="1.31264057.1.1.3" Name="c4" Width="0.000000" NullFreq="1.000000" NdvRemain="2.000000" FreqRemain="1.000000"/>
       <dxl:ColumnStatistics Mdid="1.31264057.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:RelationStatistics Mdid="2.31264029.1.1" Name="t" Rows="1.000000" EmptyRelation="false"/>
@@ -362,8 +362,8 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
       <dxl:ColumnStatistics Mdid="1.31264029.1.1.3" Name="c4" Width="0.000000" NullFreq="1.000000" NdvRemain="2.000000" FreqRemain="1.000000"/>
       <dxl:ColumnStatistics Mdid="1.31264029.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.31264057.1.1.9" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
@@ -83,104 +83,104 @@ inferred from the second operator (c4 = 'f')
       <dxl:ColumnStatistics Mdid="1.22226519.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.22226519.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.22226519.1.1.3" Name="c4" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -264,104 +264,104 @@ c4 = 'f'
       <dxl:ColumnStatistics Mdid="1.22226372.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.22226372.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.22226372.1.1.3" Name="c4" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
@@ -530,104 +530,104 @@ explain select * from t_ao where c2 = 'HEAP';
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.21846751.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" DoubleValue="315705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rg4AAA==" LintValue="3654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" DoubleValue="316051200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sg4AAA==" LintValue="3658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" DoubleValue="316396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tg4AAA==" LintValue="3662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" DoubleValue="316742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ug4AAA==" LintValue="3666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vg4AAA==" LintValue="3670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" DoubleValue="317433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wg4AAA==" LintValue="3674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" DoubleValue="317779200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xg4AAA==" LintValue="3678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" DoubleValue="318124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yg4AAA==" LintValue="3682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zg4AAA==" LintValue="3686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" DoubleValue="318816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ag4AAA==" LintValue="3690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" DoubleValue="319161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bg4AAA==" LintValue="3694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" DoubleValue="319507200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cg4AAA==" LintValue="3698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" DoubleValue="319852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dg4AAA==" LintValue="3702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" DoubleValue="320198400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eg4AAA==" LintValue="3706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" DoubleValue="320544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fg4AAA==" LintValue="3710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" DoubleValue="320889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gg4AAA==" LintValue="3714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" DoubleValue="321235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hg4AAA==" LintValue="3718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" DoubleValue="321580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ig4AAA==" LintValue="3722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" DoubleValue="321926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jg4AAA==" LintValue="3726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" DoubleValue="322272000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kg4AAA==" LintValue="3730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" DoubleValue="322617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lg4AAA==" LintValue="3734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" DoubleValue="322963200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mg4AAA==" LintValue="3738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" DoubleValue="323308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ng4AAA==" LintValue="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" DoubleValue="323654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="og4AAA==" LintValue="3746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="4.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" DoubleValue="324000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" DoubleValue="324259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pg4AAA==" LintValue="3750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qQ4AAA==" LintValue="3753"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -730,212 +730,212 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.9" Name="guelt_ab" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.002157" DistinctValues="5.250000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" DoubleValue="-3155673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SAQAAA==" DoubleValue="94694400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VHH//w==" LintValue="-36524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SAQAAA==" LintValue="1096"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.109434" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAQAAA==" DoubleValue="94694400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAQAAA==" DoubleValue="94694400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAQAAA==" LintValue="1096"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAQAAA==" LintValue="1096"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001077" DistinctValues="1.622777">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SAQAAA==" DoubleValue="94694400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tQUAAA==" DoubleValue="126230400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SAQAAA==" LintValue="1096"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tQUAAA==" LintValue="1461"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005302" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQUAAA==" DoubleValue="126230400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQUAAA==" DoubleValue="126230400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQUAAA==" LintValue="1461"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQUAAA==" LintValue="1461"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001080" DistinctValues="1.627223">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tQUAAA==" DoubleValue="126230400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IwcAAA==" DoubleValue="157852800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tQUAAA==" LintValue="1461"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IwcAAA==" LintValue="1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019331" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IwcAAA==" DoubleValue="157852800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IwcAAA==" DoubleValue="157852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IwcAAA==" LintValue="1827"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IwcAAA==" LintValue="1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000892" DistinctValues="1.344521">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IwcAAA==" DoubleValue="157852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ugcAAA==" DoubleValue="170899200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IwcAAA==" LintValue="1827"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ugcAAA==" LintValue="1978"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002320" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ugcAAA==" DoubleValue="170899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ugcAAA==" DoubleValue="170899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ugcAAA==" LintValue="1978"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ugcAAA==" LintValue="1978"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001265" DistinctValues="1.905479">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ugcAAA==" DoubleValue="170899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kAgAAA==" DoubleValue="189388800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ugcAAA==" LintValue="1978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kAgAAA==" LintValue="2192"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.048310" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kAgAAA==" DoubleValue="189388800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kAgAAA==" DoubleValue="189388800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kAgAAA==" LintValue="2192"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kAgAAA==" LintValue="2192"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001079" DistinctValues="1.625000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kAgAAA==" DoubleValue="189388800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/QkAAA==" DoubleValue="220924800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kAgAAA==" LintValue="2192"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/QkAAA==" LintValue="2557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002614" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/QkAAA==" DoubleValue="220924800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/QkAAA==" DoubleValue="220924800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/QkAAA==" LintValue="2557"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/QkAAA==" LintValue="2557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001079" DistinctValues="1.625000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/QkAAA==" DoubleValue="220924800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="agsAAA==" DoubleValue="252460800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/QkAAA==" LintValue="2557"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="agsAAA==" LintValue="2922"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038957" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="agsAAA==" DoubleValue="252460800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="agsAAA==" DoubleValue="252460800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="agsAAA==" LintValue="2922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="agsAAA==" LintValue="2922"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001073" DistinctValues="1.118852">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="agsAAA==" DoubleValue="252460800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IAwAAA==" DoubleValue="268185600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="agsAAA==" LintValue="2922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IAwAAA==" LintValue="3104"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001620" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IAwAAA==" DoubleValue="268185600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IAwAAA==" DoubleValue="268185600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IAwAAA==" LintValue="3104"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IAwAAA==" LintValue="3104"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000183" DistinctValues="0.190574">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IAwAAA==" DoubleValue="268185600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PwwAAA==" DoubleValue="270864000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IAwAAA==" LintValue="3104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PwwAAA==" LintValue="3135"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002357" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PwwAAA==" DoubleValue="270864000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PwwAAA==" DoubleValue="270864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PwwAAA==" LintValue="3135"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PwwAAA==" LintValue="3135"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000902" DistinctValues="0.940574">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PwwAAA==" DoubleValue="270864000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PwwAAA==" LintValue="3135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015649" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000535" DistinctValues="0.557877">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" DoubleValue="284083200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jQ0AAA==" DoubleValue="299721600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2AwAAA==" LintValue="3288"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jQ0AAA==" LintValue="3469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002136" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jQ0AAA==" DoubleValue="299721600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jQ0AAA==" DoubleValue="299721600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jQ0AAA==" LintValue="3469"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jQ0AAA==" LintValue="3469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000544" DistinctValues="0.567123">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jQ0AAA==" DoubleValue="299721600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RQ4AAA==" DoubleValue="315619200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jQ0AAA==" LintValue="3469"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RQ4AAA==" LintValue="3653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007990" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RQ4AAA==" DoubleValue="315619200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RQ4AAA==" DoubleValue="315619200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RQ4AAA==" LintValue="3653"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RQ4AAA==" LintValue="3653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001079" DistinctValues="1.125000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RQ4AAA==" DoubleValue="315619200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sg8AAA==" DoubleValue="347155200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RQ4AAA==" LintValue="3653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sg8AAA==" LintValue="4018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.477539" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sg8AAA==" DoubleValue="347155200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sg8AAA==" DoubleValue="347155200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sg8AAA==" LintValue="4018"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sg8AAA==" LintValue="4018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001430" DistinctValues="2.154696">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sg8AAA==" DoubleValue="347155200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KhAAAA==" DoubleValue="357523200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sg8AAA==" LintValue="4018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KhAAAA==" LintValue="4138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003719" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KhAAAA==" DoubleValue="357523200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KhAAAA==" DoubleValue="357523200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KhAAAA==" LintValue="4138"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KhAAAA==" LintValue="4138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000727" DistinctValues="1.095304">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KhAAAA==" DoubleValue="357523200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxAAAA==" DoubleValue="362793600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KhAAAA==" LintValue="4138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxAAAA==" LintValue="4199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.042787" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxAAAA==" DoubleValue="362793600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxAAAA==" DoubleValue="362793600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxAAAA==" LintValue="4199"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxAAAA==" LintValue="4199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002157" DistinctValues="4.250000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxAAAA==" DoubleValue="362793600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxAAAA==" LintValue="4199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.114110" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001622" DistinctValues="2.444215">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006849" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000535" DistinctValues="0.805785">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002725" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.560204">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031298" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000273" DistinctValues="0.284694">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004234" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001347" DistinctValues="1.405102">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017785" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000319" DistinctValues="0.148026">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002246" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000216" DistinctValues="0.100329">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004860" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000759" DistinctValues="0.351974">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008064" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000209" DistinctValues="0.097039">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001878" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000653" DistinctValues="0.302632">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7RQAAA==" DoubleValue="462844800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7RQAAA==" LintValue="5357"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002157" DistinctValues="5.250000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" DoubleValue="462844800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" LintValue="5357"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.8" Name="org_elem_nr" Width="9.000000" NullFreq="0.000000" NdvRemain="68.000000" FreqRemain="0.261249" ColStatsMissing="false">
@@ -1395,92 +1395,92 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.10" Name="guelt_bis" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.003163" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000074" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000920" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000037" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001251" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000074" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MRIAAA==" DoubleValue="402364800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MRIAAA==" DoubleValue="402364800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MRIAAA==" LintValue="4657"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MRIAAA==" LintValue="4657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000625" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004414" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" DoubleValue="418089600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5xIAAA==" LintValue="4839"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000037" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BRMAAA==" DoubleValue="420681600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BRMAAA==" DoubleValue="420681600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BRMAAA==" LintValue="4869"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BRMAAA==" LintValue="4869"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000625" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000368" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QhMAAA==" DoubleValue="425952000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QhMAAA==" DoubleValue="425952000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QhMAAA==" LintValue="4930"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QhMAAA==" LintValue="4930"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000037" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" DoubleValue="431308800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" DoubleValue="431308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" LintValue="4992"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" LintValue="4992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003605" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+RMAAA==" DoubleValue="441763200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+RMAAA==" DoubleValue="441763200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+RMAAA==" LintValue="5113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+RMAAA==" LintValue="5113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001140" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000809" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VBQAAA==" DoubleValue="449625600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VBQAAA==" DoubleValue="449625600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VBQAAA==" LintValue="5204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VBQAAA==" LintValue="5204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000920" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rxQAAA==" DoubleValue="457488000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rxQAAA==" DoubleValue="457488000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rxQAAA==" LintValue="5295"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rxQAAA==" LintValue="5295"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000478" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" DoubleValue="462844800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" DoubleValue="462844800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" LintValue="5357"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7RQAAA==" LintValue="5357"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000368" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" DoubleValue="465436800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" DoubleValue="465436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" LintValue="5387"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" LintValue="5387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" DoubleValue="473299200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" DoubleValue="473299200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" LintValue="5478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" LintValue="5478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.977629" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" DoubleValue="252455529600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" DoubleValue="252455529600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" LintValue="2921939"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" LintValue="2921939"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.3" Name="name_german" Width="57.000000" NullFreq="0.000000" NdvRemain="1567.000000" FreqRemain="0.971942" ColStatsMissing="false">
@@ -1967,494 +1967,494 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.21" Name="verarb_bis" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.003307" DistinctValues="0.289655">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025407" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015874" DistinctValues="1.390345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WxEAAA==" DoubleValue="383875200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WxEAAA==" LintValue="4443"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WxEAAA==" DoubleValue="383875200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WxEAAA==" LintValue="4443"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023603" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023050" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vBEAAA==" DoubleValue="392256000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vBEAAA==" LintValue="4540"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009933" DistinctValues="0.870000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vBEAAA==" DoubleValue="392256000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vBEAAA==" LintValue="4540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022167" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009248" DistinctValues="0.810000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003094" DistinctValues="0.270968">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" DoubleValue="397094400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9BEAAA==" LintValue="4596"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022608" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016087" DistinctValues="1.409032">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ExIAAA==" DoubleValue="399772800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ExIAAA==" LintValue="4627"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ExIAAA==" DoubleValue="399772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ExIAAA==" LintValue="4627"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023271" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022498" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008563" DistinctValues="0.446429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bhIAAA==" DoubleValue="407635200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bhIAAA==" LintValue="4718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012188" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bhIAAA==" DoubleValue="407635200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bhIAAA==" DoubleValue="407635200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bhIAAA==" LintValue="4718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bhIAAA==" LintValue="4718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001713" DistinctValues="0.089286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bhIAAA==" DoubleValue="407635200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bhIAAA==" LintValue="4718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022056" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008906" DistinctValues="0.464286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003712" DistinctValues="0.325161">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022461" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015469" DistinctValues="1.354839">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002906" DistinctValues="0.254545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024155" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016275" DistinctValues="1.425455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zRIAAA==" DoubleValue="415843200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zRIAAA==" LintValue="4813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zRIAAA==" DoubleValue="415843200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zRIAAA==" LintValue="4813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023787" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017634" DistinctValues="0.919355">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012372" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001547" DistinctValues="0.080645">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KRMAAA==" DoubleValue="423792000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KRMAAA==" LintValue="4905"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KRMAAA==" DoubleValue="423792000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ShMAAA==" DoubleValue="426643200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KRMAAA==" LintValue="4905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ShMAAA==" LintValue="4938"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012777" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ShMAAA==" DoubleValue="426643200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ShMAAA==" DoubleValue="426643200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ShMAAA==" LintValue="4938"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ShMAAA==" LintValue="4938"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009946" DistinctValues="0.518519">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ShMAAA==" DoubleValue="426643200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ShMAAA==" LintValue="4938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009235" DistinctValues="0.481481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gBMAAA==" DoubleValue="431308800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gBMAAA==" LintValue="4992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" DoubleValue="431308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pBMAAA==" DoubleValue="434419200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gBMAAA==" LintValue="4992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pBMAAA==" LintValue="5028"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010462" DistinctValues="0.916364">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pBMAAA==" DoubleValue="434419200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pBMAAA==" LintValue="5028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022093" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008719" DistinctValues="0.763636">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2xMAAA==" DoubleValue="439171200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2xMAAA==" LintValue="5083"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016071" DistinctValues="1.407568">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2xMAAA==" DoubleValue="439171200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2xMAAA==" LintValue="5083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013072" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003110" DistinctValues="0.272432">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022756" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015984" DistinctValues="0.833333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021725" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003197" DistinctValues="0.166667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021320" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OhQAAA==" DoubleValue="447379200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OhQAAA==" LintValue="5178"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009933" DistinctValues="0.870000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OhQAAA==" DoubleValue="447379200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OhQAAA==" LintValue="5178"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023639" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009248" DistinctValues="0.810000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="chQAAA==" DoubleValue="452217600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="chQAAA==" LintValue="5234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003712" DistinctValues="0.325161">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="chQAAA==" DoubleValue="452217600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="chQAAA==" LintValue="5234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021320" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015469" DistinctValues="1.354839">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kRQAAA==" DoubleValue="454896000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kRQAAA==" LintValue="5265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kRQAAA==" DoubleValue="454896000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kRQAAA==" LintValue="5265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024597" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023050" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019181" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="05UsAA==" DoubleValue="252455529600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="05UsAA==" LintValue="2921939"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012814" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" DoubleValue="252455529600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" DoubleValue="252455529600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" LintValue="2921939"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="05UsAA==" LintValue="2921939"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.20" Name="verarb_ab" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.015348" DistinctValues="1.344000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KhEAAA==" DoubleValue="379641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KhEAAA==" LintValue="4394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012703" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003837" DistinctValues="0.336000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PhEAAA==" DoubleValue="381369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PhEAAA==" LintValue="4414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024008" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" DoubleValue="381801600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QxEAAA==" LintValue="4419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002558" DistinctValues="0.224000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" DoubleValue="386553600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehEAAA==" LintValue="4474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022719" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016627" DistinctValues="1.456000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" DoubleValue="386899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fhEAAA==" LintValue="4478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003713" DistinctValues="0.325161">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" DoubleValue="389145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mBEAAA==" LintValue="4504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023566" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015472" DistinctValues="1.354839">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" DoubleValue="389664000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="txEAAA==" DoubleValue="391824000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nhEAAA==" LintValue="4510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="txEAAA==" LintValue="4535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="txEAAA==" DoubleValue="391824000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="txEAAA==" LintValue="4535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023014" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" DoubleValue="394761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2REAAA==" LintValue="4569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022792" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" DoubleValue="397526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+REAAA==" LintValue="4601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023492" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" DoubleValue="402710400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NRIAAA==" LintValue="4661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024560" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" DoubleValue="405475200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VRIAAA==" LintValue="4693"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021835" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" DoubleValue="408067200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cxIAAA==" LintValue="4723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022461" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009050" DistinctValues="0.471698">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" DoubleValue="410832000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kxIAAA==" LintValue="4755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012667" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001810" DistinctValues="0.094340">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" DoubleValue="412992000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rBIAAA==" LintValue="4780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022792" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008326" DistinctValues="0.433962">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" DoubleValue="413424000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yBIAAA==" DoubleValue="415411200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sRIAAA==" LintValue="4785"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yBIAAA==" LintValue="4808"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yBIAAA==" DoubleValue="415411200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yBIAAA==" LintValue="4808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022461" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" DoubleValue="418435200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6xIAAA==" LintValue="4843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" DoubleValue="423360000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RRMAAA==" DoubleValue="426211200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JBMAAA==" LintValue="4900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RRMAAA==" LintValue="4933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012777" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RRMAAA==" DoubleValue="426211200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RRMAAA==" DoubleValue="426211200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RRMAAA==" LintValue="4933"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RRMAAA==" LintValue="4933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RRMAAA==" DoubleValue="426211200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RRMAAA==" LintValue="4933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021393" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" DoubleValue="429062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhMAAA==" DoubleValue="433900800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZhMAAA==" LintValue="4966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nhMAAA==" LintValue="5022"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhMAAA==" DoubleValue="433900800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nhMAAA==" LintValue="5022"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022019" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009935" DistinctValues="0.517857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" DoubleValue="437011200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3xMAAA==" DoubleValue="439516800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="whMAAA==" LintValue="5058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3xMAAA==" LintValue="5087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013072" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3xMAAA==" DoubleValue="439516800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3xMAAA==" DoubleValue="439516800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3xMAAA==" LintValue="5087"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3xMAAA==" LintValue="5087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009250" DistinctValues="0.482143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3xMAAA==" DoubleValue="439516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3xMAAA==" LintValue="5087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003713" DistinctValues="0.325161">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" DoubleValue="441849600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+hMAAA==" LintValue="5114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021577" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015472" DistinctValues="1.354839">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" DoubleValue="442368000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ABQAAA==" LintValue="5120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021725" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003426" DistinctValues="0.178571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" DoubleValue="444528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GRQAAA==" LintValue="5145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023014" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015760" DistinctValues="0.821429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" DoubleValue="444960000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HhQAAA==" LintValue="5150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="2.680000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" DoubleValue="446947200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NRQAAA==" LintValue="5173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023603" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" DoubleValue="449884800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VxQAAA==" LintValue="5207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022424" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" DoubleValue="452736000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eBQAAA==" LintValue="5240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024855" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" DoubleValue="457747200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="shQAAA==" LintValue="5298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022019" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019186" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" DoubleValue="460598400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8BQAAA==" DoubleValue="463104000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0xQAAA==" LintValue="5331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8BQAAA==" LintValue="5360"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012814" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8BQAAA==" DoubleValue="463104000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8BQAAA==" DoubleValue="463104000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8BQAAA==" LintValue="5360"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8BQAAA==" LintValue="5360"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15754853.1.1.13" Name="fid_kst" Width="2.000000" NullFreq="0.110907" NdvRemain="21.090909" FreqRemain="0.026520" ColStatsMissing="false">

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10745,34 +10745,34 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.25160.1.1.3" Name="i_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.669176" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.165623" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.165201" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.25160.1.1.2" Name="i_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.500902" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.165201" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.164855" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.169041" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -734,28 +734,28 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.10" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.3" Name="dt" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.583333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.2" Name="pn" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -733,28 +733,28 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.10" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.3" Name="dt" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.583333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.29191993.1.1.2" Name="pn" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -195,11 +195,11 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
               <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
               <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
             </dxl:Comparison>
           </dxl:And>
         </dxl:PartConstraint>
@@ -254,21 +254,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -285,7 +285,7 @@
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
           <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.318877.1.1" TableName="test_orders_2">
@@ -341,7 +341,7 @@
           <dxl:Filter>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
               <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:Comparison>
           </dxl:Filter>
           <dxl:OneTimeFilter/>
@@ -375,26 +375,26 @@
                       <dxl:And>
                         <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1096.1.0">
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                         </dxl:Comparison>
                         <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
                       </dxl:And>
                       <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                         <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                       </dxl:Comparison>
                     </dxl:Or>
                     <dxl:Or>
                       <dxl:And>
                         <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                         </dxl:Comparison>
                         <dxl:PartBoundInclusion Level="0" LowerBound="false"/>
                       </dxl:And>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                       </dxl:Comparison>
                     </dxl:Or>
                   </dxl:And>
@@ -417,20 +417,20 @@
                       <dxl:Or>
                         <dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1096.1.0">
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
                             <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                           </dxl:Comparison>
                           <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
                         </dxl:And>
                         <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                         </dxl:Comparison>
                       </dxl:Or>
                       <dxl:Or>
                         <dxl:And>
                           <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
                             <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                           </dxl:Comparison>
                           <dxl:Not>
@@ -438,7 +438,7 @@
                           </dxl:Not>
                         </dxl:And>
                         <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                         </dxl:Comparison>
                       </dxl:Or>
@@ -454,20 +454,20 @@
                         <dxl:Or>
                           <dxl:And>
                             <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1096.1.0">
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
                               <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                             </dxl:Comparison>
                             <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
                           </dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
                             <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="true"/>
                           </dxl:Comparison>
                         </dxl:Or>
                         <dxl:Or>
                           <dxl:And>
                             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
                               <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                             </dxl:Comparison>
                             <dxl:Not>
@@ -475,7 +475,7 @@
                             </dxl:Not>
                           </dxl:And>
                           <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
                             <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
                           </dxl:Comparison>
                         </dxl:Or>
@@ -489,7 +489,7 @@
               <dxl:PrintableFilter>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                 </dxl:Comparison>
               </dxl:PrintableFilter>
             </dxl:PartitionSelector>
@@ -528,7 +528,7 @@
                 <dxl:IndexCondList>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                     <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                   </dxl:Comparison>
                 </dxl:IndexCondList>
                 <dxl:IndexDescriptor Mdid="0.318973.1.0" IndexName="test_orders_2_1_prt_orders_1_ind"/>
@@ -565,7 +565,7 @@
                 <dxl:Filter>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                     <dxl:Ident ColId="11" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
                   </dxl:Comparison>
                 </dxl:Filter>
                 <dxl:TableDescriptor Mdid="0.318877.1.1" TableName="test_orders_2">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -171,11 +171,11 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
               <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
               <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
             </dxl:Comparison>
           </dxl:And>
         </dxl:PartConstraint>
@@ -230,21 +230,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -261,7 +261,7 @@
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
           <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.318877.1.1" TableName="test_orders_2">
@@ -320,7 +320,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -334,7 +334,7 @@
             <dxl:PrintableFilter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
@@ -356,7 +356,7 @@
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.318877.1.1" TableName="test_orders_2">

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -146,21 +146,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -226,21 +226,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -297,21 +297,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -328,7 +328,7 @@
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
           <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.310650.1.1" TableName="test_orders">
@@ -387,7 +387,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -401,7 +401,7 @@
             <dxl:PrintableFilter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
@@ -424,7 +424,7 @@
             <dxl:IndexCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:IndexCondList>
             <dxl:IndexDescriptor Mdid="0.310765.1.0" IndexName="ord_ind_1_prt_orders_1"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -109,21 +109,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -210,21 +210,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -281,21 +281,21 @@
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" DoubleValue="394329600000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1BEAAA==" LintValue="4564"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:And>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" DoubleValue="394416000000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="1REAAA==" LintValue="4565"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" DoubleValue="410227200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="jBIAAA==" LintValue="4748"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:Or>
@@ -312,7 +312,7 @@
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
           <dxl:Ident ColId="2" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.310650.1.1" TableName="test_orders">
@@ -371,7 +371,7 @@
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -385,7 +385,7 @@
             <dxl:PrintableFilter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
@@ -408,7 +408,7 @@
             <dxl:IndexCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="1" ColName="ship_date" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" DoubleValue="381456000000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="PxEAAA==" LintValue="4415"/>
               </dxl:Comparison>
             </dxl:IndexCondList>
             <dxl:IndexDescriptor Mdid="0.310765.1.0" IndexName="ord_ind_1_prt_orders_1"/>

--- a/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -2717,108 +2717,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1962503.1.1.2" Name="d_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VnH//w==" DoubleValue="-3155500800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yXz//w==" DoubleValue="-2902262400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VnH//w==" LintValue="-36522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yXz//w==" LintValue="-33591"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yXz//w==" DoubleValue="-2902262400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LIj//w==" DoubleValue="-2650406400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yXz//w==" LintValue="-33591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LIj//w==" LintValue="-30676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LIj//w==" DoubleValue="-2650406400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="spP//w==" DoubleValue="-2395526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LIj//w==" LintValue="-30676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="spP//w==" LintValue="-27726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="spP//w==" DoubleValue="-2395526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1p7//w==" DoubleValue="-2149113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="spP//w==" LintValue="-27726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1p7//w==" LintValue="-24874"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1p7//w==" DoubleValue="-2149113600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EKr//w==" DoubleValue="-1900800000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1p7//w==" LintValue="-24874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EKr//w==" LintValue="-22000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EKr//w==" DoubleValue="-1900800000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U7X//w==" DoubleValue="-1651708800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EKr//w==" LintValue="-22000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U7X//w==" LintValue="-19117"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U7X//w==" DoubleValue="-1651708800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="08D//w==" DoubleValue="-1397347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U7X//w==" LintValue="-19117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="08D//w==" LintValue="-16173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="08D//w==" DoubleValue="-1397347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZMz//w==" DoubleValue="-1141516800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="08D//w==" LintValue="-16173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZMz//w==" LintValue="-13212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZMz//w==" DoubleValue="-1141516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ytf//w==" DoubleValue="-898387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZMz//w==" LintValue="-13212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ytf//w==" LintValue="-10398"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ytf//w==" DoubleValue="-898387200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="auP//w==" DoubleValue="-632275200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ytf//w==" LintValue="-10398"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="auP//w==" LintValue="-7318"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="auP//w==" DoubleValue="-632275200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JO///w==" DoubleValue="-372902400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="auP//w==" LintValue="-7318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JO///w==" LintValue="-4316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JO///w==" DoubleValue="-372902400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JO///w==" LintValue="-4316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BwYAAA==" DoubleValue="133315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BwYAAA==" LintValue="1543"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BwYAAA==" DoubleValue="133315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxEAAA==" DoubleValue="379036800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BwYAAA==" LintValue="1543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxEAAA==" LintValue="4387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxEAAA==" DoubleValue="379036800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lh0AAA==" DoubleValue="645408000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxEAAA==" LintValue="4387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lh0AAA==" LintValue="7470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lh0AAA==" DoubleValue="645408000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TCgAAA==" DoubleValue="891302400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lh0AAA==" LintValue="7470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TCgAAA==" LintValue="10316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TCgAAA==" DoubleValue="891302400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IzQAAA==" DoubleValue="1153180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TCgAAA==" LintValue="10316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IzQAAA==" LintValue="13347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IzQAAA==" DoubleValue="1153180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4T4AAA==" DoubleValue="1390780800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IzQAAA==" LintValue="13347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4T4AAA==" LintValue="16097"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4T4AAA==" DoubleValue="1390780800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KEoAAA==" DoubleValue="1640217600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4T4AAA==" LintValue="16097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KEoAAA==" LintValue="18984"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KEoAAA==" DoubleValue="1640217600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="clUAAA==" DoubleValue="1889913600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KEoAAA==" LintValue="18984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="clUAAA==" LintValue="21874"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="clUAAA==" DoubleValue="1889913600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZGAAAA==" DoubleValue="2132006400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="clUAAA==" LintValue="21874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZGAAAA==" LintValue="24676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZGAAAA==" DoubleValue="2132006400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f2sAAA==" DoubleValue="2377641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZGAAAA==" LintValue="24676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f2sAAA==" LintValue="27519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f2sAAA==" DoubleValue="2377641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnYAAA==" DoubleValue="2623276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f2sAAA==" LintValue="27519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnYAAA==" LintValue="30362"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnYAAA==" DoubleValue="2623276800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g4EAAA==" DoubleValue="2864592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnYAAA==" LintValue="30362"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g4EAAA==" LintValue="33155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g4EAAA==" DoubleValue="2864592000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N44AAA==" DoubleValue="3145564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g4EAAA==" LintValue="33155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N44AAA==" LintValue="36407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N44AAA==" DoubleValue="3145564800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rI4AAA==" DoubleValue="3155673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N44AAA==" LintValue="36407"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rI4AAA==" LintValue="36524"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/EqualityPredicateOverDate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/EqualityPredicateOverDate.mdp
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="1">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102152,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16384.1.0" Name="test" Rows="1000001.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16384.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="d" Attno="1" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.435.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16384.1.0.0" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.008282" DistinctValues="8.323944">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rxkAAA==" LintValue="6575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uBkAAA==" LintValue="6584"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003333" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uBkAAA==" LintValue="6584"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uBkAAA==" LintValue="6584"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.183117" DistinctValues="184.051643">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uBkAAA==" LintValue="6584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fxoAAA==" LintValue="6783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fxoAAA==" LintValue="6783"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fxoAAA==" LintValue="6783"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004601" DistinctValues="4.624413">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fxoAAA==" LintValue="6783"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hBoAAA==" LintValue="6788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.051216" DistinctValues="51.738693">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hBoAAA==" LintValue="6788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uBoAAA==" LintValue="6840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uBoAAA==" LintValue="6840"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uBoAAA==" LintValue="6840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.144784" DistinctValues="146.261307">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uBoAAA==" LintValue="6840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SxsAAA==" LintValue="6987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.196000" DistinctValues="199.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SxsAAA==" LintValue="6987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DxwAAA==" LintValue="7183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.095958" DistinctValues="96.937500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DxwAAA==" LintValue="7183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bRwAAA==" LintValue="7277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bRwAAA==" LintValue="7277"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bRwAAA==" LintValue="7277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100042" DistinctValues="101.062500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bRwAAA==" LintValue="7277"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zxwAAA==" LintValue="7375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.049495" DistinctValues="50.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zxwAAA==" LintValue="7375"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AR0AAA==" LintValue="7425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AR0AAA==" LintValue="7425"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AR0AAA==" LintValue="7425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.146505" DistinctValues="148.000000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AR0AAA==" LintValue="7425"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lR0AAA==" LintValue="7573"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.435.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7113.1.0"/>
+        <dxl:EqualityOp Mdid="0.1093.1.0"/>
+        <dxl:InequalityOp Mdid="0.1094.1.0"/>
+        <dxl:LessThanOp Mdid="0.1095.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1096.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1097.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1098.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1092.1.0"/>
+        <dxl:ArrayType Mdid="0.1182.1.0"/>
+        <dxl:MinAgg Mdid="0.2138.1.0"/>
+        <dxl:MaxAgg Mdid="0.2122.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.1093.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.1082.1.0"/>
+        <dxl:RightType Mdid="0.1082.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1086.1.0"/>
+        <dxl:Commutator Mdid="0.1093.1.0"/>
+        <dxl:InverseOp Mdid="0.1094.1.0"/>
+        <dxl:HashOpfamily Mdid="0.435.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7113.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.434.1.0"/>
+          <dxl:Opfamily Mdid="0.435.1.0"/>
+          <dxl:Opfamily Mdid="0.7022.1.0"/>
+          <dxl:Opfamily Mdid="0.7113.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+          <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="txoAAA==" LintValue="6839"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="d" TypeMdid="0.1082.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="482.634091" Rows="984.924062" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="d">
+            <dxl:Ident ColId="0" ColName="d" TypeMdid="0.1082.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="482.607379" Rows="984.924062" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="d">
+              <dxl:Ident ColId="0" ColName="d" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+              <dxl:Ident ColId="0" ColName="d" TypeMdid="0.1082.1.0"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="txoAAA==" LintValue="6839"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="d" TypeMdid="0.1082.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -814,214 +814,214 @@
       <dxl:ColumnStatistics Mdid="1.24726.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" DoubleValue="-249868800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" LintValue="-2892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/j//w==" DoubleValue="-163900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/j//w==" LintValue="-1897"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/j//w==" DoubleValue="-163900800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pj//w==" DoubleValue="-155520000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/j//w==" LintValue="-1897"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pj//w==" LintValue="-1800"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pj//w==" DoubleValue="-155520000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pj//w==" LintValue="-1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvr//w==" DoubleValue="-121824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvr//w==" LintValue="-1410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvr//w==" DoubleValue="-121824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvr//w==" LintValue="-1410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/7//w==" DoubleValue="-37065600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/7//w==" LintValue="-429"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvT//w==" DoubleValue="-252115200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvT//w==" LintValue="-2918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/X//w==" DoubleValue="-230256000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/X//w==" LintValue="-2665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/X//w==" DoubleValue="-230256000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/X//w==" LintValue="-2665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfj//w==" DoubleValue="-163728000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfj//w==" LintValue="-1895"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfj//w==" DoubleValue="-163728000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfj//w==" LintValue="-1895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fv//w==" DoubleValue="-89078400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fv//w==" LintValue="-1031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fv//w==" DoubleValue="-89078400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fv//w==" LintValue="-1031"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/z//w==" DoubleValue="-72316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/z//w==" LintValue="-837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/z//w==" DoubleValue="-72316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/z//w==" LintValue="-837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="af7//w==" DoubleValue="-35164800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="af7//w==" LintValue="-407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="af7//w==" DoubleValue="-35164800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/7//w==" DoubleValue="-34300800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="af7//w==" LintValue="-407"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/7//w==" LintValue="-397"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -1244,108 +1244,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/T//w==" DoubleValue="-251683200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/T//w==" LintValue="-2913"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfb//w==" DoubleValue="-212457600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfb//w==" LintValue="-2459"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfb//w==" DoubleValue="-212457600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfb//w==" DoubleValue="-204163200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfb//w==" LintValue="-2459"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfb//w==" LintValue="-2363"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfb//w==" DoubleValue="-204163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfb//w==" LintValue="-2363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPf//w==" DoubleValue="-187660800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPf//w==" LintValue="-2172"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPf//w==" DoubleValue="-187660800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pf//w==" DoubleValue="-179020800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPf//w==" LintValue="-2172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pf//w==" LintValue="-2072"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pf//w==" DoubleValue="-179020800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pf//w==" LintValue="-2072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPj//w==" DoubleValue="-162432000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPj//w==" LintValue="-1880"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPj//w==" DoubleValue="-162432000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvn//w==" DoubleValue="-154310400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPj//w==" LintValue="-1880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvn//w==" LintValue="-1786"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvn//w==" DoubleValue="-154310400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfn//w==" DoubleValue="-146102400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvn//w==" LintValue="-1786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfn//w==" LintValue="-1691"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfn//w==" DoubleValue="-146102400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfn//w==" LintValue="-1691"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvr//w==" DoubleValue="-120441600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvr//w==" LintValue="-1394"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvr//w==" DoubleValue="-120441600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pr//w==" DoubleValue="-111974400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvr//w==" LintValue="-1394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pr//w==" LintValue="-1296"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pr//w==" DoubleValue="-111974400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svv//w==" DoubleValue="-104198400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pr//w==" LintValue="-1296"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svv//w==" LintValue="-1206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svv//w==" DoubleValue="-104198400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPv//w==" DoubleValue="-95731200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svv//w==" LintValue="-1206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPv//w==" LintValue="-1108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPv//w==" DoubleValue="-95731200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPv//w==" LintValue="-1108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aPz//w==" DoubleValue="-79488000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aPz//w==" LintValue="-920"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aPz//w==" DoubleValue="-79488000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aPz//w==" LintValue="-920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lf3//w==" DoubleValue="-62467200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lf3//w==" LintValue="-723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lf3//w==" DoubleValue="-62467200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/3//w==" DoubleValue="-54345600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lf3//w==" LintValue="-723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/3//w==" LintValue="-629"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/3//w==" DoubleValue="-54345600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/3//w==" LintValue="-629"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev7//w==" DoubleValue="-33696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev7//w==" LintValue="-390"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev7//w==" DoubleValue="-33696000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf7//w==" DoubleValue="-31708800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev7//w==" LintValue="-390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf7//w==" LintValue="-367"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.5" Name="l_extendedprice" Width="10.000000">

--- a/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -814,214 +814,214 @@
       <dxl:ColumnStatistics Mdid="1.24726.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" DoubleValue="-249868800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" LintValue="-2892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/j//w==" DoubleValue="-163900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/j//w==" LintValue="-1897"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/j//w==" DoubleValue="-163900800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pj//w==" DoubleValue="-155520000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/j//w==" LintValue="-1897"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pj//w==" LintValue="-1800"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pj//w==" DoubleValue="-155520000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pj//w==" LintValue="-1800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvr//w==" DoubleValue="-121824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvr//w==" LintValue="-1410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvr//w==" DoubleValue="-121824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvr//w==" LintValue="-1410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/7//w==" DoubleValue="-37065600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/7//w==" LintValue="-429"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvT//w==" DoubleValue="-252115200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvT//w==" LintValue="-2918"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/X//w==" DoubleValue="-230256000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/X//w==" LintValue="-2665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/X//w==" DoubleValue="-230256000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/X//w==" LintValue="-2665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" DoubleValue="-180316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2ff//w==" LintValue="-2087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" DoubleValue="-172195200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfj//w==" DoubleValue="-163728000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/j//w==" LintValue="-1993"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfj//w==" LintValue="-1895"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfj//w==" DoubleValue="-163728000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfj//w==" LintValue="-1895"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" DoubleValue="-147484800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfn//w==" LintValue="-1707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" DoubleValue="-105494400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/v//w==" LintValue="-1221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fv//w==" DoubleValue="-89078400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fv//w==" LintValue="-1031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fv//w==" DoubleValue="-89078400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fv//w==" LintValue="-1031"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" DoubleValue="-80784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/z//w==" DoubleValue="-72316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfz//w==" LintValue="-935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/z//w==" LintValue="-837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/z//w==" DoubleValue="-72316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/z//w==" LintValue="-837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="af7//w==" DoubleValue="-35164800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="af7//w==" LintValue="-407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="af7//w==" DoubleValue="-35164800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/7//w==" DoubleValue="-34300800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="af7//w==" LintValue="-407"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/7//w==" LintValue="-397"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -1244,108 +1244,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/T//w==" DoubleValue="-251683200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/T//w==" LintValue="-2913"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfb//w==" DoubleValue="-212457600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfb//w==" LintValue="-2459"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfb//w==" DoubleValue="-212457600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfb//w==" DoubleValue="-204163200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfb//w==" LintValue="-2459"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfb//w==" LintValue="-2363"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfb//w==" DoubleValue="-204163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfb//w==" LintValue="-2363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPf//w==" DoubleValue="-187660800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPf//w==" LintValue="-2172"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPf//w==" DoubleValue="-187660800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pf//w==" DoubleValue="-179020800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPf//w==" LintValue="-2172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pf//w==" LintValue="-2072"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pf//w==" DoubleValue="-179020800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pf//w==" LintValue="-2072"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPj//w==" DoubleValue="-162432000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPj//w==" LintValue="-1880"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPj//w==" DoubleValue="-162432000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvn//w==" DoubleValue="-154310400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPj//w==" LintValue="-1880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvn//w==" LintValue="-1786"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvn//w==" DoubleValue="-154310400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfn//w==" DoubleValue="-146102400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvn//w==" LintValue="-1786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfn//w==" LintValue="-1691"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfn//w==" DoubleValue="-146102400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfn//w==" LintValue="-1691"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" DoubleValue="-137289600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/n//w==" LintValue="-1589"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvr//w==" DoubleValue="-120441600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvr//w==" LintValue="-1394"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvr//w==" DoubleValue="-120441600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pr//w==" DoubleValue="-111974400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvr//w==" LintValue="-1394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pr//w==" LintValue="-1296"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pr//w==" DoubleValue="-111974400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svv//w==" DoubleValue="-104198400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pr//w==" LintValue="-1296"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svv//w==" LintValue="-1206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svv//w==" DoubleValue="-104198400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPv//w==" DoubleValue="-95731200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svv//w==" LintValue="-1206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPv//w==" LintValue="-1108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPv//w==" DoubleValue="-95731200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPv//w==" LintValue="-1108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aPz//w==" DoubleValue="-79488000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aPz//w==" LintValue="-920"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aPz//w==" DoubleValue="-79488000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aPz//w==" LintValue="-920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lf3//w==" DoubleValue="-62467200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lf3//w==" LintValue="-723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lf3//w==" DoubleValue="-62467200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/3//w==" DoubleValue="-54345600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lf3//w==" LintValue="-723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/3//w==" LintValue="-629"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/3//w==" DoubleValue="-54345600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/3//w==" LintValue="-629"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev7//w==" DoubleValue="-33696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev7//w==" LintValue="-390"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.884615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev7//w==" DoubleValue="-33696000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf7//w==" DoubleValue="-31708800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev7//w==" LintValue="-390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf7//w==" LintValue="-367"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.24726.1.1.5" Name="l_extendedprice" Width="10.000000">

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -5387,108 +5387,108 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1962503.1.1.2" Name="d_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VnH//w==" DoubleValue="-3155500800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yXz//w==" DoubleValue="-2902262400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VnH//w==" LintValue="-36522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yXz//w==" LintValue="-33591"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yXz//w==" DoubleValue="-2902262400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LIj//w==" DoubleValue="-2650406400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yXz//w==" LintValue="-33591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LIj//w==" LintValue="-30676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LIj//w==" DoubleValue="-2650406400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="spP//w==" DoubleValue="-2395526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LIj//w==" LintValue="-30676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="spP//w==" LintValue="-27726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="spP//w==" DoubleValue="-2395526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1p7//w==" DoubleValue="-2149113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="spP//w==" LintValue="-27726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1p7//w==" LintValue="-24874"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1p7//w==" DoubleValue="-2149113600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EKr//w==" DoubleValue="-1900800000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1p7//w==" LintValue="-24874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EKr//w==" LintValue="-22000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EKr//w==" DoubleValue="-1900800000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U7X//w==" DoubleValue="-1651708800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EKr//w==" LintValue="-22000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U7X//w==" LintValue="-19117"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U7X//w==" DoubleValue="-1651708800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="08D//w==" DoubleValue="-1397347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U7X//w==" LintValue="-19117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="08D//w==" LintValue="-16173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="08D//w==" DoubleValue="-1397347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZMz//w==" DoubleValue="-1141516800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="08D//w==" LintValue="-16173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZMz//w==" LintValue="-13212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZMz//w==" DoubleValue="-1141516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ytf//w==" DoubleValue="-898387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZMz//w==" LintValue="-13212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ytf//w==" LintValue="-10398"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ytf//w==" DoubleValue="-898387200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="auP//w==" DoubleValue="-632275200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ytf//w==" LintValue="-10398"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="auP//w==" LintValue="-7318"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="auP//w==" DoubleValue="-632275200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JO///w==" DoubleValue="-372902400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="auP//w==" LintValue="-7318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JO///w==" LintValue="-4316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JO///w==" DoubleValue="-372902400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JO///w==" LintValue="-4316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BwYAAA==" DoubleValue="133315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BwYAAA==" LintValue="1543"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BwYAAA==" DoubleValue="133315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxEAAA==" DoubleValue="379036800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BwYAAA==" LintValue="1543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxEAAA==" LintValue="4387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxEAAA==" DoubleValue="379036800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lh0AAA==" DoubleValue="645408000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxEAAA==" LintValue="4387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lh0AAA==" LintValue="7470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lh0AAA==" DoubleValue="645408000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TCgAAA==" DoubleValue="891302400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lh0AAA==" LintValue="7470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TCgAAA==" LintValue="10316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TCgAAA==" DoubleValue="891302400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IzQAAA==" DoubleValue="1153180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TCgAAA==" LintValue="10316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IzQAAA==" LintValue="13347"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IzQAAA==" DoubleValue="1153180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4T4AAA==" DoubleValue="1390780800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IzQAAA==" LintValue="13347"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4T4AAA==" LintValue="16097"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4T4AAA==" DoubleValue="1390780800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KEoAAA==" DoubleValue="1640217600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4T4AAA==" LintValue="16097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KEoAAA==" LintValue="18984"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KEoAAA==" DoubleValue="1640217600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="clUAAA==" DoubleValue="1889913600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KEoAAA==" LintValue="18984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="clUAAA==" LintValue="21874"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="clUAAA==" DoubleValue="1889913600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZGAAAA==" DoubleValue="2132006400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="clUAAA==" LintValue="21874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZGAAAA==" LintValue="24676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZGAAAA==" DoubleValue="2132006400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f2sAAA==" DoubleValue="2377641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZGAAAA==" LintValue="24676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f2sAAA==" LintValue="27519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f2sAAA==" DoubleValue="2377641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnYAAA==" DoubleValue="2623276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f2sAAA==" LintValue="27519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnYAAA==" LintValue="30362"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnYAAA==" DoubleValue="2623276800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g4EAAA==" DoubleValue="2864592000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnYAAA==" LintValue="30362"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g4EAAA==" LintValue="33155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g4EAAA==" DoubleValue="2864592000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N44AAA==" DoubleValue="3145564800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g4EAAA==" LintValue="33155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N44AAA==" LintValue="36407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N44AAA==" DoubleValue="3145564800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rI4AAA==" DoubleValue="3155673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N44AAA==" LintValue="36407"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rI4AAA==" LintValue="36524"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -412,34 +412,34 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.672855.1.1.3" Name="i_rec_end_date" Width="4.000000" NullFreq="0.501672" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.167224" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.167224" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.167224" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.672855.1.1.2" Name="i_rec_start_date" Width="4.000000" NullFreq="0.002564" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.499334" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166649" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166426" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166593" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -889,308 +889,308 @@ ORDER BY s_name;
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.18" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" DoubleValue="-249696000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NvX//w==" DoubleValue="-238636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" LintValue="-2890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NvX//w==" LintValue="-2762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014359" DistinctValues="35.575092">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NvX//w==" DoubleValue="-238636800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NvX//w==" LintValue="-2762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023333" DistinctValues="57.809524">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/X//w==" DoubleValue="-229564800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/X//w==" LintValue="-2657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/X//w==" DoubleValue="-229564800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fX//w==" DoubleValue="-221443200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/X//w==" LintValue="-2657"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fX//w==" LintValue="-2563"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009727" DistinctValues="24.099256">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fX//w==" DoubleValue="-221443200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fX//w==" LintValue="-2563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027965" DistinctValues="69.285360">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvb//w==" DoubleValue="-205113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvb//w==" LintValue="-2374"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvb//w==" DoubleValue="-205113600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvb//w==" LintValue="-2374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000785" DistinctValues="1.924679">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPf//w==" DoubleValue="-196646400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPf//w==" LintValue="-2276"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPf//w==" DoubleValue="-196646400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPf//w==" DoubleValue="-196646400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPf//w==" LintValue="-2276"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPf//w==" LintValue="-2276"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014134" DistinctValues="34.644231">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPf//w==" DoubleValue="-196646400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPf//w==" DoubleValue="-193536000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPf//w==" LintValue="-2276"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPf//w==" LintValue="-2240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPf//w==" DoubleValue="-193536000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPf//w==" DoubleValue="-193536000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPf//w==" LintValue="-2240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPf//w==" LintValue="-2240"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022772" DistinctValues="55.815705">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPf//w==" DoubleValue="-193536000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evf//w==" DoubleValue="-188524800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPf//w==" LintValue="-2240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evf//w==" LintValue="-2182"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030301" DistinctValues="75.073906">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evf//w==" DoubleValue="-188524800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evf//w==" LintValue="-2182"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007391" DistinctValues="18.310709">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pf//w==" DoubleValue="-179712000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pf//w==" LintValue="-2080"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034484" DistinctValues="85.436989">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pf//w==" DoubleValue="-179712000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvj//w==" DoubleValue="-172281600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pf//w==" LintValue="-2080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvj//w==" LintValue="-1994"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvj//w==" DoubleValue="-172281600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvj//w==" DoubleValue="-172281600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvj//w==" LintValue="-1994"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvj//w==" LintValue="-1994"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003208" DistinctValues="7.947627">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvj//w==" DoubleValue="-172281600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvj//w==" LintValue="-1994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005440" DistinctValues="13.478192">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPj//w==" DoubleValue="-170380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPj//w==" LintValue="-1972"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPj//w==" DoubleValue="-170380800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPj//w==" DoubleValue="-170380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPj//w==" LintValue="-1972"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPj//w==" LintValue="-1972"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032252" DistinctValues="79.906423">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPj//w==" DoubleValue="-170380800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPj//w==" LintValue="-1972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000397" DistinctValues="0.961943">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPj//w==" DoubleValue="-163123200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPj//w==" LintValue="-1888"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPj//w==" DoubleValue="-163123200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPj//w==" DoubleValue="-163123200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPj//w==" LintValue="-1888"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPj//w==" LintValue="-1888"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004761" DistinctValues="11.543320">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPj//w==" DoubleValue="-163123200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPj//w==" LintValue="-1888"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001984" DistinctValues="4.809717">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfj//w==" DoubleValue="-161654400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfj//w==" LintValue="-1871"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfj//w==" DoubleValue="-161654400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfj//w==" DoubleValue="-161654400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfj//w==" LintValue="-1871"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfj//w==" LintValue="-1871"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030550" DistinctValues="74.069636">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfj//w==" DoubleValue="-161654400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vj//w==" DoubleValue="-155001600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfj//w==" LintValue="-1871"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vj//w==" LintValue="-1794"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vj//w==" DoubleValue="-155001600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vj//w==" LintValue="-1794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008106" DistinctValues="19.867659">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/n//w==" DoubleValue="-144892800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/n//w==" LintValue="-1677"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/n//w==" DoubleValue="-144892800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/n//w==" DoubleValue="-144892800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/n//w==" LintValue="-1677"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/n//w==" LintValue="-1677"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012159" DistinctValues="29.801489">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/n//w==" DoubleValue="-144892800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/n//w==" LintValue="-1677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017427" DistinctValues="42.715467">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022772" DistinctValues="56.419872">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vn//w==" DoubleValue="-133574400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vn//w==" LintValue="-1546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vn//w==" DoubleValue="-133574400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vn//w==" DoubleValue="-133574400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vn//w==" LintValue="-1546"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vn//w==" LintValue="-1546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014920" DistinctValues="36.964744">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vn//w==" DoubleValue="-133574400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vn//w==" LintValue="-1546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" DoubleValue="-130291200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPr//w==" DoubleValue="-121651200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPr//w==" LintValue="-1508"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPr//w==" LintValue="-1408"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002048" DistinctValues="4.966555">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPr//w==" DoubleValue="-121651200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfr//w==" DoubleValue="-121219200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPr//w==" LintValue="-1408"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfr//w==" LintValue="-1403"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfr//w==" DoubleValue="-121219200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hfr//w==" DoubleValue="-121219200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfr//w==" LintValue="-1403"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hfr//w==" LintValue="-1403"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004916" DistinctValues="11.919732">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hfr//w==" DoubleValue="-121219200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfr//w==" DoubleValue="-120182400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hfr//w==" LintValue="-1403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfr//w==" LintValue="-1391"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfr//w==" DoubleValue="-120182400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfr//w==" DoubleValue="-120182400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfr//w==" LintValue="-1391"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfr//w==" LintValue="-1391"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008194" DistinctValues="19.866221">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfr//w==" DoubleValue="-120182400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfr//w==" LintValue="-1391"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022533" DistinctValues="54.632107">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfv//w==" DoubleValue="-105321600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfv//w==" LintValue="-1219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfv//w==" DoubleValue="-105321600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPv//w==" DoubleValue="-96768000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfv//w==" LintValue="-1219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPv//w==" LintValue="-1120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003571" DistinctValues="8.657490">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPv//w==" DoubleValue="-96768000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfv//w==" DoubleValue="-95990400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPv//w==" LintValue="-1120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfv//w==" LintValue="-1111"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfv//w==" DoubleValue="-95990400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qfv//w==" DoubleValue="-95990400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfv//w==" LintValue="-1111"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qfv//w==" LintValue="-1111"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000397" DistinctValues="0.961943">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qfv//w==" DoubleValue="-95990400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qfv//w==" LintValue="-1111"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016664" DistinctValues="40.401619">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pv//w==" DoubleValue="-92275200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pv//w==" LintValue="-1068"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pv//w==" DoubleValue="-92275200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pv//w==" DoubleValue="-92275200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pv//w==" LintValue="-1068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pv//w==" LintValue="-1068"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017061" DistinctValues="41.363563">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pv//w==" DoubleValue="-92275200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//v//w==" DoubleValue="-88560000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pv//w==" LintValue="-1068"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//v//w==" LintValue="-1025"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026423" DistinctValues="65.465504">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//v//w==" DoubleValue="-88560000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/z//w==" DoubleValue="-82684800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//v//w==" LintValue="-1025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/z//w==" LintValue="-957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/z//w==" DoubleValue="-82684800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/z//w==" DoubleValue="-82684800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/z//w==" LintValue="-957"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/z//w==" LintValue="-957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011269" DistinctValues="27.919112">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/z//w==" DoubleValue="-82684800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/z//w==" LintValue="-957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004863" DistinctValues="12.049628">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032828" DistinctValues="81.334988">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005555" DistinctValues="13.614575">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kv3//w==" DoubleValue="-62726400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kv3//w==" LintValue="-726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kv3//w==" DoubleValue="-62726400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kv3//w==" DoubleValue="-62726400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kv3//w==" LintValue="-726"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kv3//w==" LintValue="-726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005555" DistinctValues="13.614575">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kv3//w==" DoubleValue="-62726400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OP3//w==" DoubleValue="-61516800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kv3//w==" LintValue="-726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OP3//w==" LintValue="-712"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OP3//w==" DoubleValue="-61516800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OP3//w==" DoubleValue="-61516800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OP3//w==" LintValue="-712"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OP3//w==" LintValue="-712"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026583" DistinctValues="65.155466">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OP3//w==" DoubleValue="-61516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/3//w==" DoubleValue="-55728000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OP3//w==" LintValue="-712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/3//w==" LintValue="-645"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008106" DistinctValues="19.867659">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/3//w==" DoubleValue="-55728000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/3//w==" DoubleValue="-54000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/3//w==" LintValue="-645"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/3//w==" LintValue="-625"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/3//w==" DoubleValue="-54000000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/3//w==" DoubleValue="-54000000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/3//w==" LintValue="-625"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/3//w==" LintValue="-625"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027560" DistinctValues="67.550041">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/3//w==" DoubleValue="-54000000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/3//w==" LintValue="-625"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002026" DistinctValues="4.966915">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UP7//w==" DoubleValue="-37324800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UP7//w==" LintValue="-432"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.3" Name="l_linenumber" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -1225,304 +1225,304 @@ ORDER BY s_name;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.10" Name="l_shipdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/T//w==" DoubleValue="-252028800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OvX//w==" DoubleValue="-238291200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/T//w==" LintValue="-2917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OvX//w==" LintValue="-2758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035001" DistinctValues="87.639472">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OvX//w==" DoubleValue="-238291200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OvX//w==" LintValue="-2758"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001902" DistinctValues="4.763015">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/X//w==" DoubleValue="-229910400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/X//w==" LintValue="-2661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/X//w==" DoubleValue="-229910400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/X//w==" DoubleValue="-229910400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/X//w==" LintValue="-2661"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/X//w==" LintValue="-2661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000761" DistinctValues="1.905206">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/X//w==" DoubleValue="-229910400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfX//w==" DoubleValue="-229737600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/X//w==" LintValue="-2661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfX//w==" LintValue="-2659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfX//w==" DoubleValue="-229737600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//X//w==" DoubleValue="-221270400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfX//w==" LintValue="-2659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//X//w==" LintValue="-2561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//X//w==" DoubleValue="-221270400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//X//w==" DoubleValue="-221270400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//X//w==" LintValue="-2561"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//X//w==" LintValue="-2561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022995" DistinctValues="56.356275">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//X//w==" DoubleValue="-221270400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofb//w==" DoubleValue="-216259200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//X//w==" LintValue="-2561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofb//w==" LintValue="-2503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000937" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofb//w==" DoubleValue="-216259200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofb//w==" DoubleValue="-216259200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofb//w==" LintValue="-2503"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofb//w==" LintValue="-2503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002379" DistinctValues="5.829960">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofb//w==" DoubleValue="-216259200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/b//w==" DoubleValue="-215740800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofb//w==" LintValue="-2503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/b//w==" LintValue="-2497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/b//w==" DoubleValue="-215740800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="P/b//w==" DoubleValue="-215740800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/b//w==" LintValue="-2497"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="P/b//w==" LintValue="-2497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005947" DistinctValues="14.574899">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="P/b//w==" DoubleValue="-215740800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvb//w==" DoubleValue="-214444800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="P/b//w==" LintValue="-2497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvb//w==" LintValue="-2482"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvb//w==" DoubleValue="-214444800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvb//w==" DoubleValue="-214444800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvb//w==" LintValue="-2482"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvb//w==" LintValue="-2482"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006343" DistinctValues="15.546559">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvb//w==" DoubleValue="-214444800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvb//w==" LintValue="-2482"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" DoubleValue="-213062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPb//w==" DoubleValue="-204940800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvb//w==" LintValue="-2466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPb//w==" LintValue="-2372"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002483" DistinctValues="6.218090">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPb//w==" DoubleValue="-204940800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wvb//w==" DoubleValue="-204422400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPb//w==" LintValue="-2372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wvb//w==" LintValue="-2366"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wvb//w==" DoubleValue="-204422400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wvb//w==" DoubleValue="-204422400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wvb//w==" LintValue="-2366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wvb//w==" LintValue="-2366"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034353" DistinctValues="86.016906">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wvb//w==" DoubleValue="-204422400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wvb//w==" LintValue="-2366"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000828" DistinctValues="2.072697">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" DoubleValue="-197251200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Fff//w==" LintValue="-2283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028640" DistinctValues="72.473558">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009024" DistinctValues="22.834135">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004946" DistinctValues="12.383838">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6ff//w==" DoubleValue="-178934400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6ff//w==" LintValue="-2071"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6ff//w==" DoubleValue="-178934400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6ff//w==" DoubleValue="-178934400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6ff//w==" LintValue="-2071"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6ff//w==" LintValue="-2071"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020544" DistinctValues="51.440559">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6ff//w==" DoubleValue="-178934400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/j//w==" DoubleValue="-174268800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6ff//w==" LintValue="-2071"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/j//w==" LintValue="-2017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/j//w==" DoubleValue="-174268800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/j//w==" DoubleValue="-174268800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/j//w==" LintValue="-2017"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/j//w==" LintValue="-2017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012174" DistinctValues="30.483294">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/j//w==" DoubleValue="-174268800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/j//w==" DoubleValue="-171504000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/j//w==" LintValue="-2017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/j//w==" LintValue="-1985"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000396" DistinctValues="1.003239">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/j//w==" DoubleValue="-171504000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPj//w==" DoubleValue="-171417600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/j//w==" LintValue="-1985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPj//w==" LintValue="-1984"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPj//w==" DoubleValue="-171417600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPj//w==" DoubleValue="-171417600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPj//w==" LintValue="-1984"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPj//w==" LintValue="-1984"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037267" DistinctValues="94.304453">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPj//w==" DoubleValue="-171417600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPj//w==" LintValue="-1984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018832" DistinctValues="47.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvj//w==" DoubleValue="-159148800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvj//w==" LintValue="-1842"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvj//w==" DoubleValue="-159148800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zvj//w==" DoubleValue="-159148800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvj//w==" LintValue="-1842"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zvj//w==" LintValue="-1842"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018832" DistinctValues="47.653846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zvj//w==" DoubleValue="-159148800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vj//w==" DoubleValue="-155001600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zvj//w==" LintValue="-1842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vj//w==" LintValue="-1794"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vj//w==" DoubleValue="-155001600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vj//w==" LintValue="-1794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017295" DistinctValues="43.304553">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPn//w==" DoubleValue="-142732800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPn//w==" LintValue="-1652"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPn//w==" DoubleValue="-142732800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPn//w==" DoubleValue="-142732800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPn//w==" LintValue="-1652"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPn//w==" LintValue="-1652"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014220" DistinctValues="35.605965">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPn//w==" DoubleValue="-142732800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPn//w==" LintValue="-1652"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006149" DistinctValues="15.397174">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007290" DistinctValues="18.253102">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010530" DistinctValues="26.365591">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fn//w==" DoubleValue="-134352000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fn//w==" LintValue="-1555"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fn//w==" DoubleValue="-134352000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fn//w==" DoubleValue="-134352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fn//w==" LintValue="-1555"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fn//w==" LintValue="-1555"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019844" DistinctValues="49.688999">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fn//w==" DoubleValue="-134352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fn//w==" LintValue="-1555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005381" DistinctValues="13.472527">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" DoubleValue="-130118400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPr//w==" DoubleValue="-128908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvr//w==" LintValue="-1506"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPr//w==" LintValue="-1492"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPr//w==" DoubleValue="-128908800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPr//w==" DoubleValue="-128908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPr//w==" LintValue="-1492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPr//w==" LintValue="-1492"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001153" DistinctValues="2.886970">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPr//w==" DoubleValue="-128908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/r//w==" DoubleValue="-128649600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPr//w==" LintValue="-1492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/r//w==" LintValue="-1489"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/r//w==" DoubleValue="-128649600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/r//w==" DoubleValue="-128649600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/r//w==" LintValue="-1489"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/r//w==" LintValue="-1489"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031130" DistinctValues="77.948195">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/r//w==" DoubleValue="-128649600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPr//w==" DoubleValue="-121651200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/r//w==" LintValue="-1489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPr//w==" LintValue="-1408"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025382" DistinctValues="64.229097">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPr//w==" DoubleValue="-121651200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvr//w==" DoubleValue="-116294400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPr//w==" LintValue="-1408"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvr//w==" LintValue="-1346"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001060" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvr//w==" DoubleValue="-116294400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvr//w==" DoubleValue="-116294400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvr//w==" LintValue="-1346"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvr//w==" LintValue="-1346"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012282" DistinctValues="31.078595">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvr//w==" DoubleValue="-116294400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvr//w==" LintValue="-1346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010761" DistinctValues="27.230769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pr//w==" DoubleValue="-111283200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pr//w==" LintValue="-1288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pr//w==" DoubleValue="-111283200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pr//w==" DoubleValue="-111283200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pr//w==" LintValue="-1288"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pr//w==" LintValue="-1288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026903" DistinctValues="68.076923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pr//w==" DoubleValue="-111283200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pr//w==" LintValue="-1288"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/v//w==" DoubleValue="-96854400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/v//w==" LintValue="-1121"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/v//w==" DoubleValue="-96854400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Avz//w==" DoubleValue="-88300800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/v//w==" LintValue="-1121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Avz//w==" LintValue="-1022"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Avz//w==" DoubleValue="-88300800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Avz//w==" LintValue="-1022"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021936" DistinctValues="55.508876">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/z//w==" DoubleValue="-75427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/z//w==" LintValue="-873"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/z//w==" DoubleValue="-75427200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/z//w==" DoubleValue="-75427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/z//w==" LintValue="-873"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/z//w==" LintValue="-873"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015728" DistinctValues="39.798817">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/z//w==" DoubleValue="-75427200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/z//w==" LintValue="-873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hv3//w==" DoubleValue="-63763200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hv3//w==" LintValue="-738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009216" DistinctValues="23.319967">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hv3//w==" DoubleValue="-63763200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nf3//w==" DoubleValue="-61776000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hv3//w==" LintValue="-738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nf3//w==" LintValue="-715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nf3//w==" DoubleValue="-61776000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nf3//w==" DoubleValue="-61776000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nf3//w==" LintValue="-715"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nf3//w==" LintValue="-715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028448" DistinctValues="71.987725">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nf3//w==" DoubleValue="-61776000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nf3//w==" LintValue="-715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003606" DistinctValues="9.125205">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034058" DistinctValues="86.182488">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001345" DistinctValues="3.403846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036319" DistinctValues="91.903846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zv7//w==" DoubleValue="-35424000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zv7//w==" LintValue="-410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037664" DistinctValues="96.307692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zv7//w==" DoubleValue="-35424000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bf7//w==" DoubleValue="-34819200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zv7//w==" LintValue="-410"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bf7//w==" LintValue="-403"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.2" Name="l_suppkey" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -4923,308 +4923,308 @@ ORDER BY s_name;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.12" Name="l_receiptdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.028258" DistinctValues="71.711538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPT//w==" DoubleValue="-251251200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/X//w==" DoubleValue="-240624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPT//w==" LintValue="-2908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/X//w==" LintValue="-2785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/X//w==" DoubleValue="-240624000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/X//w==" DoubleValue="-240624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/X//w==" LintValue="-2785"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/X//w==" LintValue="-2785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009419" DistinctValues="23.903846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/X//w==" DoubleValue="-240624000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/X//w==" LintValue="-2785"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfX//w==" DoubleValue="-228355200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfX//w==" LintValue="-2643"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008843" DistinctValues="22.440345">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfX//w==" DoubleValue="-228355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPX//w==" DoubleValue="-226368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfX//w==" LintValue="-2643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPX//w==" LintValue="-2620"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPX//w==" DoubleValue="-226368000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPX//w==" DoubleValue="-226368000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPX//w==" LintValue="-2620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPX//w==" LintValue="-2620"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028835" DistinctValues="73.175039">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPX//w==" DoubleValue="-226368000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/b//w==" DoubleValue="-219888000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPX//w==" LintValue="-2620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/b//w==" LintValue="-2545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/b//w==" DoubleValue="-219888000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvb//w==" DoubleValue="-211680000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/b//w==" LintValue="-2545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvb//w==" LintValue="-2450"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvb//w==" DoubleValue="-211680000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPb//w==" DoubleValue="-203558400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvb//w==" LintValue="-2450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPb//w==" LintValue="-2356"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010885" DistinctValues="27.044444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPb//w==" DoubleValue="-203558400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPb//w==" LintValue="-2356"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005861" DistinctValues="14.562393">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012141" DistinctValues="30.164957">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Eff//w==" DoubleValue="-197596800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Eff//w==" LintValue="-2287"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Eff//w==" DoubleValue="-197596800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Eff//w==" DoubleValue="-197596800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Eff//w==" LintValue="-2287"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Eff//w==" LintValue="-2287"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008791" DistinctValues="21.843590">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Eff//w==" DoubleValue="-197596800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvf//w==" DoubleValue="-195782400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Eff//w==" LintValue="-2287"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvf//w==" LintValue="-2266"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007912" DistinctValues="19.869231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvf//w==" DoubleValue="-195782400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvf//w==" LintValue="-2266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017709" DistinctValues="44.469231">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012057" DistinctValues="30.276923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035014" DistinctValues="88.854701">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/j//w==" DoubleValue="-170812800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/j//w==" LintValue="-1977"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/j//w==" DoubleValue="-170812800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/j//w==" DoubleValue="-170812800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/j//w==" LintValue="-1977"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/j//w==" LintValue="-1977"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002664" DistinctValues="6.760684">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/j//w==" DoubleValue="-170812800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvj//w==" DoubleValue="-170208000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/j//w==" LintValue="-1977"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvj//w==" LintValue="-1970"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006814" DistinctValues="16.930442">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvj//w==" DoubleValue="-170208000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/j//w==" DoubleValue="-168739200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvj//w==" LintValue="-1970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/j//w==" LintValue="-1953"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/j//w==" DoubleValue="-168739200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/j//w==" DoubleValue="-168739200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/j//w==" LintValue="-1953"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/j//w==" LintValue="-1953"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001202" DistinctValues="2.987725">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/j//w==" DoubleValue="-168739200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/j//w==" LintValue="-1953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000937" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026855" DistinctValues="66.725859">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfj//w==" DoubleValue="-162691200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfj//w==" LintValue="-1883"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfj//w==" DoubleValue="-162691200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfj//w==" DoubleValue="-162691200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfj//w==" LintValue="-1883"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfj//w==" LintValue="-1883"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002806" DistinctValues="6.971358">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfj//w==" DoubleValue="-162691200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfj//w==" LintValue="-1883"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" DoubleValue="-162086400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/n//w==" DoubleValue="-153532800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPj//w==" LintValue="-1876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/n//w==" LintValue="-1777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/n//w==" DoubleValue="-153532800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvn//w==" DoubleValue="-145324800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/n//w==" LintValue="-1777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvn//w==" LintValue="-1682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017269" DistinctValues="43.365385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvn//w==" DoubleValue="-145324800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvn//w==" LintValue="-1682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016876" DistinctValues="42.379808">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003532" DistinctValues="8.870192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvn//w==" DoubleValue="-137030400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvn//w==" LintValue="-1586"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028651" DistinctValues="71.947115">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvn//w==" DoubleValue="-137030400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvn//w==" LintValue="-1586"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005102" DistinctValues="12.812500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPr//w==" DoubleValue="-129600000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPr//w==" LintValue="-1500"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000937" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPr//w==" DoubleValue="-129600000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPr//w==" DoubleValue="-129600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPr//w==" LintValue="-1500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPr//w==" LintValue="-1500"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003925" DistinctValues="9.855769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPr//w==" DoubleValue="-129600000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPr//w==" LintValue="-1500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003884" DistinctValues="9.754163">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPr//w==" DoubleValue="-127872000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPr//w==" LintValue="-1480"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPr//w==" DoubleValue="-127872000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OPr//w==" DoubleValue="-127872000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPr//w==" LintValue="-1480"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="OPr//w==" LintValue="-1480"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006603" DistinctValues="16.582078">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OPr//w==" DoubleValue="-127872000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfr//w==" DoubleValue="-126403200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="OPr//w==" LintValue="-1480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfr//w==" LintValue="-1463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfr//w==" DoubleValue="-126403200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfr//w==" DoubleValue="-126403200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfr//w==" LintValue="-1463"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfr//w==" LintValue="-1463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027190" DistinctValues="68.279144">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfr//w==" DoubleValue="-126403200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/r//w==" DoubleValue="-120355200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfr//w==" LintValue="-1463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/r//w==" LintValue="-1393"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/r//w==" DoubleValue="-120355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fr//w==" DoubleValue="-112233600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/r//w==" LintValue="-1393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fr//w==" LintValue="-1299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012952" DistinctValues="32.867788">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fr//w==" DoubleValue="-112233600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvv//w==" DoubleValue="-109382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fr//w==" LintValue="-1299"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvv//w==" LintValue="-1266"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvv//w==" DoubleValue="-109382400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvv//w==" DoubleValue="-109382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvv//w==" LintValue="-1266"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvv//w==" LintValue="-1266"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024726" DistinctValues="62.747596">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvv//w==" DoubleValue="-109382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfv//w==" DoubleValue="-103939200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvv//w==" LintValue="-1266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfv//w==" LintValue="-1203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfv//w==" DoubleValue="-103939200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvv//w==" DoubleValue="-95558400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfv//w==" LintValue="-1203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvv//w==" LintValue="-1106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009419" DistinctValues="23.903846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvv//w==" DoubleValue="-95558400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/v//w==" DoubleValue="-93398400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvv//w==" LintValue="-1106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/v//w==" LintValue="-1081"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/v//w==" DoubleValue="-93398400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/v//w==" DoubleValue="-93398400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/v//w==" LintValue="-1081"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/v//w==" LintValue="-1081"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028258" DistinctValues="71.711538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/v//w==" DoubleValue="-93398400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evz//w==" DoubleValue="-86918400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/v//w==" LintValue="-1081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evz//w==" LintValue="-1006"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008017" DistinctValues="20.343699">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evz//w==" DoubleValue="-86918400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvz//w==" DoubleValue="-85190400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evz//w==" LintValue="-1006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvz//w==" LintValue="-986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000815" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvz//w==" DoubleValue="-85190400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvz//w==" DoubleValue="-85190400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvz//w==" LintValue="-986"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvz//w==" LintValue="-986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029661" DistinctValues="75.271686">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvz//w==" DoubleValue="-85190400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cPz//w==" DoubleValue="-78796800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvz//w==" LintValue="-986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cPz//w==" LintValue="-912"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013370" DistinctValues="33.928040">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cPz//w==" DoubleValue="-78796800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfz//w==" DoubleValue="-75945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cPz//w==" LintValue="-912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfz//w==" LintValue="-879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfz//w==" DoubleValue="-75945600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfz//w==" DoubleValue="-75945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfz//w==" LintValue="-879"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfz//w==" LintValue="-879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024308" DistinctValues="61.687345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfz//w==" DoubleValue="-75945600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfz//w==" DoubleValue="-70761600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfz//w==" LintValue="-879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfz//w==" LintValue="-819"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfz//w==" DoubleValue="-70761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lv3//w==" DoubleValue="-62380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfz//w==" LintValue="-819"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lv3//w==" LintValue="-722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001202" DistinctValues="3.019640">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lv3//w==" DoubleValue="-62380800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lv3//w==" LintValue="-722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024450" DistinctValues="61.399345">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv3//w==" DoubleValue="-56851200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv3//w==" LintValue="-658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv3//w==" DoubleValue="-56851200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bv3//w==" DoubleValue="-56851200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv3//w==" LintValue="-658"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bv3//w==" LintValue="-658"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012025" DistinctValues="30.196399">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bv3//w==" DoubleValue="-56851200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jP3//w==" DoubleValue="-54259200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bv3//w==" LintValue="-658"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jP3//w==" LintValue="-628"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023903" DistinctValues="60.024814">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jP3//w==" DoubleValue="-54259200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/3//w==" DoubleValue="-49161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jP3//w==" LintValue="-628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/3//w==" LintValue="-569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000856" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/3//w==" DoubleValue="-49161600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/3//w==" DoubleValue="-49161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/3//w==" LintValue="-569"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/3//w==" LintValue="-569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008913" DistinctValues="22.382134">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/3//w==" DoubleValue="-49161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3f3//w==" DoubleValue="-47260800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/3//w==" LintValue="-569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3f3//w==" LintValue="-547"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000774" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3f3//w==" DoubleValue="-47260800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3f3//w==" DoubleValue="-47260800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3f3//w==" LintValue="-547"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3f3//w==" LintValue="-547"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004862" DistinctValues="12.208437">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3f3//w==" DoubleValue="-47260800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3f3//w==" LintValue="-547"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" DoubleValue="-46224000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dP7//w==" DoubleValue="-34214400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f3//w==" LintValue="-535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dP7//w==" LintValue="-396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037678" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dP7//w==" DoubleValue="-34214400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf7//w==" DoubleValue="-32745600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dP7//w==" LintValue="-396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf7//w==" LintValue="-379"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.5" Name="l_extendedprice" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
@@ -6314,7 +6314,7 @@ ORDER BY s_name;
                               </dxl:Comparison>
                               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                                 <dxl:Ident ColId="48" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
                               </dxl:Comparison>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                                 <dxl:Ident ColId="40" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
@@ -6757,7 +6757,7 @@ ORDER BY s_name;
                                 <dxl:Filter>
                                   <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                                     <dxl:Ident ColId="47" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
+                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
                                   </dxl:Comparison>
                                 </dxl:Filter>
                                 <dxl:TableDescriptor Mdid="0.11778166.1.1" TableName="lineitem_ao_column_none_level0">

--- a/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -688,308 +688,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.12" Name="l_receiptdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" DoubleValue="-251856000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" LintValue="-2915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016693" DistinctValues="42.323077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" DoubleValue="-228873600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/X//w==" LintValue="-2649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021066" DistinctValues="53.407692">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvb//w==" DoubleValue="-220665600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvb//w==" LintValue="-2554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028118" DistinctValues="71.288871">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvb//w==" DoubleValue="-220665600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvb//w==" LintValue="-2554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009641" DistinctValues="24.441899">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPb//w==" DoubleValue="-212544000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPb//w==" LintValue="-2460"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009539" DistinctValues="23.931984">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPb//w==" DoubleValue="-212544000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPb//w==" DoubleValue="-210470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPb//w==" LintValue="-2460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPb//w==" LintValue="-2436"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPb//w==" DoubleValue="-210470400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPb//w==" DoubleValue="-210470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPb//w==" LintValue="-2436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPb//w==" LintValue="-2436"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026630" DistinctValues="66.810121">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPb//w==" DoubleValue="-210470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPb//w==" LintValue="-2436"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001590" DistinctValues="3.988664">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012863" DistinctValues="31.930262">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vb//w==" DoubleValue="-201657600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vb//w==" LintValue="-2334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vb//w==" DoubleValue="-201657600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4vb//w==" DoubleValue="-201657600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vb//w==" LintValue="-2334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4vb//w==" LintValue="-2334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001245" DistinctValues="3.090025">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4vb//w==" DoubleValue="-201657600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fb//w==" DoubleValue="-201398400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4vb//w==" LintValue="-2334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fb//w==" LintValue="-2331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fb//w==" DoubleValue="-201398400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fb//w==" DoubleValue="-201398400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fb//w==" LintValue="-2331"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fb//w==" LintValue="-2331"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000415" DistinctValues="1.030008">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fb//w==" DoubleValue="-201398400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fb//w==" LintValue="-2331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023236" DistinctValues="57.680473">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvf//w==" DoubleValue="-196473600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvf//w==" LintValue="-2274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006567" DistinctValues="16.301003">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvf//w==" DoubleValue="-196473600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvf//w==" LintValue="-2274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000837" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001642" DistinctValues="4.075251">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvf//w==" DoubleValue="-194745600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvf//w==" LintValue="-2254"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000837" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvf//w==" DoubleValue="-194745600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvf//w==" DoubleValue="-194745600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvf//w==" LintValue="-2254"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvf//w==" LintValue="-2254"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011081" DistinctValues="27.507943">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvf//w==" DoubleValue="-194745600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tff//w==" DoubleValue="-192412800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvf//w==" LintValue="-2254"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tff//w==" LintValue="-2227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tff//w==" DoubleValue="-192412800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tff//w==" DoubleValue="-192412800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tff//w==" LintValue="-2227"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tff//w==" LintValue="-2227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018469" DistinctValues="45.846572">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tff//w==" DoubleValue="-192412800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evf//w==" DoubleValue="-188524800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tff//w==" LintValue="-2227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evf//w==" LintValue="-2182"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evf//w==" DoubleValue="-188524800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evf//w==" LintValue="-2182"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001168" DistinctValues="2.960745">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036591" DistinctValues="92.770024">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPj//w==" DoubleValue="-171763200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPj//w==" LintValue="-1988"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPj//w==" DoubleValue="-171763200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfj//w==" DoubleValue="-163382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPj//w==" LintValue="-1988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfj//w==" LintValue="-1891"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013804" DistinctValues="34.998346">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfj//w==" DoubleValue="-163382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfj//w==" LintValue="-1891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023955" DistinctValues="60.732423">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023356" DistinctValues="57.359239">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvn//w==" DoubleValue="-150163200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvn//w==" LintValue="-1738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvn//w==" DoubleValue="-150163200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvn//w==" DoubleValue="-150163200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvn//w==" LintValue="-1738"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvn//w==" LintValue="-1738"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001557" DistinctValues="3.823949">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvn//w==" DoubleValue="-150163200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvn//w==" LintValue="-1738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002336" DistinctValues="5.735924">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001557" DistinctValues="3.823949">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPn//w==" DoubleValue="-148953600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPn//w==" LintValue="-1724"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPn//w==" DoubleValue="-148953600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPn//w==" DoubleValue="-148953600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPn//w==" LintValue="-1724"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPn//w==" LintValue="-1724"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008953" DistinctValues="21.987708">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPn//w==" DoubleValue="-148953600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/n//w==" DoubleValue="-146966400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPn//w==" LintValue="-1724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/n//w==" LintValue="-1701"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/n//w==" DoubleValue="-146966400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/n//w==" LintValue="-1701"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" DoubleValue="-138758400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvn//w==" LintValue="-1606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006902" DistinctValues="17.133581">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfr//w==" DoubleValue="-129168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfr//w==" LintValue="-1495"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfr//w==" DoubleValue="-129168000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfr//w==" DoubleValue="-129168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfr//w==" LintValue="-1495"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfr//w==" LintValue="-1495"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007308" DistinctValues="18.141439">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfr//w==" DoubleValue="-129168000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfr//w==" LintValue="-1495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000807" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017052" DistinctValues="42.330025">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006496" DistinctValues="16.125724">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfr//w==" DoubleValue="-122601600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfr//w==" LintValue="-1419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032151" DistinctValues="81.513328">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfr//w==" DoubleValue="-122601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/r//w==" DoubleValue="-115171200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfr//w==" LintValue="-1419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/r//w==" LintValue="-1333"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/r//w==" DoubleValue="-115171200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/r//w==" DoubleValue="-115171200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/r//w==" LintValue="-1333"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/r//w==" LintValue="-1333"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005608" DistinctValues="14.217441">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/r//w==" DoubleValue="-115171200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/r//w==" LintValue="-1333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033521" DistinctValues="84.985479">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPv//w==" DoubleValue="-98150400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPv//w==" LintValue="-1136"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPv//w==" DoubleValue="-98150400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kPv//w==" DoubleValue="-98150400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPv//w==" LintValue="-1136"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kPv//w==" LintValue="-1136"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004238" DistinctValues="10.745290">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kPv//w==" DoubleValue="-98150400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kPv//w==" LintValue="-1136"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002697" DistinctValues="6.766484">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" DoubleValue="-88992000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vv//w==" LintValue="-1030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005009" DistinctValues="12.566327">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030053" DistinctValues="75.397959">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XPz//w==" DoubleValue="-80524800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XPz//w==" LintValue="-932"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001573" DistinctValues="3.988782">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XPz//w==" DoubleValue="-80524800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XPz//w==" LintValue="-932"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036186" DistinctValues="91.741987">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" DoubleValue="-80179200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPz//w==" LintValue="-928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023206" DistinctValues="58.834535">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/z//w==" DoubleValue="-67132800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/z//w==" LintValue="-777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/z//w==" DoubleValue="-67132800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/z//w==" DoubleValue="-67132800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/z//w==" LintValue="-777"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/z//w==" LintValue="-777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014553" DistinctValues="36.896234">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/z//w==" DoubleValue="-67132800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/z//w==" LintValue="-777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5P3//w==" DoubleValue="-46656000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5P3//w==" LintValue="-540"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5P3//w==" DoubleValue="-46656000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dP7//w==" DoubleValue="-34214400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5P3//w==" LintValue="-540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dP7//w==" LintValue="-396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037759" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dP7//w==" DoubleValue="-34214400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="if7//w==" DoubleValue="-32400000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dP7//w==" LintValue="-396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="if7//w==" LintValue="-375"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.5" Name="l_extendedprice" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -2233,300 +2233,300 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.5844948.1.1.4" Name="o_orderdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" DoubleValue="-252460800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/T//w==" DoubleValue="-244080000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" LintValue="-2922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/T//w==" LintValue="-2825"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/T//w==" DoubleValue="-244080000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/T//w==" DoubleValue="-244080000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/T//w==" LintValue="-2825"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/T//w==" LintValue="-2825"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033090" DistinctValues="79.515000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/T//w==" DoubleValue="-244080000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/T//w==" LintValue="-2825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006128" DistinctValues="14.725000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" DoubleValue="-237081600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPX//w==" LintValue="-2744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001201" DistinctValues="2.915510">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WvX//w==" DoubleValue="-235526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WvX//w==" LintValue="-2726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WvX//w==" DoubleValue="-235526400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WvX//w==" DoubleValue="-235526400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WvX//w==" LintValue="-2726"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WvX//w==" LintValue="-2726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038018" DistinctValues="92.324490">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WvX//w==" DoubleValue="-235526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufX//w==" DoubleValue="-227318400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WvX//w==" LintValue="-2726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufX//w==" LintValue="-2631"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023615" DistinctValues="57.348817">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufX//w==" DoubleValue="-227318400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufX//w==" LintValue="-2631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015603" DistinctValues="37.891183">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvb//w==" DoubleValue="-219283200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvb//w==" LintValue="-2538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009179" DistinctValues="22.056170">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvb//w==" DoubleValue="-219283200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvb//w==" LintValue="-2538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024198" DistinctValues="58.148085">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005841" DistinctValues="14.035745">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPb//w==" DoubleValue="-211161600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPb//w==" LintValue="-2444"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009507" DistinctValues="23.088485">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPb//w==" DoubleValue="-211161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPb//w==" LintValue="-2444"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000804" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029711" DistinctValues="72.151515">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/b//w==" DoubleValue="-202608000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/b//w==" LintValue="-2345"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/b//w==" DoubleValue="-202608000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvf//w==" DoubleValue="-194400000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/b//w==" LintValue="-2345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvf//w==" LintValue="-2250"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvf//w==" DoubleValue="-194400000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvf//w==" LintValue="-2250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006803" DistinctValues="16.521224">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPf//w==" DoubleValue="-184550400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPf//w==" LintValue="-2136"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPf//w==" DoubleValue="-184550400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPf//w==" DoubleValue="-184550400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPf//w==" LintValue="-2136"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPf//w==" LintValue="-2136"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032415" DistinctValues="78.718776">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPf//w==" DoubleValue="-184550400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+ff//w==" DoubleValue="-177552000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPf//w==" LintValue="-2136"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+ff//w==" LintValue="-2055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013641" DistinctValues="33.126957">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+ff//w==" DoubleValue="-177552000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfj//w==" DoubleValue="-174787200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+ff//w==" LintValue="-2055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfj//w==" LintValue="-2023"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfj//w==" DoubleValue="-174787200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfj//w==" DoubleValue="-174787200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfj//w==" LintValue="-2023"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfj//w==" LintValue="-2023"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025577" DistinctValues="62.113043">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfj//w==" DoubleValue="-174787200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfj//w==" LintValue="-2023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033439" DistinctValues="81.204632">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvj//w==" DoubleValue="-162604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvj//w==" LintValue="-1882"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvj//w==" DoubleValue="-162604800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pvj//w==" DoubleValue="-162604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvj//w==" LintValue="-1882"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pvj//w==" LintValue="-1882"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005780" DistinctValues="14.035368">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pvj//w==" DoubleValue="-162604800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPj//w==" DoubleValue="-161395200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pvj//w==" LintValue="-1882"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPj//w==" LintValue="-1868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPj//w==" DoubleValue="-161395200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvn//w==" DoubleValue="-152928000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPj//w==" LintValue="-1868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvn//w==" LintValue="-1770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015346" DistinctValues="36.876522">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvn//w==" DoubleValue="-152928000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvn//w==" LintValue="-1770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000707" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001279" DistinctValues="3.073043">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" DoubleValue="-149817600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfn//w==" DoubleValue="-149558400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovn//w==" LintValue="-1734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfn//w==" LintValue="-1731"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000965" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfn//w==" DoubleValue="-149558400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfn//w==" DoubleValue="-149558400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfn//w==" LintValue="-1731"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfn//w==" LintValue="-1731"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022593" DistinctValues="54.290435">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfn//w==" DoubleValue="-149558400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvn//w==" DoubleValue="-144979200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfn//w==" LintValue="-1731"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvn//w==" LintValue="-1678"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003234" DistinctValues="7.854845">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvn//w==" DoubleValue="-144979200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evn//w==" DoubleValue="-144288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvn//w==" LintValue="-1678"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evn//w==" LintValue="-1670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000707" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evn//w==" DoubleValue="-144288000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="evn//w==" DoubleValue="-144288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evn//w==" LintValue="-1670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="evn//w==" LintValue="-1670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035984" DistinctValues="87.385155">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="evn//w==" DoubleValue="-144288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="evn//w==" LintValue="-1670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023923" DistinctValues="58.096400">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" DoubleValue="-136598400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/n//w==" LintValue="-1581"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015295" DistinctValues="37.143600">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018990" DistinctValues="45.147789">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000804" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005780" DistinctValues="13.740632">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" DoubleValue="-123984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/r//w==" DoubleValue="-122774400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zfr//w==" LintValue="-1435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/r//w==" LintValue="-1421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000868" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/r//w==" DoubleValue="-122774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/r//w==" DoubleValue="-122774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/r//w==" LintValue="-1421"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/r//w==" LintValue="-1421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007018" DistinctValues="16.685053">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/r//w==" DoubleValue="-122774400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPr//w==" DoubleValue="-121305600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/r//w==" LintValue="-1421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPr//w==" LintValue="-1404"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPr//w==" DoubleValue="-121305600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hPr//w==" DoubleValue="-121305600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPr//w==" LintValue="-1404"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hPr//w==" LintValue="-1404"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007431" DistinctValues="17.666526">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hPr//w==" DoubleValue="-121305600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvr//w==" DoubleValue="-119750400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hPr//w==" LintValue="-1404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvr//w==" LintValue="-1386"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvr//w==" DoubleValue="-119750400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvr//w==" LintValue="-1386"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034366" DistinctValues="82.581443">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/v//w==" DoubleValue="-104112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/v//w==" LintValue="-1205"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/v//w==" DoubleValue="-104112000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/v//w==" DoubleValue="-104112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/v//w==" LintValue="-1205"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/v//w==" LintValue="-1205"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004447" DistinctValues="10.687010">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/v//w==" DoubleValue="-104112000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvv//w==" DoubleValue="-103161600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/v//w==" LintValue="-1205"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvv//w==" LintValue="-1194"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000804" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvv//w==" DoubleValue="-103161600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvv//w==" DoubleValue="-103161600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvv//w==" LintValue="-1194"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvv//w==" LintValue="-1194"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000404" DistinctValues="0.971546">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvv//w==" DoubleValue="-103161600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/v//w==" DoubleValue="-103075200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvv//w==" LintValue="-1194"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/v//w==" LintValue="-1193"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020641" DistinctValues="49.600000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/v//w==" DoubleValue="-103075200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/v//w==" LintValue="-1193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002477" DistinctValues="5.952000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000836" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016100" DistinctValues="38.688000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvv//w==" DoubleValue="-94867200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvv//w==" LintValue="-1098"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007673" DistinctValues="18.633913">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvv//w==" DoubleValue="-94867200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPv//w==" DoubleValue="-93312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvv//w==" LintValue="-1098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPv//w==" LintValue="-1080"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000836" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPv//w==" DoubleValue="-93312000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPv//w==" DoubleValue="-93312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPv//w==" LintValue="-1080"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPv//w==" LintValue="-1080"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031545" DistinctValues="76.606087">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPv//w==" DoubleValue="-93312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evz//w==" DoubleValue="-86918400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPv//w==" LintValue="-1080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evz//w==" LintValue="-1006"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evz//w==" DoubleValue="-86918400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/z//w==" DoubleValue="-78192000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evz//w==" LintValue="-1006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/z//w==" LintValue="-905"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015274" DistinctValues="37.093474">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/z//w==" DoubleValue="-78192000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/z//w==" LintValue="-905"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023944" DistinctValues="58.146526">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vz//w==" DoubleValue="-69984000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vz//w==" LintValue="-810"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039218" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vz//w==" DoubleValue="-69984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/3//w==" DoubleValue="-61257600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vz//w==" LintValue="-810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/3//w==" LintValue="-709"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012362" DistinctValues="30.021304">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/3//w==" DoubleValue="-61257600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WP3//w==" DoubleValue="-58752000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/3//w==" LintValue="-709"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WP3//w==" LintValue="-680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000868" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WP3//w==" DoubleValue="-58752000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WP3//w==" DoubleValue="-58752000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WP3//w==" LintValue="-680"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WP3//w==" LintValue="-680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026856" DistinctValues="65.218696">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WP3//w==" DoubleValue="-58752000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/3//w==" DoubleValue="-53308800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WP3//w==" LintValue="-680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/3//w==" LintValue="-617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002745" DistinctValues="6.666800">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/3//w==" DoubleValue="-53308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/3//w==" LintValue="-617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000740" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036473" DistinctValues="88.573200">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" DoubleValue="-44668800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" LintValue="-517"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:GPDBFunc Mdid="0.1740.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
@@ -3499,614 +3499,614 @@
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.18" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" DoubleValue="-249868800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NvX//w==" DoubleValue="-238636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPT//w==" LintValue="-2892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NvX//w==" LintValue="-2762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NvX//w==" DoubleValue="-238636800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NvX//w==" LintValue="-2762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028210" DistinctValues="69.246559">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" DoubleValue="-230342400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvX//w==" LintValue="-2666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000807" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008741" DistinctValues="21.456680">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000795" DistinctValues="1.950607">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fX//w==" DoubleValue="-222134400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fX//w==" LintValue="-2571"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016688" DistinctValues="40.962753">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fX//w==" DoubleValue="-222134400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/b//w==" DoubleValue="-218505600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fX//w==" LintValue="-2571"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/b//w==" LintValue="-2529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/b//w==" DoubleValue="-218505600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/b//w==" DoubleValue="-218505600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/b//w==" LintValue="-2529"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/b//w==" LintValue="-2529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019866" DistinctValues="48.765182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/b//w==" DoubleValue="-218505600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/b//w==" LintValue="-2529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001192" DistinctValues="2.925911">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008741" DistinctValues="21.456680">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avb//w==" DoubleValue="-212025600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avb//w==" LintValue="-2454"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avb//w==" DoubleValue="-212025600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avb//w==" DoubleValue="-212025600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avb//w==" LintValue="-2454"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avb//w==" LintValue="-2454"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017085" DistinctValues="41.938057">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avb//w==" DoubleValue="-212025600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfb//w==" DoubleValue="-208310400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avb//w==" LintValue="-2454"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfb//w==" LintValue="-2411"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfb//w==" DoubleValue="-208310400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfb//w==" DoubleValue="-208310400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfb//w==" LintValue="-2411"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfb//w==" LintValue="-2411"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011920" DistinctValues="29.259109">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfb//w==" DoubleValue="-208310400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfb//w==" LintValue="-2411"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007052" DistinctValues="17.495773">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030695" DistinctValues="76.158073">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvf//w==" DoubleValue="-197856000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvf//w==" LintValue="-2290"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvf//w==" DoubleValue="-197856000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvf//w==" LintValue="-2290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018289" DistinctValues="44.894132">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mff//w==" DoubleValue="-185846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mff//w==" LintValue="-2151"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mff//w==" DoubleValue="-185846400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mff//w==" DoubleValue="-185846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mff//w==" LintValue="-2151"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mff//w==" LintValue="-2151"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007783" DistinctValues="19.103886">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mff//w==" DoubleValue="-185846400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rff//w==" DoubleValue="-184118400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mff//w==" LintValue="-2151"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rff//w==" LintValue="-2131"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000807" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rff//w==" DoubleValue="-184118400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rff//w==" DoubleValue="-184118400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rff//w==" LintValue="-2131"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rff//w==" LintValue="-2131"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011674" DistinctValues="28.655829">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rff//w==" DoubleValue="-184118400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rff//w==" LintValue="-2131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvj//w==" DoubleValue="-173318400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvj//w==" LintValue="-2006"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvj//w==" DoubleValue="-173318400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvj//w==" LintValue="-2006"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004575" DistinctValues="11.351981">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvj//w==" DoubleValue="-163987200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvj//w==" LintValue="-1898"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvj//w==" DoubleValue="-163987200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lvj//w==" DoubleValue="-163987200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvj//w==" LintValue="-1898"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lvj//w==" LintValue="-1898"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033171" DistinctValues="82.301865">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lvj//w==" DoubleValue="-163987200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fj//w==" DoubleValue="-156470400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lvj//w==" LintValue="-1898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fj//w==" LintValue="-1811"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032769" DistinctValues="80.435757">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fj//w==" DoubleValue="-156470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPn//w==" DoubleValue="-149644800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fj//w==" LintValue="-1811"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPn//w==" LintValue="-1732"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPn//w==" DoubleValue="-149644800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPn//w==" DoubleValue="-149644800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPn//w==" LintValue="-1732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPn//w==" LintValue="-1732"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002489" DistinctValues="6.109045">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPn//w==" DoubleValue="-149644800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvn//w==" DoubleValue="-149126400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPn//w==" LintValue="-1732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvn//w==" LintValue="-1726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000777" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvn//w==" DoubleValue="-149126400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvn//w==" DoubleValue="-149126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvn//w==" LintValue="-1726"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvn//w==" LintValue="-1726"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002489" DistinctValues="6.109045">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvn//w==" DoubleValue="-149126400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPn//w==" DoubleValue="-148608000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvn//w==" LintValue="-1726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPn//w==" LintValue="-1720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPn//w==" DoubleValue="-148608000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfn//w==" DoubleValue="-140227200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPn//w==" LintValue="-1720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfn//w==" LintValue="-1623"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfn//w==" DoubleValue="-140227200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfn//w==" LintValue="-1623"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030669" DistinctValues="76.093750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/r//w==" DoubleValue="-116899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/r//w==" LintValue="-1353"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000807" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/r//w==" DoubleValue="-116899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="t/r//w==" DoubleValue="-116899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/r//w==" LintValue="-1353"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="t/r//w==" LintValue="-1353"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007077" DistinctValues="17.560096">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="t/r//w==" DoubleValue="-116899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yfr//w==" DoubleValue="-115344000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="t/r//w==" LintValue="-1353"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yfr//w==" LintValue="-1335"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yfr//w==" DoubleValue="-115344000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfv//w==" DoubleValue="-107049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yfr//w==" LintValue="-1335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfv//w==" LintValue="-1239"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004718" DistinctValues="11.331731">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfv//w==" DoubleValue="-107049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfv//w==" LintValue="-1239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010616" DistinctValues="25.496394">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPv//w==" DoubleValue="-103680000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPv//w==" LintValue="-1200"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPv//w==" DoubleValue="-103680000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPv//w==" DoubleValue="-103680000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPv//w==" LintValue="-1200"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPv//w==" LintValue="-1200"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014941" DistinctValues="35.883814">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPv//w==" DoubleValue="-103680000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvv//w==" DoubleValue="-100396800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPv//w==" LintValue="-1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvv//w==" LintValue="-1162"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvv//w==" DoubleValue="-100396800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvv//w==" DoubleValue="-100396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvv//w==" LintValue="-1162"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvv//w==" LintValue="-1162"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004718" DistinctValues="11.331731">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvv//w==" DoubleValue="-100396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvv//w==" DoubleValue="-99360000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvv//w==" LintValue="-1162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvv//w==" LintValue="-1150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvv//w==" DoubleValue="-99360000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvv//w==" DoubleValue="-99360000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvv//w==" LintValue="-1150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvv//w==" LintValue="-1150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002752" DistinctValues="6.610176">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvv//w==" DoubleValue="-99360000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvv//w==" LintValue="-1150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000778" DistinctValues="1.910389">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vv//w==" DoubleValue="-90028800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vv//w==" LintValue="-1042"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vv//w==" DoubleValue="-90028800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vv//w==" DoubleValue="-90028800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vv//w==" LintValue="-1042"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vv//w==" LintValue="-1042"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036190" DistinctValues="88.833069">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vv//w==" DoubleValue="-90028800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vv//w==" LintValue="-1042"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000778" DistinctValues="1.910389">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfz//w==" DoubleValue="-81820800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfz//w==" LintValue="-947"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032125" DistinctValues="79.705401">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfz//w==" DoubleValue="-81820800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfz//w==" DoubleValue="-74908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfz//w==" LintValue="-947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfz//w==" LintValue="-867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfz//w==" DoubleValue="-74908800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nfz//w==" DoubleValue="-74908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfz//w==" LintValue="-867"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nfz//w==" LintValue="-867"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005622" DistinctValues="13.948445">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nfz//w==" DoubleValue="-74908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nfz//w==" LintValue="-867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024634" DistinctValues="61.121457">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" DoubleValue="-73699200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6fz//w==" DoubleValue="-68342400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/z//w==" LintValue="-853"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6fz//w==" LintValue="-791"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6fz//w==" DoubleValue="-68342400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6fz//w==" DoubleValue="-68342400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6fz//w==" LintValue="-791"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6fz//w==" LintValue="-791"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013112" DistinctValues="32.532389">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6fz//w==" DoubleValue="-68342400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6fz//w==" LintValue="-791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011285" DistinctValues="27.700634">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/3//w==" DoubleValue="-62985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/3//w==" LintValue="-729"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/3//w==" DoubleValue="-62985600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/3//w==" DoubleValue="-62985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/3//w==" LintValue="-729"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/3//w==" LintValue="-729"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008561" DistinctValues="21.014274">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/3//w==" DoubleValue="-62985600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/3//w==" LintValue="-729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017900" DistinctValues="43.938937">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007549" DistinctValues="18.530769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gP3//w==" DoubleValue="-55296000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gP3//w==" LintValue="-640"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000837" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gP3//w==" DoubleValue="-55296000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gP3//w==" DoubleValue="-55296000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gP3//w==" LintValue="-640"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gP3//w==" LintValue="-640"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019053" DistinctValues="46.768132">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gP3//w==" DoubleValue="-55296000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gP3//w==" LintValue="-640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011144" DistinctValues="27.354945">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1P3//w==" DoubleValue="-48038400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1P3//w==" LintValue="-556"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1P3//w==" DoubleValue="-48038400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/7//w==" DoubleValue="-38102400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1P3//w==" LintValue="-556"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/7//w==" LintValue="-441"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/7//w==" DoubleValue="-38102400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vf7//w==" DoubleValue="-36892800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/7//w==" LintValue="-441"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vf7//w==" LintValue="-427"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.10" Name="l_shipdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/T//w==" DoubleValue="-252374400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPX//w==" DoubleValue="-238464000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/T//w==" LintValue="-2921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPX//w==" LintValue="-2760"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007077" DistinctValues="17.747596">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPX//w==" DoubleValue="-238464000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SvX//w==" DoubleValue="-236908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPX//w==" LintValue="-2760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SvX//w==" LintValue="-2742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000807" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SvX//w==" DoubleValue="-236908800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SvX//w==" DoubleValue="-236908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SvX//w==" LintValue="-2742"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SvX//w==" LintValue="-2742"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007471" DistinctValues="18.733574">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SvX//w==" DoubleValue="-236908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SvX//w==" LintValue="-2742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023198" DistinctValues="58.172676">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPX//w==" DoubleValue="-230169600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPX//w==" LintValue="-2664"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPX//w==" DoubleValue="-230169600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vX//w==" DoubleValue="-222048000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPX//w==" LintValue="-2664"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vX//w==" LintValue="-2570"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010440" DistinctValues="26.457447">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vX//w==" DoubleValue="-222048000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vX//w==" LintValue="-2570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027306" DistinctValues="69.196399">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001659" DistinctValues="4.160609">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013273" DistinctValues="33.284869">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pb//w==" DoubleValue="-202521600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pb//w==" LintValue="-2344"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pb//w==" DoubleValue="-202521600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pb//w==" DoubleValue="-202521600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pb//w==" LintValue="-2344"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pb//w==" LintValue="-2344"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022814" DistinctValues="57.208369">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pb//w==" DoubleValue="-202521600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/f//w==" DoubleValue="-197769600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pb//w==" LintValue="-2344"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/f//w==" LintValue="-2289"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000415" DistinctValues="1.029163">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/f//w==" DoubleValue="-197769600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPf//w==" DoubleValue="-197683200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/f//w==" LintValue="-2289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPf//w==" LintValue="-2288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPf//w==" DoubleValue="-197683200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPf//w==" DoubleValue="-197683200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPf//w==" LintValue="-2288"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPf//w==" LintValue="-2288"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024888" DistinctValues="61.749789">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPf//w==" DoubleValue="-197683200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPf//w==" DoubleValue="-192499200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPf//w==" LintValue="-2288"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPf//w==" LintValue="-2228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000867" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPf//w==" DoubleValue="-192499200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPf//w==" DoubleValue="-192499200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPf//w==" LintValue="-2228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPf//w==" LintValue="-2228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010370" DistinctValues="25.729079">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPf//w==" DoubleValue="-192499200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPf//w==" LintValue="-2228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002074" DistinctValues="5.145816">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007394" DistinctValues="18.344568">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" DoubleValue="-189907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fff//w==" DoubleValue="-188265600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avf//w==" LintValue="-2198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fff//w==" LintValue="-2179"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fff//w==" DoubleValue="-188265600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fff//w==" DoubleValue="-188265600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fff//w==" LintValue="-2179"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fff//w==" LintValue="-2179"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025294" DistinctValues="62.757732">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fff//w==" DoubleValue="-188265600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fff//w==" LintValue="-2179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002335" DistinctValues="5.793021">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002724" DistinctValues="6.758525">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021232" DistinctValues="53.805288">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afj//w==" DoubleValue="-176860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afj//w==" LintValue="-2047"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afj//w==" DoubleValue="-176860800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afj//w==" DoubleValue="-176860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afj//w==" LintValue="-2047"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afj//w==" LintValue="-2047"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016514" DistinctValues="41.848558">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afj//w==" DoubleValue="-176860800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afj//w==" LintValue="-2047"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000385" DistinctValues="0.955651">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPj//w==" DoubleValue="-173145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPj//w==" LintValue="-2004"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000777" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPj//w==" DoubleValue="-173145600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPj//w==" DoubleValue="-173145600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPj//w==" LintValue="-2004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LPj//w==" LintValue="-2004"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015407" DistinctValues="38.226060">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPj//w==" DoubleValue="-173145600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPj//w==" DoubleValue="-169689600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LPj//w==" LintValue="-2004"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPj//w==" LintValue="-1964"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000747" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPj//w==" DoubleValue="-169689600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPj//w==" DoubleValue="-169689600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPj//w==" LintValue="-1964"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPj//w==" LintValue="-1964"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016177" DistinctValues="40.137363">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPj//w==" DoubleValue="-169689600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvj//w==" DoubleValue="-166060800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPj//w==" LintValue="-1964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvj//w==" LintValue="-1922"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000777" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvj//w==" DoubleValue="-166060800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvj//w==" DoubleValue="-166060800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvj//w==" LintValue="-1922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvj//w==" LintValue="-1922"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005777" DistinctValues="14.334772">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvj//w==" DoubleValue="-166060800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfj//w==" DoubleValue="-164764800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvj//w==" LintValue="-1922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfj//w==" LintValue="-1907"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfj//w==" DoubleValue="-164764800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfj//w==" LintValue="-1907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005898" DistinctValues="14.945913">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031848" DistinctValues="80.707933">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" DoubleValue="-155347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/n//w==" DoubleValue="-148348800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+vj//w==" LintValue="-1798"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/n//w==" LintValue="-1717"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025032" DistinctValues="62.770445">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/n//w==" DoubleValue="-148348800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivn//w==" DoubleValue="-142905600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/n//w==" LintValue="-1717"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivn//w==" LintValue="-1654"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivn//w==" DoubleValue="-142905600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivn//w==" DoubleValue="-142905600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivn//w==" LintValue="-1654"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivn//w==" LintValue="-1654"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010728" DistinctValues="26.901619">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivn//w==" DoubleValue="-142905600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfn//w==" DoubleValue="-140572800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivn//w==" LintValue="-1654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfn//w==" LintValue="-1627"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfn//w==" DoubleValue="-140572800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfn//w==" DoubleValue="-140572800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfn//w==" LintValue="-1627"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfn//w==" LintValue="-1627"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001987" DistinctValues="4.981781">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfn//w==" DoubleValue="-140572800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvn//w==" DoubleValue="-140140800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfn//w==" LintValue="-1627"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvn//w==" LintValue="-1622"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024634" DistinctValues="62.426721">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvn//w==" DoubleValue="-140140800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pn//w==" DoubleValue="-134784000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvn//w==" LintValue="-1622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pn//w==" LintValue="-1560"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pn//w==" DoubleValue="-134784000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pn//w==" DoubleValue="-134784000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pn//w==" LintValue="-1560"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pn//w==" LintValue="-1560"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013112" DistinctValues="33.227126">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pn//w==" DoubleValue="-134784000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfr//w==" DoubleValue="-131932800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pn//w==" LintValue="-1560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfr//w==" LintValue="-1527"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016641" DistinctValues="42.169975">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfr//w==" DoubleValue="-131932800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvr//w==" DoubleValue="-128390400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfr//w==" LintValue="-1527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvr//w==" LintValue="-1486"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvr//w==" DoubleValue="-128390400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvr//w==" DoubleValue="-128390400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvr//w==" LintValue="-1486"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvr//w==" LintValue="-1486"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021105" DistinctValues="53.483871">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvr//w==" DoubleValue="-128390400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvr//w==" DoubleValue="-123897600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvr//w==" LintValue="-1486"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvr//w==" LintValue="-1434"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvr//w==" DoubleValue="-123897600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvr//w==" DoubleValue="-115257600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvr//w==" LintValue="-1434"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvr//w==" LintValue="-1334"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014701" DistinctValues="37.254656">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvr//w==" DoubleValue="-115257600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/r//w==" DoubleValue="-112060800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvr//w==" LintValue="-1334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/r//w==" LintValue="-1297"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/r//w==" DoubleValue="-112060800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/r//w==" DoubleValue="-112060800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/r//w==" LintValue="-1297"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/r//w==" LintValue="-1297"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023045" DistinctValues="58.399190">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/r//w==" DoubleValue="-112060800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfv//w==" DoubleValue="-107049600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/r//w==" LintValue="-1297"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfv//w==" LintValue="-1239"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfv//w==" DoubleValue="-107049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfv//w==" DoubleValue="-98409600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfv//w==" LintValue="-1239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfv//w==" LintValue="-1139"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfv//w==" DoubleValue="-98409600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfv//w==" LintValue="-1139"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfz//w==" DoubleValue="-81820800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfz//w==" LintValue="-947"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019072" DistinctValues="47.825101">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfz//w==" DoubleValue="-81820800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffz//w==" DoubleValue="-77673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfz//w==" LintValue="-947"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffz//w==" LintValue="-899"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000867" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffz//w==" DoubleValue="-77673600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffz//w==" DoubleValue="-77673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffz//w==" LintValue="-899"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffz//w==" LintValue="-899"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001987" DistinctValues="4.981781">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffz//w==" DoubleValue="-77673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffz//w==" LintValue="-899"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016688" DistinctValues="41.846964">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029964" DistinctValues="75.931404">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fz//w==" DoubleValue="-66960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fz//w==" LintValue="-775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000718" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fz//w==" DoubleValue="-66960000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+fz//w==" DoubleValue="-66960000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fz//w==" LintValue="-775"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+fz//w==" LintValue="-775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007783" DistinctValues="19.722443">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+fz//w==" DoubleValue="-66960000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+fz//w==" LintValue="-775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019826" DistinctValues="50.242424">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qf3//w==" DoubleValue="-60739200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qf3//w==" LintValue="-703"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000688" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qf3//w==" DoubleValue="-60739200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qf3//w==" DoubleValue="-60739200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qf3//w==" LintValue="-703"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qf3//w==" LintValue="-703"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017920" DistinctValues="45.411422">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qf3//w==" DoubleValue="-60739200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cP3//w==" DoubleValue="-56678400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qf3//w==" LintValue="-703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cP3//w==" LintValue="-656"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cP3//w==" DoubleValue="-56678400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cP3//w==" LintValue="-656"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" DoubleValue="-48124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/3//w==" LintValue="-557"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037746" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.5844974.1.1.3" Name="l_linenumber" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -699,308 +699,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.328293.1.1.0" Name="ymd" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.032303" DistinctValues="324.679326">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pur//w==" DoubleValue="-481248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jev//w==" DoubleValue="-452304000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pur//w==" LintValue="-5570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jev//w==" LintValue="-5235"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jev//w==" DoubleValue="-452304000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jev//w==" DoubleValue="-452304000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jev//w==" LintValue="-5235"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jev//w==" LintValue="-5235"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jev//w==" DoubleValue="-452304000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jev//w==" LintValue="-5235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.938384">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kOv//w==" DoubleValue="-452044800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kOv//w==" LintValue="-5232"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kOv//w==" DoubleValue="-452044800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kOv//w==" DoubleValue="-452044800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kOv//w==" LintValue="-5232"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kOv//w==" LintValue="-5232"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kOv//w==" DoubleValue="-452044800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kev//w==" DoubleValue="-451958400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kOv//w==" LintValue="-5232"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kev//w==" LintValue="-5231"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kev//w==" DoubleValue="-451958400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kev//w==" DoubleValue="-451958400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kev//w==" LintValue="-5231"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kev//w==" LintValue="-5231"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kev//w==" DoubleValue="-451958400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kuv//w==" DoubleValue="-451872000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kev//w==" LintValue="-5231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kuv//w==" LintValue="-5230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kuv//w==" DoubleValue="-451872000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kuv//w==" DoubleValue="-451872000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kuv//w==" LintValue="-5230"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kuv//w==" LintValue="-5230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kuv//w==" DoubleValue="-451872000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k+v//w==" DoubleValue="-451785600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kuv//w==" LintValue="-5230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k+v//w==" LintValue="-5229"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k+v//w==" DoubleValue="-451785600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k+v//w==" DoubleValue="-451785600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k+v//w==" LintValue="-5229"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k+v//w==" LintValue="-5229"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k+v//w==" DoubleValue="-451785600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lOv//w==" DoubleValue="-451699200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k+v//w==" LintValue="-5229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lOv//w==" LintValue="-5228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lOv//w==" DoubleValue="-451699200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lOv//w==" DoubleValue="-451699200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lOv//w==" LintValue="-5228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lOv//w==" LintValue="-5228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lOv//w==" DoubleValue="-451699200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lev//w==" DoubleValue="-451612800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lOv//w==" LintValue="-5228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lev//w==" LintValue="-5227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lev//w==" DoubleValue="-451612800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lev//w==" DoubleValue="-451612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lev//w==" LintValue="-5227"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lev//w==" LintValue="-5227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lev//w==" DoubleValue="-451612800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="luv//w==" DoubleValue="-451526400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lev//w==" LintValue="-5227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="luv//w==" LintValue="-5226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="luv//w==" DoubleValue="-451526400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="luv//w==" DoubleValue="-451526400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="luv//w==" LintValue="-5226"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="luv//w==" LintValue="-5226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.938384">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="luv//w==" DoubleValue="-451526400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mOv//w==" DoubleValue="-451353600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="luv//w==" LintValue="-5226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mOv//w==" LintValue="-5224"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mOv//w==" DoubleValue="-451353600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mOv//w==" DoubleValue="-451353600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mOv//w==" LintValue="-5224"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mOv//w==" LintValue="-5224"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mOv//w==" DoubleValue="-451353600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mev//w==" DoubleValue="-451267200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mOv//w==" LintValue="-5224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mev//w==" LintValue="-5223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mev//w==" DoubleValue="-451267200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mev//w==" DoubleValue="-451267200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mev//w==" LintValue="-5223"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mev//w==" LintValue="-5223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.938384">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mev//w==" DoubleValue="-451267200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m+v//w==" DoubleValue="-451094400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mev//w==" LintValue="-5223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m+v//w==" LintValue="-5221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m+v//w==" DoubleValue="-451094400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m+v//w==" DoubleValue="-451094400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m+v//w==" LintValue="-5221"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m+v//w==" LintValue="-5221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m+v//w==" DoubleValue="-451094400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nOv//w==" DoubleValue="-451008000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m+v//w==" LintValue="-5221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nOv//w==" LintValue="-5220"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nOv//w==" DoubleValue="-451008000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nOv//w==" DoubleValue="-451008000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nOv//w==" LintValue="-5220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nOv//w==" LintValue="-5220"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nOv//w==" DoubleValue="-451008000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nev//w==" DoubleValue="-450921600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nOv//w==" LintValue="-5220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nev//w==" LintValue="-5219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nev//w==" DoubleValue="-450921600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nev//w==" DoubleValue="-450921600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nev//w==" LintValue="-5219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nev//w==" LintValue="-5219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nev//w==" DoubleValue="-450921600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nuv//w==" DoubleValue="-450835200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nev//w==" LintValue="-5219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nuv//w==" LintValue="-5218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nuv//w==" DoubleValue="-450835200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nuv//w==" DoubleValue="-450835200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nuv//w==" LintValue="-5218"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nuv//w==" LintValue="-5218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nuv//w==" DoubleValue="-450835200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n+v//w==" DoubleValue="-450748800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nuv//w==" LintValue="-5218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n+v//w==" LintValue="-5217"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n+v//w==" DoubleValue="-450748800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n+v//w==" DoubleValue="-450748800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n+v//w==" LintValue="-5217"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n+v//w==" LintValue="-5217"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="n+v//w==" DoubleValue="-450748800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oOv//w==" DoubleValue="-450662400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="n+v//w==" LintValue="-5217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oOv//w==" LintValue="-5216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oOv//w==" DoubleValue="-450662400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oOv//w==" DoubleValue="-450662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oOv//w==" LintValue="-5216"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oOv//w==" LintValue="-5216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oOv//w==" DoubleValue="-450662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oev//w==" DoubleValue="-450576000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oOv//w==" LintValue="-5216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oev//w==" LintValue="-5215"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oev//w==" DoubleValue="-450576000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oev//w==" DoubleValue="-450576000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oev//w==" LintValue="-5215"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oev//w==" LintValue="-5215"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oev//w==" DoubleValue="-450576000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ouv//w==" DoubleValue="-450489600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oev//w==" LintValue="-5215"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ouv//w==" LintValue="-5214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ouv//w==" DoubleValue="-450489600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ouv//w==" DoubleValue="-450489600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ouv//w==" LintValue="-5214"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ouv//w==" LintValue="-5214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ouv//w==" DoubleValue="-450489600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o+v//w==" DoubleValue="-450403200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ouv//w==" LintValue="-5214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o+v//w==" LintValue="-5213"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o+v//w==" DoubleValue="-450403200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="o+v//w==" DoubleValue="-450403200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o+v//w==" LintValue="-5213"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="o+v//w==" LintValue="-5213"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="o+v//w==" DoubleValue="-450403200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pOv//w==" DoubleValue="-450316800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="o+v//w==" LintValue="-5213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pOv//w==" LintValue="-5212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pOv//w==" DoubleValue="-450316800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pOv//w==" DoubleValue="-450316800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pOv//w==" LintValue="-5212"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pOv//w==" LintValue="-5212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000289" DistinctValues="2.907576">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pOv//w==" DoubleValue="-450316800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p+v//w==" DoubleValue="-450057600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pOv//w==" LintValue="-5212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p+v//w==" LintValue="-5209"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p+v//w==" DoubleValue="-450057600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p+v//w==" DoubleValue="-450057600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p+v//w==" LintValue="-5209"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p+v//w==" LintValue="-5209"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p+v//w==" DoubleValue="-450057600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qOv//w==" DoubleValue="-449971200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p+v//w==" LintValue="-5209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qOv//w==" LintValue="-5208"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qOv//w==" DoubleValue="-449971200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qOv//w==" DoubleValue="-449971200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qOv//w==" LintValue="-5208"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qOv//w==" LintValue="-5208"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qOv//w==" DoubleValue="-449971200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qev//w==" DoubleValue="-449884800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qOv//w==" LintValue="-5208"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qev//w==" LintValue="-5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qev//w==" DoubleValue="-449884800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qev//w==" DoubleValue="-449884800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qev//w==" LintValue="-5207"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qev//w==" LintValue="-5207"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000096" DistinctValues="0.969192">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qev//w==" DoubleValue="-449884800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qev//w==" LintValue="-5207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000187" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003182" DistinctValues="31.983337">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" DoubleValue="-449798400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y+v//w==" DoubleValue="-446947200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="quv//w==" LintValue="-5206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y+v//w==" LintValue="-5173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y+v//w==" DoubleValue="-446947200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="du3//w==" DoubleValue="-410054400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y+v//w==" LintValue="-5173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="du3//w==" LintValue="-4746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="du3//w==" DoubleValue="-410054400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ie///w==" DoubleValue="-373161600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="du3//w==" LintValue="-4746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ie///w==" LintValue="-4319"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ie///w==" DoubleValue="-373161600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPD//w==" DoubleValue="-336268800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ie///w==" LintValue="-4319"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPD//w==" LintValue="-3892"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPD//w==" DoubleValue="-336268800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/L//w==" DoubleValue="-299376000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPD//w==" LintValue="-3892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/L//w==" LintValue="-3465"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/L//w==" DoubleValue="-299376000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IvT//w==" DoubleValue="-262483200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/L//w==" LintValue="-3465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IvT//w==" LintValue="-3038"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IvT//w==" DoubleValue="-262483200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfX//w==" DoubleValue="-225590400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IvT//w==" LintValue="-3038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfX//w==" LintValue="-2611"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfX//w==" DoubleValue="-225590400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfX//w==" LintValue="-2611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I/n//w==" DoubleValue="-151804800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I/n//w==" LintValue="-1757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I/n//w==" DoubleValue="-151804800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvr//w==" DoubleValue="-114912000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I/n//w==" LintValue="-1757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvr//w==" LintValue="-1330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvr//w==" DoubleValue="-114912000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efz//w==" DoubleValue="-78019200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvr//w==" LintValue="-1330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efz//w==" LintValue="-903"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efz//w==" DoubleValue="-78019200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JP7//w==" DoubleValue="-41126400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efz//w==" LintValue="-903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JP7//w==" LintValue="-476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JP7//w==" DoubleValue="-41126400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z////w==" DoubleValue="-4233600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JP7//w==" LintValue="-476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z////w==" LintValue="-49"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z////w==" DoubleValue="-4233600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="egEAAA==" DoubleValue="32659200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z////w==" LintValue="-49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="egEAAA==" LintValue="378"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="egEAAA==" DoubleValue="32659200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JQMAAA==" DoubleValue="69552000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="egEAAA==" LintValue="378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JQMAAA==" LintValue="805"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JQMAAA==" DoubleValue="69552000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0AQAAA==" DoubleValue="106444800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JQMAAA==" LintValue="805"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0AQAAA==" LintValue="1232"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0AQAAA==" DoubleValue="106444800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ewYAAA==" DoubleValue="143337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0AQAAA==" LintValue="1232"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ewYAAA==" LintValue="1659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ewYAAA==" DoubleValue="143337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JggAAA==" DoubleValue="180230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ewYAAA==" LintValue="1659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JggAAA==" LintValue="2086"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JggAAA==" DoubleValue="180230400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0QkAAA==" DoubleValue="217123200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JggAAA==" LintValue="2086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0QkAAA==" LintValue="2513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0QkAAA==" DoubleValue="217123200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fAsAAA==" DoubleValue="254016000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0QkAAA==" LintValue="2513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fAsAAA==" LintValue="2940"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fAsAAA==" DoubleValue="254016000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jw0AAA==" DoubleValue="290908800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fAsAAA==" LintValue="2940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jw0AAA==" LintValue="3367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jw0AAA==" DoubleValue="290908800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0g4AAA==" DoubleValue="327801600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jw0AAA==" LintValue="3367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0g4AAA==" LintValue="3794"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0g4AAA==" DoubleValue="327801600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fRAAAA==" DoubleValue="364694400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0g4AAA==" LintValue="3794"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fRAAAA==" LintValue="4221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fRAAAA==" DoubleValue="364694400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KBIAAA==" DoubleValue="401587200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fRAAAA==" LintValue="4221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KBIAAA==" LintValue="4648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KBIAAA==" DoubleValue="401587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xMAAA==" DoubleValue="438480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KBIAAA==" LintValue="4648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0xMAAA==" LintValue="5075"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038282" DistinctValues="409.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xMAAA==" DoubleValue="438480000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hMAAA==" DoubleValue="439084800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0xMAAA==" LintValue="5075"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hMAAA==" LintValue="5082"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:GPDBFunc Mdid="0.6084.1.0" Name="gp_partition_selection" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
@@ -1112,308 +1112,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.328475.1.1.0" Name="sales_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.034478" DistinctValues="303.492421">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+r//w==" DoubleValue="-478742400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+r//w==" LintValue="-5541"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003706" DistinctValues="32.622964">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" DoubleValue="-452217600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r+v//w==" DoubleValue="-449366400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="juv//w==" LintValue="-5234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r+v//w==" LintValue="-5201"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002033" DistinctValues="17.793127">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r+v//w==" DoubleValue="-449366400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wev//w==" DoubleValue="-447811200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r+v//w==" LintValue="-5201"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wev//w==" LintValue="-5183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wev//w==" DoubleValue="-447811200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wev//w==" DoubleValue="-447811200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wev//w==" LintValue="-5183"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wev//w==" LintValue="-5183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007908" DistinctValues="69.195494">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wev//w==" DoubleValue="-447811200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B+z//w==" DoubleValue="-441763200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wev//w==" LintValue="-5183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B+z//w==" LintValue="-5113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000261" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B+z//w==" DoubleValue="-441763200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B+z//w==" DoubleValue="-441763200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B+z//w==" LintValue="-5113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B+z//w==" LintValue="-5113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005197" DistinctValues="45.471325">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B+z//w==" DoubleValue="-441763200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nez//w==" DoubleValue="-437788800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B+z//w==" LintValue="-5113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nez//w==" LintValue="-5067"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nez//w==" DoubleValue="-437788800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nez//w==" DoubleValue="-437788800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nez//w==" LintValue="-5067"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nez//w==" LintValue="-5067"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023046" DistinctValues="201.655439">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nez//w==" DoubleValue="-437788800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ae3//w==" DoubleValue="-420163200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nez//w==" LintValue="-5067"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ae3//w==" LintValue="-4863"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030982" DistinctValues="272.716375">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ae3//w==" DoubleValue="-420163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EO7//w==" DoubleValue="-396748800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ae3//w==" LintValue="-4863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EO7//w==" LintValue="-4592"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EO7//w==" DoubleValue="-396748800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EO7//w==" DoubleValue="-396748800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EO7//w==" LintValue="-4592"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EO7//w==" LintValue="-4592"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007202" DistinctValues="63.399010">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EO7//w==" DoubleValue="-396748800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T+7//w==" DoubleValue="-391305600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EO7//w==" LintValue="-4592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T+7//w==" LintValue="-4529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033820" DistinctValues="297.702198">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T+7//w==" DoubleValue="-391305600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="he///w==" DoubleValue="-364521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T+7//w==" LintValue="-4529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="he///w==" LintValue="-4219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="he///w==" DoubleValue="-364521600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="he///w==" DoubleValue="-364521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="he///w==" LintValue="-4219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="he///w==" LintValue="-4219"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004364" DistinctValues="38.413187">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="he///w==" DoubleValue="-364521600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="re///w==" DoubleValue="-361065600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="he///w==" LintValue="-4219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="re///w==" LintValue="-4179"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036492" DistinctValues="321.218304">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="re///w==" DoubleValue="-361065600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BvH//w==" DoubleValue="-331257600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="re///w==" LintValue="-4179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BvH//w==" LintValue="-3834"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BvH//w==" DoubleValue="-331257600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BvH//w==" DoubleValue="-331257600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BvH//w==" LintValue="-3834"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BvH//w==" LintValue="-3834"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001692" DistinctValues="14.897081">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BvH//w==" DoubleValue="-331257600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FvH//w==" DoubleValue="-329875200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BvH//w==" LintValue="-3834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FvH//w==" LintValue="-3818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FvH//w==" DoubleValue="-329875200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvL//w==" DoubleValue="-299462400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FvH//w==" LintValue="-3818"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvL//w==" LintValue="-3466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018231" DistinctValues="160.002040">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvL//w==" DoubleValue="-299462400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KvP//w==" DoubleValue="-283910400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvL//w==" LintValue="-3466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KvP//w==" LintValue="-3286"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KvP//w==" DoubleValue="-283910400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KvP//w==" DoubleValue="-283910400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KvP//w==" LintValue="-3286"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KvP//w==" LintValue="-3286"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006077" DistinctValues="53.334013">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KvP//w==" DoubleValue="-283910400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZvP//w==" DoubleValue="-278726400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KvP//w==" LintValue="-3286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZvP//w==" LintValue="-3226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZvP//w==" DoubleValue="-278726400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZvP//w==" DoubleValue="-278726400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZvP//w==" LintValue="-3226"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZvP//w==" LintValue="-3226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013876" DistinctValues="121.779331">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZvP//w==" DoubleValue="-278726400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/P//w==" DoubleValue="-266889600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZvP//w==" LintValue="-3226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/P//w==" LintValue="-3089"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011002" DistinctValues="96.558670">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/P//w==" DoubleValue="-266889600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VfT//w==" DoubleValue="-258076800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/P//w==" LintValue="-3089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VfT//w==" LintValue="-2987"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VfT//w==" DoubleValue="-258076800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VfT//w==" DoubleValue="-258076800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VfT//w==" LintValue="-2987"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VfT//w==" LintValue="-2987"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006256" DistinctValues="54.905910">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VfT//w==" DoubleValue="-258076800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/T//w==" DoubleValue="-253065600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VfT//w==" LintValue="-2987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/T//w==" LintValue="-2929"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/T//w==" DoubleValue="-253065600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/T//w==" DoubleValue="-253065600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/T//w==" LintValue="-2929"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/T//w==" LintValue="-2929"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020926" DistinctValues="183.650804">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/T//w==" DoubleValue="-253065600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UfX//w==" DoubleValue="-236304000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/T//w==" LintValue="-2929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UfX//w==" LintValue="-2735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UfX//w==" DoubleValue="-236304000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/b//w==" DoubleValue="-205372800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UfX//w==" LintValue="-2735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/b//w==" LintValue="-2377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/b//w==" DoubleValue="-205372800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evj//w==" DoubleValue="-175392000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/b//w==" LintValue="-2377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evj//w==" LintValue="-2030"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028971" DistinctValues="255.017777">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evj//w==" DoubleValue="-175392000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/n//w==" DoubleValue="-152841600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evj//w==" LintValue="-2030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/n//w==" LintValue="-1769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/n//w==" DoubleValue="-152841600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/n//w==" DoubleValue="-152841600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/n//w==" LintValue="-1769"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/n//w==" LintValue="-1769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009213" DistinctValues="81.097607">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/n//w==" DoubleValue="-152841600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avn//w==" DoubleValue="-145670400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/n//w==" LintValue="-1769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avn//w==" LintValue="-1686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029786" DistinctValues="262.189714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avn//w==" DoubleValue="-145670400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avn//w==" LintValue="-1686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008398" DistinctValues="73.925671">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/r//w==" DoubleValue="-116208000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/r//w==" LintValue="-1345"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022054" DistinctValues="194.135610">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/r//w==" DoubleValue="-116208000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/r//w==" LintValue="-1345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016129" DistinctValues="141.979775">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/z//w==" DoubleValue="-86140800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/z//w==" LintValue="-997"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/z//w==" DoubleValue="-86140800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/z//w==" LintValue="-997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013645" DistinctValues="119.753048">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020688" DistinctValues="181.561073">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uf7//w==" DoubleValue="-28252800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uf7//w==" LintValue="-327"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uf7//w==" DoubleValue="-28252800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uf7//w==" DoubleValue="-28252800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uf7//w==" LintValue="-327"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uf7//w==" LintValue="-327"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003851" DistinctValues="33.801264">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uf7//w==" DoubleValue="-28252800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3P7//w==" DoubleValue="-25228800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uf7//w==" LintValue="-327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3P7//w==" LintValue="-292"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001992" DistinctValues="17.484281">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3P7//w==" DoubleValue="-25228800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v7//w==" DoubleValue="-23673600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3P7//w==" LintValue="-292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v7//w==" LintValue="-274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000348" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v7//w==" DoubleValue="-23673600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7v7//w==" DoubleValue="-23673600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v7//w==" LintValue="-274"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7v7//w==" LintValue="-274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027780" DistinctValues="243.808584">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7v7//w==" DoubleValue="-23673600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f///w==" DoubleValue="-1987200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7v7//w==" LintValue="-274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6f///w==" LintValue="-23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f///w==" DoubleValue="-1987200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6f///w==" DoubleValue="-1987200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6f///w==" LintValue="-23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6f///w==" LintValue="-23"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008412" DistinctValues="73.822520">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6f///w==" DoubleValue="-1987200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NQAAAA==" DoubleValue="4579200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6f///w==" LintValue="-23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NQAAAA==" LintValue="53"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010894" DistinctValues="95.897327">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NQAAAA==" DoubleValue="4579200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mgAAAA==" DoubleValue="13305600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NQAAAA==" LintValue="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mgAAAA==" LintValue="154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mgAAAA==" DoubleValue="13305600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mgAAAA==" DoubleValue="13305600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mgAAAA==" LintValue="154"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mgAAAA==" LintValue="154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027290" DistinctValues="240.218057">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mgAAAA==" DoubleValue="13305600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lwEAAA==" DoubleValue="35164800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mgAAAA==" LintValue="154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lwEAAA==" LintValue="407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036766" DistinctValues="323.631099">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lwEAAA==" DoubleValue="35164800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6AIAAA==" DoubleValue="64281600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lwEAAA==" LintValue="407"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6AIAAA==" LintValue="744"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6AIAAA==" DoubleValue="64281600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6AIAAA==" DoubleValue="64281600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6AIAAA==" LintValue="744"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6AIAAA==" LintValue="744"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001418" DistinctValues="12.484286">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6AIAAA==" DoubleValue="64281600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9QIAAA==" DoubleValue="65404800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6AIAAA==" LintValue="744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9QIAAA==" LintValue="757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025127" DistinctValues="221.179377">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9QIAAA==" DoubleValue="65404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2gMAAA==" DoubleValue="85190400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9QIAAA==" LintValue="757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2gMAAA==" LintValue="986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2gMAAA==" DoubleValue="85190400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2gMAAA==" DoubleValue="85190400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2gMAAA==" LintValue="986"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2gMAAA==" LintValue="986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013057" DistinctValues="114.936008">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2gMAAA==" DoubleValue="85190400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UQQAAA==" DoubleValue="95472000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2gMAAA==" LintValue="986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UQQAAA==" LintValue="1105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015229" DistinctValues="133.658737">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UQQAAA==" DoubleValue="95472000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2wQAAA==" DoubleValue="107395200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UQQAAA==" LintValue="1105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2wQAAA==" LintValue="1243"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000304" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2wQAAA==" DoubleValue="107395200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2wQAAA==" DoubleValue="107395200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2wQAAA==" LintValue="1243"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2wQAAA==" LintValue="1243"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020306" DistinctValues="178.211650">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2wQAAA==" DoubleValue="107395200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kwUAAA==" DoubleValue="123292800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2wQAAA==" LintValue="1243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kwUAAA==" LintValue="1427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kwUAAA==" DoubleValue="123292800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kwUAAA==" DoubleValue="123292800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kwUAAA==" LintValue="1427"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kwUAAA==" LintValue="1427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002649" DistinctValues="23.244998">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kwUAAA==" DoubleValue="123292800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qwUAAA==" DoubleValue="125366400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kwUAAA==" LintValue="1427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qwUAAA==" LintValue="1451"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qwUAAA==" DoubleValue="125366400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EQcAAA==" DoubleValue="156297600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qwUAAA==" LintValue="1451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EQcAAA==" LintValue="1809"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025343" DistinctValues="223.085432">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EQcAAA==" DoubleValue="156297600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8gcAAA==" DoubleValue="175737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EQcAAA==" LintValue="1809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8gcAAA==" LintValue="2034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8gcAAA==" DoubleValue="175737600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8gcAAA==" DoubleValue="175737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8gcAAA==" LintValue="2034"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8gcAAA==" LintValue="2034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012841" DistinctValues="113.029952">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8gcAAA==" DoubleValue="175737600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZAgAAA==" DoubleValue="185587200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8gcAAA==" LintValue="2034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZAgAAA==" LintValue="2148"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010404" DistinctValues="91.582001">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZAgAAA==" DoubleValue="185587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xQgAAA==" DoubleValue="193968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZAgAAA==" LintValue="2148"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xQgAAA==" LintValue="2245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000283" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xQgAAA==" DoubleValue="193968000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xQgAAA==" DoubleValue="193968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xQgAAA==" LintValue="2245"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xQgAAA==" LintValue="2245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027780" DistinctValues="244.533384">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xQgAAA==" DoubleValue="193968000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yAkAAA==" DoubleValue="216345600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xQgAAA==" LintValue="2245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yAkAAA==" LintValue="2504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yAkAAA==" DoubleValue="216345600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KwsAAA==" DoubleValue="247017600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yAkAAA==" LintValue="2504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KwsAAA==" LintValue="2859"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwsAAA==" DoubleValue="247017600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lwwAAA==" DoubleValue="278467200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwsAAA==" LintValue="2859"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lwwAAA==" LintValue="3223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038184" DistinctValues="337.115385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lwwAAA==" DoubleValue="278467200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mgwAAA==" DoubleValue="278726400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lwwAAA==" LintValue="3223"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mgwAAA==" LintValue="3226"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -9243,34 +9243,34 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.641665.1.1.3" Name="web_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.659091" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv///w==" DoubleValue="-11923200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dv///w==" DoubleValue="-11923200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv///w==" LintValue="-138"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dv///w==" LintValue="-138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.181818" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4wAAAA==" DoubleValue="19612800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4wAAAA==" DoubleValue="19612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4wAAAA==" LintValue="227"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4wAAAA==" LintValue="227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.159091" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UAIAAA==" DoubleValue="51148800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UAIAAA==" DoubleValue="51148800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UAIAAA==" LintValue="592"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UAIAAA==" LintValue="592"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.641665.1.1.2" Name="web_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.522727" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.159091" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d////w==" DoubleValue="-11836800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d////w==" DoubleValue="-11836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d////w==" LintValue="-137"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d////w==" LintValue="-137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.159091" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5AAAAA==" DoubleValue="19699200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5AAAAA==" DoubleValue="19699200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5AAAAA==" LintValue="228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5AAAAA==" LintValue="228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.159091" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UQIAAA==" DoubleValue="51235200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UQIAAA==" DoubleValue="51235200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UQIAAA==" LintValue="593"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UQIAAA==" LintValue="593"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.641613.1.1.35" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
@@ -521,34 +521,34 @@ select * from customer_address, store where customer_address.ca_county::text = s
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.516672.1.1.3" Name="s_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.642215" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.214072" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.142714" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.516672.1.1.2" Name="s_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.570858" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.142714" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.142714" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.142714" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -214,1204 +214,1204 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.31256.1.0.12" Name="l_receiptdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvT//w==" DoubleValue="-249350400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fT//w==" DoubleValue="-243561600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvT//w==" LintValue="-2886"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fT//w==" LintValue="-2819"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002390" DistinctValues="4.190345">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fT//w==" DoubleValue="-243561600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BfX//w==" DoubleValue="-242870400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fT//w==" LintValue="-2819"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BfX//w==" LintValue="-2811"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BfX//w==" DoubleValue="-242870400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BfX//w==" DoubleValue="-242870400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BfX//w==" LintValue="-2811"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BfX//w==" LintValue="-2811"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005975" DistinctValues="10.475862">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BfX//w==" DoubleValue="-242870400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GfX//w==" DoubleValue="-241142400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BfX//w==" LintValue="-2811"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GfX//w==" LintValue="-2791"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GfX//w==" DoubleValue="-241142400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GfX//w==" DoubleValue="-241142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GfX//w==" LintValue="-2791"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GfX//w==" LintValue="-2791"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000299" DistinctValues="0.523793">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GfX//w==" DoubleValue="-241142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GfX//w==" LintValue="-2791"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000666" DistinctValues="1.014615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPX//w==" DoubleValue="-240883200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPX//w==" LintValue="-2788"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPX//w==" DoubleValue="-240883200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPX//w==" DoubleValue="-240883200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPX//w==" LintValue="-2788"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPX//w==" LintValue="-2788"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002999" DistinctValues="4.565769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPX//w==" DoubleValue="-240883200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JfX//w==" DoubleValue="-240105600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPX//w==" LintValue="-2788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JfX//w==" LintValue="-2779"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JfX//w==" DoubleValue="-240105600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JfX//w==" DoubleValue="-240105600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JfX//w==" LintValue="-2779"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JfX//w==" LintValue="-2779"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001000" DistinctValues="1.521923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JfX//w==" DoubleValue="-240105600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPX//w==" DoubleValue="-239846400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JfX//w==" LintValue="-2779"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPX//w==" LintValue="-2776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPX//w==" DoubleValue="-239846400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KPX//w==" DoubleValue="-239846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPX//w==" LintValue="-2776"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KPX//w==" LintValue="-2776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002332" DistinctValues="3.551154">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KPX//w==" DoubleValue="-239846400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KPX//w==" LintValue="-2776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001666" DistinctValues="2.536538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005776" DistinctValues="10.793333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPX//w==" DoubleValue="-237427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPX//w==" LintValue="-2748"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPX//w==" DoubleValue="-237427200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPX//w==" DoubleValue="-237427200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPX//w==" LintValue="-2748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPX//w==" LintValue="-2748"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002888" DistinctValues="5.396667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPX//w==" DoubleValue="-237427200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPX//w==" DoubleValue="-236736000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPX//w==" LintValue="-2748"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPX//w==" LintValue="-2740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000963" DistinctValues="1.354444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPX//w==" DoubleValue="-236736000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPX//w==" LintValue="-2740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000321" DistinctValues="0.451481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001925" DistinctValues="2.708889">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VvX//w==" DoubleValue="-235872000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VvX//w==" LintValue="-2730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VvX//w==" DoubleValue="-235872000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VvX//w==" DoubleValue="-235872000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VvX//w==" LintValue="-2730"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VvX//w==" LintValue="-2730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000321" DistinctValues="0.451481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VvX//w==" DoubleValue="-235872000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VvX//w==" LintValue="-2730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002888" DistinctValues="4.063333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" DoubleValue="-235785600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPX//w==" DoubleValue="-235008000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="V/X//w==" LintValue="-2729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPX//w==" LintValue="-2720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPX//w==" DoubleValue="-235008000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPX//w==" DoubleValue="-235008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPX//w==" LintValue="-2720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPX//w==" LintValue="-2720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002246" DistinctValues="3.160370">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPX//w==" DoubleValue="-235008000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/X//w==" DoubleValue="-234403200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPX//w==" LintValue="-2720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/X//w==" LintValue="-2713"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004332" DistinctValues="6.595000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/X//w==" DoubleValue="-234403200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/X//w==" DoubleValue="-233020800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/X//w==" LintValue="-2713"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/X//w==" LintValue="-2697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/X//w==" DoubleValue="-233020800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d/X//w==" DoubleValue="-233020800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/X//w==" LintValue="-2697"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d/X//w==" LintValue="-2697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000541" DistinctValues="0.824375">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d/X//w==" DoubleValue="-233020800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efX//w==" DoubleValue="-232848000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d/X//w==" LintValue="-2697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efX//w==" LintValue="-2695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efX//w==" DoubleValue="-232848000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="efX//w==" DoubleValue="-232848000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efX//w==" LintValue="-2695"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="efX//w==" LintValue="-2695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001354" DistinctValues="2.060938">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="efX//w==" DoubleValue="-232848000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvX//w==" DoubleValue="-232416000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="efX//w==" LintValue="-2695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvX//w==" LintValue="-2690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvX//w==" DoubleValue="-232416000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvX//w==" DoubleValue="-232416000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvX//w==" LintValue="-2690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvX//w==" LintValue="-2690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001354" DistinctValues="2.060938">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvX//w==" DoubleValue="-232416000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/X//w==" DoubleValue="-231984000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvX//w==" LintValue="-2690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/X//w==" LintValue="-2685"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/X//w==" DoubleValue="-231984000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g/X//w==" DoubleValue="-231984000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/X//w==" LintValue="-2685"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g/X//w==" LintValue="-2685"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001083" DistinctValues="1.648750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g/X//w==" DoubleValue="-231984000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/X//w==" DoubleValue="-231638400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g/X//w==" LintValue="-2685"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/X//w==" LintValue="-2681"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002363" DistinctValues="3.324545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/X//w==" DoubleValue="-231638400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/X//w==" LintValue="-2681"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.554091">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003741" DistinctValues="5.263864">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPX//w==" DoubleValue="-228787200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPX//w==" LintValue="-2648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPX//w==" DoubleValue="-228787200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPX//w==" DoubleValue="-228787200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPX//w==" LintValue="-2648"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPX//w==" LintValue="-2648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000788" DistinctValues="1.108182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPX//w==" DoubleValue="-228787200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPX//w==" DoubleValue="-228441600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPX//w==" LintValue="-2648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPX//w==" LintValue="-2644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPX//w==" DoubleValue="-228441600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPX//w==" DoubleValue="-228441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPX//w==" LintValue="-2644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPX//w==" LintValue="-2644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.554091">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPX//w==" DoubleValue="-228441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvX//w==" DoubleValue="-228268800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPX//w==" LintValue="-2644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvX//w==" LintValue="-2642"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvX//w==" DoubleValue="-228268800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rvX//w==" DoubleValue="-228268800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvX//w==" LintValue="-2642"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rvX//w==" LintValue="-2642"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000984" DistinctValues="1.385227">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rvX//w==" DoubleValue="-228268800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/X//w==" DoubleValue="-227836800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rvX//w==" LintValue="-2642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/X//w==" LintValue="-2637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002987" DistinctValues="5.237931">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/X//w==" DoubleValue="-227836800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfX//w==" DoubleValue="-226972800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/X//w==" LintValue="-2637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfX//w==" LintValue="-2627"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfX//w==" DoubleValue="-226972800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vfX//w==" DoubleValue="-226972800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfX//w==" LintValue="-2627"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vfX//w==" LintValue="-2627"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004182" DistinctValues="7.333103">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vfX//w==" DoubleValue="-226972800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/X//w==" DoubleValue="-225763200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vfX//w==" LintValue="-2627"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/X//w==" LintValue="-2613"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/X//w==" DoubleValue="-225763200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/X//w==" DoubleValue="-225763200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/X//w==" LintValue="-2613"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/X//w==" LintValue="-2613"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001494" DistinctValues="2.618966">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/X//w==" DoubleValue="-225763200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0PX//w==" DoubleValue="-225331200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/X//w==" LintValue="-2613"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0PX//w==" LintValue="-2608"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000279" DistinctValues="0.393226">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0PX//w==" DoubleValue="-225331200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0PX//w==" LintValue="-2608"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003354" DistinctValues="4.718710">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002795" DistinctValues="3.932258">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" DoubleValue="-224208000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fX//w==" LintValue="-2595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000279" DistinctValues="0.393226">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000838" DistinctValues="1.179677">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001118" DistinctValues="1.572903">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/X//w==" DoubleValue="-222652800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/X//w==" LintValue="-2577"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000928" DistinctValues="1.306071">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/X//w==" DoubleValue="-222652800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/X//w==" LintValue="-2577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002475" DistinctValues="3.482857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vX//w==" DoubleValue="-221702400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vX//w==" LintValue="-2566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vX//w==" DoubleValue="-221702400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+vX//w==" DoubleValue="-221702400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vX//w==" LintValue="-2566"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+vX//w==" LintValue="-2566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002166" DistinctValues="3.047500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+vX//w==" DoubleValue="-221702400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+vX//w==" LintValue="-2566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001238" DistinctValues="1.741429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfb//w==" DoubleValue="-220752000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfb//w==" LintValue="-2555"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfb//w==" DoubleValue="-220752000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfb//w==" DoubleValue="-220752000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfb//w==" LintValue="-2555"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfb//w==" LintValue="-2555"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001238" DistinctValues="1.741429">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfb//w==" DoubleValue="-220752000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfb//w==" DoubleValue="-220406400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfb//w==" LintValue="-2555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfb//w==" LintValue="-2551"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfb//w==" DoubleValue="-220406400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfb//w==" DoubleValue="-220406400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfb//w==" LintValue="-2551"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfb//w==" LintValue="-2551"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000619" DistinctValues="0.870714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfb//w==" DoubleValue="-220406400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/b//w==" DoubleValue="-220233600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfb//w==" LintValue="-2551"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/b//w==" LintValue="-2549"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000642" DistinctValues="1.199259">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/b//w==" DoubleValue="-220233600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfb//w==" DoubleValue="-220060800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/b//w==" LintValue="-2549"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfb//w==" LintValue="-2547"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfb//w==" DoubleValue="-220060800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfb//w==" DoubleValue="-220060800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfb//w==" LintValue="-2547"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfb//w==" LintValue="-2547"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008022" DistinctValues="14.990741">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfb//w==" DoubleValue="-220060800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvb//w==" DoubleValue="-217900800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfb//w==" LintValue="-2547"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvb//w==" LintValue="-2522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001083" DistinctValues="2.023750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvb//w==" DoubleValue="-217900800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvb//w==" LintValue="-2522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007580" DistinctValues="14.166250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvb//w==" DoubleValue="-215827200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvb//w==" LintValue="-2498"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002246" DistinctValues="4.197407">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvb//w==" DoubleValue="-215827200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvb//w==" LintValue="-2498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006417" DistinctValues="11.992593">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfb//w==" DoubleValue="-213494400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfb//w==" LintValue="-2471"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006301" DistinctValues="11.774545">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfb//w==" DoubleValue="-213494400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfb//w==" LintValue="-2471"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002363" DistinctValues="4.415455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/b//w==" DoubleValue="-211593600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/b//w==" LintValue="-2449"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/b//w==" DoubleValue="-211593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/b//w==" LintValue="-2449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005119" DistinctValues="8.975909">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfb//w==" DoubleValue="-209001600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jfb//w==" LintValue="-2419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfb//w==" DoubleValue="-209001600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jfb//w==" DoubleValue="-209001600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jfb//w==" LintValue="-2419"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jfb//w==" LintValue="-2419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001575" DistinctValues="2.761818">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jfb//w==" DoubleValue="-209001600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jfb//w==" LintValue="-2419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001969" DistinctValues="3.452273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvb//w==" DoubleValue="-208224000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvb//w==" LintValue="-2410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvb//w==" DoubleValue="-208224000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvb//w==" DoubleValue="-206841600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvb//w==" LintValue="-2410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvb//w==" LintValue="-2394"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvb//w==" DoubleValue="-206841600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvb//w==" LintValue="-2394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003465" DistinctValues="6.476000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005198" DistinctValues="9.714000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/b//w==" DoubleValue="-202953600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/b//w==" LintValue="-2349"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002707" DistinctValues="4.746875">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/b//w==" DoubleValue="-202953600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fb//w==" DoubleValue="-202089600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/b//w==" LintValue="-2349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fb//w==" LintValue="-2339"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fb//w==" DoubleValue="-202089600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fb//w==" DoubleValue="-202089600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fb//w==" LintValue="-2339"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fb//w==" LintValue="-2339"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004602" DistinctValues="8.069688">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fb//w==" DoubleValue="-202089600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vb//w==" DoubleValue="-200620800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fb//w==" LintValue="-2339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vb//w==" LintValue="-2322"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vb//w==" DoubleValue="-200620800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vb//w==" DoubleValue="-200620800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vb//w==" LintValue="-2322"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vb//w==" LintValue="-2322"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001354" DistinctValues="2.373438">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vb//w==" DoubleValue="-200620800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/b//w==" DoubleValue="-200188800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vb//w==" LintValue="-2322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/b//w==" LintValue="-2317"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/b//w==" DoubleValue="-200188800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/f//w==" DoubleValue="-197769600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/b//w==" LintValue="-2317"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/f//w==" LintValue="-2289"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001507" DistinctValues="2.815652">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/f//w==" DoubleValue="-197769600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/f//w==" LintValue="-2289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007157" DistinctValues="13.374348">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvf//w==" DoubleValue="-195782400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvf//w==" LintValue="-2266"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvf//w==" DoubleValue="-195782400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvf//w==" LintValue="-2266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000347" DistinctValues="0.647600">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" DoubleValue="-193968000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/f//w==" LintValue="-2245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008317" DistinctValues="15.542400">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPf//w==" DoubleValue="-191808000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPf//w==" LintValue="-2220"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007970" DistinctValues="14.894800">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPf//w==" DoubleValue="-191808000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/f//w==" DoubleValue="-189820800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPf//w==" LintValue="-2220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/f//w==" LintValue="-2197"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/f//w==" DoubleValue="-189820800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a/f//w==" DoubleValue="-189820800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/f//w==" LintValue="-2197"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a/f//w==" LintValue="-2197"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000693" DistinctValues="1.295200">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a/f//w==" DoubleValue="-189820800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bff//w==" DoubleValue="-189648000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a/f//w==" LintValue="-2197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bff//w==" LintValue="-2195"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001733" DistinctValues="3.038000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bff//w==" DoubleValue="-189648000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bff//w==" LintValue="-2195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001299" DistinctValues="2.278500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPf//w==" DoubleValue="-189043200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPf//w==" LintValue="-2188"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPf//w==" DoubleValue="-189043200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dPf//w==" DoubleValue="-189043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPf//w==" LintValue="-2188"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dPf//w==" LintValue="-2188"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005631" DistinctValues="9.873500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dPf//w==" DoubleValue="-189043200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gff//w==" DoubleValue="-187920000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dPf//w==" LintValue="-2188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gff//w==" LintValue="-2175"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004873" DistinctValues="8.544375">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gff//w==" DoubleValue="-187920000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gff//w==" LintValue="-2175"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001083" DistinctValues="1.898750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" DoubleValue="-187142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPf//w==" DoubleValue="-186969600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivf//w==" LintValue="-2166"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPf//w==" LintValue="-2164"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPf//w==" DoubleValue="-186969600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPf//w==" DoubleValue="-186969600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPf//w==" LintValue="-2164"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPf//w==" LintValue="-2164"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002707" DistinctValues="4.746875">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPf//w==" DoubleValue="-186969600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kff//w==" DoubleValue="-186537600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPf//w==" LintValue="-2164"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kff//w==" LintValue="-2159"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002888" DistinctValues="5.063333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kff//w==" DoubleValue="-186537600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPf//w==" DoubleValue="-185932800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kff//w==" LintValue="-2159"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPf//w==" LintValue="-2152"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPf//w==" DoubleValue="-185932800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPf//w==" DoubleValue="-185932800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPf//w==" LintValue="-2152"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPf//w==" LintValue="-2152"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004950" DistinctValues="8.680000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPf//w==" DoubleValue="-185932800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPf//w==" DoubleValue="-184896000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPf//w==" LintValue="-2152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPf//w==" LintValue="-2140"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPf//w==" DoubleValue="-184896000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pPf//w==" DoubleValue="-184896000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPf//w==" LintValue="-2140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pPf//w==" LintValue="-2140"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000825" DistinctValues="1.446667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pPf//w==" DoubleValue="-184896000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvf//w==" DoubleValue="-184723200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pPf//w==" LintValue="-2140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvf//w==" LintValue="-2138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvf//w==" DoubleValue="-184723200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvf//w==" DoubleValue="-182995200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvf//w==" LintValue="-2138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvf//w==" LintValue="-2118"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002406" DistinctValues="4.497222">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvf//w==" DoubleValue="-182995200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvf//w==" LintValue="-2118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006257" DistinctValues="11.692778">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007088" DistinctValues="13.246364">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" DoubleValue="-181440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPf//w==" LintValue="-2100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001575" DistinctValues="2.943636">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vf//w==" DoubleValue="-179539200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vf//w==" LintValue="-2078"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vf//w==" DoubleValue="-179539200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vf//w==" DoubleValue="-178156800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vf//w==" LintValue="-2078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vf//w==" LintValue="-2062"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001805" DistinctValues="3.372917">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vf//w==" DoubleValue="-178156800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/f//w==" DoubleValue="-177724800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vf//w==" LintValue="-2062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9/f//w==" LintValue="-2057"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/f//w==" DoubleValue="-177724800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/f//w==" DoubleValue="-177724800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9/f//w==" LintValue="-2057"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9/f//w==" LintValue="-2057"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006858" DistinctValues="12.817083">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/f//w==" DoubleValue="-177724800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvj//w==" DoubleValue="-176083200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9/f//w==" LintValue="-2057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvj//w==" LintValue="-2038"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000896" DistinctValues="1.364483">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvj//w==" DoubleValue="-176083200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvj//w==" LintValue="-2038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004481" DistinctValues="6.822414">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPj//w==" DoubleValue="-174528000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPj//w==" LintValue="-2020"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPj//w==" DoubleValue="-174528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPj//w==" DoubleValue="-174528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPj//w==" LintValue="-2020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPj//w==" LintValue="-2020"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000299" DistinctValues="0.454828">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPj//w==" DoubleValue="-174528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPj//w==" LintValue="-2020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000299" DistinctValues="0.454828">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvj//w==" DoubleValue="-174355200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvj//w==" LintValue="-2018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvj//w==" DoubleValue="-174355200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvj//w==" DoubleValue="-174355200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvj//w==" LintValue="-2018"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hvj//w==" LintValue="-2018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002689" DistinctValues="4.093448">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvj//w==" DoubleValue="-174355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/j//w==" DoubleValue="-173577600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hvj//w==" LintValue="-2018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/j//w==" LintValue="-2009"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/j//w==" DoubleValue="-173577600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/j//w==" DoubleValue="-171158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/j//w==" LintValue="-2009"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/j//w==" LintValue="-1981"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000838" DistinctValues="1.470000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/j//w==" DoubleValue="-171158400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvj//w==" DoubleValue="-170899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/j//w==" LintValue="-1981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvj//w==" LintValue="-1978"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvj//w==" DoubleValue="-170899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvj//w==" DoubleValue="-170899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvj//w==" LintValue="-1978"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvj//w==" LintValue="-1978"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002515" DistinctValues="4.410000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvj//w==" DoubleValue="-170899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/j//w==" DoubleValue="-170121600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvj//w==" LintValue="-1978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/j//w==" LintValue="-1969"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/j//w==" DoubleValue="-170121600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/j//w==" DoubleValue="-170121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/j//w==" LintValue="-1969"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/j//w==" LintValue="-1969"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005310" DistinctValues="9.310000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/j//w==" DoubleValue="-170121600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/j//w==" LintValue="-1969"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" DoubleValue="-168480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfj//w==" DoubleValue="-166838400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvj//w==" LintValue="-1950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfj//w==" LintValue="-1931"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfj//w==" DoubleValue="-166838400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPj//w==" DoubleValue="-165196800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfj//w==" LintValue="-1931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPj//w==" LintValue="-1912"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPj//w==" DoubleValue="-165196800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfj//w==" DoubleValue="-163382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPj//w==" LintValue="-1912"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfj//w==" LintValue="-1891"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002666" DistinctValues="4.981538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfj//w==" DoubleValue="-163382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfj//w==" DoubleValue="-162345600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfj//w==" LintValue="-1891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfj//w==" LintValue="-1879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfj//w==" DoubleValue="-162345600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qfj//w==" DoubleValue="-162345600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfj//w==" LintValue="-1879"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qfj//w==" LintValue="-1879"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005998" DistinctValues="11.208462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qfj//w==" DoubleValue="-162345600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPj//w==" DoubleValue="-160012800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qfj//w==" LintValue="-1879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPj//w==" LintValue="-1852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPj//w==" DoubleValue="-160012800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/j//w==" DoubleValue="-158371200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPj//w==" LintValue="-1852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/j//w==" LintValue="-1833"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002736" DistinctValues="5.112632">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/j//w==" DoubleValue="-158371200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/j//w==" LintValue="-1833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005928" DistinctValues="11.077368">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//j//w==" DoubleValue="-154915200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//j//w==" LintValue="-1793"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//j//w==" DoubleValue="-154915200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/n//w==" DoubleValue="-153532800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//j//w==" LintValue="-1793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/n//w==" LintValue="-1777"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/n//w==" DoubleValue="-153532800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/n//w==" LintValue="-1777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007545" DistinctValues="14.100968">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001118" DistinctValues="2.089032">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002363" DistinctValues="4.415455">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPn//w==" DoubleValue="-143424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPn//w==" LintValue="-1660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPn//w==" DoubleValue="-143424000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hPn//w==" DoubleValue="-143424000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPn//w==" LintValue="-1660"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hPn//w==" LintValue="-1660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006301" DistinctValues="11.774545">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hPn//w==" DoubleValue="-143424000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPn//w==" DoubleValue="-142041600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hPn//w==" LintValue="-1660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPn//w==" LintValue="-1644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPn//w==" DoubleValue="-142041600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvn//w==" DoubleValue="-139795200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPn//w==" LintValue="-1644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvn//w==" LintValue="-1618"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003390" DistinctValues="5.943913">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvn//w==" DoubleValue="-139795200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/n//w==" DoubleValue="-139017600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvn//w==" LintValue="-1618"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/n//w==" LintValue="-1609"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/n//w==" DoubleValue="-139017600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="t/n//w==" DoubleValue="-139017600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/n//w==" LintValue="-1609"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="t/n//w==" LintValue="-1609"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001883" DistinctValues="3.302174">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="t/n//w==" DoubleValue="-139017600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="t/n//w==" LintValue="-1609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003390" DistinctValues="5.943913">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" DoubleValue="-138585600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vPn//w==" LintValue="-1604"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008270" DistinctValues="15.454091">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" DoubleValue="-137808000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vn//w==" DoubleValue="-135993600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfn//w==" LintValue="-1595"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vn//w==" LintValue="-1574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vn//w==" DoubleValue="-135993600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vn//w==" DoubleValue="-135993600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vn//w==" LintValue="-1574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vn//w==" LintValue="-1574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.735909">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vn//w==" DoubleValue="-135993600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/n//w==" DoubleValue="-135907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vn//w==" LintValue="-1574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/n//w==" LintValue="-1573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007580" DistinctValues="14.166250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/n//w==" DoubleValue="-135907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pn//w==" DoubleValue="-134092800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/n//w==" LintValue="-1573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pn//w==" LintValue="-1552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pn//w==" DoubleValue="-134092800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pn//w==" DoubleValue="-134092800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pn//w==" LintValue="-1552"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pn//w==" LintValue="-1552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001083" DistinctValues="2.023750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pn//w==" DoubleValue="-134092800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/n//w==" DoubleValue="-133833600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pn//w==" LintValue="-1552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/n//w==" LintValue="-1549"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005472" DistinctValues="10.225263">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/n//w==" DoubleValue="-133833600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//n//w==" DoubleValue="-132796800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/n//w==" LintValue="-1549"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//n//w==" LintValue="-1537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//n//w==" DoubleValue="-132796800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//n//w==" DoubleValue="-132796800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//n//w==" LintValue="-1537"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//n//w==" LintValue="-1537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003192" DistinctValues="5.964737">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//n//w==" DoubleValue="-132796800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvr//w==" DoubleValue="-132192000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//n//w==" LintValue="-1537"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvr//w==" LintValue="-1530"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvr//w==" DoubleValue="-132192000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvr//w==" DoubleValue="-130809600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvr//w==" LintValue="-1530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fvr//w==" LintValue="-1514"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002063" DistinctValues="3.378571">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvr//w==" DoubleValue="-130809600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fvr//w==" LintValue="-1514"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001650" DistinctValues="2.702857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003300" DistinctValues="5.405714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001650" DistinctValues="2.702857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003300" DistinctValues="6.167619">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/r//w==" DoubleValue="-128304000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/r//w==" LintValue="-1485"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/r//w==" DoubleValue="-128304000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="M/r//w==" DoubleValue="-128304000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/r//w==" LintValue="-1485"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="M/r//w==" LintValue="-1485"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005363" DistinctValues="10.022381">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="M/r//w==" DoubleValue="-128304000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="M/r//w==" LintValue="-1485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/r//w==" DoubleValue="-124848000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/r//w==" LintValue="-1445"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005472" DistinctValues="9.593684">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/r//w==" DoubleValue="-124848000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/r//w==" DoubleValue="-123811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/r//w==" LintValue="-1445"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/r//w==" LintValue="-1433"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/r//w==" DoubleValue="-123811200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/r//w==" DoubleValue="-123811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/r//w==" LintValue="-1433"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/r//w==" LintValue="-1433"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002280" DistinctValues="3.997368">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/r//w==" DoubleValue="-123811200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPr//w==" DoubleValue="-123379200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/r//w==" LintValue="-1433"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPr//w==" LintValue="-1428"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPr//w==" DoubleValue="-123379200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bPr//w==" DoubleValue="-123379200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPr//w==" LintValue="-1428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bPr//w==" LintValue="-1428"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000912" DistinctValues="1.598947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bPr//w==" DoubleValue="-123379200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bPr//w==" LintValue="-1428"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" DoubleValue="-118454400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfr//w==" LintValue="-1371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005198" DistinctValues="9.714000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003465" DistinctValues="6.476000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/r//w==" DoubleValue="-113443200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/r//w==" LintValue="-1313"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/r//w==" DoubleValue="-113443200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fr//w==" DoubleValue="-110851200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/r//w==" LintValue="-1313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fr//w==" LintValue="-1283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fr//w==" DoubleValue="-110851200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fr//w==" LintValue="-1283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/v//w==" DoubleValue="-107222400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/v//w==" LintValue="-1241"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001999" DistinctValues="3.736154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/v//w==" DoubleValue="-107222400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfv//w==" DoubleValue="-106704000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/v//w==" LintValue="-1241"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfv//w==" LintValue="-1235"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfv//w==" DoubleValue="-106704000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfv//w==" DoubleValue="-106704000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfv//w==" LintValue="-1235"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfv//w==" LintValue="-1235"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006664" DistinctValues="12.453846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfv//w==" DoubleValue="-106704000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qfv//w==" DoubleValue="-104976000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfv//w==" LintValue="-1235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qfv//w==" LintValue="-1215"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qfv//w==" DoubleValue="-104976000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPv//w==" DoubleValue="-102988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qfv//w==" LintValue="-1215"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPv//w==" LintValue="-1192"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPv//w==" DoubleValue="-102988800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avv//w==" DoubleValue="-101433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPv//w==" LintValue="-1192"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avv//w==" LintValue="-1174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avv//w==" DoubleValue="-101433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avv//w==" LintValue="-1174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002567" DistinctValues="4.204444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" DoubleValue="-98236800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/v//w==" LintValue="-1137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004492" DistinctValues="7.357778">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfv//w==" DoubleValue="-96336000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pfv//w==" LintValue="-1115"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfv//w==" DoubleValue="-96336000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfv//w==" DoubleValue="-96336000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pfv//w==" LintValue="-1115"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pfv//w==" LintValue="-1115"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000963" DistinctValues="1.576667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfv//w==" DoubleValue="-96336000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPv//w==" DoubleValue="-96076800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pfv//w==" LintValue="-1115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qPv//w==" LintValue="-1112"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPv//w==" DoubleValue="-96076800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPv//w==" DoubleValue="-96076800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qPv//w==" LintValue="-1112"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qPv//w==" LintValue="-1112"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000642" DistinctValues="1.051111">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPv//w==" DoubleValue="-96076800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qPv//w==" LintValue="-1112"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004813" DistinctValues="8.994444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" DoubleValue="-95904000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvv//w==" LintValue="-1110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003850" DistinctValues="7.195556">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfv//w==" DoubleValue="-93571200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xfv//w==" LintValue="-1083"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfv//w==" DoubleValue="-93571200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pv//w==" DoubleValue="-91929600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xfv//w==" LintValue="-1083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pv//w==" LintValue="-1064"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pv//w==" DoubleValue="-91929600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pv//w==" DoubleValue="-90547200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pv//w==" LintValue="-1064"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pv//w==" LintValue="-1048"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000559" DistinctValues="0.915484">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pv//w==" DoubleValue="-90547200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pv//w==" LintValue="-1048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000559" DistinctValues="0.915484">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000279" DistinctValues="0.457742">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" DoubleValue="-90201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fv//w==" DoubleValue="-90115200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pv//w==" LintValue="-1044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fv//w==" LintValue="-1043"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fv//w==" DoubleValue="-90115200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fv//w==" DoubleValue="-90115200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fv//w==" LintValue="-1043"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fv//w==" LintValue="-1043"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007266" DistinctValues="11.901290">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fv//w==" DoubleValue="-90115200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fv//w==" LintValue="-1043"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPz//w==" DoubleValue="-86400000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPz//w==" LintValue="-1000"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004693" DistinctValues="8.227917">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPz//w==" DoubleValue="-86400000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jfz//w==" DoubleValue="-85276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPz//w==" LintValue="-1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jfz//w==" LintValue="-987"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jfz//w==" DoubleValue="-85276800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jfz//w==" DoubleValue="-85276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jfz//w==" LintValue="-987"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jfz//w==" LintValue="-987"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001444" DistinctValues="2.531667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jfz//w==" DoubleValue="-85276800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jfz//w==" LintValue="-987"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002527" DistinctValues="4.430417">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPz//w==" DoubleValue="-84326400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPz//w==" LintValue="-976"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPz//w==" DoubleValue="-84326400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/z//w==" DoubleValue="-82339200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPz//w==" LintValue="-976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/z//w==" LintValue="-953"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000333" DistinctValues="0.584231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/z//w==" DoubleValue="-82339200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/z//w==" LintValue="-953"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001333" DistinctValues="2.336923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006997" DistinctValues="12.268846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfz//w==" DoubleValue="-80092800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfz//w==" LintValue="-927"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfz//w==" DoubleValue="-80092800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvz//w==" DoubleValue="-78624000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfz//w==" LintValue="-927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvz//w==" LintValue="-910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvz//w==" DoubleValue="-78624000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/z//w==" DoubleValue="-76809600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvz//w==" LintValue="-910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/z//w==" LintValue="-889"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003585" DistinctValues="6.699310">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/z//w==" DoubleValue="-76809600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/z//w==" DoubleValue="-75772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/z//w==" LintValue="-889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/z//w==" LintValue="-877"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/z//w==" DoubleValue="-75772800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/z//w==" DoubleValue="-75772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/z//w==" LintValue="-877"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/z//w==" LintValue="-877"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005078" DistinctValues="9.490690">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/z//w==" DoubleValue="-75772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPz//w==" DoubleValue="-74304000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/z//w==" LintValue="-877"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPz//w==" LintValue="-860"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003610" DistinctValues="6.745833">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPz//w==" DoubleValue="-74304000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPz//w==" LintValue="-860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005054" DistinctValues="9.444167">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" DoubleValue="-72230400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pz//w==" DoubleValue="-69811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPz//w==" LintValue="-836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2Pz//w==" LintValue="-808"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pz//w==" DoubleValue="-69811200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fz//w==" DoubleValue="-67305600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2Pz//w==" LintValue="-808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fz//w==" LintValue="-779"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fz//w==" DoubleValue="-67305600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fz//w==" LintValue="-779"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iv3//w==" DoubleValue="-63417600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iv3//w==" LintValue="-734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004813" DistinctValues="8.994444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iv3//w==" DoubleValue="-63417600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iv3//w==" LintValue="-734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003850" DistinctValues="7.195556">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004158" DistinctValues="7.771200">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" DoubleValue="-61084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf3//w==" DoubleValue="-60048000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pf3//w==" LintValue="-707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf3//w==" LintValue="-695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf3//w==" DoubleValue="-60048000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf3//w==" DoubleValue="-60048000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf3//w==" LintValue="-695"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf3//w==" LintValue="-695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004505" DistinctValues="8.418800">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf3//w==" DoubleValue="-60048000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vv3//w==" DoubleValue="-58924800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf3//w==" LintValue="-695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vv3//w==" LintValue="-682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vv3//w==" DoubleValue="-58924800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/3//w==" DoubleValue="-56764800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vv3//w==" LintValue="-682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/3//w==" LintValue="-657"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003898" DistinctValues="7.285500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/3//w==" DoubleValue="-56764800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/3//w==" LintValue="-657"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004765" DistinctValues="8.904500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/3//w==" DoubleValue="-55036800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/3//w==" LintValue="-637"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004492" DistinctValues="8.394815">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/3//w==" DoubleValue="-55036800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/3//w==" LintValue="-637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004171" DistinctValues="7.795185">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004143" DistinctValues="7.743043">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" DoubleValue="-52704000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qf3//w==" DoubleValue="-51753600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nv3//w==" LintValue="-610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qf3//w==" LintValue="-599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qf3//w==" DoubleValue="-51753600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qf3//w==" DoubleValue="-51753600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qf3//w==" LintValue="-599"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="qf3//w==" LintValue="-599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004520" DistinctValues="8.446957">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qf3//w==" DoubleValue="-51753600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="qf3//w==" LintValue="-599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004125" DistinctValues="7.233333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" DoubleValue="-50716800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/3//w==" DoubleValue="-49852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tf3//w==" LintValue="-587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/3//w==" LintValue="-577"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/3//w==" DoubleValue="-49852800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/3//w==" DoubleValue="-49852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/3//w==" LintValue="-577"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/3//w==" LintValue="-577"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000413" DistinctValues="0.723333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/3//w==" DoubleValue="-49852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wP3//w==" DoubleValue="-49766400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/3//w==" LintValue="-577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wP3//w==" LintValue="-576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wP3//w==" DoubleValue="-49766400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wP3//w==" DoubleValue="-49766400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wP3//w==" LintValue="-576"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wP3//w==" LintValue="-576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004125" DistinctValues="7.233333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wP3//w==" DoubleValue="-49766400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yv3//w==" DoubleValue="-48902400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wP3//w==" LintValue="-576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yv3//w==" LintValue="-566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008270" DistinctValues="15.454091">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yv3//w==" DoubleValue="-48902400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yv3//w==" LintValue="-566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.735909">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4P3//w==" DoubleValue="-47001600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4P3//w==" LintValue="-544"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4P3//w==" DoubleValue="-47001600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4P3//w==" LintValue="-544"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006931" DistinctValues="12.952000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" DoubleValue="-44496000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df7//w==" DoubleValue="-43113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/f3//w==" LintValue="-515"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df7//w==" LintValue="-499"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df7//w==" DoubleValue="-43113600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Df7//w==" DoubleValue="-43113600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df7//w==" LintValue="-499"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Df7//w==" LintValue="-499"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001733" DistinctValues="3.238000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Df7//w==" DoubleValue="-43113600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ef7//w==" DoubleValue="-42768000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Df7//w==" LintValue="-499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ef7//w==" LintValue="-495"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008663" DistinctValues="17.190000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ef7//w==" DoubleValue="-42768000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Of7//w==" DoubleValue="-39312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ef7//w==" LintValue="-495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Of7//w==" LintValue="-455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000939" DistinctValues="1.755542">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Of7//w==" DoubleValue="-39312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv7//w==" DoubleValue="-38534400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Of7//w==" LintValue="-455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv7//w==" LintValue="-446"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv7//w==" DoubleValue="-38534400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv7//w==" DoubleValue="-38534400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv7//w==" LintValue="-446"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv7//w==" LintValue="-446"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007724" DistinctValues="14.434458">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv7//w==" DoubleValue="-38534400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv7//w==" LintValue="-446"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:RelationStatistics Mdid="2.31256.1.0" Name="heap_lineitem" Rows="2985.000000" EmptyRelation="false"/>
@@ -3911,1204 +3911,1204 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.31256.1.0.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.005764" DistinctValues="9.234930">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" DoubleValue="-249436800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6fT//w==" DoubleValue="-245289600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" LintValue="-2887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6fT//w==" LintValue="-2839"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6fT//w==" DoubleValue="-245289600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6fT//w==" DoubleValue="-245289600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6fT//w==" LintValue="-2839"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6fT//w==" LintValue="-2839"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000961" DistinctValues="1.539155">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6fT//w==" DoubleValue="-245289600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fT//w==" DoubleValue="-244598400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6fT//w==" LintValue="-2839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fT//w==" LintValue="-2831"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fT//w==" DoubleValue="-244598400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fT//w==" DoubleValue="-244598400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fT//w==" LintValue="-2831"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fT//w==" LintValue="-2831"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001561" DistinctValues="2.501127">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fT//w==" DoubleValue="-244598400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vT//w==" DoubleValue="-243475200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fT//w==" LintValue="-2831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vT//w==" LintValue="-2818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vT//w==" DoubleValue="-243475200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/vT//w==" DoubleValue="-243475200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vT//w==" LintValue="-2818"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/vT//w==" LintValue="-2818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000240" DistinctValues="0.384789">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/vT//w==" DoubleValue="-243475200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APX//w==" DoubleValue="-243302400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/vT//w==" LintValue="-2818"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APX//w==" LintValue="-2816"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.055000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APX//w==" DoubleValue="-243302400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APX//w==" LintValue="-2816"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000355" DistinctValues="0.527500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/X//w==" DoubleValue="-243043200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/X//w==" LintValue="-2813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/X//w==" DoubleValue="-243043200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="A/X//w==" DoubleValue="-243043200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/X//w==" LintValue="-2813"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="A/X//w==" LintValue="-2813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006394" DistinctValues="9.495000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="A/X//w==" DoubleValue="-243043200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FfX//w==" DoubleValue="-241488000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="A/X//w==" LintValue="-2813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FfX//w==" LintValue="-2795"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FfX//w==" DoubleValue="-241488000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FfX//w==" DoubleValue="-241488000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FfX//w==" LintValue="-2795"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FfX//w==" LintValue="-2795"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.055000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FfX//w==" DoubleValue="-241488000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/X//w==" DoubleValue="-241315200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FfX//w==" LintValue="-2795"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/X//w==" LintValue="-2793"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/X//w==" DoubleValue="-241315200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/X//w==" DoubleValue="-241315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/X//w==" LintValue="-2793"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/X//w==" LintValue="-2793"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000355" DistinctValues="0.527500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/X//w==" DoubleValue="-241315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPX//w==" DoubleValue="-241228800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/X//w==" LintValue="-2793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPX//w==" LintValue="-2792"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001640" DistinctValues="2.242308">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPX//w==" DoubleValue="-241228800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HfX//w==" DoubleValue="-240796800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPX//w==" LintValue="-2792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HfX//w==" LintValue="-2787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HfX//w==" DoubleValue="-240796800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HfX//w==" DoubleValue="-240796800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HfX//w==" LintValue="-2787"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HfX//w==" LintValue="-2787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000984" DistinctValues="1.345385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HfX//w==" DoubleValue="-240796800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HfX//w==" LintValue="-2787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000656" DistinctValues="0.896923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IvX//w==" DoubleValue="-240364800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IvX//w==" LintValue="-2782"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IvX//w==" DoubleValue="-240364800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IvX//w==" DoubleValue="-240364800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IvX//w==" LintValue="-2782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IvX//w==" LintValue="-2782"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003935" DistinctValues="5.381538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IvX//w==" DoubleValue="-240364800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LvX//w==" DoubleValue="-239328000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IvX//w==" LintValue="-2782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LvX//w==" LintValue="-2770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LvX//w==" DoubleValue="-239328000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LvX//w==" DoubleValue="-239328000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LvX//w==" LintValue="-2770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LvX//w==" LintValue="-2770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000984" DistinctValues="1.345385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LvX//w==" DoubleValue="-239328000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="LvX//w==" LintValue="-2770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000328" DistinctValues="0.448462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003069" DistinctValues="5.637600">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005457" DistinctValues="10.022400">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/X//w==" DoubleValue="-236822400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/X//w==" LintValue="-2741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/X//w==" DoubleValue="-236822400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WfX//w==" DoubleValue="-235612800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/X//w==" LintValue="-2741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WfX//w==" LintValue="-2727"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WfX//w==" DoubleValue="-235612800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPX//w==" DoubleValue="-233971200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WfX//w==" LintValue="-2727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPX//w==" LintValue="-2708"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPX//w==" DoubleValue="-233971200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPX//w==" LintValue="-2708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/X//w==" DoubleValue="-229219200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/X//w==" LintValue="-2653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003654" DistinctValues="6.711429">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/X//w==" DoubleValue="-229219200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/X//w==" DoubleValue="-228182400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/X//w==" LintValue="-2653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/X//w==" LintValue="-2641"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/X//w==" DoubleValue="-228182400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/X//w==" DoubleValue="-228182400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/X//w==" LintValue="-2641"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/X//w==" LintValue="-2641"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004872" DistinctValues="8.948571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/X//w==" DoubleValue="-228182400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/X//w==" DoubleValue="-226800000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/X//w==" LintValue="-2641"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/X//w==" LintValue="-2625"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005903" DistinctValues="10.841538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/X//w==" DoubleValue="-226800000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/X//w==" LintValue="-2625"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002680" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002623" DistinctValues="4.818462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" DoubleValue="-225244800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fX//w==" DoubleValue="-224553600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fX//w==" LintValue="-2607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fX//w==" LintValue="-2599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000502" DistinctValues="0.921176">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fX//w==" DoubleValue="-224553600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vX//w==" DoubleValue="-224467200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fX//w==" LintValue="-2599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vX//w==" LintValue="-2598"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vX//w==" DoubleValue="-224467200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vX//w==" DoubleValue="-224467200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vX//w==" LintValue="-2598"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vX//w==" LintValue="-2598"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008024" DistinctValues="14.738824">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vX//w==" DoubleValue="-224467200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vX//w==" LintValue="-2598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vX//w==" DoubleValue="-221356800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vX//w==" LintValue="-2562"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vX//w==" DoubleValue="-221356800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vX//w==" LintValue="-2562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007247" DistinctValues="13.311000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" DoubleValue="-219801600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvb//w==" DoubleValue="-216864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPb//w==" LintValue="-2544"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvb//w==" LintValue="-2510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvb//w==" DoubleValue="-216864000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvb//w==" DoubleValue="-216864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvb//w==" LintValue="-2510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvb//w==" LintValue="-2510"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001279" DistinctValues="2.349000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvb//w==" DoubleValue="-216864000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPb//w==" DoubleValue="-216345600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvb//w==" LintValue="-2510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPb//w==" LintValue="-2504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004689" DistinctValues="8.063000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPb//w==" DoubleValue="-216345600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/b//w==" DoubleValue="-215395200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPb//w==" LintValue="-2504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/b//w==" LintValue="-2493"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/b//w==" DoubleValue="-215395200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/b//w==" DoubleValue="-215395200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/b//w==" LintValue="-2493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/b//w==" LintValue="-2493"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000426" DistinctValues="0.733000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/b//w==" DoubleValue="-215395200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPb//w==" DoubleValue="-215308800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/b//w==" LintValue="-2493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPb//w==" LintValue="-2492"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPb//w==" DoubleValue="-215308800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPb//w==" DoubleValue="-215308800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPb//w==" LintValue="-2492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPb//w==" LintValue="-2492"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003410" DistinctValues="5.864000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPb//w==" DoubleValue="-215308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPb//w==" LintValue="-2492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004487" DistinctValues="8.242105">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvb//w==" DoubleValue="-213753600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvb//w==" LintValue="-2474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvb//w==" DoubleValue="-213753600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvb//w==" DoubleValue="-213753600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvb//w==" LintValue="-2474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvb//w==" LintValue="-2474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004039" DistinctValues="7.417895">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvb//w==" DoubleValue="-213753600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/b//w==" DoubleValue="-212976000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvb//w==" LintValue="-2474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/b//w==" LintValue="-2465"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001066" DistinctValues="1.707500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/b//w==" DoubleValue="-212976000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/b//w==" LintValue="-2465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002664" DistinctValues="4.268750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002664" DistinctValues="4.268750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" DoubleValue="-212371200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/b//w==" DoubleValue="-211939200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zvb//w==" LintValue="-2458"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/b//w==" LintValue="-2453"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/b//w==" DoubleValue="-211939200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a/b//w==" DoubleValue="-211939200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/b//w==" LintValue="-2453"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="a/b//w==" LintValue="-2453"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002131" DistinctValues="3.415000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a/b//w==" DoubleValue="-211939200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/b//w==" DoubleValue="-211593600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="a/b//w==" LintValue="-2453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b/b//w==" LintValue="-2449"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003141" DistinctValues="5.769474">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/b//w==" DoubleValue="-211593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvb//w==" DoubleValue="-210988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b/b//w==" LintValue="-2449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvb//w==" LintValue="-2442"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvb//w==" DoubleValue="-210988800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvb//w==" DoubleValue="-210988800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvb//w==" LintValue="-2442"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvb//w==" LintValue="-2442"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005385" DistinctValues="9.890526">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvb//w==" DoubleValue="-210988800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvb//w==" DoubleValue="-209952000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvb//w==" LintValue="-2442"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvb//w==" LintValue="-2430"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvb//w==" DoubleValue="-209952000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvb//w==" DoubleValue="-208224000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvb//w==" LintValue="-2430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvb//w==" LintValue="-2410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvb//w==" DoubleValue="-208224000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfb//w==" DoubleValue="-205891200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvb//w==" LintValue="-2410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfb//w==" LintValue="-2383"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008024" DistinctValues="14.738824">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfb//w==" DoubleValue="-205891200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfb//w==" LintValue="-2383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000502" DistinctValues="0.921176">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/b//w==" DoubleValue="-202953600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/b//w==" LintValue="-2349"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003837" DistinctValues="7.047000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/b//w==" DoubleValue="-202953600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pb//w==" DoubleValue="-202176000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/b//w==" LintValue="-2349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pb//w==" LintValue="-2340"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pb//w==" DoubleValue="-202176000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pb//w==" DoubleValue="-202176000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pb//w==" LintValue="-2340"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pb//w==" LintValue="-2340"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004689" DistinctValues="8.613000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pb//w==" DoubleValue="-202176000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/b//w==" DoubleValue="-201225600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pb//w==" LintValue="-2340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/b//w==" LintValue="-2329"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005329" DistinctValues="9.787500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/b//w==" DoubleValue="-201225600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vb//w==" DoubleValue="-199929600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/b//w==" LintValue="-2329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vb//w==" LintValue="-2314"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vb//w==" DoubleValue="-199929600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vb//w==" DoubleValue="-199929600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vb//w==" LintValue="-2314"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vb//w==" LintValue="-2314"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003197" DistinctValues="5.872500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vb//w==" DoubleValue="-199929600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vb//w==" LintValue="-2314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPf//w==" DoubleValue="-194918400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPf//w==" LintValue="-2256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPf//w==" DoubleValue="-194918400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvf//w==" DoubleValue="-193017600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPf//w==" LintValue="-2256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvf//w==" LintValue="-2234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvf//w==" DoubleValue="-193017600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvf//w==" LintValue="-2234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001421" DistinctValues="2.276667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPf//w==" DoubleValue="-190425600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPf//w==" LintValue="-2204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPf//w==" DoubleValue="-190425600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPf//w==" DoubleValue="-190425600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPf//w==" LintValue="-2204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPf//w==" LintValue="-2204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005329" DistinctValues="8.537500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPf//w==" DoubleValue="-190425600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPf//w==" LintValue="-2204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001421" DistinctValues="2.276667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000355" DistinctValues="0.569167">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002436" DistinctValues="4.474286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006090" DistinctValues="11.185714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvf//w==" DoubleValue="-187488000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvf//w==" LintValue="-2170"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001066" DistinctValues="1.832500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvf//w==" DoubleValue="-187488000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvf//w==" LintValue="-2170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003730" DistinctValues="6.413750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/f//w==" DoubleValue="-186710400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="j/f//w==" LintValue="-2161"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/f//w==" DoubleValue="-186710400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/f//w==" DoubleValue="-186710400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="j/f//w==" LintValue="-2161"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="j/f//w==" LintValue="-2161"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003730" DistinctValues="6.413750">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/f//w==" DoubleValue="-186710400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvf//w==" DoubleValue="-186105600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="j/f//w==" LintValue="-2161"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvf//w==" LintValue="-2154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000426" DistinctValues="0.683000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvf//w==" DoubleValue="-186105600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvf//w==" LintValue="-2154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001279" DistinctValues="2.049000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" DoubleValue="-186019200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/f//w==" LintValue="-2153"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000853" DistinctValues="1.366000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPf//w==" DoubleValue="-185587200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPf//w==" LintValue="-2148"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPf//w==" DoubleValue="-185587200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPf//w==" DoubleValue="-185587200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPf//w==" LintValue="-2148"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPf//w==" LintValue="-2148"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005968" DistinctValues="9.562000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPf//w==" DoubleValue="-185587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvf//w==" DoubleValue="-184377600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPf//w==" LintValue="-2148"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvf//w==" LintValue="-2134"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002368" DistinctValues="4.350000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvf//w==" DoubleValue="-184377600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/f//w==" DoubleValue="-183945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvf//w==" LintValue="-2134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/f//w==" LintValue="-2129"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/f//w==" DoubleValue="-183945600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/f//w==" DoubleValue="-183945600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/f//w==" LintValue="-2129"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/f//w==" LintValue="-2129"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006158" DistinctValues="11.310000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/f//w==" DoubleValue="-183945600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/f//w==" LintValue="-2129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0ff//w==" DoubleValue="-181008000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0ff//w==" LintValue="-2095"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0ff//w==" DoubleValue="-181008000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0ff//w==" LintValue="-2095"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002842" DistinctValues="4.886667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfj//w==" DoubleValue="-176169600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfj//w==" LintValue="-2039"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfj//w==" DoubleValue="-176169600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfj//w==" DoubleValue="-176169600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfj//w==" LintValue="-2039"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfj//w==" LintValue="-2039"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004547" DistinctValues="7.818667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfj//w==" DoubleValue="-176169600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfj//w==" LintValue="-2039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001137" DistinctValues="1.954667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/j//w==" DoubleValue="-175305600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/j//w==" LintValue="-2029"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006902" DistinctValues="12.677143">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/j//w==" DoubleValue="-175305600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/j//w==" LintValue="-2029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001624" DistinctValues="2.982857">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPj//w==" DoubleValue="-173491200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPj//w==" LintValue="-2008"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000947" DistinctValues="1.740000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPj//w==" DoubleValue="-173491200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPj//w==" LintValue="-2008"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007579" DistinctValues="13.920000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" DoubleValue="-173232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/j//w==" DoubleValue="-171158400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/j//w==" LintValue="-2005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/j//w==" LintValue="-1981"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000449" DistinctValues="0.718947">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/j//w==" DoubleValue="-171158400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPj//w==" DoubleValue="-171072000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/j//w==" LintValue="-1981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPj//w==" LintValue="-1980"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPj//w==" DoubleValue="-171072000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPj//w==" DoubleValue="-171072000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPj//w==" LintValue="-1980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RPj//w==" LintValue="-1980"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000449" DistinctValues="0.718947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPj//w==" DoubleValue="-171072000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfj//w==" DoubleValue="-170985600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="RPj//w==" LintValue="-1980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfj//w==" LintValue="-1979"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfj//w==" DoubleValue="-170985600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfj//w==" DoubleValue="-170985600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfj//w==" LintValue="-1979"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfj//w==" LintValue="-1979"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007180" DistinctValues="11.503158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfj//w==" DoubleValue="-170985600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfj//w==" LintValue="-1979"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000449" DistinctValues="0.718947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvj//w==" DoubleValue="-169516800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvj//w==" LintValue="-1962"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvj//w==" DoubleValue="-169516800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bfj//w==" DoubleValue="-167529600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvj//w==" LintValue="-1962"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bfj//w==" LintValue="-1939"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bfj//w==" DoubleValue="-167529600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bfj//w==" LintValue="-1939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001640" DistinctValues="2.819231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001968" DistinctValues="3.383077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002345" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004919" DistinctValues="8.457692">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" DoubleValue="-163296000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfj//w==" DoubleValue="-162000000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nvj//w==" LintValue="-1890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfj//w==" LintValue="-1875"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003751" DistinctValues="6.890400">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfj//w==" DoubleValue="-162000000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPj//w==" DoubleValue="-161049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfj//w==" LintValue="-1875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPj//w==" LintValue="-1864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPj//w==" DoubleValue="-161049600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPj//w==" DoubleValue="-161049600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPj//w==" LintValue="-1864"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPj//w==" LintValue="-1864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004775" DistinctValues="8.769600">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPj//w==" DoubleValue="-161049600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvj//w==" DoubleValue="-159840000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPj//w==" LintValue="-1864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvj//w==" LintValue="-1850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004737" DistinctValues="8.700000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvj//w==" DoubleValue="-159840000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvj//w==" LintValue="-1850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003789" DistinctValues="6.960000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007503" DistinctValues="13.780800">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APn//w==" DoubleValue="-154828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APn//w==" LintValue="-1792"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APn//w==" DoubleValue="-154828800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APn//w==" DoubleValue="-154828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APn//w==" LintValue="-1792"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APn//w==" LintValue="-1792"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001023" DistinctValues="1.879200">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="APn//w==" DoubleValue="-154828800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="APn//w==" LintValue="-1792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005038" DistinctValues="9.253636">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPn//w==" DoubleValue="-153446400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPn//w==" LintValue="-1776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPn//w==" DoubleValue="-153446400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPn//w==" DoubleValue="-153446400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPn//w==" LintValue="-1776"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPn//w==" LintValue="-1776"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003488" DistinctValues="6.406364">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPn//w==" DoubleValue="-153446400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfn//w==" DoubleValue="-152668800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPn//w==" LintValue="-1776"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfn//w==" LintValue="-1767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001795" DistinctValues="3.086316">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfn//w==" DoubleValue="-152668800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfn//w==" DoubleValue="-152323200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfn//w==" LintValue="-1767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfn//w==" LintValue="-1763"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfn//w==" DoubleValue="-152323200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfn//w==" DoubleValue="-152323200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfn//w==" LintValue="-1763"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfn//w==" LintValue="-1763"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005834" DistinctValues="10.030526">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfn//w==" DoubleValue="-152323200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfn//w==" LintValue="-1763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.543158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" DoubleValue="-151200000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPn//w==" DoubleValue="-151027200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kvn//w==" LintValue="-1750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPn//w==" LintValue="-1748"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPn//w==" DoubleValue="-151027200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPn//w==" DoubleValue="-147916800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPn//w==" LintValue="-1748"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPn//w==" LintValue="-1712"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004831" DistinctValues="8.874000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPn//w==" DoubleValue="-147916800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPn//w==" LintValue="-1712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003695" DistinctValues="6.786000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvn//w==" DoubleValue="-145324800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvn//w==" LintValue="-1682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004263" DistinctValues="7.830000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvn//w==" DoubleValue="-145324800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvn//w==" LintValue="-1682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004263" DistinctValues="7.830000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" DoubleValue="-143942400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvn//w==" DoubleValue="-142560000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvn//w==" LintValue="-1666"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvn//w==" LintValue="-1650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvn//w==" DoubleValue="-142560000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvn//w==" LintValue="-1650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002131" DistinctValues="3.665000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvn//w==" DoubleValue="-140486400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvn//w==" LintValue="-1626"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvn//w==" DoubleValue="-140486400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pvn//w==" DoubleValue="-140486400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvn//w==" LintValue="-1626"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="pvn//w==" LintValue="-1626"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003197" DistinctValues="5.497500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pvn//w==" DoubleValue="-140486400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="pvn//w==" LintValue="-1626"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003197" DistinctValues="5.497500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007673" DistinctValues="14.094000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000853" DistinctValues="1.566000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" DoubleValue="-137376000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvn//w==" LintValue="-1590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" DoubleValue="-137203200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fn//w==" DoubleValue="-135734400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zPn//w==" LintValue="-1588"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fn//w==" LintValue="-1571"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fn//w==" DoubleValue="-135734400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fn//w==" DoubleValue="-133660800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fn//w==" LintValue="-1571"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fn//w==" LintValue="-1547"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fn//w==" DoubleValue="-133660800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfr//w==" DoubleValue="-131932800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fn//w==" LintValue="-1547"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfr//w==" LintValue="-1527"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001163" DistinctValues="1.726364">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfr//w==" DoubleValue="-131932800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfr//w==" LintValue="-1527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000775" DistinctValues="1.150909">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000775" DistinctValues="1.150909">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003100" DistinctValues="4.603636">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" DoubleValue="-131328000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="EPr//w==" LintValue="-1520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002713" DistinctValues="4.028182">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001218" DistinctValues="2.094286">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000609" DistinctValues="1.047143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivr//w==" DoubleValue="-129772800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivr//w==" LintValue="-1502"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivr//w==" DoubleValue="-129772800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivr//w==" DoubleValue="-129772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivr//w==" LintValue="-1502"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivr//w==" LintValue="-1502"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006699" DistinctValues="11.518571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivr//w==" DoubleValue="-129772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivr//w==" LintValue="-1502"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003552" DistinctValues="5.691667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001421" DistinctValues="2.276667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" DoubleValue="-127958400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/r//w==" LintValue="-1481"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002842" DistinctValues="4.553333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" DoubleValue="-127612800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/r//w==" DoubleValue="-126921600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/r//w==" LintValue="-1477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/r//w==" LintValue="-1469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/r//w==" DoubleValue="-126921600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/r//w==" DoubleValue="-126921600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/r//w==" LintValue="-1469"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/r//w==" LintValue="-1469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.138333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/r//w==" DoubleValue="-126921600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfr//w==" DoubleValue="-126748800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/r//w==" LintValue="-1469"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfr//w==" LintValue="-1467"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfr//w==" DoubleValue="-126748800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfr//w==" LintValue="-1467"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/r//w==" DoubleValue="-122428800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/r//w==" LintValue="-1417"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/r//w==" DoubleValue="-122428800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/r//w==" DoubleValue="-120700800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/r//w==" LintValue="-1417"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/r//w==" LintValue="-1397"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001483" DistinctValues="2.549565">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/r//w==" DoubleValue="-120700800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/r//w==" DoubleValue="-120009600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/r//w==" LintValue="-1397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/r//w==" LintValue="-1389"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/r//w==" DoubleValue="-120009600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/r//w==" DoubleValue="-120009600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/r//w==" LintValue="-1389"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="k/r//w==" LintValue="-1389"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000185" DistinctValues="0.318696">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/r//w==" DoubleValue="-120009600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPr//w==" DoubleValue="-119923200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="k/r//w==" LintValue="-1389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPr//w==" LintValue="-1388"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPr//w==" DoubleValue="-119923200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPr//w==" DoubleValue="-119923200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPr//w==" LintValue="-1388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPr//w==" LintValue="-1388"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006858" DistinctValues="11.791739">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPr//w==" DoubleValue="-119923200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufr//w==" DoubleValue="-116726400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPr//w==" LintValue="-1388"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufr//w==" LintValue="-1351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007870" DistinctValues="14.455385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufr//w==" DoubleValue="-116726400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufr//w==" LintValue="-1351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000656" DistinctValues="1.204615">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005931" DistinctValues="10.198261">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000741" DistinctValues="1.274783">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fr//w==" DoubleValue="-112924800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fr//w==" LintValue="-1307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fr//w==" DoubleValue="-112924800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fr//w==" DoubleValue="-112924800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fr//w==" LintValue="-1307"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fr//w==" LintValue="-1307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001853" DistinctValues="3.186957">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fr//w==" DoubleValue="-112924800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vr//w==" DoubleValue="-112492800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fr//w==" LintValue="-1307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vr//w==" LintValue="-1302"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vr//w==" DoubleValue="-112492800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvv//w==" DoubleValue="-109728000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vr//w==" LintValue="-1302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvv//w==" LintValue="-1270"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004819" DistinctValues="8.286087">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvv//w==" DoubleValue="-109728000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/v//w==" DoubleValue="-108604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvv//w==" LintValue="-1270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/v//w==" LintValue="-1257"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/v//w==" DoubleValue="-108604800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/v//w==" DoubleValue="-108604800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/v//w==" LintValue="-1257"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/v//w==" LintValue="-1257"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000371" DistinctValues="0.637391">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/v//w==" DoubleValue="-108604800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/v//w==" LintValue="-1257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003336" DistinctValues="5.736522">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifv//w==" DoubleValue="-107740800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifv//w==" LintValue="-1247"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifv//w==" DoubleValue="-107740800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvv//w==" DoubleValue="-104889600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifv//w==" LintValue="-1247"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvv//w==" LintValue="-1214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvv//w==" DoubleValue="-104889600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPv//w==" DoubleValue="-102297600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvv//w==" LintValue="-1214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPv//w==" LintValue="-1184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008052" DistinctValues="14.790000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPv//w==" DoubleValue="-102297600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfv//w==" DoubleValue="-100828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPv//w==" LintValue="-1184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfv//w==" LintValue="-1167"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfv//w==" DoubleValue="-100828800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cfv//w==" DoubleValue="-100828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfv//w==" LintValue="-1167"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cfv//w==" LintValue="-1167"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000474" DistinctValues="0.870000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cfv//w==" DoubleValue="-100828800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvv//w==" DoubleValue="-100742400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cfv//w==" LintValue="-1167"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvv//w==" LintValue="-1166"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005385" DistinctValues="9.258947">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvv//w==" DoubleValue="-100742400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvv//w==" DoubleValue="-99705600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvv//w==" LintValue="-1166"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvv//w==" LintValue="-1154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvv//w==" DoubleValue="-99705600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvv//w==" DoubleValue="-99705600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvv//w==" LintValue="-1154"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvv//w==" LintValue="-1154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000897" DistinctValues="1.543158">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvv//w==" DoubleValue="-99705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPv//w==" DoubleValue="-99532800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvv//w==" LintValue="-1154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPv//w==" LintValue="-1152"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPv//w==" DoubleValue="-99532800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPv//w==" DoubleValue="-99532800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPv//w==" LintValue="-1152"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPv//w==" LintValue="-1152"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002244" DistinctValues="3.857895">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPv//w==" DoubleValue="-99532800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfv//w==" DoubleValue="-99100800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPv//w==" LintValue="-1152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfv//w==" LintValue="-1147"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001279" DistinctValues="2.349000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfv//w==" DoubleValue="-99100800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfv//w==" LintValue="-1147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007247" DistinctValues="13.311000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" DoubleValue="-98841600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfv//w==" DoubleValue="-97372800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="iPv//w==" LintValue="-1144"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mfv//w==" LintValue="-1127"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000853" DistinctValues="1.566000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfv//w==" DoubleValue="-97372800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfv//w==" LintValue="-1127"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007673" DistinctValues="14.094000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfv//w==" DoubleValue="-95644800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfv//w==" LintValue="-1107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002046" DistinctValues="3.758400">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfv//w==" DoubleValue="-95644800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/v//w==" DoubleValue="-95126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfv//w==" LintValue="-1107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/v//w==" LintValue="-1101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002010" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/v//w==" DoubleValue="-95126400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="s/v//w==" DoubleValue="-95126400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/v//w==" LintValue="-1101"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="s/v//w==" LintValue="-1101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006480" DistinctValues="11.901600">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="s/v//w==" DoubleValue="-95126400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvv//w==" DoubleValue="-93484800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="s/v//w==" LintValue="-1101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvv//w==" LintValue="-1082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005176" DistinctValues="8.293571">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvv//w==" DoubleValue="-93484800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/v//w==" DoubleValue="-92016000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvv//w==" LintValue="-1082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/v//w==" LintValue="-1065"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/v//w==" DoubleValue="-92016000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1/v//w==" DoubleValue="-92016000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/v//w==" LintValue="-1065"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1/v//w==" LintValue="-1065"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000609" DistinctValues="0.975714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1/v//w==" DoubleValue="-92016000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fv//w==" DoubleValue="-91843200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1/v//w==" LintValue="-1065"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fv//w==" LintValue="-1063"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fv//w==" DoubleValue="-91843200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2fv//w==" DoubleValue="-91843200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fv//w==" LintValue="-1063"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2fv//w==" LintValue="-1063"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002131" DistinctValues="3.415000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2fv//w==" DoubleValue="-91843200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pv//w==" DoubleValue="-91238400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2fv//w==" LintValue="-1063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pv//w==" LintValue="-1056"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pv//w==" DoubleValue="-91238400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pv//w==" DoubleValue="-91238400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pv//w==" LintValue="-1056"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pv//w==" LintValue="-1056"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000609" DistinctValues="0.975714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pv//w==" DoubleValue="-91238400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vv//w==" DoubleValue="-91065600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pv//w==" LintValue="-1056"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vv//w==" LintValue="-1054"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001505" DistinctValues="2.587059">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vv//w==" DoubleValue="-91065600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fv//w==" DoubleValue="-90806400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vv//w==" LintValue="-1054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fv//w==" LintValue="-1051"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fv//w==" DoubleValue="-90806400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fv//w==" DoubleValue="-90806400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fv//w==" LintValue="-1051"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5fv//w==" LintValue="-1051"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002508" DistinctValues="4.311765">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fv//w==" DoubleValue="-90806400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5fv//w==" LintValue="-1051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004514" DistinctValues="7.761176">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" DoubleValue="-90374400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6vv//w==" LintValue="-1046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000947" DistinctValues="1.517778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002210" DistinctValues="3.541481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fv//w==" DoubleValue="-88732800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fv//w==" LintValue="-1027"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fv//w==" DoubleValue="-88732800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fv//w==" DoubleValue="-88732800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fv//w==" LintValue="-1027"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fv//w==" LintValue="-1027"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003158" DistinctValues="5.059259">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fv//w==" DoubleValue="-88732800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fv//w==" LintValue="-1027"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002210" DistinctValues="3.541481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" DoubleValue="-87868800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B/z//w==" LintValue="-1017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" DoubleValue="-87264000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvz//w==" LintValue="-1010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPz//w==" DoubleValue="-83635200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPz//w==" LintValue="-968"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPz//w==" DoubleValue="-83635200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPz//w==" LintValue="-968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005785" DistinctValues="10.626429">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfz//w==" DoubleValue="-78364800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dfz//w==" LintValue="-907"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfz//w==" DoubleValue="-78364800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dfz//w==" DoubleValue="-78364800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dfz//w==" LintValue="-907"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dfz//w==" LintValue="-907"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002740" DistinctValues="5.033571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dfz//w==" DoubleValue="-78364800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvz//w==" DoubleValue="-77587200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dfz//w==" LintValue="-907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvz//w==" LintValue="-898"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvz//w==" DoubleValue="-77587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvz//w==" LintValue="-898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004689" DistinctValues="8.613000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPz//w==" DoubleValue="-74649600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPz//w==" LintValue="-864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPz//w==" DoubleValue="-74649600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPz//w==" DoubleValue="-74649600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPz//w==" LintValue="-864"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPz//w==" LintValue="-864"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003837" DistinctValues="7.047000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPz//w==" DoubleValue="-74649600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfz//w==" DoubleValue="-73872000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPz//w==" LintValue="-864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qfz//w==" LintValue="-855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfz//w==" DoubleValue="-73872000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qfz//w==" LintValue="-855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pz//w==" DoubleValue="-69120000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pz//w==" LintValue="-800"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007308" DistinctValues="13.422857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pz//w==" DoubleValue="-69120000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vz//w==" DoubleValue="-66528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pz//w==" LintValue="-800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vz//w==" LintValue="-770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vz//w==" DoubleValue="-66528000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/vz//w==" DoubleValue="-66528000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vz//w==" LintValue="-770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/vz//w==" LintValue="-770"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001218" DistinctValues="2.237143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/vz//w==" DoubleValue="-66528000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/3//w==" DoubleValue="-66096000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/vz//w==" LintValue="-770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/3//w==" LintValue="-765"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/3//w==" DoubleValue="-66096000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gf3//w==" DoubleValue="-64195200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/3//w==" LintValue="-765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gf3//w==" LintValue="-743"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005329" DistinctValues="9.162500">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gf3//w==" DoubleValue="-64195200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KP3//w==" DoubleValue="-62899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gf3//w==" LintValue="-743"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KP3//w==" LintValue="-728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KP3//w==" DoubleValue="-62899200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KP3//w==" DoubleValue="-62899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KP3//w==" LintValue="-728"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KP3//w==" LintValue="-728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001066" DistinctValues="1.832500">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KP3//w==" DoubleValue="-62899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/3//w==" DoubleValue="-62640000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="KP3//w==" LintValue="-728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/3//w==" LintValue="-725"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/3//w==" DoubleValue="-62640000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/3//w==" DoubleValue="-62640000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/3//w==" LintValue="-725"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/3//w==" LintValue="-725"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002131" DistinctValues="3.665000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/3//w==" DoubleValue="-62640000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/3//w==" LintValue="-725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002224" DistinctValues="3.563478">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" DoubleValue="-62121600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/3//w==" DoubleValue="-61603200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mf3//w==" LintValue="-719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/3//w==" LintValue="-713"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/3//w==" DoubleValue="-61603200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/3//w==" DoubleValue="-61603200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/3//w==" LintValue="-713"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/3//w==" LintValue="-713"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001112" DistinctValues="1.781739">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/3//w==" DoubleValue="-61603200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ov3//w==" DoubleValue="-61344000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/3//w==" LintValue="-713"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ov3//w==" LintValue="-710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ov3//w==" DoubleValue="-61344000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ov3//w==" DoubleValue="-61344000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ov3//w==" LintValue="-710"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ov3//w==" LintValue="-710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004819" DistinctValues="7.720870">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ov3//w==" DoubleValue="-61344000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/3//w==" DoubleValue="-60220800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ov3//w==" LintValue="-710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/3//w==" LintValue="-697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/3//w==" DoubleValue="-60220800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/3//w==" DoubleValue="-60220800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/3//w==" LintValue="-697"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/3//w==" LintValue="-697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000371" DistinctValues="0.593913">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/3//w==" DoubleValue="-60220800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SP3//w==" DoubleValue="-60134400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/3//w==" LintValue="-697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SP3//w==" LintValue="-696"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SP3//w==" DoubleValue="-60134400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bf3//w==" DoubleValue="-56937600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SP3//w==" LintValue="-696"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bf3//w==" LintValue="-659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bf3//w==" DoubleValue="-56937600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/3//w==" DoubleValue="-55382400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bf3//w==" LintValue="-659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/3//w==" LintValue="-641"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/3//w==" DoubleValue="-55382400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/3//w==" LintValue="-641"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007194" DistinctValues="12.369375">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" DoubleValue="-53827200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rP3//w==" DoubleValue="-51494400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kf3//w==" LintValue="-623"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rP3//w==" LintValue="-596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rP3//w==" DoubleValue="-51494400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rP3//w==" DoubleValue="-51494400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rP3//w==" LintValue="-596"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rP3//w==" LintValue="-596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000533" DistinctValues="0.916250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rP3//w==" DoubleValue="-51494400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rv3//w==" DoubleValue="-51321600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rP3//w==" LintValue="-596"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rv3//w==" LintValue="-594"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rv3//w==" DoubleValue="-51321600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rv3//w==" DoubleValue="-51321600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rv3//w==" LintValue="-594"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rv3//w==" LintValue="-594"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000799" DistinctValues="1.374375">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rv3//w==" DoubleValue="-51321600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sf3//w==" DoubleValue="-51062400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rv3//w==" LintValue="-594"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sf3//w==" LintValue="-591"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sf3//w==" DoubleValue="-51062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wv3//w==" DoubleValue="-49593600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sf3//w==" LintValue="-591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wv3//w==" LintValue="-574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wv3//w==" DoubleValue="-49593600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wv3//w==" LintValue="-574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003234" DistinctValues="5.181379">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3P3//w==" DoubleValue="-47347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3P3//w==" LintValue="-548"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3P3//w==" DoubleValue="-47347200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3P3//w==" DoubleValue="-47347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3P3//w==" LintValue="-548"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3P3//w==" LintValue="-548"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001764" DistinctValues="2.826207">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3P3//w==" DoubleValue="-47347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3P3//w==" LintValue="-548"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001675" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001470" DistinctValues="2.355172">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/3//w==" DoubleValue="-46396800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/3//w==" LintValue="-537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001340" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/3//w==" DoubleValue="-46396800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/3//w==" DoubleValue="-46396800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/3//w==" LintValue="-537"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/3//w==" LintValue="-537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002058" DistinctValues="3.297241">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/3//w==" DoubleValue="-46396800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/3//w==" LintValue="-537"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CP7//w==" DoubleValue="-43545600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CP7//w==" LintValue="-504"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CP7//w==" DoubleValue="-43545600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv7//w==" DoubleValue="-40953600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CP7//w==" LintValue="-504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv7//w==" LintValue="-474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008526" DistinctValues="16.660000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv7//w==" DoubleValue="-40953600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv7//w==" LintValue="-474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.31256.1.0.2" Name="l_suppkey" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -310,7 +310,7 @@
               </dxl:Cast>
               <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAD3l5eXktbW1tLWRk" LintValue="2057460884"/>
             </dxl:FuncExpr>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" DoubleValue="623203200000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" LintValue="7213"/>
           </dxl:Comparison>
         </dxl:And>
         <dxl:LogicalJoin JoinType="Left">
@@ -478,7 +478,7 @@
                     </dxl:Cast>
                     <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAD3l5eXktbW1tLWRk" LintValue="2057460884"/>
                   </dxl:FuncExpr>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" DoubleValue="623203200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" LintValue="7213"/>
                 </dxl:Comparison>
               </dxl:And>
             </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -313,7 +313,7 @@
                 </dxl:Cast>
                 <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAD3l5eXktbW1tLWRk" LintValue="2057460884"/>
               </dxl:FuncExpr>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" DoubleValue="623203200000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" LintValue="7213"/>
             </dxl:Comparison>
           </dxl:And>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
@@ -482,7 +482,7 @@
                       </dxl:Cast>
                       <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAD3l5eXktbW1tLWRk" LintValue="2057460884"/>
                     </dxl:FuncExpr>
-                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" DoubleValue="623203200000000.000000"/>
+                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="LRwAAA==" LintValue="7213"/>
                   </dxl:Comparison>
                 </dxl:And>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -9385,34 +9385,34 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17281181.1.1.3" Name="s_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.666001" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17281181.1.1.2" Name="s_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.499500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.15668460.1.1.27" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -11453,34 +11453,34 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17281135.1.1.3" Name="i_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.666005" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" DoubleValue="-5702400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vv///w==" LintValue="-66"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166501" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" DoubleValue="25833600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="KwEAAA==" LintValue="299"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166501" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" DoubleValue="57369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mAIAAA==" LintValue="664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17281135.1.1.2" Name="i_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.499504" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" DoubleValue="-68774400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pz//w==" LintValue="-796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166501" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" DoubleValue="-5616000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v////w==" LintValue="-65"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166501" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" DoubleValue="25920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="LAEAAA==" LintValue="300"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166501" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" LintValue="665"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
     </dxl:Metadata>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-1.mdp
@@ -2078,7 +2078,7 @@
         <dxl:LogicalSelect>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
             <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
           </dxl:Comparison>
           <dxl:UnionAll InputColumns="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,33;397,398,399,400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,419,420,421,422,423,424,425,429" CastAcrossInputs="false">
             <dxl:Columns>
@@ -3281,7 +3281,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3295,7 +3295,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3320,7 +3320,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17347476.1.1" TableName="mr_star1_cashflows_col_part" ExecuteAsUser="10">
@@ -3403,7 +3403,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3417,7 +3417,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3442,7 +3442,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17355788.1.1" TableName="mr_star1_decorrelation_col_part" ExecuteAsUser="10">
@@ -3525,7 +3525,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3539,7 +3539,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3564,7 +3564,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17364111.1.1" TableName="mr_star1_deltas_col_part" ExecuteAsUser="10">
@@ -3647,7 +3647,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3661,7 +3661,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3686,7 +3686,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17384494.1.1" TableName="mr_star1_fxdeltas_col_part" ExecuteAsUser="10">
@@ -3769,7 +3769,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3783,7 +3783,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3808,7 +3808,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17392806.1.1" TableName="mr_star1_gammas_col_part" ExecuteAsUser="10">
@@ -3891,7 +3891,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3905,7 +3905,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3930,7 +3930,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17413178.1.1" TableName="mr_star1_kappa_col_part" ExecuteAsUser="10">
@@ -4013,7 +4013,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4027,7 +4027,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4052,7 +4052,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17421490.1.1" TableName="mr_star1_netexposure_col_part" ExecuteAsUser="10">
@@ -4135,7 +4135,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4149,7 +4149,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4174,7 +4174,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17429813.1.1" TableName="mr_star1_position_col_part" ExecuteAsUser="10">
@@ -4257,7 +4257,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4271,7 +4271,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4296,7 +4296,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17438125.1.1" TableName="mr_star1_seasonality_col_part" ExecuteAsUser="10">
@@ -4379,7 +4379,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4393,7 +4393,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4418,7 +4418,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17446437.1.1" TableName="mr_star1_skew_col_part" ExecuteAsUser="10">
@@ -4501,7 +4501,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4515,7 +4515,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4540,7 +4540,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17454760.1.1" TableName="mr_star1_theta_col_part" ExecuteAsUser="10">
@@ -4623,7 +4623,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4637,7 +4637,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4662,7 +4662,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17463072.1.1" TableName="mr_star1_voldrip_col_part" ExecuteAsUser="10">
@@ -4745,7 +4745,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4759,7 +4759,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4784,7 +4784,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17471384.1.1" TableName="mr_star1_volofvol_col_part" ExecuteAsUser="10">

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -2078,7 +2078,7 @@
         <dxl:LogicalSelect>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
             <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
           </dxl:Comparison>
           <dxl:UnionAll InputColumns="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,33;397,398,399,400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,419,420,421,422,423,424,425,429" CastAcrossInputs="false">
             <dxl:Columns>
@@ -3281,7 +3281,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3295,7 +3295,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3320,7 +3320,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17347476.1.1" TableName="mr_star1_cashflows_col_part">
@@ -3403,7 +3403,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3417,7 +3417,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3442,7 +3442,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17355788.1.1" TableName="mr_star1_decorrelation_col_part">
@@ -3525,7 +3525,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3539,7 +3539,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3564,7 +3564,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17364111.1.1" TableName="mr_star1_deltas_col_part">
@@ -3647,7 +3647,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3661,7 +3661,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3686,7 +3686,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17384494.1.1" TableName="mr_star1_fxdeltas_col_part">
@@ -3769,7 +3769,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3783,7 +3783,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3808,7 +3808,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17392806.1.1" TableName="mr_star1_gammas_col_part">
@@ -3891,7 +3891,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3905,7 +3905,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -3930,7 +3930,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17413178.1.1" TableName="mr_star1_kappa_col_part">
@@ -4013,7 +4013,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4027,7 +4027,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4052,7 +4052,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17421490.1.1" TableName="mr_star1_netexposure_col_part">
@@ -4135,7 +4135,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4149,7 +4149,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4174,7 +4174,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17429813.1.1" TableName="mr_star1_position_col_part">
@@ -4257,7 +4257,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4271,7 +4271,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4296,7 +4296,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17438125.1.1" TableName="mr_star1_seasonality_col_part">
@@ -4379,7 +4379,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4393,7 +4393,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4418,7 +4418,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17446437.1.1" TableName="mr_star1_skew_col_part">
@@ -4501,7 +4501,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4515,7 +4515,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4540,7 +4540,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17454760.1.1" TableName="mr_star1_theta_col_part">
@@ -4623,7 +4623,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4637,7 +4637,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4662,7 +4662,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17463072.1.1" TableName="mr_star1_voldrip_col_part">
@@ -4745,7 +4745,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4759,7 +4759,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -4784,7 +4784,7 @@
                             <dxl:Filter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" DoubleValue="458006400000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="tRQAAA==" LintValue="5301"/>
                               </dxl:Comparison>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.17471384.1.1" TableName="mr_star1_volofvol_col_part">

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-4.mdp
@@ -2084,7 +2084,7 @@
                                 <dxl:LogicalSelect>
                                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                     <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                   </dxl:Comparison>
                                   <dxl:LogicalGet>
                                     <dxl:TableDescriptor Mdid="0.17347476.1.1" TableName="mr_star1_cashflows_col_part" ExecuteAsUser="10">
@@ -2141,7 +2141,7 @@
                                 <dxl:LogicalSelect>
                                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                     <dxl:Ident ColId="36" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                   </dxl:Comparison>
                                   <dxl:LogicalGet>
                                     <dxl:TableDescriptor Mdid="0.17355788.1.1" TableName="mr_star1_decorrelation_col_part" ExecuteAsUser="10">
@@ -2199,7 +2199,7 @@
                               <dxl:LogicalSelect>
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                   <dxl:Ident ColId="69" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                 </dxl:Comparison>
                                 <dxl:LogicalGet>
                                   <dxl:TableDescriptor Mdid="0.17364111.1.1" TableName="mr_star1_deltas_col_part" ExecuteAsUser="10">
@@ -2257,7 +2257,7 @@
                             <dxl:LogicalSelect>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="102" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                               <dxl:LogicalGet>
                                 <dxl:TableDescriptor Mdid="0.17384494.1.1" TableName="mr_star1_fxdeltas_col_part" ExecuteAsUser="10">
@@ -2315,7 +2315,7 @@
                           <dxl:LogicalSelect>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="135" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                             <dxl:LogicalGet>
                               <dxl:TableDescriptor Mdid="0.17392806.1.1" TableName="mr_star1_gammas_col_part" ExecuteAsUser="10">
@@ -2373,7 +2373,7 @@
                         <dxl:LogicalSelect>
                           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                             <dxl:Ident ColId="168" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:Comparison>
                           <dxl:LogicalGet>
                             <dxl:TableDescriptor Mdid="0.17413178.1.1" TableName="mr_star1_kappa_col_part" ExecuteAsUser="10">
@@ -2431,7 +2431,7 @@
                       <dxl:LogicalSelect>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                           <dxl:Ident ColId="201" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                         </dxl:Comparison>
                         <dxl:LogicalGet>
                           <dxl:TableDescriptor Mdid="0.17421490.1.1" TableName="mr_star1_netexposure_col_part" ExecuteAsUser="10">
@@ -2489,7 +2489,7 @@
                     <dxl:LogicalSelect>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                         <dxl:Ident ColId="234" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                       </dxl:Comparison>
                       <dxl:LogicalGet>
                         <dxl:TableDescriptor Mdid="0.17429813.1.1" TableName="mr_star1_position_col_part" ExecuteAsUser="10">
@@ -2547,7 +2547,7 @@
                   <dxl:LogicalSelect>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                       <dxl:Ident ColId="267" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                      <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                     </dxl:Comparison>
                     <dxl:LogicalGet>
                       <dxl:TableDescriptor Mdid="0.17438125.1.1" TableName="mr_star1_seasonality_col_part" ExecuteAsUser="10">
@@ -2605,7 +2605,7 @@
                 <dxl:LogicalSelect>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                     <dxl:Ident ColId="300" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                   </dxl:Comparison>
                   <dxl:LogicalGet>
                     <dxl:TableDescriptor Mdid="0.17446437.1.1" TableName="mr_star1_skew_col_part" ExecuteAsUser="10">
@@ -2663,7 +2663,7 @@
               <dxl:LogicalSelect>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="333" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                 </dxl:Comparison>
                 <dxl:LogicalGet>
                   <dxl:TableDescriptor Mdid="0.17454760.1.1" TableName="mr_star1_theta_col_part" ExecuteAsUser="10">
@@ -2721,7 +2721,7 @@
             <dxl:LogicalSelect>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="366" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
               </dxl:Comparison>
               <dxl:LogicalGet>
                 <dxl:TableDescriptor Mdid="0.17463072.1.1" TableName="mr_star1_voldrip_col_part" ExecuteAsUser="10">
@@ -2779,7 +2779,7 @@
           <dxl:LogicalSelect>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
               <dxl:Ident ColId="399" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
             </dxl:Comparison>
             <dxl:LogicalGet>
               <dxl:TableDescriptor Mdid="0.17471384.1.1" TableName="mr_star1_volofvol_col_part" ExecuteAsUser="10">
@@ -3014,7 +3014,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3028,7 +3028,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -3053,7 +3053,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17347476.1.1" TableName="mr_star1_cashflows_col_part" ExecuteAsUser="10">
@@ -3235,7 +3235,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3249,7 +3249,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -3274,7 +3274,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17355788.1.1" TableName="mr_star1_decorrelation_col_part" ExecuteAsUser="10">
@@ -3456,7 +3456,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3470,7 +3470,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -3495,7 +3495,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17364111.1.1" TableName="mr_star1_deltas_col_part" ExecuteAsUser="10">
@@ -3677,7 +3677,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3691,7 +3691,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -3716,7 +3716,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="101" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17384494.1.1" TableName="mr_star1_fxdeltas_col_part" ExecuteAsUser="10">
@@ -3898,7 +3898,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -3912,7 +3912,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -3937,7 +3937,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="134" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17392806.1.1" TableName="mr_star1_gammas_col_part" ExecuteAsUser="10">
@@ -4119,7 +4119,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4133,7 +4133,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -4158,7 +4158,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="167" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17413178.1.1" TableName="mr_star1_kappa_col_part" ExecuteAsUser="10">
@@ -4340,7 +4340,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4354,7 +4354,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -4379,7 +4379,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="200" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17421490.1.1" TableName="mr_star1_netexposure_col_part" ExecuteAsUser="10">
@@ -4561,7 +4561,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4575,7 +4575,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -4600,7 +4600,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="233" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17429813.1.1" TableName="mr_star1_position_col_part" ExecuteAsUser="10">
@@ -4782,7 +4782,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -4796,7 +4796,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -4821,7 +4821,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="266" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17438125.1.1" TableName="mr_star1_seasonality_col_part" ExecuteAsUser="10">
@@ -5003,7 +5003,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5017,7 +5017,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -5042,7 +5042,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="299" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17446437.1.1" TableName="mr_star1_skew_col_part" ExecuteAsUser="10">
@@ -5224,7 +5224,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5238,7 +5238,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -5263,7 +5263,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="332" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17454760.1.1" TableName="mr_star1_theta_col_part" ExecuteAsUser="10">
@@ -5445,7 +5445,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5459,7 +5459,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -5484,7 +5484,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="365" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17463072.1.1" TableName="mr_star1_voldrip_col_part" ExecuteAsUser="10">
@@ -5666,7 +5666,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -5680,7 +5680,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -5705,7 +5705,7 @@
                           <dxl:Filter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="398" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:Filter>
                           <dxl:TableDescriptor Mdid="0.17471384.1.1" TableName="mr_star1_volofvol_col_part" ExecuteAsUser="10">

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -639,7 +639,7 @@
             </dxl:IsNotNull>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
               <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
             </dxl:Comparison>
           </dxl:And>
           <dxl:UnionAll InputColumns="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,33;67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,99" CastAcrossInputs="false">
@@ -1056,7 +1056,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1070,7 +1070,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -1109,7 +1109,7 @@
                                 </dxl:Not>
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                   <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                 </dxl:Comparison>
                               </dxl:And>
                             </dxl:Filter>
@@ -1196,7 +1196,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1210,7 +1210,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -1249,7 +1249,7 @@
                                 </dxl:Not>
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                   <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                 </dxl:Comparison>
                               </dxl:And>
                             </dxl:Filter>
@@ -1336,7 +1336,7 @@
                             </dxl:Properties>
                             <dxl:ProjList/>
                             <dxl:PartEqFilters>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:PartEqFilters>
                             <dxl:PartFilters>
                               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1350,7 +1350,7 @@
                             <dxl:PrintableFilter>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
@@ -1389,7 +1389,7 @@
                                 </dxl:Not>
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                   <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                                 </dxl:Comparison>
                               </dxl:And>
                             </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-6.mdp
@@ -651,7 +651,7 @@
                 </dxl:IsNotNull>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                 </dxl:Comparison>
               </dxl:And>
               <dxl:LogicalGet>
@@ -716,7 +716,7 @@
                 </dxl:IsNotNull>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="36" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                 </dxl:Comparison>
               </dxl:And>
               <dxl:LogicalGet>
@@ -782,7 +782,7 @@
               </dxl:IsNotNull>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="69" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:LogicalGet>
@@ -1024,7 +1024,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1038,7 +1038,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1077,7 +1077,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>
@@ -1267,7 +1267,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1281,7 +1281,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1320,7 +1320,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>
@@ -1510,7 +1510,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1524,7 +1524,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1563,7 +1563,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MS-UnionAll-7.mdp
@@ -651,7 +651,7 @@
                 </dxl:IsNotNull>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="3" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                 </dxl:Comparison>
               </dxl:And>
               <dxl:LogicalGet>
@@ -716,7 +716,7 @@
                 </dxl:IsNotNull>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="36" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                 </dxl:Comparison>
               </dxl:And>
               <dxl:LogicalGet>
@@ -782,7 +782,7 @@
               </dxl:IsNotNull>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="69" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
               </dxl:Comparison>
             </dxl:And>
             <dxl:LogicalGet>
@@ -1024,7 +1024,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1038,7 +1038,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1077,7 +1077,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="2" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>
@@ -1267,7 +1267,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1281,7 +1281,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1320,7 +1320,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="35" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>
@@ -1510,7 +1510,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:PartEqFilters>
-                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                           </dxl:PartEqFilters>
                           <dxl:PartFilters>
                             <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
@@ -1524,7 +1524,7 @@
                           <dxl:PrintableFilter>
                             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                               <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                             </dxl:Comparison>
                           </dxl:PrintableFilter>
                         </dxl:PartitionSelector>
@@ -1563,7 +1563,7 @@
                               </dxl:Not>
                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                                 <dxl:Ident ColId="68" ColName="businessdate" TypeMdid="0.1082.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" DoubleValue="451267200000000.000000"/>
+                                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxQAAA==" LintValue="5223"/>
                               </dxl:Comparison>
                             </dxl:And>
                           </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -298,108 +298,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71316.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SA4AAA==" DoubleValue="315878400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sh0AAA==" DoubleValue="656812800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SA4AAA==" LintValue="3656"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sh0AAA==" LintValue="7602"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sh0AAA==" DoubleValue="656812800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SC0AAA==" DoubleValue="1001548800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sh0AAA==" LintValue="7602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SC0AAA==" LintValue="11592"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SC0AAA==" DoubleValue="1001548800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CzwAAA==" DoubleValue="1328054400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SC0AAA==" LintValue="11592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CzwAAA==" LintValue="15371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CzwAAA==" DoubleValue="1328054400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eUwAAA==" DoubleValue="1691452800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CzwAAA==" LintValue="15371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eUwAAA==" LintValue="19577"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eUwAAA==" DoubleValue="1691452800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ClsAAA==" DoubleValue="2013638400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eUwAAA==" LintValue="19577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ClsAAA==" LintValue="23306"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ClsAAA==" DoubleValue="2013638400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dWoAAA==" DoubleValue="2354659200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ClsAAA==" LintValue="23306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dWoAAA==" LintValue="27253"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dWoAAA==" DoubleValue="2354659200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M3oAAA==" DoubleValue="2702851200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dWoAAA==" LintValue="27253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M3oAAA==" LintValue="31283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M3oAAA==" DoubleValue="2702851200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rYkAAA==" DoubleValue="3045168000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M3oAAA==" LintValue="31283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rYkAAA==" LintValue="35245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rYkAAA==" DoubleValue="3045168000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H5kAAA==" DoubleValue="3386793600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rYkAAA==" LintValue="35245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H5kAAA==" LintValue="39199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H5kAAA==" DoubleValue="3386793600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3KgAAA==" DoubleValue="3734899200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H5kAAA==" LintValue="39199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3KgAAA==" LintValue="43228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3KgAAA==" DoubleValue="3734899200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VbgAAA==" DoubleValue="4077129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3KgAAA==" LintValue="43228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VbgAAA==" LintValue="47189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VbgAAA==" DoubleValue="4077129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tccAAA==" DoubleValue="4417200000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VbgAAA==" LintValue="47189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tccAAA==" LintValue="51125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tccAAA==" DoubleValue="4417200000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ldcAAA==" DoubleValue="4768329600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tccAAA==" LintValue="51125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ldcAAA==" LintValue="55189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ldcAAA==" DoubleValue="4768329600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GucAAA==" DoubleValue="5111596800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ldcAAA==" LintValue="55189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GucAAA==" LintValue="59162"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GucAAA==" DoubleValue="5111596800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5PYAAA==" DoubleValue="5460825600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GucAAA==" LintValue="59162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5PYAAA==" LintValue="63204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5PYAAA==" DoubleValue="5460825600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EAcBAA==" DoubleValue="5818521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5PYAAA==" LintValue="63204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EAcBAA==" LintValue="67344"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EAcBAA==" DoubleValue="5818521600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tRYBAA==" DoubleValue="6164553600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EAcBAA==" LintValue="67344"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tRYBAA==" LintValue="71349"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tRYBAA==" DoubleValue="6164553600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSYBAA==" DoubleValue="6504969600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tRYBAA==" LintValue="71349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSYBAA==" LintValue="75289"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSYBAA==" DoubleValue="6504969600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="azUBAA==" DoubleValue="6843830400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSYBAA==" LintValue="75289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="azUBAA==" LintValue="79211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="azUBAA==" DoubleValue="6843830400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0kUBAA==" DoubleValue="7206624000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="azUBAA==" LintValue="79211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0kUBAA==" LintValue="83410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0kUBAA==" DoubleValue="7206624000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l1UBAA==" DoubleValue="7555420800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0kUBAA==" LintValue="83410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l1UBAA==" LintValue="87447"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l1UBAA==" DoubleValue="7555420800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JWUBAA==" DoubleValue="7899465600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l1UBAA==" LintValue="87447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JWUBAA==" LintValue="91429"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JWUBAA==" DoubleValue="7899465600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="onQBAA==" DoubleValue="8242041600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JWUBAA==" LintValue="91429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="onQBAA==" LintValue="95394"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="onQBAA==" DoubleValue="8242041600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KoQBAA==" DoubleValue="8585568000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="onQBAA==" LintValue="95394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KoQBAA==" LintValue="99370"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KoQBAA==" DoubleValue="8585568000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lpQBAA==" DoubleValue="8948793600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KoQBAA==" LintValue="99370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lpQBAA==" LintValue="103574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lpQBAA==" DoubleValue="8948793600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5JQBAA==" DoubleValue="8955532800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lpQBAA==" LintValue="103574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5JQBAA==" LintValue="103652"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
@@ -430,104 +430,104 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71822.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rw4AAA==" DoubleValue="315792000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1w8AAA==" DoubleValue="350352000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rw4AAA==" LintValue="3655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1w8AAA==" LintValue="4055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1w8AAA==" DoubleValue="350352000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxEAAA==" DoubleValue="384912000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1w8AAA==" LintValue="4055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxEAAA==" LintValue="4455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxEAAA==" DoubleValue="384912000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9xIAAA==" DoubleValue="419472000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxEAAA==" LintValue="4455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9xIAAA==" LintValue="4855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9xIAAA==" DoubleValue="419472000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxQAAA==" DoubleValue="454032000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9xIAAA==" LintValue="4855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxQAAA==" LintValue="5255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxQAAA==" DoubleValue="454032000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FxYAAA==" DoubleValue="488592000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxQAAA==" LintValue="5255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FxYAAA==" LintValue="5655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FxYAAA==" DoubleValue="488592000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pxcAAA==" DoubleValue="523152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FxYAAA==" LintValue="5655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pxcAAA==" LintValue="6055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pxcAAA==" DoubleValue="523152000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NxkAAA==" DoubleValue="557712000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pxcAAA==" LintValue="6055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NxkAAA==" LintValue="6455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NxkAAA==" DoubleValue="557712000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxoAAA==" DoubleValue="592272000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NxkAAA==" LintValue="6455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxoAAA==" LintValue="6855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxoAAA==" DoubleValue="592272000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxwAAA==" DoubleValue="626832000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxoAAA==" LintValue="6855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxwAAA==" LintValue="7255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxwAAA==" DoubleValue="626832000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5x0AAA==" DoubleValue="661392000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxwAAA==" LintValue="7255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5x0AAA==" LintValue="7655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5x0AAA==" DoubleValue="661392000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dx8AAA==" DoubleValue="695952000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5x0AAA==" LintValue="7655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dx8AAA==" LintValue="8055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dx8AAA==" DoubleValue="695952000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ByEAAA==" DoubleValue="730512000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dx8AAA==" LintValue="8055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ByEAAA==" LintValue="8455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ByEAAA==" DoubleValue="730512000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lyIAAA==" DoubleValue="765072000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ByEAAA==" LintValue="8455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lyIAAA==" LintValue="8855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lyIAAA==" DoubleValue="765072000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JyQAAA==" DoubleValue="799632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lyIAAA==" LintValue="8855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JyQAAA==" LintValue="9255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JyQAAA==" DoubleValue="799632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tyUAAA==" DoubleValue="834192000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JyQAAA==" LintValue="9255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tyUAAA==" LintValue="9655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tyUAAA==" DoubleValue="834192000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RycAAA==" DoubleValue="868752000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tyUAAA==" LintValue="9655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RycAAA==" LintValue="10055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RycAAA==" DoubleValue="868752000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ygAAA==" DoubleValue="903312000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RycAAA==" LintValue="10055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ygAAA==" LintValue="10455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ygAAA==" DoubleValue="903312000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZyoAAA==" DoubleValue="937872000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ygAAA==" LintValue="10455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZyoAAA==" LintValue="10855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZyoAAA==" DoubleValue="937872000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ysAAA==" DoubleValue="972432000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZyoAAA==" LintValue="10855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ysAAA==" LintValue="11255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ysAAA==" DoubleValue="972432000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hy0AAA==" DoubleValue="1006992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ysAAA==" LintValue="11255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hy0AAA==" LintValue="11655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hy0AAA==" DoubleValue="1006992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fy8AAA==" DoubleValue="1041552000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hy0AAA==" LintValue="11655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fy8AAA==" LintValue="12055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fy8AAA==" DoubleValue="1041552000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pzAAAA==" DoubleValue="1076112000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fy8AAA==" LintValue="12055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pzAAAA==" LintValue="12455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pzAAAA==" DoubleValue="1076112000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NzIAAA==" DoubleValue="1110672000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pzAAAA==" LintValue="12455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NzIAAA==" LintValue="12855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NzIAAA==" DoubleValue="1110672000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xzMAAA==" DoubleValue="1145232000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NzIAAA==" LintValue="12855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xzMAAA==" LintValue="13255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xzMAAA==" DoubleValue="1145232000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VjUAAA==" DoubleValue="1179705600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xzMAAA==" LintValue="13255"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VjUAAA==" LintValue="13654"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71316.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-RangeJoinPred.mdp
@@ -725,8 +725,8 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.17" Name="row_effective_from_dtm" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.16" Name="process_run_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -737,14 +737,14 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.9" Name="update_dtm" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.8" Name="create_dtm" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.1" Name="imsi_number" Width="18.000000" NullFreq="0.000000" NdvRemain="101915.000000" FreqRemain="0.990332">
@@ -1728,8 +1728,8 @@ where d.msisdn=f.subscriberaddress and f.sessioncreationtimestamp >= d.start_dtm
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.19" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.18" Name="row_effective_to_dtm" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" DoubleValue="461203200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2hQAAA==" LintValue="5338"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.1277041.1.1.3" Name="imei_number" Width="15.000000" NullFreq="0.000000" NdvRemain="87302.000000" FreqRemain="0.985436">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
@@ -327,7 +327,7 @@
           <dxl:Or>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
               <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
               <dxl:Ident ColId="14" ColName="region" TypeMdid="0.25.1.0"/>
@@ -482,7 +482,7 @@
                     <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="12" ColName="date" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
                         <dxl:Ident ColId="13" ColName="region" TypeMdid="0.25.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncNoPredPushDown.mdp
@@ -325,7 +325,7 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
               <dxl:Ident ColId="14" ColName="date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
               <dxl:Ident ColId="16" ColName="region" TypeMdid="0.25.1.0"/>
@@ -362,7 +362,7 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
               <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
               <dxl:Ident ColId="15" ColName="region" TypeMdid="0.25.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
@@ -337,7 +337,7 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
               <dxl:Ident ColId="14" ColName="date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
               <dxl:Ident ColId="16" ColName="region" TypeMdid="0.25.1.0"/>
@@ -502,7 +502,7 @@
                       <dxl:Or>
                         <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                           <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                         </dxl:Comparison>
                         <dxl:Or>
                           <dxl:DefaultPart Level="0"/>
@@ -520,7 +520,7 @@
                     <dxl:PrintableFilter>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                     </dxl:PrintableFilter>
                   </dxl:PartitionSelector>
@@ -545,7 +545,7 @@
                     <dxl:Filter>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                     </dxl:Filter>
                     <dxl:TableDescriptor Mdid="0.50202.1.0" TableName="sales">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -350,7 +350,7 @@
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
               <dxl:Ident ColId="14" ColName="date" TypeMdid="0.1082.1.0"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
             </dxl:Comparison>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
               <dxl:Ident ColId="16" ColName="region" TypeMdid="0.25.1.0"/>
@@ -491,7 +491,7 @@
                     <dxl:Or>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:PartBound Level="0" Type="0.1082.1.0" LowerBound="false"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                       <dxl:Or>
                         <dxl:DefaultPart Level="0"/>
@@ -516,7 +516,7 @@
                     <dxl:And>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
                         <dxl:Ident ColId="15" ColName="region" TypeMdid="0.25.1.0"/>
@@ -547,7 +547,7 @@
                     <dxl:And>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" DoubleValue="352252800000000.000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="7Q8AAA==" LintValue="4077"/>
                       </dxl:Comparison>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
                         <dxl:Ident ColId="15" ColName="region" TypeMdid="0.25.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -295,108 +295,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71316.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SA4AAA==" DoubleValue="315878400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sh0AAA==" DoubleValue="656812800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SA4AAA==" LintValue="3656"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sh0AAA==" LintValue="7602"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sh0AAA==" DoubleValue="656812800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SC0AAA==" DoubleValue="1001548800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sh0AAA==" LintValue="7602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SC0AAA==" LintValue="11592"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SC0AAA==" DoubleValue="1001548800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CzwAAA==" DoubleValue="1328054400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SC0AAA==" LintValue="11592"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CzwAAA==" LintValue="15371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CzwAAA==" DoubleValue="1328054400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eUwAAA==" DoubleValue="1691452800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CzwAAA==" LintValue="15371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eUwAAA==" LintValue="19577"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eUwAAA==" DoubleValue="1691452800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ClsAAA==" DoubleValue="2013638400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eUwAAA==" LintValue="19577"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ClsAAA==" LintValue="23306"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ClsAAA==" DoubleValue="2013638400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dWoAAA==" DoubleValue="2354659200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ClsAAA==" LintValue="23306"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dWoAAA==" LintValue="27253"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dWoAAA==" DoubleValue="2354659200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M3oAAA==" DoubleValue="2702851200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dWoAAA==" LintValue="27253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M3oAAA==" LintValue="31283"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M3oAAA==" DoubleValue="2702851200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rYkAAA==" DoubleValue="3045168000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M3oAAA==" LintValue="31283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rYkAAA==" LintValue="35245"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rYkAAA==" DoubleValue="3045168000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H5kAAA==" DoubleValue="3386793600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rYkAAA==" LintValue="35245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H5kAAA==" LintValue="39199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H5kAAA==" DoubleValue="3386793600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3KgAAA==" DoubleValue="3734899200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H5kAAA==" LintValue="39199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3KgAAA==" LintValue="43228"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3KgAAA==" DoubleValue="3734899200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VbgAAA==" DoubleValue="4077129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3KgAAA==" LintValue="43228"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VbgAAA==" LintValue="47189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VbgAAA==" DoubleValue="4077129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tccAAA==" DoubleValue="4417200000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VbgAAA==" LintValue="47189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tccAAA==" LintValue="51125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tccAAA==" DoubleValue="4417200000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ldcAAA==" DoubleValue="4768329600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tccAAA==" LintValue="51125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ldcAAA==" LintValue="55189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ldcAAA==" DoubleValue="4768329600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GucAAA==" DoubleValue="5111596800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ldcAAA==" LintValue="55189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GucAAA==" LintValue="59162"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GucAAA==" DoubleValue="5111596800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5PYAAA==" DoubleValue="5460825600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GucAAA==" LintValue="59162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5PYAAA==" LintValue="63204"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5PYAAA==" DoubleValue="5460825600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EAcBAA==" DoubleValue="5818521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5PYAAA==" LintValue="63204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="EAcBAA==" LintValue="67344"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EAcBAA==" DoubleValue="5818521600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tRYBAA==" DoubleValue="6164553600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="EAcBAA==" LintValue="67344"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tRYBAA==" LintValue="71349"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tRYBAA==" DoubleValue="6164553600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSYBAA==" DoubleValue="6504969600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tRYBAA==" LintValue="71349"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GSYBAA==" LintValue="75289"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSYBAA==" DoubleValue="6504969600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="azUBAA==" DoubleValue="6843830400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GSYBAA==" LintValue="75289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="azUBAA==" LintValue="79211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="azUBAA==" DoubleValue="6843830400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0kUBAA==" DoubleValue="7206624000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="azUBAA==" LintValue="79211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0kUBAA==" LintValue="83410"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0kUBAA==" DoubleValue="7206624000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l1UBAA==" DoubleValue="7555420800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0kUBAA==" LintValue="83410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l1UBAA==" LintValue="87447"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l1UBAA==" DoubleValue="7555420800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JWUBAA==" DoubleValue="7899465600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l1UBAA==" LintValue="87447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JWUBAA==" LintValue="91429"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JWUBAA==" DoubleValue="7899465600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="onQBAA==" DoubleValue="8242041600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JWUBAA==" LintValue="91429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="onQBAA==" LintValue="95394"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="onQBAA==" DoubleValue="8242041600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KoQBAA==" DoubleValue="8585568000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="onQBAA==" LintValue="95394"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KoQBAA==" LintValue="99370"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KoQBAA==" DoubleValue="8585568000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lpQBAA==" DoubleValue="8948793600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KoQBAA==" LintValue="99370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lpQBAA==" LintValue="103574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="3846.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lpQBAA==" DoubleValue="8948793600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5JQBAA==" DoubleValue="8955532800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lpQBAA==" LintValue="103574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5JQBAA==" LintValue="103652"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
@@ -430,104 +430,104 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71822.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rw4AAA==" DoubleValue="315792000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1w8AAA==" DoubleValue="350352000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rw4AAA==" LintValue="3655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1w8AAA==" LintValue="4055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1w8AAA==" DoubleValue="350352000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxEAAA==" DoubleValue="384912000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1w8AAA==" LintValue="4055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZxEAAA==" LintValue="4455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxEAAA==" DoubleValue="384912000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9xIAAA==" DoubleValue="419472000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZxEAAA==" LintValue="4455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9xIAAA==" LintValue="4855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9xIAAA==" DoubleValue="419472000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxQAAA==" DoubleValue="454032000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9xIAAA==" LintValue="4855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hxQAAA==" LintValue="5255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxQAAA==" DoubleValue="454032000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FxYAAA==" DoubleValue="488592000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hxQAAA==" LintValue="5255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FxYAAA==" LintValue="5655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FxYAAA==" DoubleValue="488592000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pxcAAA==" DoubleValue="523152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FxYAAA==" LintValue="5655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pxcAAA==" LintValue="6055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pxcAAA==" DoubleValue="523152000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NxkAAA==" DoubleValue="557712000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pxcAAA==" LintValue="6055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NxkAAA==" LintValue="6455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NxkAAA==" DoubleValue="557712000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxoAAA==" DoubleValue="592272000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NxkAAA==" LintValue="6455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxoAAA==" LintValue="6855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxoAAA==" DoubleValue="592272000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxwAAA==" DoubleValue="626832000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxoAAA==" LintValue="6855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VxwAAA==" LintValue="7255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxwAAA==" DoubleValue="626832000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5x0AAA==" DoubleValue="661392000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VxwAAA==" LintValue="7255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5x0AAA==" LintValue="7655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5x0AAA==" DoubleValue="661392000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dx8AAA==" DoubleValue="695952000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5x0AAA==" LintValue="7655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dx8AAA==" LintValue="8055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dx8AAA==" DoubleValue="695952000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ByEAAA==" DoubleValue="730512000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dx8AAA==" LintValue="8055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ByEAAA==" LintValue="8455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ByEAAA==" DoubleValue="730512000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lyIAAA==" DoubleValue="765072000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ByEAAA==" LintValue="8455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lyIAAA==" LintValue="8855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lyIAAA==" DoubleValue="765072000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JyQAAA==" DoubleValue="799632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lyIAAA==" LintValue="8855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JyQAAA==" LintValue="9255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JyQAAA==" DoubleValue="799632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tyUAAA==" DoubleValue="834192000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JyQAAA==" LintValue="9255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tyUAAA==" LintValue="9655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tyUAAA==" DoubleValue="834192000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RycAAA==" DoubleValue="868752000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tyUAAA==" LintValue="9655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RycAAA==" LintValue="10055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RycAAA==" DoubleValue="868752000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ygAAA==" DoubleValue="903312000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RycAAA==" LintValue="10055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ygAAA==" LintValue="10455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ygAAA==" DoubleValue="903312000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZyoAAA==" DoubleValue="937872000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ygAAA==" LintValue="10455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZyoAAA==" LintValue="10855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZyoAAA==" DoubleValue="937872000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ysAAA==" DoubleValue="972432000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZyoAAA==" LintValue="10855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ysAAA==" LintValue="11255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ysAAA==" DoubleValue="972432000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hy0AAA==" DoubleValue="1006992000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ysAAA==" LintValue="11255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hy0AAA==" LintValue="11655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hy0AAA==" DoubleValue="1006992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fy8AAA==" DoubleValue="1041552000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hy0AAA==" LintValue="11655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fy8AAA==" LintValue="12055"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fy8AAA==" DoubleValue="1041552000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pzAAAA==" DoubleValue="1076112000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fy8AAA==" LintValue="12055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pzAAAA==" LintValue="12455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pzAAAA==" DoubleValue="1076112000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NzIAAA==" DoubleValue="1110672000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pzAAAA==" LintValue="12455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NzIAAA==" LintValue="12855"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NzIAAA==" DoubleValue="1110672000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xzMAAA==" DoubleValue="1145232000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NzIAAA==" LintValue="12855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xzMAAA==" LintValue="13255"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="400.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xzMAAA==" DoubleValue="1145232000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VjUAAA==" DoubleValue="1179705600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xzMAAA==" LintValue="13255"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VjUAAA==" LintValue="13654"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.71316.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -353,606 +353,606 @@
       <dxl:ColumnStatistics Mdid="1.740207.1.1.20" Name="xmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.740207.1.1.13" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" DoubleValue="-251769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" LintValue="-2914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014088" DistinctValues="35.695689">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YfX//w==" DoubleValue="-234921600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YfX//w==" LintValue="-2719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YfX//w==" DoubleValue="-234921600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YfX//w==" DoubleValue="-234921600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YfX//w==" LintValue="-2719"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YfX//w==" LintValue="-2719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023618" DistinctValues="59.842773">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YfX//w==" DoubleValue="-234921600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvX//w==" DoubleValue="-229996800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YfX//w==" LintValue="-2719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvX//w==" LintValue="-2662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008420" DistinctValues="21.110530">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvX//w==" DoubleValue="-229996800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfX//w==" DoubleValue="-228009600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvX//w==" LintValue="-2662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfX//w==" LintValue="-2639"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfX//w==" DoubleValue="-228009600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfX//w==" DoubleValue="-228009600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfX//w==" LintValue="-2639"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfX//w==" LintValue="-2639"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021232" DistinctValues="53.235250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfX//w==" DoubleValue="-228009600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfX//w==" LintValue="-2639"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008054" DistinctValues="20.192681">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" DoubleValue="-222998400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/X//w==" LintValue="-2581"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032733" DistinctValues="81.203719">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002072" DistinctValues="5.139476">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/f//w==" DoubleValue="-188438400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/f//w==" LintValue="-2181"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/f//w==" DoubleValue="-188438400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/f//w==" DoubleValue="-188438400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/f//w==" LintValue="-2181"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/f//w==" LintValue="-2181"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002900" DistinctValues="7.195266">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/f//w==" DoubleValue="-188438400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/f//w==" LintValue="-2181"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000885" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037257" DistinctValues="93.413004">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000449" DistinctValues="1.125458">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vf//w==" DoubleValue="-180576000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vf//w==" LintValue="-2090"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028786" DistinctValues="72.937965">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vf//w==" DoubleValue="-180576000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vf//w==" LintValue="-2090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008920" DistinctValues="22.600496">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/j//w==" DoubleValue="-172540800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/j//w==" LintValue="-1997"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008641" DistinctValues="21.894231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/j//w==" DoubleValue="-172540800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfj//w==" DoubleValue="-170640000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/j//w==" LintValue="-1997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfj//w==" LintValue="-1975"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfj//w==" DoubleValue="-170640000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfj//w==" DoubleValue="-170640000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfj//w==" LintValue="-1975"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfj//w==" LintValue="-1975"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029065" DistinctValues="73.644231">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfj//w==" DoubleValue="-170640000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfj//w==" LintValue="-1975"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022062" DistinctValues="55.900164">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvj//w==" DoubleValue="-159494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvj//w==" LintValue="-1846"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvj//w==" DoubleValue="-159494400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvj//w==" DoubleValue="-159494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvj//w==" LintValue="-1846"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvj//w==" LintValue="-1846"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015644" DistinctValues="39.638298">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvj//w==" DoubleValue="-159494400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvj//w==" LintValue="-1846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009333" DistinctValues="23.648134">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvn//w==" DoubleValue="-153964800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvn//w==" LintValue="-1782"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvn//w==" DoubleValue="-153964800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvn//w==" DoubleValue="-153964800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvn//w==" LintValue="-1782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvn//w==" LintValue="-1782"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028372" DistinctValues="71.890327">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvn//w==" DoubleValue="-153964800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvn//w==" DoubleValue="-147398400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvn//w==" LintValue="-1782"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvn//w==" LintValue="-1706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012689" DistinctValues="31.815828">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvn//w==" DoubleValue="-147398400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efn//w==" DoubleValue="-144374400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvn//w==" LintValue="-1706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efn//w==" LintValue="-1671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efn//w==" DoubleValue="-144374400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="efn//w==" DoubleValue="-144374400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efn//w==" LintValue="-1671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="efn//w==" LintValue="-1671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018490" DistinctValues="46.360207">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="efn//w==" DoubleValue="-144374400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPn//w==" DoubleValue="-139968000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="efn//w==" LintValue="-1671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPn//w==" LintValue="-1620"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPn//w==" DoubleValue="-139968000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPn//w==" DoubleValue="-139968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPn//w==" LintValue="-1620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPn//w==" LintValue="-1620"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006526" DistinctValues="16.362426">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPn//w==" DoubleValue="-139968000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPn//w==" LintValue="-1620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028565" DistinctValues="72.377622">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avr//w==" DoubleValue="-123552000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="avr//w==" LintValue="-1430"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avr//w==" DoubleValue="-123552000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avr//w==" DoubleValue="-123552000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="avr//w==" LintValue="-1430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="avr//w==" LintValue="-1430"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009141" DistinctValues="23.160839">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avr//w==" DoubleValue="-123552000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="avr//w==" LintValue="-1430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003887" DistinctValues="9.746233">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPr//w==" DoubleValue="-120614400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPr//w==" LintValue="-1396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000885" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPr//w==" DoubleValue="-120614400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPr//w==" DoubleValue="-120614400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPr//w==" LintValue="-1396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPr//w==" LintValue="-1396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026044" DistinctValues="65.299762">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPr//w==" DoubleValue="-120614400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/r//w==" DoubleValue="-114825600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPr//w==" LintValue="-1396"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/r//w==" LintValue="-1329"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/r//w==" DoubleValue="-114825600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="z/r//w==" DoubleValue="-114825600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/r//w==" LintValue="-1329"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="z/r//w==" LintValue="-1329"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007774" DistinctValues="19.492466">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="z/r//w==" DoubleValue="-114825600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="z/r//w==" LintValue="-1329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032319" DistinctValues="81.890110">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005386" DistinctValues="13.648352">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033818" DistinctValues="85.689136">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003887" DistinctValues="9.849326">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" DoubleValue="-97113600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvv//w==" DoubleValue="-96249600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPv//w==" LintValue="-1124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvv//w==" LintValue="-1114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007541" DistinctValues="19.107692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvv//w==" DoubleValue="-96249600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvv//w==" LintValue="-1114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030164" DistinctValues="76.430769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" DoubleValue="-94608000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfz//w==" DoubleValue="-88041600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ufv//w==" LintValue="-1095"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfz//w==" LintValue="-1019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013785" DistinctValues="34.562448">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfz//w==" DoubleValue="-88041600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfz//w==" LintValue="-1019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000811" DistinctValues="2.033085">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" DoubleValue="-85104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/z//w==" LintValue="-985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023110" DistinctValues="57.942928">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" DoubleValue="-84931200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfz//w==" LintValue="-983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033651" DistinctValues="85.265509">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfz//w==" DoubleValue="-72835200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfz//w==" LintValue="-843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfz//w==" DoubleValue="-72835200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tfz//w==" DoubleValue="-72835200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfz//w==" LintValue="-843"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tfz//w==" LintValue="-843"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004054" DistinctValues="10.272953">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tfz//w==" DoubleValue="-72835200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/z//w==" DoubleValue="-71971200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tfz//w==" LintValue="-843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/z//w==" LintValue="-833"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/z//w==" DoubleValue="-71971200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iv3//w==" DoubleValue="-63417600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/z//w==" LintValue="-833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iv3//w==" LintValue="-734"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015996" DistinctValues="40.107226">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iv3//w==" DoubleValue="-63417600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP3//w==" DoubleValue="-59788800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iv3//w==" LintValue="-734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP3//w==" LintValue="-692"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP3//w==" DoubleValue="-59788800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TP3//w==" DoubleValue="-59788800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP3//w==" LintValue="-692"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TP3//w==" LintValue="-692"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000762" DistinctValues="1.909868">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TP3//w==" DoubleValue="-59788800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tv3//w==" DoubleValue="-59616000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TP3//w==" LintValue="-692"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tv3//w==" LintValue="-690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tv3//w==" DoubleValue="-59616000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tv3//w==" DoubleValue="-59616000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tv3//w==" LintValue="-690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tv3//w==" LintValue="-690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020947" DistinctValues="52.521368">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tv3//w==" DoubleValue="-59616000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tv3//w==" LintValue="-690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df7//w==" DoubleValue="-34128000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df7//w==" LintValue="-395"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037705" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df7//w==" DoubleValue="-34128000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df7//w==" LintValue="-395"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.740207.1.1.12" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" DoubleValue="-249696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LfX//w==" DoubleValue="-239414400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" LintValue="-2890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LfX//w==" LintValue="-2771"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LfX//w==" DoubleValue="-239414400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LfX//w==" LintValue="-2771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vX//w==" DoubleValue="-222739200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vX//w==" LintValue="-2578"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030748" DistinctValues="76.252427">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vX//w==" DoubleValue="-222739200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvb//w==" DoubleValue="-215481600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vX//w==" LintValue="-2578"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvb//w==" LintValue="-2494"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvb//w==" DoubleValue="-215481600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvb//w==" DoubleValue="-215481600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvb//w==" LintValue="-2494"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvb//w==" LintValue="-2494"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006955" DistinctValues="17.247573">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvb//w==" DoubleValue="-215481600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvb//w==" LintValue="-2494"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023710" DistinctValues="58.798969">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvb//w==" DoubleValue="-208569600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvb//w==" LintValue="-2414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvb//w==" DoubleValue="-208569600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kvb//w==" DoubleValue="-208569600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvb//w==" LintValue="-2414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kvb//w==" LintValue="-2414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013993" DistinctValues="34.701031">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kvb//w==" DoubleValue="-208569600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvb//w==" DoubleValue="-205459200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kvb//w==" LintValue="-2414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvb//w==" LintValue="-2378"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026930" DistinctValues="66.071429">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvb//w==" DoubleValue="-205459200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/Pb//w==" DoubleValue="-199411200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvb//w==" LintValue="-2378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/Pb//w==" LintValue="-2308"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/Pb//w==" DoubleValue="-199411200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/Pb//w==" DoubleValue="-199411200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/Pb//w==" LintValue="-2308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/Pb//w==" LintValue="-2308"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010387" DistinctValues="25.484694">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/Pb//w==" DoubleValue="-199411200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/Pb//w==" LintValue="-2308"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000923" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000385" DistinctValues="0.943878">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015250" DistinctValues="36.606742">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009320" DistinctValues="22.370787">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" DoubleValue="-193881600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvf//w==" DoubleValue="-191980800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="PPf//w==" LintValue="-2244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvf//w==" LintValue="-2222"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvf//w==" DoubleValue="-191980800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvf//w==" DoubleValue="-191980800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvf//w==" LintValue="-2222"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvf//w==" LintValue="-2222"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003389" DistinctValues="8.134831">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvf//w==" DoubleValue="-191980800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvf//w==" DoubleValue="-191289600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvf//w==" LintValue="-2222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvf//w==" LintValue="-2214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvf//w==" DoubleValue="-191289600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvf//w==" DoubleValue="-191289600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvf//w==" LintValue="-2214"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvf//w==" LintValue="-2214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004660" DistinctValues="11.185393">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvf//w==" DoubleValue="-191289600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvf//w==" LintValue="-2214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005083" DistinctValues="12.202247">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" DoubleValue="-190339200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Zff//w==" LintValue="-2203"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003142" DistinctValues="7.708333">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000885" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031868" DistinctValues="78.184524">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002693" DistinctValues="6.607143">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" DoubleValue="-182563200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/f//w==" LintValue="-2113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025818" DistinctValues="64.027174">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" DoubleValue="-182044800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xff//w==" LintValue="-2107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011884" DistinctValues="29.472826">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" DoubleValue="-176601600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifj//w==" DoubleValue="-174096000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BPj//w==" LintValue="-2044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifj//w==" LintValue="-2015"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifj//w==" DoubleValue="-174096000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfj//w==" DoubleValue="-165801600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifj//w==" LintValue="-2015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfj//w==" LintValue="-1919"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026351" DistinctValues="65.349462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfj//w==" DoubleValue="-165801600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wvj//w==" DoubleValue="-160185600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfj//w==" LintValue="-1919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wvj//w==" LintValue="-1854"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wvj//w==" DoubleValue="-160185600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wvj//w==" DoubleValue="-160185600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wvj//w==" LintValue="-1854"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wvj//w==" LintValue="-1854"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011351" DistinctValues="28.150538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wvj//w==" DoubleValue="-160185600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vj//w==" DoubleValue="-157766400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wvj//w==" LintValue="-1854"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vj//w==" LintValue="-1826"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vj//w==" DoubleValue="-157766400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vj//w==" LintValue="-1826"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" DoubleValue="-148867200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvn//w==" DoubleValue="-139795200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfn//w==" LintValue="-1723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvn//w==" LintValue="-1618"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007462" DistinctValues="18.307292">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvn//w==" DoubleValue="-139795200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvn//w==" LintValue="-1618"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006284" DistinctValues="15.416667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023957" DistinctValues="58.776042">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" DoubleValue="-136771200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0fn//w==" LintValue="-1583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024622" DistinctValues="61.061224">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfr//w==" DoubleValue="-117417600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfr//w==" LintValue="-1359"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfr//w==" DoubleValue="-117417600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfr//w==" DoubleValue="-117417600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfr//w==" LintValue="-1359"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfr//w==" LintValue="-1359"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013080" DistinctValues="32.438776">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfr//w==" DoubleValue="-117417600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfr//w==" LintValue="-1359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019038" DistinctValues="47.212871">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000885" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018665" DistinctValues="46.287129">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPv//w==" DoubleValue="-105753600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPv//w==" LintValue="-1224"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009115" DistinctValues="22.362637">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPv//w==" DoubleValue="-105753600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvv//w==" DoubleValue="-103852800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPv//w==" LintValue="-1224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvv//w==" LintValue="-1202"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvv//w==" DoubleValue="-103852800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvv//w==" DoubleValue="-103852800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvv//w==" LintValue="-1202"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvv//w==" LintValue="-1202"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024444" DistinctValues="59.972527">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvv//w==" DoubleValue="-103852800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvv//w==" LintValue="-1202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004143" DistinctValues="10.164835">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" DoubleValue="-98755200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/v//w==" DoubleValue="-97891200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ifv//w==" LintValue="-1143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/v//w==" LintValue="-1133"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021160" DistinctValues="52.474490">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/v//w==" DoubleValue="-97891200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvv//w==" DoubleValue="-93139200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/v//w==" LintValue="-1133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvv//w==" LintValue="-1078"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvv//w==" DoubleValue="-93139200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvv//w==" DoubleValue="-93139200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvv//w==" LintValue="-1078"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yvv//w==" LintValue="-1078"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016543" DistinctValues="41.025510">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvv//w==" DoubleValue="-93139200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fv//w==" DoubleValue="-89424000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yvv//w==" LintValue="-1078"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9fv//w==" LintValue="-1035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018013" DistinctValues="44.194444">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fv//w==" DoubleValue="-89424000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPz//w==" DoubleValue="-85708800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9fv//w==" LintValue="-1035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPz//w==" LintValue="-992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPz//w==" DoubleValue="-85708800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPz//w==" DoubleValue="-85708800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPz//w==" LintValue="-992"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPz//w==" LintValue="-992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016757" DistinctValues="41.111111">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPz//w==" DoubleValue="-85708800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPz//w==" LintValue="-992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002932" DistinctValues="7.194444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/z//w==" DoubleValue="-81648000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/z//w==" LintValue="-945"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020240" DistinctValues="50.194737">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/z//w==" DoubleValue="-81648000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/z//w==" LintValue="-945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017462" DistinctValues="43.305263">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" DoubleValue="-77241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gvz//w==" LintValue="-894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010825" DistinctValues="26.846535">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026877" DistinctValues="66.653465">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/3//w==" DoubleValue="-64713600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/3//w==" LintValue="-749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/3//w==" DoubleValue="-64713600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df3//w==" DoubleValue="-56246400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/3//w==" LintValue="-749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df3//w==" LintValue="-651"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012311" DistinctValues="30.530612">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df3//w==" DoubleValue="-56246400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lf3//w==" DoubleValue="-53481600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df3//w==" LintValue="-651"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lf3//w==" LintValue="-619"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lf3//w==" DoubleValue="-53481600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lf3//w==" DoubleValue="-53481600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lf3//w==" LintValue="-619"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lf3//w==" LintValue="-619"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025391" DistinctValues="62.969388">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lf3//w==" DoubleValue="-53481600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/3//w==" DoubleValue="-47779200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lf3//w==" LintValue="-619"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/3//w==" LintValue="-553"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003969" DistinctValues="9.842105">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/3//w==" DoubleValue="-47779200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/3//w==" DoubleValue="-46742400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/3//w==" LintValue="-553"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/3//w==" LintValue="-541"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/3//w==" DoubleValue="-46742400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/3//w==" DoubleValue="-46742400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/3//w==" LintValue="-541"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/3//w==" LintValue="-541"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033734" DistinctValues="83.657895">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/3//w==" DoubleValue="-46742400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/3//w==" LintValue="-541"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037702" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.740207.1.1.5" Name="l_quantity" Width="7.000000">
@@ -1328,712 +1328,712 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.738647.1.1.9" Name="week_end_date" Width="4.000000">
         <dxl:StatsBucket Frequency="0.023859" DistinctValues="7.974359">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfT//w==" DoubleValue="-252201600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/T//w==" DoubleValue="-246153600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfT//w==" LintValue="-2919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/T//w==" LintValue="-2849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/T//w==" DoubleValue="-246153600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/T//w==" DoubleValue="-246153600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/T//w==" LintValue="-2849"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3/T//w==" LintValue="-2849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004772" DistinctValues="1.594872">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/T//w==" DoubleValue="-246153600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fT//w==" DoubleValue="-244944000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3/T//w==" LintValue="-2849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7fT//w==" LintValue="-2835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fT//w==" DoubleValue="-244944000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fT//w==" DoubleValue="-244944000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7fT//w==" LintValue="-2835"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7fT//w==" LintValue="-2835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007158" DistinctValues="2.392308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fT//w==" DoubleValue="-244944000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7fT//w==" LintValue="-2835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" DoubleValue="-243129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPX//w==" DoubleValue="-234662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AvX//w==" LintValue="-2814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPX//w==" LintValue="-2716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028631" DistinctValues="10.369231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPX//w==" DoubleValue="-234662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPX//w==" LintValue="-2716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007158" DistinctValues="2.592308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfX//w==" DoubleValue="-225590400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zfX//w==" LintValue="-2611"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfX//w==" DoubleValue="-225590400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/b//w==" DoubleValue="-217123200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zfX//w==" LintValue="-2611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/b//w==" LintValue="-2513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.708791">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/b//w==" DoubleValue="-217123200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfb//w==" DoubleValue="-215913600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/b//w==" LintValue="-2513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfb//w==" LintValue="-2499"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfb//w==" DoubleValue="-215913600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfb//w==" DoubleValue="-215913600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfb//w==" LintValue="-2499"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pfb//w==" LintValue="-2499"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015338" DistinctValues="5.126374">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfb//w==" DoubleValue="-215913600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/b//w==" DoubleValue="-212284800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pfb//w==" LintValue="-2499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/b//w==" LintValue="-2457"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/b//w==" DoubleValue="-212284800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/b//w==" DoubleValue="-212284800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/b//w==" LintValue="-2457"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/b//w==" LintValue="-2457"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015338" DistinctValues="5.126374">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/b//w==" DoubleValue="-212284800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/b//w==" LintValue="-2457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" DoubleValue="-208656000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vb//w==" DoubleValue="-199584000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfb//w==" LintValue="-2415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vb//w==" LintValue="-2310"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vb//w==" DoubleValue="-199584000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XPf//w==" DoubleValue="-191116800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vb//w==" LintValue="-2310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XPf//w==" LintValue="-2212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020451" DistinctValues="7.406593">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XPf//w==" DoubleValue="-191116800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPf//w==" DoubleValue="-186278400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XPf//w==" LintValue="-2212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPf//w==" LintValue="-2156"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPf//w==" DoubleValue="-186278400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPf//w==" DoubleValue="-186278400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPf//w==" LintValue="-2156"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPf//w==" LintValue="-2156"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015338" DistinctValues="5.554945">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPf//w==" DoubleValue="-186278400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPf//w==" LintValue="-2156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.703297">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vf//w==" DoubleValue="-180230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vf//w==" LintValue="-2086"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vf//w==" DoubleValue="-180230400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vf//w==" DoubleValue="-180230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vf//w==" LintValue="-2086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vf//w==" LintValue="-2086"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025563" DistinctValues="9.258242">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vf//w==" DoubleValue="-180230400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPj//w==" DoubleValue="-174182400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vf//w==" LintValue="-2086"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPj//w==" LintValue="-2016"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPj//w==" DoubleValue="-174182400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPj//w==" LintValue="-2016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030676" DistinctValues="11.109890">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.851648">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" DoubleValue="-157852800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fj//w==" LintValue="-1827"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="6.480769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="6.480769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfn//w==" DoubleValue="-148176000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfn//w==" LintValue="-1715"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011929" DistinctValues="3.987179">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfn//w==" DoubleValue="-148176000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cPn//w==" DoubleValue="-145152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfn//w==" LintValue="-1715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cPn//w==" LintValue="-1680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cPn//w==" DoubleValue="-145152000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cPn//w==" DoubleValue="-145152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cPn//w==" LintValue="-1680"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cPn//w==" LintValue="-1680"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014315" DistinctValues="4.784615">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cPn//w==" DoubleValue="-145152000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cPn//w==" LintValue="-1680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009544" DistinctValues="3.189744">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" DoubleValue="-141523200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvn//w==" LintValue="-1638"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.565934">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPn//w==" DoubleValue="-137894400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPn//w==" LintValue="-1596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPn//w==" DoubleValue="-137894400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPn//w==" DoubleValue="-137894400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPn//w==" LintValue="-1596"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xPn//w==" LintValue="-1596"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.131868">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPn//w==" DoubleValue="-137894400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pn//w==" DoubleValue="-135475200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xPn//w==" LintValue="-1596"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pn//w==" LintValue="-1568"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pn//w==" DoubleValue="-135475200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pn//w==" DoubleValue="-135475200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pn//w==" LintValue="-1568"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pn//w==" LintValue="-1568"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="5.480769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pn//w==" DoubleValue="-135475200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pn//w==" LintValue="-1568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002556" DistinctValues="0.782967">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007669" DistinctValues="2.777473">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028120" DistinctValues="10.184066">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" DoubleValue="-128822400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfr//w==" LintValue="-1491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="5.980769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/r//w==" DoubleValue="-117936000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/r//w==" LintValue="-1365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/r//w==" DoubleValue="-117936000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/r//w==" DoubleValue="-117936000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/r//w==" LintValue="-1365"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/r//w==" LintValue="-1365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.417582">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/r//w==" DoubleValue="-117936000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/r//w==" DoubleValue="-115516800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/r//w==" LintValue="-1365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/r//w==" LintValue="-1337"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/r//w==" DoubleValue="-115516800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/r//w==" DoubleValue="-115516800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/r//w==" LintValue="-1337"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/r//w==" LintValue="-1337"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007669" DistinctValues="2.563187">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/r//w==" DoubleValue="-115516800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/r//w==" LintValue="-1337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002386" DistinctValues="0.597436">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009544" DistinctValues="2.389744">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//r//w==" DoubleValue="-110678400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//r//w==" LintValue="-1281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//r//w==" DoubleValue="-110678400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//r//w==" DoubleValue="-110678400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//r//w==" LintValue="-1281"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//r//w==" LintValue="-1281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002386" DistinctValues="0.597436">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//r//w==" DoubleValue="-110678400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//r//w==" LintValue="-1281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004772" DistinctValues="1.194872">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" DoubleValue="-110073600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPv//w==" DoubleValue="-108864000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvv//w==" LintValue="-1274"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPv//w==" LintValue="-1260"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPv//w==" DoubleValue="-108864000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPv//w==" DoubleValue="-108864000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPv//w==" LintValue="-1260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPv//w==" LintValue="-1260"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014315" DistinctValues="3.584615">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPv//w==" DoubleValue="-108864000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPv//w==" LintValue="-1260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002386" DistinctValues="0.597436">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028120" DistinctValues="10.184066">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pv//w==" DoubleValue="-89510400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pv//w==" LintValue="-1036"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pv//w==" DoubleValue="-89510400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pv//w==" DoubleValue="-89510400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pv//w==" LintValue="-1036"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pv//w==" LintValue="-1036"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007669" DistinctValues="2.777473">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pv//w==" DoubleValue="-89510400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfz//w==" DoubleValue="-87696000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pv//w==" LintValue="-1036"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfz//w==" LintValue="-1015"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfz//w==" DoubleValue="-87696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvz//w==" DoubleValue="-78624000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfz//w==" LintValue="-1015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvz//w==" LintValue="-910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvz//w==" DoubleValue="-78624000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pz//w==" DoubleValue="-70156800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvz//w==" LintValue="-910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pz//w==" LintValue="-812"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pz//w==" DoubleValue="-70156800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nv3//w==" DoubleValue="-61689600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pz//w==" LintValue="-812"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nv3//w==" LintValue="-714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.703297">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nv3//w==" DoubleValue="-61689600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uv3//w==" DoubleValue="-59270400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nv3//w==" LintValue="-714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uv3//w==" LintValue="-686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv3//w==" DoubleValue="-59270400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv3//w==" DoubleValue="-59270400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv3//w==" LintValue="-686"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv3//w==" LintValue="-686"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025563" DistinctValues="9.258242">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Uv3//w==" DoubleValue="-59270400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mP3//w==" DoubleValue="-53222400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Uv3//w==" LintValue="-686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mP3//w==" LintValue="-616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023859" DistinctValues="8.641026">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mP3//w==" DoubleValue="-53222400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3v3//w==" DoubleValue="-47174400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mP3//w==" LintValue="-616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3v3//w==" LintValue="-546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3v3//w==" DoubleValue="-47174400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3v3//w==" DoubleValue="-47174400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3v3//w==" LintValue="-546"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3v3//w==" LintValue="-546"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011929" DistinctValues="4.320513">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3v3//w==" DoubleValue="-47174400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Af7//w==" DoubleValue="-44150400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3v3//w==" LintValue="-546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Af7//w==" LintValue="-511"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Af7//w==" DoubleValue="-44150400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Af7//w==" LintValue="-511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eP7//w==" DoubleValue="-33868800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eP7//w==" LintValue="-392"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.738647.1.1.8" Name="week_start_date" Width="4.000000">
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/T//w==" DoubleValue="-252720000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/PT//w==" DoubleValue="-243648000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/T//w==" LintValue="-2925"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/PT//w==" LintValue="-2820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025563" DistinctValues="8.543956">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/PT//w==" DoubleValue="-243648000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/PT//w==" LintValue="-2820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.708791">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.708791">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" DoubleValue="-236390400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="UPX//w==" LintValue="-2736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" DoubleValue="-235180800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/X//w==" DoubleValue="-226108800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XvX//w==" LintValue="-2722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/X//w==" LintValue="-2617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/X//w==" DoubleValue="-226108800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/X//w==" LintValue="-2617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.703297">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" DoubleValue="-217641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfb//w==" LintValue="-2519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025563" DistinctValues="9.258242">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" DoubleValue="-215222400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/b//w==" DoubleValue="-209174400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfb//w==" LintValue="-2491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/b//w==" LintValue="-2421"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014315" DistinctValues="5.184615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/b//w==" DoubleValue="-209174400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/b//w==" LintValue="-2421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021473" DistinctValues="7.776923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvf//w==" DoubleValue="-191635200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vvf//w==" LintValue="-2218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvf//w==" DoubleValue="-191635200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPf//w==" DoubleValue="-183168000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vvf//w==" LintValue="-2218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPf//w==" LintValue="-2120"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.708791">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPf//w==" DoubleValue="-183168000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPf//w==" LintValue="-2120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="7.689560">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfj//w==" DoubleValue="-176515200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfj//w==" LintValue="-2043"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfj//w==" DoubleValue="-176515200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfj//w==" DoubleValue="-176515200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfj//w==" LintValue="-2043"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfj//w==" LintValue="-2043"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007669" DistinctValues="2.563187">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfj//w==" DoubleValue="-176515200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvj//w==" DoubleValue="-174700800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfj//w==" LintValue="-2043"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvj//w==" LintValue="-2022"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016701" DistinctValues="6.048718">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvj//w==" DoubleValue="-174700800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/j//w==" DoubleValue="-170467200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvj//w==" LintValue="-2022"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/j//w==" LintValue="-1973"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/j//w==" DoubleValue="-170467200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/j//w==" DoubleValue="-170467200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/j//w==" LintValue="-1973"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="S/j//w==" LintValue="-1973"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019087" DistinctValues="6.912821">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/j//w==" DoubleValue="-170467200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="S/j//w==" LintValue="-1973"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="12.961538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fj//w==" DoubleValue="-157161600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5fj//w==" LintValue="-1819"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="7.689560">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fj//w==" DoubleValue="-157161600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5fj//w==" LintValue="-1819"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.417582">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002556" DistinctValues="0.854396">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/n//w==" DoubleValue="-148694400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/n//w==" LintValue="-1721"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/n//w==" DoubleValue="-148694400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/n//w==" LintValue="-1721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evr//w==" DoubleValue="-131155200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evr//w==" LintValue="-1518"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028120" DistinctValues="9.398352">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evr//w==" DoubleValue="-131155200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evr//w==" LintValue="-1518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005113" DistinctValues="1.708791">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" DoubleValue="-124502400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bfr//w==" DoubleValue="-123292800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/r//w==" LintValue="-1441"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bfr//w==" LintValue="-1427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bfr//w==" DoubleValue="-123292800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bfr//w==" DoubleValue="-123292800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bfr//w==" LintValue="-1427"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bfr//w==" LintValue="-1427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002556" DistinctValues="0.854396">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bfr//w==" DoubleValue="-123292800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bfr//w==" LintValue="-1427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012782" DistinctValues="4.629121">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" DoubleValue="-122688000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/r//w==" DoubleValue="-119664000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dPr//w==" LintValue="-1420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/r//w==" LintValue="-1385"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/r//w==" DoubleValue="-119664000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/r//w==" DoubleValue="-119664000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/r//w==" LintValue="-1385"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="l/r//w==" LintValue="-1385"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023007" DistinctValues="8.332418">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/r//w==" DoubleValue="-119664000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vr//w==" DoubleValue="-114220800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="l/r//w==" LintValue="-1385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vr//w==" LintValue="-1322"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002386" DistinctValues="0.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vr//w==" DoubleValue="-114220800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fr//w==" DoubleValue="-113616000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vr//w==" LintValue="-1322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fr//w==" LintValue="-1315"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fr//w==" DoubleValue="-113616000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fr//w==" DoubleValue="-113616000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fr//w==" LintValue="-1315"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3fr//w==" LintValue="-1315"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004772" DistinctValues="1.461538">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fr//w==" DoubleValue="-113616000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/r//w==" DoubleValue="-112406400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3fr//w==" LintValue="-1315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/r//w==" LintValue="-1301"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/r//w==" DoubleValue="-112406400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/r//w==" DoubleValue="-112406400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/r//w==" LintValue="-1301"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/r//w==" LintValue="-1301"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016701" DistinctValues="5.115385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/r//w==" DoubleValue="-112406400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPv//w==" DoubleValue="-108172800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/r//w==" LintValue="-1301"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPv//w==" LintValue="-1252"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPv//w==" DoubleValue="-108172800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPv//w==" DoubleValue="-108172800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPv//w==" LintValue="-1252"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPv//w==" LintValue="-1252"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011929" DistinctValues="3.653846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPv//w==" DoubleValue="-108172800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/v//w==" DoubleValue="-105148800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPv//w==" LintValue="-1252"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/v//w==" LintValue="-1217"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007669" DistinctValues="2.777473">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/v//w==" DoubleValue="-105148800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPv//w==" DoubleValue="-103334400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/v//w==" LintValue="-1217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPv//w==" LintValue="-1196"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPv//w==" DoubleValue="-103334400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPv//w==" DoubleValue="-103334400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPv//w==" LintValue="-1196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPv//w==" LintValue="-1196"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028120" DistinctValues="10.184066">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPv//w==" DoubleValue="-103334400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofv//w==" DoubleValue="-96681600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPv//w==" LintValue="-1196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofv//w==" LintValue="-1119"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="6.480769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofv//w==" DoubleValue="-96681600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vv//w==" DoubleValue="-92448000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofv//w==" LintValue="-1119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vv//w==" LintValue="-1070"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vv//w==" DoubleValue="-92448000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0vv//w==" DoubleValue="-92448000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vv//w==" LintValue="-1070"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0vv//w==" LintValue="-1070"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017894" DistinctValues="6.480769">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0vv//w==" DoubleValue="-92448000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0vv//w==" LintValue="-1070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014315" DistinctValues="5.184615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfz//w==" DoubleValue="-84585600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfz//w==" LintValue="-979"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfz//w==" DoubleValue="-84585600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfz//w==" DoubleValue="-84585600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfz//w==" LintValue="-979"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfz//w==" LintValue="-979"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021473" DistinctValues="7.776923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfz//w==" DoubleValue="-84585600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfz//w==" LintValue="-979"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033232" DistinctValues="12.035714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/z//w==" DoubleValue="-71280000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/z//w==" LintValue="-825"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/z//w==" DoubleValue="-71280000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/z//w==" DoubleValue="-71280000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/z//w==" LintValue="-825"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/z//w==" LintValue="-825"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002556" DistinctValues="0.925824">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/z//w==" DoubleValue="-71280000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/z//w==" LintValue="-825"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020451" DistinctValues="7.406593">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bv3//w==" DoubleValue="-65836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bv3//w==" LintValue="-762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bv3//w==" DoubleValue="-65836800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bv3//w==" DoubleValue="-65836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bv3//w==" LintValue="-762"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bv3//w==" LintValue="-762"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015338" DistinctValues="5.554945">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bv3//w==" DoubleValue="-65836800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bv3//w==" LintValue="-762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025563" DistinctValues="9.258242">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010225" DistinctValues="3.703297">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kv3//w==" DoubleValue="-53740800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kv3//w==" LintValue="-622"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kv3//w==" DoubleValue="-53740800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kv3//w==" DoubleValue="-53740800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kv3//w==" LintValue="-622"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kv3//w==" LintValue="-622"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028631" DistinctValues="9.569231">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kv3//w==" DoubleValue="-53740800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kv3//w==" LintValue="-622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007158" DistinctValues="2.392308">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/3//w==" DoubleValue="-44668800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/3//w==" LintValue="-517"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015338" DistinctValues="5.554945">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" DoubleValue="-44668800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf7//w==" DoubleValue="-41040000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" LintValue="-517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf7//w==" LintValue="-475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf7//w==" DoubleValue="-41040000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf7//w==" DoubleValue="-41040000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf7//w==" LintValue="-475"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf7//w==" LintValue="-475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020451" DistinctValues="7.406593">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf7//w==" DoubleValue="-41040000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xf7//w==" DoubleValue="-36201600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf7//w==" LintValue="-475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xf7//w==" LintValue="-419"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035788" DistinctValues="13.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xf7//w==" DoubleValue="-36201600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xf7//w==" LintValue="-419"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.738647.1.1.1" Name="date_id" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfT//w==" DoubleValue="-252201600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APX//w==" DoubleValue="-243302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mfT//w==" LintValue="-2919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APX//w==" LintValue="-2816"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APX//w==" DoubleValue="-243302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPX//w==" DoubleValue="-234662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APX//w==" LintValue="-2816"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPX//w==" LintValue="-2716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPX//w==" DoubleValue="-234662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPX//w==" DoubleValue="-226022400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPX//w==" LintValue="-2716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPX//w==" LintValue="-2616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPX//w==" DoubleValue="-226022400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPX//w==" LintValue="-2616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" DoubleValue="-217382400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPb//w==" DoubleValue="-208742400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LPb//w==" LintValue="-2516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kPb//w==" LintValue="-2416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPb//w==" DoubleValue="-208742400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kPb//w==" LintValue="-2416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" DoubleValue="-200102400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pb//w==" LintValue="-2316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPj//w==" DoubleValue="-174182400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPj//w==" LintValue="-2016"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPj//w==" DoubleValue="-174182400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPj//w==" LintValue="-2016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pj//w==" DoubleValue="-156902400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6Pj//w==" LintValue="-1816"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pj//w==" DoubleValue="-156902400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6Pj//w==" LintValue="-1816"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPr//w==" DoubleValue="-130982400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPr//w==" LintValue="-1516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPr//w==" DoubleValue="-130982400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPr//w==" LintValue="-1516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" DoubleValue="-113702400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPv//w==" DoubleValue="-105062400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pr//w==" LintValue="-1316"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPv//w==" LintValue="-1216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPv//w==" DoubleValue="-105062400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPv//w==" DoubleValue="-96422400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPv//w==" LintValue="-1216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPv//w==" LintValue="-1116"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPv//w==" DoubleValue="-96422400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CPz//w==" DoubleValue="-87782400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPv//w==" LintValue="-1116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CPz//w==" LintValue="-1016"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CPz//w==" DoubleValue="-87782400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CPz//w==" LintValue="-1016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" DoubleValue="-79142400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pz//w==" DoubleValue="-70502400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bPz//w==" LintValue="-916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pz//w==" LintValue="-816"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pz//w==" DoubleValue="-70502400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NP3//w==" DoubleValue="-61862400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pz//w==" LintValue="-816"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NP3//w==" LintValue="-716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NP3//w==" DoubleValue="-61862400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mP3//w==" DoubleValue="-53222400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NP3//w==" LintValue="-716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mP3//w==" LintValue="-616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mP3//w==" DoubleValue="-53222400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/P3//w==" DoubleValue="-44582400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mP3//w==" LintValue="-616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/P3//w==" LintValue="-516"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/P3//w==" DoubleValue="-44582400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YP7//w==" DoubleValue="-35942400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/P3//w==" LintValue="-516"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YP7//w==" LintValue="-416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.846154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YP7//w==" DoubleValue="-35942400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YP7//w==" LintValue="-416"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.738647.1.1.0" Name="id" Width="4.000000">
@@ -4013,308 +4013,308 @@
       <dxl:ColumnStatistics Mdid="1.740207.1.1.18" Name="xmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.740207.1.1.11" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.029184" DistinctValues="73.051106">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" DoubleValue="-251856000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" LintValue="-2915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003099" DistinctValues="7.757640">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005424" DistinctValues="13.575869">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" DoubleValue="-241056000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GvX//w==" LintValue="-2790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002049" DistinctValues="5.183946">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035658" DistinctValues="90.200669">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" DoubleValue="-238809600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="NPX//w==" LintValue="-2764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/b//w==" DoubleValue="-205372800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="t/b//w==" LintValue="-2377"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017104" DistinctValues="42.813640">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/b//w==" DoubleValue="-205372800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/b//w==" DoubleValue="-201571200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="t/b//w==" LintValue="-2377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/b//w==" LintValue="-2333"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000885" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/b//w==" DoubleValue="-201571200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/b//w==" DoubleValue="-201571200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/b//w==" LintValue="-2333"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/b//w==" LintValue="-2333"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001166" DistinctValues="2.919112">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/b//w==" DoubleValue="-201571200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/b//w==" LintValue="-2333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019437" DistinctValues="48.651864">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" DoubleValue="-201312000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5vb//w==" LintValue="-2330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037293" DistinctValues="94.336433">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" DoubleValue="-196992000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvf//w==" DoubleValue="-189216000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPf//w==" LintValue="-2280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvf//w==" LintValue="-2190"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvf//w==" DoubleValue="-189216000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cvf//w==" DoubleValue="-189216000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvf//w==" LintValue="-2190"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cvf//w==" LintValue="-2190"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.048183">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cvf//w==" DoubleValue="-189216000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="cvf//w==" LintValue="-2190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004938" DistinctValues="12.228938">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvf//w==" DoubleValue="-188179200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvf//w==" LintValue="-2178"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvf//w==" DoubleValue="-188179200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvf//w==" DoubleValue="-188179200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvf//w==" LintValue="-2178"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fvf//w==" LintValue="-2178"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004040" DistinctValues="10.005495">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvf//w==" DoubleValue="-188179200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fvf//w==" LintValue="-2178"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023791" DistinctValues="58.921245">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004938" DistinctValues="12.228938">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" DoubleValue="-182822400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/f//w==" DoubleValue="-181872000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vPf//w==" LintValue="-2116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/f//w==" LintValue="-2105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000405" DistinctValues="1.014888">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/f//w==" DoubleValue="-181872000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPf//w==" DoubleValue="-181785600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/f//w==" LintValue="-2105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPf//w==" LintValue="-2104"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPf//w==" DoubleValue="-181785600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPf//w==" DoubleValue="-181785600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPf//w==" LintValue="-2104"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPf//w==" LintValue="-2104"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020678" DistinctValues="51.759305">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPf//w==" DoubleValue="-181785600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/f//w==" DoubleValue="-177379200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPf//w==" LintValue="-2104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/f//w==" LintValue="-2053"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000808" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/f//w==" DoubleValue="-177379200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/f//w==" DoubleValue="-177379200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/f//w==" LintValue="-2053"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/f//w==" LintValue="-2053"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016623" DistinctValues="41.610422">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+/f//w==" DoubleValue="-177379200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+/f//w==" LintValue="-2053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vj//w==" DoubleValue="-157420800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vj//w==" LintValue="-1822"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vj//w==" DoubleValue="-157420800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/n//w==" DoubleValue="-148694400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vj//w==" LintValue="-1822"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/n//w==" LintValue="-1721"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017766" DistinctValues="44.469675">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/n//w==" DoubleValue="-148694400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePn//w==" DoubleValue="-144460800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/n//w==" LintValue="-1721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePn//w==" LintValue="-1672"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePn//w==" DoubleValue="-144460800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ePn//w==" DoubleValue="-144460800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePn//w==" LintValue="-1672"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ePn//w==" LintValue="-1672"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002901" DistinctValues="7.260355">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ePn//w==" DoubleValue="-144460800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ePn//w==" LintValue="-1672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017041" DistinctValues="42.654586">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019623" DistinctValues="49.638932">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" DoubleValue="-139708800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vn//w==" DoubleValue="-135302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/n//w==" LintValue="-1617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4vn//w==" LintValue="-1566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vn//w==" DoubleValue="-135302400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4vn//w==" DoubleValue="-135302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4vn//w==" LintValue="-1566"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4vn//w==" LintValue="-1566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018084" DistinctValues="45.745683">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4vn//w==" DoubleValue="-135302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4vn//w==" LintValue="-1566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010107" DistinctValues="24.494845">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001944" DistinctValues="4.710547">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" DoubleValue="-128995200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPr//w==" DoubleValue="-128563200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="K/r//w==" LintValue="-1493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPr//w==" LintValue="-1488"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPr//w==" DoubleValue="-128563200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MPr//w==" DoubleValue="-128563200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPr//w==" LintValue="-1488"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MPr//w==" LintValue="-1488"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014383" DistinctValues="34.858049">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MPr//w==" DoubleValue="-128563200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfr//w==" DoubleValue="-125366400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MPr//w==" LintValue="-1488"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfr//w==" LintValue="-1451"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfr//w==" DoubleValue="-125366400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfr//w==" DoubleValue="-125366400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfr//w==" LintValue="-1451"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfr//w==" LintValue="-1451"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005442" DistinctValues="13.189532">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfr//w==" DoubleValue="-125366400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/r//w==" DoubleValue="-124156800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfr//w==" LintValue="-1451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/r//w==" LintValue="-1437"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/r//w==" DoubleValue="-124156800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/r//w==" DoubleValue="-124156800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/r//w==" LintValue="-1437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/r//w==" LintValue="-1437"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004276" DistinctValues="10.363204">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/r//w==" DoubleValue="-124156800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/r//w==" LintValue="-1437"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001555" DistinctValues="3.768438">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" DoubleValue="-123206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bvr//w==" LintValue="-1426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007998" DistinctValues="20.233100">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029708" DistinctValues="75.151515">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" DoubleValue="-121046400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1fr//w==" DoubleValue="-114307200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="h/r//w==" LintValue="-1401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1fr//w==" LintValue="-1323"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023960" DistinctValues="60.608974">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1fr//w==" DoubleValue="-114307200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1fr//w==" LintValue="-1323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000731" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013747" DistinctValues="34.775641">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" DoubleValue="-109036800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Evv//w==" LintValue="-1262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" DoubleValue="-106012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfv//w==" LintValue="-1227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014289" DistinctValues="36.145749">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" DoubleValue="-97545600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/v//w==" DoubleValue="-94435200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="l/v//w==" LintValue="-1129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="u/v//w==" LintValue="-1093"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/v//w==" DoubleValue="-94435200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u/v//w==" DoubleValue="-94435200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="u/v//w==" LintValue="-1093"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="u/v//w==" LintValue="-1093"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023418" DistinctValues="59.238866">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u/v//w==" DoubleValue="-94435200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="u/v//w==" LintValue="-1093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023021" DistinctValues="58.234818">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/z//w==" DoubleValue="-76464000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/z//w==" LintValue="-885"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/z//w==" DoubleValue="-76464000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="i/z//w==" DoubleValue="-76464000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/z//w==" LintValue="-885"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="i/z//w==" LintValue="-885"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014686" DistinctValues="37.149798">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="i/z//w==" DoubleValue="-76464000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPz//w==" DoubleValue="-73267200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="i/z//w==" LintValue="-885"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPz//w==" LintValue="-848"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001143" DistinctValues="2.890443">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPz//w==" DoubleValue="-73267200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPz//w==" LintValue="-848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000846" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036564" DistinctValues="92.494172">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/3//w==" DoubleValue="-64713600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/3//w==" LintValue="-749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/3//w==" DoubleValue="-64713600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/3//w==" LintValue="-749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001178" DistinctValues="2.980769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" DoubleValue="-56160000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dv3//w==" LintValue="-650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000769" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036529" DistinctValues="92.403846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YP7//w==" DoubleValue="-35942400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YP7//w==" LintValue="-416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037707" DistinctValues="96.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YP7//w==" DoubleValue="-35942400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YP7//w==" LintValue="-416"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.740207.1.1.10" Name="l_linestatus" Width="2.000000">
@@ -4976,7 +4976,7 @@
           </dxl:SubqueryAny>
           <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
             <dxl:Ident ColId="14" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
           </dxl:Comparison>
         </dxl:Or>
       </dxl:LogicalJoin>
@@ -5014,7 +5014,7 @@
               <dxl:Ident ColId="57" ColName="ColRef_0057" TypeMdid="0.16.1.0"/>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
               </dxl:Comparison>
             </dxl:Or>
           </dxl:JoinFilter>

--- a/src/backend/gporca/data/dxl/minidump/Select-Over-PartTbl.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Over-PartTbl.mdp
@@ -463,308 +463,308 @@
       <dxl:ColumnStatistics Mdid="1.559056.1.1.18" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.559056.1.1.10" Name="l_shipdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.028403" DistinctValues="71.838864">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPT//w==" DoubleValue="-252288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/X//w==" DoubleValue="-242352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPT//w==" LintValue="-2920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/X//w==" LintValue="-2805"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/X//w==" DoubleValue="-242352000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="C/X//w==" DoubleValue="-242352000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/X//w==" LintValue="-2805"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="C/X//w==" LintValue="-2805"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009385" DistinctValues="23.738059">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="C/X//w==" DoubleValue="-242352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="C/X//w==" LintValue="-2805"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008660" DistinctValues="21.903045">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" DoubleValue="-239068800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MfX//w==" LintValue="-2767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029128" DistinctValues="73.673878">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" DoubleValue="-237168000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfX//w==" DoubleValue="-230774400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="R/X//w==" LintValue="-2745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfX//w==" LintValue="-2671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfX//w==" DoubleValue="-230774400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfX//w==" LintValue="-2671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" DoubleValue="-222393600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vX//w==" LintValue="-2574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005784" DistinctValues="14.476060">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011953" DistinctValues="29.917190">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" DoubleValue="-212803200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfb//w==" LintValue="-2463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020051" DistinctValues="50.183673">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evf//w==" DoubleValue="-197510400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Evf//w==" LintValue="-2286"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020126" DistinctValues="50.905100">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evf//w==" DoubleValue="-197510400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/f//w==" DoubleValue="-193276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Evf//w==" LintValue="-2286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/f//w==" LintValue="-2237"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/f//w==" DoubleValue="-193276800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/f//w==" DoubleValue="-193276800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/f//w==" LintValue="-2237"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/f//w==" LintValue="-2237"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017662" DistinctValues="44.671823">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/f//w==" DoubleValue="-193276800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvf//w==" DoubleValue="-189561600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/f//w==" LintValue="-2237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvf//w==" LintValue="-2194"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022437" DistinctValues="56.748798">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvf//w==" DoubleValue="-189561600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/f//w==" DoubleValue="-184636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvf//w==" LintValue="-2194"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/f//w==" LintValue="-2137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/f//w==" DoubleValue="-184636800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p/f//w==" DoubleValue="-184636800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/f//w==" LintValue="-2137"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="p/f//w==" LintValue="-2137"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015351" DistinctValues="38.828125">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p/f//w==" DoubleValue="-184636800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvf//w==" DoubleValue="-181267200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="p/f//w==" LintValue="-2137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvf//w==" LintValue="-2098"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026373" DistinctValues="66.704728">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvf//w==" DoubleValue="-181267200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvf//w==" LintValue="-2098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011415" DistinctValues="28.872196">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" DoubleValue="-175478400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvj//w==" DoubleValue="-172972800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efj//w==" LintValue="-2031"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvj//w==" LintValue="-2002"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvj//w==" DoubleValue="-172972800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPj//w==" DoubleValue="-164160000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvj//w==" LintValue="-2002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPj//w==" LintValue="-1900"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001679" DistinctValues="4.247863">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPj//w==" DoubleValue="-164160000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPj//w==" LintValue="-1900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036109" DistinctValues="91.329060">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" DoubleValue="-163814400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vj//w==" DoubleValue="-156384000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mPj//w==" LintValue="-1896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vj//w==" LintValue="-1810"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029163" DistinctValues="73.760452">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vj//w==" DoubleValue="-156384000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfn//w==" DoubleValue="-150249600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vj//w==" LintValue="-1810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfn//w==" LintValue="-1739"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000756" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfn//w==" DoubleValue="-150249600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfn//w==" DoubleValue="-150249600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfn//w==" LintValue="-1739"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfn//w==" LintValue="-1739"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008626" DistinctValues="21.816472">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfn//w==" DoubleValue="-150249600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svn//w==" DoubleValue="-148435200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfn//w==" LintValue="-1739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svn//w==" LintValue="-1718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005064" DistinctValues="12.675258">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svn//w==" DoubleValue="-148435200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/n//w==" DoubleValue="-147312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svn//w==" LintValue="-1718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="V/n//w==" LintValue="-1705"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/n//w==" DoubleValue="-147312000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="V/n//w==" DoubleValue="-147312000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="V/n//w==" LintValue="-1705"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="V/n//w==" LintValue="-1705"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028438" DistinctValues="71.176447">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="V/n//w==" DoubleValue="-147312000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="V/n//w==" LintValue="-1705"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004285" DistinctValues="10.725218">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" DoubleValue="-141004800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/n//w==" DoubleValue="-140054400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="oPn//w==" LintValue="-1632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/n//w==" LintValue="-1621"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005117" DistinctValues="12.807292">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/n//w==" DoubleValue="-140054400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/n//w==" LintValue="-1621"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032277" DistinctValues="80.784455">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" DoubleValue="-138931200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPn//w==" LintValue="-1608"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000780" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.985176">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" DoubleValue="-131846400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/r//w==" DoubleValue="-131760000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvr//w==" LintValue="-1526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/r//w==" LintValue="-1525"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011256" DistinctValues="27.873977">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/r//w==" DoubleValue="-131760000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/r//w==" LintValue="-1525"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000803" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015276" DistinctValues="37.828969">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" DoubleValue="-129340800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfr//w==" DoubleValue="-126057600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/r//w==" LintValue="-1497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfr//w==" LintValue="-1459"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfr//w==" DoubleValue="-126057600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfr//w==" DoubleValue="-126057600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfr//w==" LintValue="-1459"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Tfr//w==" LintValue="-1459"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004422" DistinctValues="10.950491">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfr//w==" DoubleValue="-126057600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Tfr//w==" LintValue="-1459"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006834" DistinctValues="16.923486">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" DoubleValue="-125107200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPr//w==" LintValue="-1448"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPr//w==" DoubleValue="-115430400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPr//w==" LintValue="-1336"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016482" DistinctValues="41.251637">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPr//w==" DoubleValue="-115430400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fr//w==" DoubleValue="-111888000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPr//w==" LintValue="-1336"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fr//w==" LintValue="-1295"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fr//w==" DoubleValue="-111888000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fr//w==" DoubleValue="-111888000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fr//w==" LintValue="-1295"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fr//w==" LintValue="-1295"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007236" DistinctValues="18.110475">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fr//w==" DoubleValue="-111888000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fr//w==" LintValue="-1295"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000756" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014070" DistinctValues="35.214812">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvv//w==" DoubleValue="-107308800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvv//w==" LintValue="-1242"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvv//w==" DoubleValue="-107308800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/v//w==" DoubleValue="-98928000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvv//w==" LintValue="-1242"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/v//w==" LintValue="-1145"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/v//w==" DoubleValue="-98928000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/v//w==" LintValue="-1145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031165" DistinctValues="78.826328">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/z//w==" DoubleValue="-83376000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/z//w==" LintValue="-965"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/z//w==" DoubleValue="-83376000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/z//w==" DoubleValue="-83376000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/z//w==" LintValue="-965"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="O/z//w==" LintValue="-965"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006623" DistinctValues="16.750595">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/z//w==" DoubleValue="-83376000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="O/z//w==" LintValue="-965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028148" DistinctValues="70.450157">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" DoubleValue="-81907200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPz//w==" LintValue="-948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008869" DistinctValues="22.196625">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" DoubleValue="-75600000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfz//w==" LintValue="-875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000771" DistinctValues="1.930141">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012729" DistinctValues="31.857490">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" DoubleValue="-73440000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rvz//w==" LintValue="-850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019888" DistinctValues="49.777328">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" DoubleValue="-70675200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AP3//w==" DoubleValue="-66355200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="zvz//w==" LintValue="-818"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="AP3//w==" LintValue="-768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AP3//w==" DoubleValue="-66355200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AP3//w==" DoubleValue="-66355200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="AP3//w==" LintValue="-768"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="AP3//w==" LintValue="-768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005171" DistinctValues="12.942105">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AP3//w==" DoubleValue="-66355200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="AP3//w==" LintValue="-768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007314" DistinctValues="18.305211">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002438" DistinctValues="6.101737">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf3//w==" DoubleValue="-63158400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf3//w==" LintValue="-731"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf3//w==" DoubleValue="-63158400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf3//w==" DoubleValue="-63158400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf3//w==" LintValue="-731"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Jf3//w==" LintValue="-731"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028036" DistinctValues="70.169975">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf3//w==" DoubleValue="-63158400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="av3//w==" DoubleValue="-57196800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Jf3//w==" LintValue="-731"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="av3//w==" LintValue="-662"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="av3//w==" DoubleValue="-57196800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="av3//w==" LintValue="-662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xv7//w==" DoubleValue="-36115200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xv7//w==" LintValue="-418"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037788" DistinctValues="96.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xv7//w==" DoubleValue="-36115200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bf7//w==" DoubleValue="-34819200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xv7//w==" LintValue="-418"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bf7//w==" LintValue="-403"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.559056.1.1.3" Name="l_linenumber" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -1105,308 +1105,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.559056.1.1.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" DoubleValue="-249782400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" LintValue="-2891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016750" DistinctValues="41.448454">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021035" DistinctValues="52.051546">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" DoubleValue="-235267200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="XfX//w==" LintValue="-2723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000402" DistinctValues="0.984043">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" DoubleValue="-230601600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPX//w==" DoubleValue="-230515200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/X//w==" LintValue="-2669"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPX//w==" LintValue="-2668"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPX//w==" DoubleValue="-230515200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPX//w==" DoubleValue="-230515200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPX//w==" LintValue="-2668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lPX//w==" LintValue="-2668"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014471" DistinctValues="35.425532">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPX//w==" DoubleValue="-230515200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lPX//w==" LintValue="-2668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000756" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022912" DistinctValues="56.090426">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" DoubleValue="-227404800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPX//w==" LintValue="-2632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002755" DistinctValues="6.817708">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+PX//w==" DoubleValue="-221875200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+PX//w==" LintValue="-2568"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000756" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+PX//w==" DoubleValue="-221875200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+PX//w==" DoubleValue="-221875200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+PX//w==" LintValue="-2568"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+PX//w==" LintValue="-2568"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035030" DistinctValues="86.682292">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+PX//w==" DoubleValue="-221875200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+PX//w==" LintValue="-2568"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021538" DistinctValues="53.295000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" DoubleValue="-214185600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivb//w==" DoubleValue="-209260800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufb//w==" LintValue="-2479"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivb//w==" LintValue="-2422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivb//w==" DoubleValue="-209260800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivb//w==" DoubleValue="-209260800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivb//w==" LintValue="-2422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivb//w==" LintValue="-2422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016248" DistinctValues="40.205000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivb//w==" DoubleValue="-209260800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivb//w==" LintValue="-2422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003396" DistinctValues="8.134831">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" DoubleValue="-205545600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfb//w==" DoubleValue="-204854400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfb//w==" LintValue="-2379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfb//w==" LintValue="-2371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfb//w==" DoubleValue="-204854400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vfb//w==" DoubleValue="-204854400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfb//w==" LintValue="-2371"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vfb//w==" LintValue="-2371"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014010" DistinctValues="33.556180">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vfb//w==" DoubleValue="-204854400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vb//w==" DoubleValue="-202003200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vfb//w==" LintValue="-2371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vb//w==" LintValue="-2338"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vb//w==" DoubleValue="-202003200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vb//w==" DoubleValue="-202003200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vb//w==" LintValue="-2338"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3vb//w==" LintValue="-2338"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013161" DistinctValues="31.522472">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vb//w==" DoubleValue="-202003200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3vb//w==" LintValue="-2338"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005519" DistinctValues="13.219101">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvf//w==" DoubleValue="-198201600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvf//w==" LintValue="-2294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvf//w==" DoubleValue="-198201600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvf//w==" DoubleValue="-198201600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvf//w==" LintValue="-2294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cvf//w==" LintValue="-2294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001698" DistinctValues="4.067416">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvf//w==" DoubleValue="-198201600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvf//w==" DoubleValue="-197856000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cvf//w==" LintValue="-2294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvf//w==" LintValue="-2290"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029433" DistinctValues="72.831579">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvf//w==" DoubleValue="-197856000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvf//w==" LintValue="-2290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008353" DistinctValues="20.668421">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" DoubleValue="-191462400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bff//w==" DoubleValue="-189648000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="WPf//w==" LintValue="-2216"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bff//w==" LintValue="-2195"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bff//w==" DoubleValue="-189648000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zff//w==" DoubleValue="-181353600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bff//w==" LintValue="-2195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zff//w==" LintValue="-2099"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016138" DistinctValues="39.505208">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zff//w==" DoubleValue="-181353600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vf//w==" DoubleValue="-177811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zff//w==" LintValue="-2099"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vf//w==" LintValue="-2058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vf//w==" DoubleValue="-177811200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vf//w==" DoubleValue="-177811200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vf//w==" LintValue="-2058"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vf//w==" LintValue="-2058"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011808" DistinctValues="28.906250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vf//w==" DoubleValue="-177811200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPj//w==" DoubleValue="-175219200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vf//w==" LintValue="-2058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPj//w==" LintValue="-2028"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPj//w==" DoubleValue="-175219200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPj//w==" DoubleValue="-175219200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPj//w==" LintValue="-2028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPj//w==" LintValue="-2028"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009840" DistinctValues="24.088542">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPj//w==" DoubleValue="-175219200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfj//w==" DoubleValue="-173059200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPj//w==" LintValue="-2028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lfj//w==" LintValue="-2003"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfj//w==" DoubleValue="-173059200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfj//w==" DoubleValue="-164419200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lfj//w==" LintValue="-2003"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfj//w==" LintValue="-1903"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019313" DistinctValues="47.277778">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfj//w==" DoubleValue="-164419200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfj//w==" LintValue="-1903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004198" DistinctValues="10.277778">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" DoubleValue="-160444800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yfj//w==" DoubleValue="-159580800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="v/j//w==" LintValue="-1857"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yfj//w==" LintValue="-1847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yfj//w==" DoubleValue="-159580800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yfj//w==" DoubleValue="-159580800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yfj//w==" LintValue="-1847"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yfj//w==" LintValue="-1847"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014274" DistinctValues="34.944444">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yfj//w==" DoubleValue="-159580800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yfj//w==" LintValue="-1847"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005568" DistinctValues="13.631579">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013921" DistinctValues="34.078947">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018296" DistinctValues="44.789474">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" DoubleValue="-152409600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svn//w==" DoubleValue="-148435200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="HPn//w==" LintValue="-1764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Svn//w==" LintValue="-1718"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svn//w==" DoubleValue="-148435200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvn//w==" DoubleValue="-140140800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Svn//w==" LintValue="-1718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qvn//w==" LintValue="-1622"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035086" DistinctValues="86.821429">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvn//w==" DoubleValue="-140140800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfr//w==" DoubleValue="-132278400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qvn//w==" LintValue="-1622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfr//w==" LintValue="-1531"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfr//w==" DoubleValue="-132278400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfr//w==" DoubleValue="-132278400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfr//w==" LintValue="-1531"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfr//w==" LintValue="-1531"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002699" DistinctValues="6.678571">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfr//w==" DoubleValue="-132278400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfr//w==" LintValue="-1531"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" DoubleValue="-131673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPr//w==" LintValue="-1524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013125" DistinctValues="32.131579">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" DoubleValue="-123638400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivr//w==" DoubleValue="-120787200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afr//w==" LintValue="-1431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivr//w==" LintValue="-1398"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivr//w==" DoubleValue="-120787200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivr//w==" DoubleValue="-120787200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivr//w==" LintValue="-1398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ivr//w==" LintValue="-1398"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004375" DistinctValues="10.710526">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivr//w==" DoubleValue="-120787200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfr//w==" DoubleValue="-119836800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ivr//w==" LintValue="-1398"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfr//w==" LintValue="-1387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfr//w==" DoubleValue="-119836800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfr//w==" DoubleValue="-119836800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfr//w==" LintValue="-1387"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="lfr//w==" LintValue="-1387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020285" DistinctValues="49.657895">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfr//w==" DoubleValue="-119836800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPr//w==" DoubleValue="-115430400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="lfr//w==" LintValue="-1387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPr//w==" LintValue="-1336"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018893" DistinctValues="46.750000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPr//w==" DoubleValue="-115430400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPr//w==" LintValue="-1336"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018893" DistinctValues="46.750000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" DoubleValue="-111456000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPv//w==" DoubleValue="-107481600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vr//w==" LintValue="-1290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPv//w==" LintValue="-1244"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026878" DistinctValues="66.510309">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPv//w==" DoubleValue="-107481600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afv//w==" DoubleValue="-101520000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPv//w==" LintValue="-1244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afv//w==" LintValue="-1175"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afv//w==" DoubleValue="-101520000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afv//w==" DoubleValue="-101520000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afv//w==" LintValue="-1175"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afv//w==" LintValue="-1175"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010907" DistinctValues="26.989691">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afv//w==" DoubleValue="-101520000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfv//w==" DoubleValue="-99100800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afv//w==" LintValue="-1175"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfv//w==" LintValue="-1147"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023905" DistinctValues="59.153061">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfv//w==" DoubleValue="-99100800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfv//w==" LintValue="-1147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013880" DistinctValues="34.346939">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/v//w==" DoubleValue="-90633600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/v//w==" LintValue="-1049"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028047" DistinctValues="69.402062">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/v//w==" DoubleValue="-90633600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/z//w==" DoubleValue="-84412800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/v//w==" LintValue="-1049"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/z//w==" LintValue="-977"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/z//w==" DoubleValue="-84412800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/z//w==" DoubleValue="-84412800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/z//w==" LintValue="-977"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="L/z//w==" LintValue="-977"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009739" DistinctValues="24.097938">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/z//w==" DoubleValue="-84412800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="L/z//w==" LintValue="-977"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" DoubleValue="-82252800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPz//w==" LintValue="-952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021127" DistinctValues="52.279570">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/z//w==" DoubleValue="-68860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/z//w==" LintValue="-797"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/z//w==" DoubleValue="-68860800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/z//w==" DoubleValue="-68860800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/z//w==" LintValue="-797"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/z//w==" LintValue="-797"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016658" DistinctValues="41.220430">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/z//w==" DoubleValue="-68860800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DP3//w==" DoubleValue="-65318400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/z//w==" LintValue="-797"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DP3//w==" LintValue="-756"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000390" DistinctValues="0.963918">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DP3//w==" DoubleValue="-65318400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DP3//w==" LintValue="-756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037396" DistinctValues="92.536082">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bf3//w==" DoubleValue="-56937600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bf3//w==" LintValue="-659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bf3//w==" DoubleValue="-56937600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zf3//w==" DoubleValue="-48643200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bf3//w==" LintValue="-659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zf3//w==" LintValue="-563"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zf3//w==" DoubleValue="-48643200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/7//w==" DoubleValue="-37756800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zf3//w==" LintValue="-563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/7//w==" LintValue="-437"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037785" DistinctValues="94.500000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/7//w==" DoubleValue="-37756800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VP7//w==" DoubleValue="-36979200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/7//w==" LintValue="-437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VP7//w==" LintValue="-428"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
@@ -1460,308 +1460,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.559056.1.1.12" Name="l_receiptdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovT//w==" DoubleValue="-251424000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPX//w==" DoubleValue="-237772800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovT//w==" LintValue="-2910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPX//w==" LintValue="-2752"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPX//w==" DoubleValue="-237772800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovX//w==" DoubleValue="-229305600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPX//w==" LintValue="-2752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovX//w==" LintValue="-2654"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovX//w==" DoubleValue="-229305600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovX//w==" LintValue="-2654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007790" DistinctValues="19.571768">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000827" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000779" DistinctValues="1.957177">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/b//w==" DoubleValue="-219196800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/b//w==" LintValue="-2537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/b//w==" DoubleValue="-219196800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/b//w==" DoubleValue="-219196800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/b//w==" LintValue="-2537"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="F/b//w==" LintValue="-2537"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029212" DistinctValues="73.394132">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/b//w==" DoubleValue="-219196800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="F/b//w==" LintValue="-2537"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022591" DistinctValues="57.356067">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPb//w==" DoubleValue="-207705600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPb//w==" LintValue="-2404"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPb//w==" DoubleValue="-207705600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPb//w==" DoubleValue="-207705600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPb//w==" LintValue="-2404"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPb//w==" LintValue="-2404"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015190" DistinctValues="38.567010">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPb//w==" DoubleValue="-207705600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPb//w==" LintValue="-2404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iff//w==" DoubleValue="-196214400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Iff//w==" LintValue="-2271"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020759" DistinctValues="51.056636">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iff//w==" DoubleValue="-196214400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/f//w==" DoubleValue="-191894400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Iff//w==" LintValue="-2271"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/f//w==" LintValue="-2221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/f//w==" DoubleValue="-191894400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/f//w==" DoubleValue="-191894400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/f//w==" LintValue="-2221"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="U/f//w==" LintValue="-2221"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005397" DistinctValues="13.274725">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="U/f//w==" DoubleValue="-191894400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="U/f//w==" LintValue="-2221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003737" DistinctValues="9.190194">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" DoubleValue="-190771200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aff//w==" DoubleValue="-189993600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="YPf//w==" LintValue="-2208"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="aff//w==" LintValue="-2199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aff//w==" DoubleValue="-189993600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="aff//w==" DoubleValue="-189993600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="aff//w==" LintValue="-2199"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="aff//w==" LintValue="-2199"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006643" DistinctValues="16.338123">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="aff//w==" DoubleValue="-189993600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="aff//w==" LintValue="-2199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001246" DistinctValues="3.063398">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022360" DistinctValues="56.770801">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" DoubleValue="-188352000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvf//w==" DoubleValue="-183340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPf//w==" LintValue="-2180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvf//w==" LintValue="-2122"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvf//w==" DoubleValue="-183340800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tvf//w==" DoubleValue="-183340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvf//w==" LintValue="-2122"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tvf//w==" LintValue="-2122"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015421" DistinctValues="39.152276">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tvf//w==" DoubleValue="-183340800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tvf//w==" LintValue="-2122"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001968" DistinctValues="4.891827">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" DoubleValue="-179884800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/f//w==" DoubleValue="-179452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3vf//w==" LintValue="-2082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/f//w==" LintValue="-2077"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/f//w==" DoubleValue="-179452800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/f//w==" DoubleValue="-179452800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/f//w==" LintValue="-2077"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/f//w==" LintValue="-2077"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022039" DistinctValues="54.788462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/f//w==" DoubleValue="-179452800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/j//w==" DoubleValue="-174614400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/f//w==" LintValue="-2077"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/j//w==" LintValue="-2021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/j//w==" DoubleValue="-174614400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G/j//w==" DoubleValue="-174614400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/j//w==" LintValue="-2021"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="G/j//w==" LintValue="-2021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000787" DistinctValues="1.956731">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G/j//w==" DoubleValue="-174614400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="G/j//w==" LintValue="-2021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012987" DistinctValues="32.286058">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" DoubleValue="-174441600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfj//w==" LintValue="-2019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010956" DistinctValues="27.817692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026824" DistinctValues="68.105385">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovj//w==" DoubleValue="-162950400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovj//w==" LintValue="-1886"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015777" DistinctValues="39.220626">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovj//w==" DoubleValue="-162950400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPj//w==" DoubleValue="-159667200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovj//w==" LintValue="-1886"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPj//w==" LintValue="-1848"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPj//w==" DoubleValue="-159667200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPj//w==" DoubleValue="-159667200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPj//w==" LintValue="-1848"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="yPj//w==" LintValue="-1848"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004567" DistinctValues="11.353339">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPj//w==" DoubleValue="-159667200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/j//w==" DoubleValue="-158716800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="yPj//w==" LintValue="-1848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/j//w==" LintValue="-1837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/j//w==" DoubleValue="-158716800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/j//w==" DoubleValue="-158716800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/j//w==" LintValue="-1837"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0/j//w==" LintValue="-1837"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002906" DistinctValues="7.224852">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/j//w==" DoubleValue="-158716800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0/j//w==" LintValue="-1837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000851" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014531" DistinctValues="36.124260">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" DoubleValue="-158112000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fj//w==" DoubleValue="-155088000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="2vj//w==" LintValue="-1830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fj//w==" LintValue="-1795"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024640" DistinctValues="61.906355">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fj//w==" DoubleValue="-155088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofn//w==" DoubleValue="-149904000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fj//w==" LintValue="-1795"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofn//w==" LintValue="-1735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofn//w==" DoubleValue="-149904000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofn//w==" DoubleValue="-149904000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofn//w==" LintValue="-1735"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofn//w==" LintValue="-1735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005339" DistinctValues="13.413043">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofn//w==" DoubleValue="-149904000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvn//w==" DoubleValue="-148780800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofn//w==" LintValue="-1735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvn//w==" LintValue="-1722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvn//w==" DoubleValue="-148780800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvn//w==" DoubleValue="-148780800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvn//w==" LintValue="-1722"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Rvn//w==" LintValue="-1722"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007803" DistinctValues="19.603679">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvn//w==" DoubleValue="-148780800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfn//w==" DoubleValue="-147139200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Rvn//w==" LintValue="-1722"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wfn//w==" LintValue="-1703"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000394" DistinctValues="0.999199">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfn//w==" DoubleValue="-147139200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvn//w==" DoubleValue="-147052800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wfn//w==" LintValue="-1703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvn//w==" LintValue="-1702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000732" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvn//w==" DoubleValue="-147052800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvn//w==" DoubleValue="-147052800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvn//w==" LintValue="-1702"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvn//w==" LintValue="-1702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037387" DistinctValues="94.923878">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvn//w==" DoubleValue="-147052800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufn//w==" DoubleValue="-138844800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvn//w==" LintValue="-1702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ufn//w==" LintValue="-1607"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010409" DistinctValues="25.876766">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufn//w==" DoubleValue="-138844800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pn//w==" DoubleValue="-136512000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufn//w==" LintValue="-1607"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pn//w==" LintValue="-1580"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pn//w==" DoubleValue="-136512000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pn//w==" DoubleValue="-136512000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pn//w==" LintValue="-1580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pn//w==" LintValue="-1580"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005783" DistinctValues="14.375981">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pn//w==" DoubleValue="-136512000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/n//w==" DoubleValue="-135216000000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pn//w==" LintValue="-1580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/n//w==" LintValue="-1565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000709" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/n//w==" DoubleValue="-135216000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/n//w==" DoubleValue="-135216000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/n//w==" LintValue="-1565"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4/n//w==" LintValue="-1565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012722" DistinctValues="31.627159">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/n//w==" DoubleValue="-135216000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPr//w==" DoubleValue="-132364800000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4/n//w==" LintValue="-1565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BPr//w==" LintValue="-1532"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPr//w==" DoubleValue="-132364800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BPr//w==" DoubleValue="-132364800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BPr//w==" LintValue="-1532"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="BPr//w==" LintValue="-1532"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008867" DistinctValues="22.043171">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BPr//w==" DoubleValue="-132364800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="BPr//w==" LintValue="-1532"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efr//w==" DoubleValue="-122256000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efr//w==" LintValue="-1415"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001181" DistinctValues="2.997596">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efr//w==" DoubleValue="-122256000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPr//w==" DoubleValue="-121996800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efr//w==" LintValue="-1415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fPr//w==" LintValue="-1412"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPr//w==" DoubleValue="-121996800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPr//w==" DoubleValue="-121996800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fPr//w==" LintValue="-1412"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fPr//w==" LintValue="-1412"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036600" DistinctValues="92.925481">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPr//w==" DoubleValue="-121996800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fr//w==" DoubleValue="-113961600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fPr//w==" LintValue="-1412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2fr//w==" LintValue="-1319"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003250" DistinctValues="8.251447">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fr//w==" DoubleValue="-113961600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2fr//w==" LintValue="-1319"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.034531" DistinctValues="87.671629">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" DoubleValue="-113270400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="4fr//w==" LintValue="-1311"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/v//w==" DoubleValue="-88905600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/v//w==" LintValue="-1029"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006297" DistinctValues="15.987179">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/v//w==" DoubleValue="-88905600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/z//w==" DoubleValue="-87523200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/v//w==" LintValue="-1029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C/z//w==" LintValue="-1013"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/z//w==" DoubleValue="-87523200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="C/z//w==" DoubleValue="-87523200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C/z//w==" LintValue="-1013"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="C/z//w==" LintValue="-1013"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031484" DistinctValues="79.935897">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="C/z//w==" DoubleValue="-87523200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="C/z//w==" LintValue="-1013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007871" DistinctValues="19.983974">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" DoubleValue="-63936000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HP3//w==" LintValue="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000685" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029910" DistinctValues="75.939103">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" DoubleValue="-62208000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000.000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="MP3//w==" LintValue="-720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" DoubleValue="-47088000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/3//w==" LintValue="-545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037781" DistinctValues="96.923077">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iv7//w==" DoubleValue="-32313600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="iv7//w==" LintValue="-374"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.559056.1.1.5" Name="l_extendedprice" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -2576,7 +2576,7 @@
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
           <dxl:Ident ColId="12" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000.000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.559056.1.1" TableName="lineitem">
@@ -2612,7 +2612,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="348946322.694889" Rows="190108557.331236" Width="138"/>
+          <dxl:Cost StartupCost="0" TotalCost="348839382.146426" Rows="189579537.420000" Width="138"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -2668,7 +2668,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="336136272.421592" Rows="190108557.331236" Width="138"/>
+            <dxl:Cost StartupCost="0" TotalCost="336064978.722617" Rows="189579537.420000" Width="138"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -2743,7 +2743,7 @@
           </dxl:PartitionSelector>
           <dxl:DynamicTableScan PartIndexId="1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="336136272.421592" Rows="190108557.331236" Width="138"/>
+              <dxl:Cost StartupCost="0" TotalCost="336064978.722617" Rows="189579537.420000" Width="138"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="l_orderkey">
@@ -2798,7 +2798,7 @@
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="11" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" DoubleValue="-220838400000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="BPb//w==" LintValue="-2556"/>
               </dxl:Comparison>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.559056.1.1" TableName="lineitem">

--- a/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnBpchar.mdp
@@ -401,214 +401,214 @@
       <dxl:ColumnStatistics Mdid="1.17165.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" DoubleValue="-249696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KfX//w==" DoubleValue="-239760000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvT//w==" LintValue="-2890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KfX//w==" LintValue="-2775"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KfX//w==" DoubleValue="-239760000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvX//w==" DoubleValue="-231724800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KfX//w==" LintValue="-2775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hvX//w==" LintValue="-2682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvX//w==" DoubleValue="-231724800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hvX//w==" LintValue="-2682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" DoubleValue="-223257600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6PX//w==" LintValue="-2584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" DoubleValue="-182131200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivj//w==" DoubleValue="-174009600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPf//w==" LintValue="-2108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ivj//w==" LintValue="-2014"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivj//w==" DoubleValue="-174009600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ivj//w==" LintValue="-2014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" DoubleValue="-165628800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/j//w==" LintValue="-1917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" DoubleValue="-148262400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPn//w==" LintValue="-1716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" DoubleValue="-139622400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPn//w==" LintValue="-1616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" DoubleValue="-130723200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/r//w==" LintValue="-1513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" DoubleValue="-114480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/r//w==" LintValue="-1325"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" DoubleValue="-105840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvv//w==" DoubleValue="-97977600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/v//w==" LintValue="-1225"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvv//w==" LintValue="-1134"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvv//w==" DoubleValue="-97977600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vv//w==" DoubleValue="-89683200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvv//w==" LintValue="-1134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vv//w==" LintValue="-1038"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vv//w==" DoubleValue="-89683200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vv//w==" LintValue="-1038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" DoubleValue="-81993600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="S/z//w==" LintValue="-949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" DoubleValue="-73612800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dv3//w==" DoubleValue="-65145600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rPz//w==" LintValue="-852"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dv3//w==" LintValue="-754"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dv3//w==" DoubleValue="-65145600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv3//w==" DoubleValue="-56505600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dv3//w==" LintValue="-754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cv3//w==" LintValue="-654"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv3//w==" DoubleValue="-56505600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cv3//w==" LintValue="-654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" DoubleValue="-48470400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP7//w==" DoubleValue="-37670400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="z/3//w==" LintValue="-561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TP7//w==" LintValue="-436"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP7//w==" DoubleValue="-37670400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TP7//w==" LintValue="-436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" DoubleValue="-251856000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/X//w==" DoubleValue="-239587200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfT//w==" LintValue="-2915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="K/X//w==" LintValue="-2773"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/X//w==" DoubleValue="-239587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="K/X//w==" LintValue="-2773"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" DoubleValue="-231811200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfX//w==" LintValue="-2683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" DoubleValue="-223084800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vX//w==" LintValue="-2582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" DoubleValue="-214099200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvb//w==" LintValue="-2478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" DoubleValue="-205286400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPb//w==" LintValue="-2376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" DoubleValue="-196819200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvf//w==" LintValue="-2278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" DoubleValue="-181958400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvf//w==" LintValue="-2106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" DoubleValue="-165542400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hPj//w==" LintValue="-1916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvn//w==" DoubleValue="-148089600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvn//w==" LintValue="-1714"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvn//w==" DoubleValue="-148089600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvn//w==" LintValue="-1714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pr//w==" DoubleValue="-114393600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1Pr//w==" LintValue="-1324"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pr//w==" DoubleValue="-114393600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/v//w==" DoubleValue="-106185600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1Pr//w==" LintValue="-1324"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/v//w==" LintValue="-1229"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/v//w==" DoubleValue="-106185600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/v//w==" LintValue="-1229"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" DoubleValue="-89596800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvz//w==" DoubleValue="-81734400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/v//w==" LintValue="-1037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Tvz//w==" LintValue="-946"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvz//w==" DoubleValue="-81734400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Tvz//w==" LintValue="-946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" DoubleValue="-48297600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv7//w==" DoubleValue="-34732800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0f3//w==" LintValue="-559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bv7//w==" LintValue="-402"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.615385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" DoubleValue="-34732800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" LintValue="-402"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -747,108 +747,108 @@
       <dxl:ColumnStatistics Mdid="1.17165.1.1.20" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" DoubleValue="-251769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" LintValue="-2914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" DoubleValue="-238204800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="O/X//w==" LintValue="-2757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" DoubleValue="-230428800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fX//w==" DoubleValue="-221788800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfX//w==" LintValue="-2667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fX//w==" LintValue="-2567"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fX//w==" DoubleValue="-221788800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fX//w==" LintValue="-2567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" DoubleValue="-212716800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPb//w==" DoubleValue="-203904000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvb//w==" LintValue="-2462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yPb//w==" LintValue="-2360"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPb//w==" DoubleValue="-203904000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yPb//w==" LintValue="-2360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" DoubleValue="-187833600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvf//w==" LintValue="-2174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" DoubleValue="-180662400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfj//w==" DoubleValue="-172713600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1ff//w==" LintValue="-2091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfj//w==" LintValue="-1999"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfj//w==" DoubleValue="-172713600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfj//w==" LintValue="-1999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/n//w==" DoubleValue="-138326400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/n//w==" LintValue="-1601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/n//w==" DoubleValue="-138326400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvr//w==" DoubleValue="-129427200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/n//w==" LintValue="-1601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jvr//w==" LintValue="-1498"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvr//w==" DoubleValue="-129427200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jvr//w==" LintValue="-1498"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" DoubleValue="-113097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPv//w==" DoubleValue="-104716800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4/r//w==" LintValue="-1309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RPv//w==" LintValue="-1212"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPv//w==" DoubleValue="-104716800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/v//w==" DoubleValue="-96508800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RPv//w==" LintValue="-1212"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/v//w==" LintValue="-1117"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/v//w==" DoubleValue="-96508800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/v//w==" LintValue="-1117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" DoubleValue="-88214400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvz//w==" DoubleValue="-80352000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/z//w==" LintValue="-1021"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvz//w==" LintValue="-930"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvz//w==" DoubleValue="-80352000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvz//w==" LintValue="-930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="If3//w==" DoubleValue="-63504000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="If3//w==" LintValue="-735"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="If3//w==" DoubleValue="-63504000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="If3//w==" LintValue="-735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" DoubleValue="-55209600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gf3//w==" LintValue="-639"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" DoubleValue="-46828800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hP7//w==" DoubleValue="-32832000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4v3//w==" LintValue="-542"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hP7//w==" LintValue="-380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.769231">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hP7//w==" DoubleValue="-32832000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hP7//w==" LintValue="-380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.5" Name="l_extendedprice" Width="10.000000">

--- a/src/backend/gporca/data/dxl/minidump/SortOverStreamAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SortOverStreamAgg.mdp
@@ -933,108 +933,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.40615.1.1.3" Name="calendar_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" DoubleValue="410313600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qhIAAA==" DoubleValue="412819200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jRIAAA==" LintValue="4749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="qhIAAA==" LintValue="4778"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qhIAAA==" DoubleValue="412819200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxIAAA==" DoubleValue="415324800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="qhIAAA==" LintValue="4778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xxIAAA==" LintValue="4807"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxIAAA==" DoubleValue="415324800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5BIAAA==" DoubleValue="417830400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xxIAAA==" LintValue="4807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5BIAAA==" LintValue="4836"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5BIAAA==" DoubleValue="417830400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ARMAAA==" DoubleValue="420336000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5BIAAA==" LintValue="4836"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ARMAAA==" LintValue="4865"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ARMAAA==" DoubleValue="420336000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhMAAA==" DoubleValue="422841600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ARMAAA==" LintValue="4865"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HhMAAA==" LintValue="4894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhMAAA==" DoubleValue="422841600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OxMAAA==" DoubleValue="425347200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HhMAAA==" LintValue="4894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OxMAAA==" LintValue="4923"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OxMAAA==" DoubleValue="425347200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WBMAAA==" DoubleValue="427852800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OxMAAA==" LintValue="4923"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="WBMAAA==" LintValue="4952"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WBMAAA==" DoubleValue="427852800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dRMAAA==" DoubleValue="430358400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="WBMAAA==" LintValue="4952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dRMAAA==" LintValue="4981"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dRMAAA==" DoubleValue="430358400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="khMAAA==" DoubleValue="432864000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dRMAAA==" LintValue="4981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="khMAAA==" LintValue="5010"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="khMAAA==" DoubleValue="432864000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rxMAAA==" DoubleValue="435369600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="khMAAA==" LintValue="5010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rxMAAA==" LintValue="5039"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rxMAAA==" DoubleValue="435369600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zBMAAA==" DoubleValue="437875200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rxMAAA==" LintValue="5039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zBMAAA==" LintValue="5068"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zBMAAA==" DoubleValue="437875200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6RMAAA==" DoubleValue="440380800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zBMAAA==" LintValue="5068"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6RMAAA==" LintValue="5097"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6RMAAA==" DoubleValue="440380800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BhQAAA==" DoubleValue="442886400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6RMAAA==" LintValue="5097"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BhQAAA==" LintValue="5126"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BhQAAA==" DoubleValue="442886400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxQAAA==" DoubleValue="445392000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BhQAAA==" LintValue="5126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IxQAAA==" LintValue="5155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxQAAA==" DoubleValue="445392000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QBQAAA==" DoubleValue="447897600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IxQAAA==" LintValue="5155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QBQAAA==" LintValue="5184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QBQAAA==" DoubleValue="447897600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XRQAAA==" DoubleValue="450403200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QBQAAA==" LintValue="5184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="XRQAAA==" LintValue="5213"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XRQAAA==" DoubleValue="450403200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehQAAA==" DoubleValue="452908800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="XRQAAA==" LintValue="5213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ehQAAA==" LintValue="5242"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehQAAA==" DoubleValue="452908800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lxQAAA==" DoubleValue="455414400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ehQAAA==" LintValue="5242"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lxQAAA==" LintValue="5271"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lxQAAA==" DoubleValue="455414400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tBQAAA==" DoubleValue="457920000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lxQAAA==" LintValue="5271"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tBQAAA==" LintValue="5300"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tBQAAA==" DoubleValue="457920000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0RQAAA==" DoubleValue="460425600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tBQAAA==" LintValue="5300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0RQAAA==" LintValue="5329"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0RQAAA==" DoubleValue="460425600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7hQAAA==" DoubleValue="462931200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0RQAAA==" LintValue="5329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7hQAAA==" LintValue="5358"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7hQAAA==" DoubleValue="462931200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CxUAAA==" DoubleValue="465436800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7hQAAA==" LintValue="5358"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CxUAAA==" LintValue="5387"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" DoubleValue="465436800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KBUAAA==" DoubleValue="467942400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CxUAAA==" LintValue="5387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KBUAAA==" LintValue="5416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KBUAAA==" DoubleValue="467942400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RRUAAA==" DoubleValue="470448000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KBUAAA==" LintValue="5416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RRUAAA==" LintValue="5445"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RRUAAA==" DoubleValue="470448000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YhUAAA==" DoubleValue="472953600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RRUAAA==" LintValue="5445"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YhUAAA==" LintValue="5474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="28.076923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YhUAAA==" DoubleValue="472953600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" DoubleValue="473299200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YhUAAA==" LintValue="5474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZhUAAA==" LintValue="5478"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.40615.1.1.2" Name="date_name_cn" Width="18.000000" NullFreq="0.000000" NdvRemain="730.000000" FreqRemain="1.000000"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -1128,108 +1128,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.32889.1.1.2" Name="d_date" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W3H//w==" DoubleValue="-3155068800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnz//w==" DoubleValue="-2906323200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W3H//w==" LintValue="-36517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mnz//w==" LintValue="-33638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnz//w==" DoubleValue="-2906323200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D4j//w==" DoubleValue="-2652912000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mnz//w==" LintValue="-33638"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D4j//w==" LintValue="-30705"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D4j//w==" DoubleValue="-2652912000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ZP//w==" DoubleValue="-2389737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D4j//w==" LintValue="-30705"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9ZP//w==" LintValue="-27659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ZP//w==" DoubleValue="-2389737600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FJ///w==" DoubleValue="-2143756800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9ZP//w==" LintValue="-27659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FJ///w==" LintValue="-24812"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FJ///w==" DoubleValue="-2143756800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yar//w==" DoubleValue="-1893801600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FJ///w==" LintValue="-24812"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yar//w==" LintValue="-21919"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yar//w==" DoubleValue="-1893801600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k7X//w==" DoubleValue="-1646179200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yar//w==" LintValue="-21919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k7X//w==" LintValue="-19053"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k7X//w==" DoubleValue="-1646179200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="msD//w==" DoubleValue="-1402272000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k7X//w==" LintValue="-19053"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="msD//w==" LintValue="-16230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="msD//w==" DoubleValue="-1402272000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xMv//w==" DoubleValue="-1155340800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="msD//w==" LintValue="-16230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xMv//w==" LintValue="-13372"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xMv//w==" DoubleValue="-1155340800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ddf//w==" DoubleValue="-905731200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xMv//w==" LintValue="-13372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ddf//w==" LintValue="-10483"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ddf//w==" DoubleValue="-905731200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h+L//w==" DoubleValue="-651888000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ddf//w==" LintValue="-10483"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h+L//w==" LintValue="-7545"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h+L//w==" DoubleValue="-651888000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W+3//w==" DoubleValue="-412387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h+L//w==" LintValue="-7545"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W+3//w==" LintValue="-4773"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+3//w==" DoubleValue="-412387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W+3//w==" LintValue="-4773"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" DoubleValue="-157248000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UwQAAA==" DoubleValue="95644800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pj//w==" LintValue="-1820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UwQAAA==" LintValue="1107"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UwQAAA==" DoubleValue="95644800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vA8AAA==" DoubleValue="348019200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UwQAAA==" LintValue="1107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vA8AAA==" LintValue="4028"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vA8AAA==" DoubleValue="348019200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wRsAAA==" DoubleValue="613872000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vA8AAA==" LintValue="4028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wRsAAA==" LintValue="7105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wRsAAA==" DoubleValue="613872000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CicAAA==" DoubleValue="863481600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wRsAAA==" LintValue="7105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CicAAA==" LintValue="9994"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CicAAA==" DoubleValue="863481600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YDIAAA==" DoubleValue="1114214400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CicAAA==" LintValue="9994"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="YDIAAA==" LintValue="12896"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YDIAAA==" DoubleValue="1114214400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1z0AAA==" DoubleValue="1367798400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="YDIAAA==" LintValue="12896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1z0AAA==" LintValue="15831"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1z0AAA==" DoubleValue="1367798400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RUkAAA==" DoubleValue="1620604800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1z0AAA==" LintValue="15831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RUkAAA==" LintValue="18757"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RUkAAA==" DoubleValue="1620604800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QlQAAA==" DoubleValue="1863648000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RUkAAA==" LintValue="18757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QlQAAA==" LintValue="21570"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QlQAAA==" DoubleValue="1863648000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GWAAAA==" DoubleValue="2125526400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QlQAAA==" LintValue="21570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GWAAAA==" LintValue="24601"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GWAAAA==" DoubleValue="2125526400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uGsAAA==" DoubleValue="2382566400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GWAAAA==" LintValue="24601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uGsAAA==" LintValue="27576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uGsAAA==" DoubleValue="2382566400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="53YAAA==" DoubleValue="2629929600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uGsAAA==" LintValue="27576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="53YAAA==" LintValue="30439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="53YAAA==" DoubleValue="2629929600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p4EAAA==" DoubleValue="2867702400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="53YAAA==" LintValue="30439"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p4EAAA==" LintValue="33191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p4EAAA==" DoubleValue="2867702400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="co4AAA==" DoubleValue="3150662400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p4EAAA==" LintValue="33191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="co4AAA==" LintValue="36466"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2805.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="co4AAA==" DoubleValue="3150662400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rY4AAA==" DoubleValue="3155760000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="co4AAA==" LintValue="36466"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rY4AAA==" LintValue="36525"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -959,108 +959,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.93299.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovT//w==" DoubleValue="-251424000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovT//w==" LintValue="-2910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" DoubleValue="-237600000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofX//w==" DoubleValue="-229392000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QvX//w==" LintValue="-2750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofX//w==" LintValue="-2655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofX//w==" DoubleValue="-229392000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/b//w==" DoubleValue="-220924800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofX//w==" LintValue="-2655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/b//w==" LintValue="-2557"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/b//w==" DoubleValue="-220924800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPb//w==" DoubleValue="-212544000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/b//w==" LintValue="-2557"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZPb//w==" LintValue="-2460"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPb//w==" DoubleValue="-212544000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZPb//w==" LintValue="-2460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" DoubleValue="-204249600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I/f//w==" DoubleValue="-196041600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPb//w==" LintValue="-2364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="I/f//w==" LintValue="-2269"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I/f//w==" DoubleValue="-196041600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/f//w==" DoubleValue="-187747200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="I/f//w==" LintValue="-2269"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="g/f//w==" LintValue="-2173"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/f//w==" DoubleValue="-187747200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5ff//w==" DoubleValue="-179280000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="g/f//w==" LintValue="-2173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5ff//w==" LintValue="-2075"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5ff//w==" DoubleValue="-179280000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvj//w==" DoubleValue="-171244800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5ff//w==" LintValue="-2075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvj//w==" LintValue="-1982"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvj//w==" DoubleValue="-171244800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovj//w==" DoubleValue="-162950400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvj//w==" LintValue="-1982"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovj//w==" LintValue="-1886"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovj//w==" DoubleValue="-162950400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovj//w==" LintValue="-1886"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvn//w==" DoubleValue="-146361600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvn//w==" LintValue="-1694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvn//w==" DoubleValue="-146361600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/n//w==" DoubleValue="-137980800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvn//w==" LintValue="-1694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/n//w==" LintValue="-1597"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/n//w==" DoubleValue="-137980800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/n//w==" LintValue="-1597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" DoubleValue="-129859200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifr//w==" LintValue="-1503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" DoubleValue="-121478400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gvr//w==" LintValue="-1406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPv//w==" DoubleValue="-105408000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PPv//w==" LintValue="-1220"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPv//w==" DoubleValue="-105408000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovv//w==" DoubleValue="-96595200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PPv//w==" LintValue="-1220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ovv//w==" LintValue="-1118"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovv//w==" DoubleValue="-96595200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ovv//w==" LintValue="-1118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" DoubleValue="-88387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/z//w==" DoubleValue="-80265600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afz//w==" LintValue="-1023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/z//w==" LintValue="-929"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/z//w==" DoubleValue="-80265600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/z//w==" DoubleValue="-71971200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/z//w==" LintValue="-929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/z//w==" LintValue="-833"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/z//w==" DoubleValue="-71971200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hf3//w==" DoubleValue="-63849600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/z//w==" LintValue="-833"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hf3//w==" LintValue="-739"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hf3//w==" DoubleValue="-63849600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev3//w==" DoubleValue="-55814400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hf3//w==" LintValue="-739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ev3//w==" LintValue="-646"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev3//w==" DoubleValue="-55814400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ev3//w==" LintValue="-646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" DoubleValue="-47520000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df7//w==" DoubleValue="-34128000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v3//w==" LintValue="-550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="df7//w==" LintValue="-395"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.961538">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df7//w==" DoubleValue="-34128000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hv7//w==" DoubleValue="-32659200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="df7//w==" LintValue="-395"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hv7//w==" LintValue="-378"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.93299.1.1.5" Name="l_extendedprice" Width="10.000000">
@@ -1866,214 +1866,214 @@
       <dxl:ColumnStatistics Mdid="1.93299.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.93299.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" DoubleValue="-249782400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" LintValue="-2891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" DoubleValue="-222220800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PX//w==" LintValue="-2572"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPf//w==" DoubleValue="-197337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPf//w==" LintValue="-2284"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPf//w==" DoubleValue="-197337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPf//w==" LintValue="-2284"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/f//w==" DoubleValue="-180835200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0/f//w==" LintValue="-2093"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/f//w==" DoubleValue="-180835200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvj//w==" DoubleValue="-172627200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0/f//w==" LintValue="-2093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mvj//w==" LintValue="-1998"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvj//w==" DoubleValue="-172627200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfj//w==" DoubleValue="-164419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mvj//w==" LintValue="-1998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfj//w==" LintValue="-1903"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfj//w==" DoubleValue="-164419200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/j//w==" DoubleValue="-155952000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfj//w==" LintValue="-1903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/j//w==" LintValue="-1805"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/j//w==" DoubleValue="-155952000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPn//w==" DoubleValue="-147571200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/j//w==" LintValue="-1805"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPn//w==" LintValue="-1708"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPn//w==" DoubleValue="-147571200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPn//w==" LintValue="-1708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" DoubleValue="-131500800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dvr//w==" LintValue="-1522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvr//w==" DoubleValue="-114912000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="zvr//w==" LintValue="-1330"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvr//w==" DoubleValue="-114912000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvv//w==" DoubleValue="-106617600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="zvr//w==" LintValue="-1330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvv//w==" LintValue="-1234"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvv//w==" DoubleValue="-106617600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvv//w==" DoubleValue="-98323200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvv//w==" LintValue="-1234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jvv//w==" LintValue="-1138"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvv//w==" DoubleValue="-98323200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fv//w==" DoubleValue="-89769600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jvv//w==" LintValue="-1138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fv//w==" LintValue="-1039"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fv//w==" DoubleValue="-89769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fv//w==" LintValue="-1039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" DoubleValue="-73353600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/z//w==" LintValue="-849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" DoubleValue="-65232000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Df3//w==" LintValue="-755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yv3//w==" DoubleValue="-48902400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yv3//w==" LintValue="-566"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yv3//w==" DoubleValue="-48902400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SP7//w==" DoubleValue="-38016000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yv3//w==" LintValue="-566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SP7//w==" LintValue="-440"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SP7//w==" DoubleValue="-38016000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uf7//w==" DoubleValue="-37238400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SP7//w==" LintValue="-440"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uf7//w==" LintValue="-431"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.93299.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPT//w==" DoubleValue="-251942400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPT//w==" LintValue="-2916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" DoubleValue="-238896000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfX//w==" DoubleValue="-230774400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/X//w==" LintValue="-2765"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfX//w==" LintValue="-2671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfX//w==" DoubleValue="-230774400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfX//w==" LintValue="-2671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" DoubleValue="-213840000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfb//w==" LintValue="-2475"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" DoubleValue="-197424000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="E/f//w==" LintValue="-2285"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" DoubleValue="-189129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vf//w==" DoubleValue="-180576000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/f//w==" LintValue="-2189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vf//w==" LintValue="-2090"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vf//w==" DoubleValue="-180576000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/j//w==" DoubleValue="-172540800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vf//w==" LintValue="-2090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="M/j//w==" LintValue="-1997"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/j//w==" DoubleValue="-172540800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvj//w==" DoubleValue="-164332800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="M/j//w==" LintValue="-1997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvj//w==" LintValue="-1902"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvj//w==" DoubleValue="-164332800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvj//w==" LintValue="-1902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" DoubleValue="-155865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9Pj//w==" LintValue="-1804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPn//w==" DoubleValue="-139276800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPn//w==" LintValue="-1612"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPn//w==" DoubleValue="-139276800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPn//w==" LintValue="-1612"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" DoubleValue="-131241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efr//w==" LintValue="-1519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" DoubleValue="-114652800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/v//w==" DoubleValue="-106531200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fr//w==" LintValue="-1327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/v//w==" LintValue="-1233"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/v//w==" DoubleValue="-106531200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfv//w==" DoubleValue="-98064000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/v//w==" LintValue="-1233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfv//w==" LintValue="-1135"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfv//w==" DoubleValue="-98064000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fv//w==" DoubleValue="-89769600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfv//w==" LintValue="-1135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fv//w==" LintValue="-1039"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fv//w==" DoubleValue="-89769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fv//w==" LintValue="-1039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPz//w==" DoubleValue="-73267200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sPz//w==" LintValue="-848"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPz//w==" DoubleValue="-73267200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sPz//w==" LintValue="-848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" DoubleValue="-65059200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/3//w==" LintValue="-753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" DoubleValue="-57110400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/3//w==" DoubleValue="-48816000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/3//w==" LintValue="-661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/3//w==" LintValue="-565"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/3//w==" DoubleValue="-48816000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZP7//w==" DoubleValue="-35596800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/3//w==" LintValue="-565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ZP7//w==" LintValue="-412"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZP7//w==" DoubleValue="-35596800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" DoubleValue="-34732800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZP7//w==" LintValue="-412"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bv7//w==" LintValue="-402"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.93299.1.1.3" Name="l_linenumber" Width="4.000000">

--- a/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCH-Q5.mdp
@@ -534,606 +534,606 @@
       <dxl:ColumnStatistics Mdid="1.447748.1.1.18" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.447748.1.1.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.032358" DistinctValues="80.167692">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" DoubleValue="-249782400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfT//w==" LintValue="-2891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005443" DistinctValues="13.486154">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" DoubleValue="-240537600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="IPX//w==" LintValue="-2784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001969" DistinctValues="4.617388">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/X//w==" DoubleValue="-238550400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/X//w==" LintValue="-2761"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/X//w==" DoubleValue="-238550400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/X//w==" DoubleValue="-238550400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/X//w==" LintValue="-2761"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="N/X//w==" LintValue="-2761"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004725" DistinctValues="11.081731">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/X//w==" DoubleValue="-238550400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="N/X//w==" LintValue="-2761"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004725" DistinctValues="11.081731">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010238" DistinctValues="24.010417">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" DoubleValue="-236476800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afX//w==" DoubleValue="-234230400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="T/X//w==" LintValue="-2737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afX//w==" LintValue="-2711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afX//w==" DoubleValue="-234230400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afX//w==" DoubleValue="-234230400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afX//w==" LintValue="-2711"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="afX//w==" LintValue="-2711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001969" DistinctValues="4.617388">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afX//w==" DoubleValue="-234230400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvX//w==" DoubleValue="-233798400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="afX//w==" LintValue="-2711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="bvX//w==" LintValue="-2706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvX//w==" DoubleValue="-233798400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bvX//w==" DoubleValue="-233798400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="bvX//w==" LintValue="-2706"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="bvX//w==" LintValue="-2706"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011419" DistinctValues="26.780849">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bvX//w==" DoubleValue="-233798400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="bvX//w==" LintValue="-2706"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002756" DistinctValues="6.464343">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" DoubleValue="-231292800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="i/X//w==" LintValue="-2677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" DoubleValue="-222307200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/X//w==" LintValue="-2573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019485" DistinctValues="48.275178">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfb//w==" DoubleValue="-209692800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hfb//w==" LintValue="-2427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfb//w==" DoubleValue="-209692800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hfb//w==" DoubleValue="-209692800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hfb//w==" LintValue="-2427"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hfb//w==" LintValue="-2427"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018316" DistinctValues="45.378668">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hfb//w==" DoubleValue="-209692800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hfb//w==" LintValue="-2427"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027874" DistinctValues="69.057887">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" DoubleValue="-205632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPb//w==" LintValue="-2380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009928" DistinctValues="24.595960">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" DoubleValue="-199324800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/fb//w==" LintValue="-2307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" DoubleValue="-197078400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="F/f//w==" LintValue="-2281"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" DoubleValue="-188697600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePf//w==" LintValue="-2184"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="93.653846">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovj//w==" DoubleValue="-171936000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ovj//w==" LintValue="-1990"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011468" DistinctValues="28.411841">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovj//w==" DoubleValue="-171936000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ovj//w==" LintValue="-1990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026334" DistinctValues="65.242005">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" DoubleValue="-169603200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Vfj//w==" LintValue="-1963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" DoubleValue="-164246400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pj//w==" DoubleValue="-156211200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="k/j//w==" LintValue="-1901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8Pj//w==" LintValue="-1808"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pj//w==" DoubleValue="-156211200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8Pj//w==" LintValue="-1808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016932" DistinctValues="41.949119">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020870" DistinctValues="51.704728">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svn//w==" DoubleValue="-139449600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svn//w==" LintValue="-1614"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004878" DistinctValues="12.084367">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svn//w==" DoubleValue="-139449600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svn//w==" LintValue="-1614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032924" DistinctValues="81.569479">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" DoubleValue="-138412800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/r//w==" DoubleValue="-131414400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvn//w==" LintValue="-1602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/r//w==" LintValue="-1521"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018901" DistinctValues="46.826923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/r//w==" DoubleValue="-131414400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/r//w==" LintValue="-1521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000781" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018901" DistinctValues="46.826923">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" DoubleValue="-127180800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPr//w==" LintValue="-1472"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015978" DistinctValues="39.162966">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" DoubleValue="-122947200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvr//w==" DoubleValue="-119404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cfr//w==" LintValue="-1423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvr//w==" LintValue="-1382"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvr//w==" DoubleValue="-119404800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvr//w==" DoubleValue="-119404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvr//w==" LintValue="-1382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvr//w==" LintValue="-1382"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015199" DistinctValues="37.252577">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvr//w==" DoubleValue="-119404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvr//w==" LintValue="-1382"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006625" DistinctValues="16.238303">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" DoubleValue="-116035200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vr//w==" DoubleValue="-114566400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wfr//w==" LintValue="-1343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vr//w==" LintValue="-1326"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025335" DistinctValues="62.768003">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vr//w==" DoubleValue="-114566400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efv//w==" DoubleValue="-109123200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vr//w==" LintValue="-1326"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Efv//w==" LintValue="-1263"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efv//w==" DoubleValue="-109123200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efv//w==" DoubleValue="-109123200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Efv//w==" LintValue="-1263"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Efv//w==" LintValue="-1263"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012466" DistinctValues="30.885843">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efv//w==" DoubleValue="-109123200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPv//w==" DoubleValue="-106444800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Efv//w==" LintValue="-1263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPv//w==" LintValue="-1232"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028351" DistinctValues="70.240385">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPv//w==" DoubleValue="-106444800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPv//w==" LintValue="-1232"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009450" DistinctValues="23.413462">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" DoubleValue="-99964800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="e/v//w==" LintValue="-1157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.032887" DistinctValues="81.478846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004914" DistinctValues="12.175000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pv//w==" DoubleValue="-89164800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+Pv//w==" LintValue="-1032"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014128" DistinctValues="35.001943">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pv//w==" DoubleValue="-89164800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+Pv//w==" LintValue="-1032"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023674" DistinctValues="58.651904">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001206" DistinctValues="2.988953">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" DoubleValue="-72144000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wPz//w==" DoubleValue="-71884800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vfz//w==" LintValue="-835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wPz//w==" LintValue="-832"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wPz//w==" DoubleValue="-71884800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wPz//w==" DoubleValue="-71884800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wPz//w==" LintValue="-832"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="wPz//w==" LintValue="-832"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036595" DistinctValues="90.664894">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wPz//w==" DoubleValue="-71884800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="wPz//w==" LintValue="-832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036158" DistinctValues="89.581940">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" DoubleValue="-64022400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/3//w==" LintValue="-741"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001644" DistinctValues="4.071906">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" DoubleValue="-56419200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/3//w==" DoubleValue="-56073600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="c/3//w==" LintValue="-653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/3//w==" LintValue="-649"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026660" DistinctValues="65.345344">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/3//w==" DoubleValue="-56073600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uv3//w==" DoubleValue="-50284800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/3//w==" LintValue="-649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uv3//w==" LintValue="-582"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uv3//w==" DoubleValue="-50284800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uv3//w==" DoubleValue="-50284800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uv3//w==" LintValue="-582"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uv3//w==" LintValue="-582"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009550" DistinctValues="23.407287">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uv3//w==" DoubleValue="-50284800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0v3//w==" DoubleValue="-48211200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uv3//w==" LintValue="-582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0v3//w==" LintValue="-558"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0v3//w==" DoubleValue="-48211200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0v3//w==" DoubleValue="-48211200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0v3//w==" LintValue="-558"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0v3//w==" LintValue="-558"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001592" DistinctValues="3.901215">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0v3//w==" DoubleValue="-48211200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0v3//w==" LintValue="-558"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007821" DistinctValues="19.376658">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029980" DistinctValues="74.277188">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" DoubleValue="-45792000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7v3//w==" LintValue="-530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037801" DistinctValues="94.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" DoubleValue="-37843200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VP7//w==" DoubleValue="-36979200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sv7//w==" LintValue="-438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VP7//w==" LintValue="-428"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.447748.1.1.10" Name="l_shipdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.028786" DistinctValues="72.907539">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/T//w==" DoubleValue="-252028800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/T//w==" LintValue="-2917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009011" DistinctValues="22.823230">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" DoubleValue="-242092800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DvX//w==" LintValue="-2802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026773" DistinctValues="67.809295">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" DoubleValue="-238982400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvX//w==" DoubleValue="-233107200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MvX//w==" LintValue="-2766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvX//w==" LintValue="-2698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvX//w==" DoubleValue="-233107200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvX//w==" DoubleValue="-233107200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvX//w==" LintValue="-2698"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="dvX//w==" LintValue="-2698"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011024" DistinctValues="27.921474">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvX//w==" DoubleValue="-233107200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="dvX//w==" LintValue="-2698"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" DoubleValue="-230688000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kvX//w==" LintValue="-2670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035097" DistinctValues="88.892857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002700" DistinctValues="6.837912">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" DoubleValue="-214617600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TPb//w==" LintValue="-2484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" DoubleValue="-214012800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/b//w==" LintValue="-2477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" DoubleValue="-205718400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gff//w==" DoubleValue="-196905600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/b//w==" LintValue="-2381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gff//w==" LintValue="-2279"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030710" DistinctValues="77.781250">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gff//w==" DoubleValue="-196905600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/f//w==" DoubleValue="-190166400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gff//w==" LintValue="-2279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/f//w==" LintValue="-2201"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/f//w==" DoubleValue="-190166400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/f//w==" DoubleValue="-190166400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/f//w==" LintValue="-2201"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/f//w==" LintValue="-2201"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007087" DistinctValues="17.949519">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/f//w==" DoubleValue="-190166400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/f//w==" LintValue="-2201"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" DoubleValue="-188611200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eff//w==" LintValue="-2183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029262" DistinctValues="74.114144">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" DoubleValue="-180057600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Pf//w==" LintValue="-2084"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008535" DistinctValues="21.616625">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" DoubleValue="-173836800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofj//w==" DoubleValue="-172022400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="JPj//w==" LintValue="-2012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofj//w==" LintValue="-1991"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002054" DistinctValues="5.202759">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofj//w==" DoubleValue="-172022400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofj//w==" LintValue="-1991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035743" DistinctValues="90.528010">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" DoubleValue="-171590400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfj//w==" DoubleValue="-164073600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvj//w==" LintValue="-1986"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lfj//w==" LintValue="-1899"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004108" DistinctValues="10.405518">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfj//w==" DoubleValue="-164073600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lfj//w==" LintValue="-1899"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033689" DistinctValues="85.325251">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" DoubleValue="-163209600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="n/j//w==" LintValue="-1889"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.030783" DistinctValues="77.151864">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" DoubleValue="-156124800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8fj//w==" LintValue="-1807"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007014" DistinctValues="17.578906">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" DoubleValue="-149299200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QPn//w==" LintValue="-1728"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005066" DistinctValues="12.695876">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019483" DistinctValues="48.830293">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" DoubleValue="-146620800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="X/n//w==" LintValue="-1697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.013248" DistinctValues="33.204600">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" DoubleValue="-142300800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/n//w==" DoubleValue="-139363200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="kfn//w==" LintValue="-1647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/n//w==" LintValue="-1613"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008217" DistinctValues="20.593645">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/n//w==" DoubleValue="-139363200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/n//w==" LintValue="-1613"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026294" DistinctValues="65.899666">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/r//w==" DoubleValue="-132105600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="B/r//w==" LintValue="-1529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000781" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/r//w==" DoubleValue="-132105600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B/r//w==" DoubleValue="-132105600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="B/r//w==" LintValue="-1529"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="B/r//w==" LintValue="-1529"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003287" DistinctValues="8.237458">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B/r//w==" DoubleValue="-132105600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/r//w==" DoubleValue="-131414400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="B/r//w==" LintValue="-1529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/r//w==" LintValue="-1521"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/r//w==" DoubleValue="-131414400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/r//w==" LintValue="-1521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" DoubleValue="-122860800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pr//w==" DoubleValue="-114739200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="cvr//w==" LintValue="-1422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0Pr//w==" LintValue="-1328"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019093" DistinctValues="48.358842">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pr//w==" DoubleValue="-114739200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afv//w==" DoubleValue="-110505600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0Pr//w==" LintValue="-1328"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afv//w==" LintValue="-1279"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afv//w==" DoubleValue="-110505600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afv//w==" DoubleValue="-110505600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afv//w==" LintValue="-1279"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afv//w==" LintValue="-1279"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018704" DistinctValues="47.371927">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afv//w==" DoubleValue="-110505600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfv//w==" DoubleValue="-106358400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afv//w==" LintValue="-1279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Mfv//w==" LintValue="-1231"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028441" DistinctValues="72.035034">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfv//w==" DoubleValue="-106358400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Mfv//w==" LintValue="-1231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009356" DistinctValues="23.695735">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001497" DistinctValues="3.751714">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" DoubleValue="-97632000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvv//w==" DoubleValue="-97286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvv//w==" LintValue="-1130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvv//w==" LintValue="-1126"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvv//w==" DoubleValue="-97286400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvv//w==" DoubleValue="-97286400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvv//w==" LintValue="-1126"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mvv//w==" LintValue="-1126"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006362" DistinctValues="15.944783">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvv//w==" DoubleValue="-97286400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/v//w==" DoubleValue="-95817600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="mvv//w==" LintValue="-1126"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/v//w==" LintValue="-1109"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/v//w==" DoubleValue="-95817600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/v//w==" DoubleValue="-95817600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/v//w==" LintValue="-1109"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/v//w==" LintValue="-1109"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.029938" DistinctValues="75.034273">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/v//w==" DoubleValue="-95817600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/v//w==" DoubleValue="-88905600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/v//w==" LintValue="-1109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/v//w==" LintValue="-1029"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/v//w==" DoubleValue="-88905600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/v//w==" LintValue="-1029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" DoubleValue="-80611200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvz//w==" DoubleValue="-72403200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/z//w==" LintValue="-933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvz//w==" LintValue="-838"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004774" DistinctValues="11.587045">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvz//w==" DoubleValue="-72403200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvz//w==" DoubleValue="-71366400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvz//w==" LintValue="-838"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xvz//w==" LintValue="-826"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvz//w==" DoubleValue="-71366400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xvz//w==" DoubleValue="-71366400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xvz//w==" LintValue="-826"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="xvz//w==" LintValue="-826"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004774" DistinctValues="11.587045">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xvz//w==" DoubleValue="-71366400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vz//w==" DoubleValue="-70329600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="xvz//w==" LintValue="-826"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0vz//w==" LintValue="-814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vz//w==" DoubleValue="-70329600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0vz//w==" DoubleValue="-70329600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0vz//w==" LintValue="-814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="0vz//w==" LintValue="-814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011538" DistinctValues="28.002024">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0vz//w==" DoubleValue="-70329600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/z//w==" DoubleValue="-67824000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="0vz//w==" LintValue="-814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7/z//w==" LintValue="-785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/z//w==" DoubleValue="-67824000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/z//w==" DoubleValue="-67824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7/z//w==" LintValue="-785"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7/z//w==" LintValue="-785"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002785" DistinctValues="6.759109">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/z//w==" DoubleValue="-67824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vz//w==" DoubleValue="-67219200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7/z//w==" LintValue="-785"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vz//w==" LintValue="-778"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vz//w==" DoubleValue="-67219200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vz//w==" DoubleValue="-67219200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vz//w==" LintValue="-778"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9vz//w==" LintValue="-778"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007957" DistinctValues="19.311741">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vz//w==" DoubleValue="-67219200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9vz//w==" LintValue="-778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005968" DistinctValues="14.483806">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" DoubleValue="-65491200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gf3//w==" DoubleValue="-64195200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Cv3//w==" LintValue="-758"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gf3//w==" LintValue="-743"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002387" DistinctValues="6.046154">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gf3//w==" DoubleValue="-64195200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gf3//w==" LintValue="-743"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.035410" DistinctValues="89.684615">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" DoubleValue="-63676800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="H/3//w==" LintValue="-737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005118" DistinctValues="12.828125">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" DoubleValue="-55987200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP3//w==" LintValue="-648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000663" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014961" DistinctValues="37.497596">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" DoubleValue="-54864000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/3//w==" DoubleValue="-51580800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="hf3//w==" LintValue="-635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="q/3//w==" LintValue="-597"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/3//w==" DoubleValue="-51580800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/3//w==" DoubleValue="-51580800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="q/3//w==" LintValue="-597"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="q/3//w==" LintValue="-597"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.017717" DistinctValues="44.405048">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/3//w==" DoubleValue="-51580800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="q/3//w==" LintValue="-597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" DoubleValue="-47692800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/7//w==" DoubleValue="-35337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2P3//w==" LintValue="-552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Z/7//w==" LintValue="-409"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037797" DistinctValues="96.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/7//w==" DoubleValue="-35337600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Z/7//w==" LintValue="-409"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.447748.1.1.3" Name="l_linenumber" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -5129,308 +5129,308 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.447748.1.1.12" Name="l_receiptdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.027137" DistinctValues="68.374021">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPT//w==" DoubleValue="-251942400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPX//w==" DoubleValue="-241574400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPT//w==" LintValue="-2916"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="FPX//w==" LintValue="-2796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPX//w==" DoubleValue="-241574400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPX//w==" DoubleValue="-241574400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="FPX//w==" LintValue="-2796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="FPX//w==" LintValue="-2796"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010176" DistinctValues="25.640258">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPX//w==" DoubleValue="-241574400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QfX//w==" DoubleValue="-237686400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="FPX//w==" LintValue="-2796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="QfX//w==" LintValue="-2751"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QfX//w==" DoubleValue="-237686400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QfX//w==" DoubleValue="-237686400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="QfX//w==" LintValue="-2751"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="QfX//w==" LintValue="-2751"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000452" DistinctValues="1.139567">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QfX//w==" DoubleValue="-237686400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="QfX//w==" LintValue="-2751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004018" DistinctValues="10.229133">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" DoubleValue="-237513600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TfX//w==" DoubleValue="-236649600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Q/X//w==" LintValue="-2749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="TfX//w==" LintValue="-2739"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TfX//w==" DoubleValue="-236649600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TfX//w==" DoubleValue="-236649600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="TfX//w==" LintValue="-2739"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="TfX//w==" LintValue="-2739"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.033748" DistinctValues="85.924714">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TfX//w==" DoubleValue="-236649600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofX//w==" DoubleValue="-229392000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="TfX//w==" LintValue="-2739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ofX//w==" LintValue="-2655"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027828" DistinctValues="70.113360">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofX//w==" DoubleValue="-229392000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofX//w==" LintValue="-2655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003578" DistinctValues="9.014575">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" DoubleValue="-223344000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/X//w==" LintValue="-2585"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006361" DistinctValues="16.025911">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APb//w==" DoubleValue="-221184000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="APb//w==" LintValue="-2560"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000763" DistinctValues="1.942502">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APb//w==" DoubleValue="-221184000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Avb//w==" DoubleValue="-221011200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APb//w==" LintValue="-2560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Avb//w==" LintValue="-2558"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Avb//w==" DoubleValue="-221011200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Avb//w==" DoubleValue="-221011200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Avb//w==" LintValue="-2558"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Avb//w==" LintValue="-2558"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037003" DistinctValues="94.211344">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Avb//w==" DoubleValue="-221011200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/b//w==" DoubleValue="-212630400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Avb//w==" LintValue="-2558"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/b//w==" LintValue="-2461"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016129" DistinctValues="41.065705">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/b//w==" DoubleValue="-212630400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/b//w==" LintValue="-2461"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021637" DistinctValues="55.088141">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" DoubleValue="-209088000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="jPb//w==" LintValue="-2420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001496" DistinctValues="3.808073">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" DoubleValue="-204336000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/b//w==" LintValue="-2365"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036270" DistinctValues="92.345773">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" DoubleValue="-203990400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="x/b//w==" LintValue="-2361"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" DoubleValue="-195609600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="KPf//w==" LintValue="-2264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036240" DistinctValues="92.268842">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" DoubleValue="-187315200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/f//w==" DoubleValue="-179107200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iPf//w==" LintValue="-2168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/f//w==" LintValue="-2073"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/f//w==" DoubleValue="-179107200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/f//w==" DoubleValue="-179107200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/f//w==" LintValue="-2073"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="5/f//w==" LintValue="-2073"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001526" DistinctValues="3.885004">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/f//w==" DoubleValue="-179107200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="5/f//w==" LintValue="-2073"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007310" DistinctValues="18.416873">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" DoubleValue="-178761600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/ff//w==" DoubleValue="-177206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/f//w==" LintValue="-2069"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/ff//w==" LintValue="-2051"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/ff//w==" DoubleValue="-177206400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/ff//w==" DoubleValue="-177206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/ff//w==" LintValue="-2051"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="/ff//w==" LintValue="-2051"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006497" DistinctValues="16.370554">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/ff//w==" DoubleValue="-177206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="/ff//w==" LintValue="-2051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000734" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023959" DistinctValues="60.366419">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" DoubleValue="-175824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfj//w==" LintValue="-2035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" DoubleValue="-170726400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPj//w==" DoubleValue="-162777600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SPj//w==" LintValue="-1976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pPj//w==" LintValue="-1884"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPj//w==" DoubleValue="-162777600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pPj//w==" LintValue="-1884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027828" DistinctValues="70.850202">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" DoubleValue="-154569600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/n//w==" LintValue="-1789"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009938" DistinctValues="25.303644">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" DoubleValue="-148521600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvn//w==" DoubleValue="-146361600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Sfn//w==" LintValue="-1719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvn//w==" LintValue="-1694"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011926" DistinctValues="30.364372">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvn//w==" DoubleValue="-146361600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvn//w==" LintValue="-1694"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025840" DistinctValues="65.789474">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" DoubleValue="-143769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="gPn//w==" LintValue="-1664"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.025713" DistinctValues="64.104746">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" DoubleValue="-138153600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afr//w==" DoubleValue="-132624000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfn//w==" LintValue="-1599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afr//w==" LintValue="-1535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000781" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afr//w==" DoubleValue="-132624000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afr//w==" DoubleValue="-132624000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afr//w==" LintValue="-1535"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Afr//w==" LintValue="-1535"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004821" DistinctValues="12.019640">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afr//w==" DoubleValue="-132624000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfr//w==" DoubleValue="-131587200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Afr//w==" LintValue="-1535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfr//w==" LintValue="-1523"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfr//w==" DoubleValue="-131587200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfr//w==" DoubleValue="-131587200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfr//w==" LintValue="-1523"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Dfr//w==" LintValue="-1523"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004419" DistinctValues="11.018003">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfr//w==" DoubleValue="-131587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Dfr//w==" LintValue="-1523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.002812" DistinctValues="7.011457">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" DoubleValue="-130636800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPr//w==" LintValue="-1512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036995" DistinctValues="94.191523">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" DoubleValue="-130032000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/r//w==" LintValue="-1505"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000771" DistinctValues="1.962323">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" DoubleValue="-121737600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfr//w==" DoubleValue="-121564800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="f/r//w==" LintValue="-1409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfr//w==" LintValue="-1407"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021865" DistinctValues="55.668016">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfr//w==" DoubleValue="-121564800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPr//w==" DoubleValue="-116812800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfr//w==" LintValue="-1407"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uPr//w==" LintValue="-1352"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPr//w==" DoubleValue="-116812800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPr//w==" DoubleValue="-116812800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uPr//w==" LintValue="-1352"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uPr//w==" LintValue="-1352"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015901" DistinctValues="40.485830">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPr//w==" DoubleValue="-116812800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uPr//w==" LintValue="-1352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.021581" DistinctValues="54.945055">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" DoubleValue="-113356800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4Pr//w==" LintValue="-1312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016185" DistinctValues="41.208791">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" DoubleValue="-108518400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvv//w==" DoubleValue="-104889600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="GPv//w==" LintValue="-1256"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qvv//w==" LintValue="-1214"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022282" DistinctValues="56.730769">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvv//w==" DoubleValue="-104889600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qvv//w==" LintValue="-1214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015484" DistinctValues="39.423077">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" DoubleValue="-99792000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvv//w==" DoubleValue="-96249600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffv//w==" LintValue="-1155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="pvv//w==" LintValue="-1114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011063" DistinctValues="28.166278">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvv//w==" DoubleValue="-96249600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="pvv//w==" LintValue="-1114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000686" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026703" DistinctValues="67.987568">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" DoubleValue="-93744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfz//w==" DoubleValue="-87696000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="w/v//w==" LintValue="-1085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Cfz//w==" LintValue="-1015"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016956" DistinctValues="42.722135">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfz//w==" DoubleValue="-87696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfz//w==" DoubleValue="-83894400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Cfz//w==" LintValue="-1015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfz//w==" LintValue="-971"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfz//w==" DoubleValue="-83894400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfz//w==" DoubleValue="-83894400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfz//w==" LintValue="-971"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Nfz//w==" LintValue="-971"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003854" DistinctValues="9.709576">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfz//w==" DoubleValue="-83894400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/z//w==" DoubleValue="-83030400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Nfz//w==" LintValue="-971"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/z//w==" LintValue="-961"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000757" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/z//w==" DoubleValue="-83030400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="P/z//w==" DoubleValue="-83030400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/z//w==" LintValue="-961"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="P/z//w==" LintValue="-961"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016956" DistinctValues="42.722135">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="P/z//w==" DoubleValue="-83030400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/z//w==" DoubleValue="-79228800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="P/z//w==" LintValue="-961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="a/z//w==" LintValue="-917"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/z//w==" DoubleValue="-79228800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="a/z//w==" LintValue="-917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" DoubleValue="-70934400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kf3//w==" DoubleValue="-62812800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/z//w==" LintValue="-821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kf3//w==" LintValue="-727"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.022499" DistinctValues="57.283142">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kf3//w==" DoubleValue="-62812800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yf3//w==" DoubleValue="-57974400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kf3//w==" LintValue="-727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yf3//w==" LintValue="-671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000852" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yf3//w==" DoubleValue="-57974400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yf3//w==" DoubleValue="-57974400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yf3//w==" LintValue="-671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Yf3//w==" LintValue="-671"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015267" DistinctValues="38.870704">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yf3//w==" DoubleValue="-57974400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/3//w==" DoubleValue="-54691200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Yf3//w==" LintValue="-671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/3//w==" LintValue="-633"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019467" DistinctValues="49.563838">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/3//w==" DoubleValue="-54691200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uf3//w==" DoubleValue="-50371200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/3//w==" LintValue="-633"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uf3//w==" LintValue="-583"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000710" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uf3//w==" DoubleValue="-50371200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uf3//w==" DoubleValue="-50371200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uf3//w==" LintValue="-583"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="uf3//w==" LintValue="-583"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018299" DistinctValues="46.590008">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uf3//w==" DoubleValue="-50371200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6P3//w==" DoubleValue="-46310400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="uf3//w==" LintValue="-583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6P3//w==" LintValue="-536"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6P3//w==" DoubleValue="-46310400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP7//w==" DoubleValue="-33868800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6P3//w==" LintValue="-536"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="eP7//w==" LintValue="-392"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037766" DistinctValues="97.153846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP7//w==" DoubleValue="-33868800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jf7//w==" DoubleValue="-32054400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="eP7//w==" LintValue="-392"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jf7//w==" LintValue="-371"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.447748.1.1.5" Name="l_extendedprice" Width="10.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
@@ -5999,304 +5999,304 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.447800.1.1.4" Name="o_orderdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.037579" DistinctValues="91.099130">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" DoubleValue="-252460800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vT//w==" DoubleValue="-244857600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" LintValue="-2922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7vT//w==" LintValue="-2834"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vT//w==" DoubleValue="-244857600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vT//w==" DoubleValue="-244857600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7vT//w==" LintValue="-2834"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7vT//w==" LintValue="-2834"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001708" DistinctValues="4.140870">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vT//w==" DoubleValue="-244857600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vT//w==" DoubleValue="-244512000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7vT//w==" LintValue="-2834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vT//w==" LintValue="-2830"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000810" DistinctValues="1.943093">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vT//w==" DoubleValue="-244512000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PT//w==" DoubleValue="-244339200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vT//w==" LintValue="-2830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9PT//w==" LintValue="-2828"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PT//w==" DoubleValue="-244339200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9PT//w==" DoubleValue="-244339200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9PT//w==" LintValue="-2828"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="9PT//w==" LintValue="-2828"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.010936" DistinctValues="26.231753">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9PT//w==" DoubleValue="-244339200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="9PT//w==" LintValue="-2828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027541" DistinctValues="66.065155">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" DoubleValue="-242006400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/X//w==" DoubleValue="-236131200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="D/X//w==" LintValue="-2801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/X//w==" LintValue="-2733"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/X//w==" DoubleValue="-236131200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svX//w==" DoubleValue="-227923200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/X//w==" LintValue="-2733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="svX//w==" LintValue="-2638"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001587" DistinctValues="3.848081">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svX//w==" DoubleValue="-227923200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvX//w==" DoubleValue="-227577600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="svX//w==" LintValue="-2638"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvX//w==" LintValue="-2634"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvX//w==" DoubleValue="-227577600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tvX//w==" DoubleValue="-227577600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvX//w==" LintValue="-2634"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tvX//w==" LintValue="-2634"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037699" DistinctValues="91.391919">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tvX//w==" DoubleValue="-227577600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="tvX//w==" LintValue="-2634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024751" DistinctValues="60.001200">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" DoubleValue="-219369600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffb//w==" LintValue="-2539"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014536" DistinctValues="35.238800">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" DoubleValue="-213926400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efb//w==" DoubleValue="-210729600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="VPb//w==" LintValue="-2476"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efb//w==" LintValue="-2439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001690" DistinctValues="4.096344">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efb//w==" DoubleValue="-210729600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffb//w==" DoubleValue="-210384000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efb//w==" LintValue="-2439"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffb//w==" LintValue="-2435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000798" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffb//w==" DoubleValue="-210384000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffb//w==" DoubleValue="-210384000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffb//w==" LintValue="-2435"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffb//w==" LintValue="-2435"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037597" DistinctValues="91.143656">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffb//w==" DoubleValue="-210384000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vb//w==" DoubleValue="-202694400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffb//w==" LintValue="-2435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1vb//w==" LintValue="-2346"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016606" DistinctValues="39.833402">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vb//w==" DoubleValue="-202694400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1vb//w==" LintValue="-2346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000723" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016201" DistinctValues="38.861856">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" DoubleValue="-199152000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="//b//w==" LintValue="-2305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000773" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.006480" DistinctValues="15.544742">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" DoubleValue="-195696000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/f//w==" DoubleValue="-194313600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="J/f//w==" LintValue="-2265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N/f//w==" LintValue="-2249"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/f//w==" DoubleValue="-194313600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N/f//w==" LintValue="-2249"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014733" DistinctValues="35.340000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" DoubleValue="-185760000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvf//w==" LintValue="-2150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000773" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018825" DistinctValues="45.156667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" DoubleValue="-182649600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pf//w==" DoubleValue="-178675200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="vvf//w==" LintValue="-2114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pf//w==" LintValue="-2068"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pf//w==" DoubleValue="-178675200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pf//w==" DoubleValue="-178675200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pf//w==" LintValue="-2068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="7Pf//w==" LintValue="-2068"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.005729" DistinctValues="13.743333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pf//w==" DoubleValue="-178675200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vf//w==" DoubleValue="-177465600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="7Pf//w==" LintValue="-2068"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+vf//w==" LintValue="-2054"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.007290" DistinctValues="17.673402">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vf//w==" DoubleValue="-177465600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPj//w==" DoubleValue="-175910400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+vf//w==" LintValue="-2054"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DPj//w==" LintValue="-2036"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000773" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPj//w==" DoubleValue="-175910400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DPj//w==" DoubleValue="-175910400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DPj//w==" LintValue="-2036"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="DPj//w==" LintValue="-2036"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.031996" DistinctValues="77.566598">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DPj//w==" DoubleValue="-175910400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="DPj//w==" LintValue="-2036"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" DoubleValue="-169084800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wPj//w==" DoubleValue="-160358400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/j//w==" LintValue="-1957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wPj//w==" LintValue="-1856"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.027108" DistinctValues="65.715600">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wPj//w==" DoubleValue="-160358400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfn//w==" DoubleValue="-154396800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wPj//w==" LintValue="-1856"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfn//w==" LintValue="-1787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfn//w==" DoubleValue="-154396800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfn//w==" DoubleValue="-154396800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfn//w==" LintValue="-1787"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Bfn//w==" LintValue="-1787"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012179" DistinctValues="29.524400">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfn//w==" DoubleValue="-154396800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Bfn//w==" LintValue="-1787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.037597" DistinctValues="90.186667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" DoubleValue="-151718400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="JPn//w==" LintValue="-1756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000845" DistinctValues="2.026667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" DoubleValue="-144028800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="ffn//w==" LintValue="-1667"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000748" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000845" DistinctValues="2.026667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfn//w==" DoubleValue="-143683200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gfn//w==" LintValue="-1663"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.018390" DistinctValues="44.112340">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfn//w==" DoubleValue="-143683200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfn//w==" DoubleValue="-139881600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gfn//w==" LintValue="-1663"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="rfn//w==" LintValue="-1619"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfn//w==" DoubleValue="-139881600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rfn//w==" DoubleValue="-139881600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="rfn//w==" LintValue="-1619"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rfn//w==" LintValue="-1619"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.001672" DistinctValues="4.010213">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rfn//w==" DoubleValue="-139881600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="rfn//w==" LintValue="-1619"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019225" DistinctValues="46.117447">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" DoubleValue="-139536000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/n//w==" DoubleValue="-135561600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="sfn//w==" LintValue="-1615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/n//w==" LintValue="-1569"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/n//w==" DoubleValue="-135561600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvr//w==" DoubleValue="-127353600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/n//w==" LintValue="-1569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvr//w==" LintValue="-1474"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvr//w==" DoubleValue="-127353600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvr//w==" LintValue="-1474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.023491" DistinctValues="56.947629">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" DoubleValue="-119145600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nfr//w==" LintValue="-1379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000748" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.015796" DistinctValues="38.292371">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vr//w==" DoubleValue="-110764800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="/vr//w==" LintValue="-1282"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.009512" DistinctValues="22.816000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vr//w==" DoubleValue="-110764800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffv//w==" DoubleValue="-108777600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="/vr//w==" LintValue="-1282"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffv//w==" LintValue="-1259"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000723" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffv//w==" DoubleValue="-108777600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffv//w==" DoubleValue="-108777600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffv//w==" LintValue="-1259"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ffv//w==" LintValue="-1259"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.016955" DistinctValues="40.672000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffv//w==" DoubleValue="-108777600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ffv//w==" LintValue="-1259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.012820" DistinctValues="30.752000">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" DoubleValue="-105235200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xfv//w==" DoubleValue="-102556800000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Pvv//w==" LintValue="-1218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xfv//w==" LintValue="-1187"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.026191" DistinctValues="62.826667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xfv//w==" DoubleValue="-102556800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xfv//w==" LintValue="-1187"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000748" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.008449" DistinctValues="20.266667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" DoubleValue="-97200000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/v//w==" DoubleValue="-95472000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="m/v//w==" LintValue="-1125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="r/v//w==" LintValue="-1105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/v//w==" DoubleValue="-95472000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/v//w==" DoubleValue="-95472000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="r/v//w==" LintValue="-1105"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="r/v//w==" LintValue="-1105"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.004647" DistinctValues="11.146667">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/v//w==" DoubleValue="-95472000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvv//w==" DoubleValue="-94521600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="r/v//w==" LintValue="-1105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="uvv//w==" LintValue="-1094"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.020264" DistinctValues="49.123789">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvv//w==" DoubleValue="-94521600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="uvv//w==" LintValue="-1094"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.019023" DistinctValues="46.116211">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" DoubleValue="-90288000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfz//w==" DoubleValue="-86313600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="6/v//w==" LintValue="-1045"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gfz//w==" LintValue="-999"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.003274" DistinctValues="7.936667">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfz//w==" DoubleValue="-86313600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifz//w==" DoubleValue="-85622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gfz//w==" LintValue="-999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifz//w==" LintValue="-991"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000673" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifz//w==" DoubleValue="-85622400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifz//w==" DoubleValue="-85622400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifz//w==" LintValue="-991"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Ifz//w==" LintValue="-991"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.036013" DistinctValues="87.303333">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifz//w==" DoubleValue="-85622400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efz//w==" DoubleValue="-78019200000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="Ifz//w==" LintValue="-991"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="efz//w==" LintValue="-903"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.014628" DistinctValues="35.461702">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efz//w==" DoubleValue="-78019200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="efz//w==" LintValue="-903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.024659" DistinctValues="59.778298">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" DoubleValue="-74995200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/z//w==" DoubleValue="-69897600000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="nPz//w==" LintValue="-868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/z//w==" LintValue="-809"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/z//w==" DoubleValue="-69897600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Of3//w==" DoubleValue="-61430400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/z//w==" LintValue="-809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Of3//w==" LintValue="-711"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.028237" DistinctValues="68.453750">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Of3//w==" DoubleValue="-61430400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Of3//w==" LintValue="-711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.000698" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.011049" DistinctValues="26.786250">
-          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" DoubleValue="-55468800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mf3//w==" DoubleValue="-53136000000000"/>
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" Value="fv3//w==" LintValue="-642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mf3//w==" LintValue="-615"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.039287" DistinctValues="96.240000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mf3//w==" DoubleValue="-53136000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" DoubleValue="-44668800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mf3//w==" LintValue="-615"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" LintValue="-517"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
     </dxl:Metadata>
@@ -6486,7 +6486,7 @@
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                 <dxl:Ident ColId="20" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2345.1.0">
                 <dxl:Ident ColId="20" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
@@ -6778,7 +6778,7 @@
                                 <dxl:And>
                                   <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1098.1.0">
                                     <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" DoubleValue="-189302400000000.000000"/>
+                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="cff//w==" LintValue="-2191"/>
                                   </dxl:Comparison>
                                   <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2345.1.0">
                                     <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -350,34 +350,34 @@ with results as
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.8403408.1.1.3" Name="s_rec_end_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.666000" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2v7//w==" LintValue="-294"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" DoubleValue="6134400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="RwAAAA==" LintValue="71"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" DoubleValue="37670400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tAEAAA==" LintValue="436"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.8403408.1.1.2" Name="s_rec_start_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.499500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" DoubleValue="-88473600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="APz//w==" LintValue="-1024"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" DoubleValue="-25315200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="2/7//w==" LintValue="-293"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" DoubleValue="6220800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="SAAAAA==" LintValue="72"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.166500" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" DoubleValue="37756800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="tQEAAA==" LintValue="437"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.8402992.1.1.33" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
@@ -4497,108 +4497,108 @@ with results as
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.8402992.1.1.2" Name="d_date" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VXH//w==" DoubleValue="-3155587200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wnz//w==" DoubleValue="-2902867200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="VXH//w==" LintValue="-36523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wnz//w==" LintValue="-33598"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wnz//w==" DoubleValue="-2902867200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Joj//w==" DoubleValue="-2650924800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wnz//w==" LintValue="-33598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Joj//w==" LintValue="-30682"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Joj//w==" DoubleValue="-2650924800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iZP//w==" DoubleValue="-2399068800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Joj//w==" LintValue="-30682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iZP//w==" LintValue="-27767"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iZP//w==" DoubleValue="-2399068800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4p7//w==" DoubleValue="-2148076800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iZP//w==" LintValue="-27767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="4p7//w==" LintValue="-24862"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4p7//w==" DoubleValue="-2148076800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C6r//w==" DoubleValue="-1901232000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="4p7//w==" LintValue="-24862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="C6r//w==" LintValue="-22005"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C6r//w==" DoubleValue="-1901232000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sLX//w==" DoubleValue="-1643673600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="C6r//w==" LintValue="-22005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="sLX//w==" LintValue="-19024"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sLX//w==" DoubleValue="-1643673600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J8H//w==" DoubleValue="-1390089600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="sLX//w==" LintValue="-19024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="J8H//w==" LintValue="-16089"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J8H//w==" DoubleValue="-1390089600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="asz//w==" DoubleValue="-1140998400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="J8H//w==" LintValue="-16089"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="asz//w==" LintValue="-13206"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="asz//w==" DoubleValue="-1140998400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ctj//w==" DoubleValue="-883872000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="asz//w==" LintValue="-13206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ctj//w==" LintValue="-10230"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ctj//w==" DoubleValue="-883872000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RuP//w==" DoubleValue="-635385600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ctj//w==" LintValue="-10230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="RuP//w==" LintValue="-7354"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RuP//w==" DoubleValue="-635385600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tu7//w==" DoubleValue="-382406400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="RuP//w==" LintValue="-7354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tu7//w==" LintValue="-4426"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tu7//w==" DoubleValue="-382406400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/n//w==" DoubleValue="-133142400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tu7//w==" LintValue="-4426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+/n//w==" LintValue="-1541"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/n//w==" DoubleValue="-133142400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PwUAAA==" DoubleValue="116035200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+/n//w==" LintValue="-1541"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PwUAAA==" LintValue="1343"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PwUAAA==" DoubleValue="116035200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BxEAAA==" DoubleValue="376617600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PwUAAA==" LintValue="1343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="BxEAAA==" LintValue="4359"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BxEAAA==" DoubleValue="376617600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="BxEAAA==" LintValue="4359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" DoubleValue="631065600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CSgAAA==" DoubleValue="885513600000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iBwAAA==" LintValue="7304"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="CSgAAA==" LintValue="10249"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CSgAAA==" DoubleValue="885513600000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PDQAAA==" DoubleValue="1155340800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="CSgAAA==" LintValue="10249"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="PDQAAA==" LintValue="13372"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PDQAAA==" DoubleValue="1155340800000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pj8AAA==" DoubleValue="1398816000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="PDQAAA==" LintValue="13372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pj8AAA==" LintValue="16190"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pj8AAA==" DoubleValue="1398816000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vUoAAA==" DoubleValue="1653091200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pj8AAA==" LintValue="16190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="vUoAAA==" LintValue="19133"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vUoAAA==" DoubleValue="1653091200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2lUAAA==" DoubleValue="1898899200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vUoAAA==" LintValue="19133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2lUAAA==" LintValue="21978"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2lUAAA==" DoubleValue="1898899200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DmEAAA==" DoubleValue="2146694400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2lUAAA==" LintValue="21978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="DmEAAA==" LintValue="24846"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DmEAAA==" DoubleValue="2146694400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N2wAAA==" DoubleValue="2393539200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="DmEAAA==" LintValue="24846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="N2wAAA==" LintValue="27703"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N2wAAA==" DoubleValue="2393539200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f3cAAA==" DoubleValue="2643062400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="N2wAAA==" LintValue="27703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f3cAAA==" LintValue="30591"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f3cAAA==" DoubleValue="2643062400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jIIAAA==" DoubleValue="2887488000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f3cAAA==" LintValue="30591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jIIAAA==" LintValue="33420"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jIIAAA==" DoubleValue="2887488000000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b44AAA==" DoubleValue="3150403200000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jIIAAA==" LintValue="33420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="b44AAA==" LintValue="36463"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="2809.576923">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b44AAA==" DoubleValue="3150403200000000.000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rY4AAA==" DoubleValue="3155760000000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="b44AAA==" LintValue="36463"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="rY4AAA==" LintValue="36525"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.8403512.1.1.23" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="737331968.000000" FreqRemain="1.000000" ColStatsMissing="false"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -224,28 +224,28 @@
       <dxl:ColumnStatistics Mdid="1.471019.1.1.10" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.471019.1.1.3" Name="dt" Width="4.000000">
         <dxl:StatsBucket Frequency="0.583333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" DoubleValue="-18902592000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="ZKn8/w==" LintValue="-218780"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" DoubleValue="-18897494400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="n6n8/w==" LintValue="-218721"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" DoubleValue="-18894816000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="vqn8/w==" LintValue="-218690"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" DoubleValue="-18892224000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3Kn8/w==" LintValue="-218660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" DoubleValue="-18892137600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="3an8/w==" LintValue="-218659"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.083333" DistinctValues="1.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" DoubleValue="-18889545600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+6n8/w==" LintValue="-218629"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.471019.1.1.2" Name="pn" Width="4.000000">

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4223,7 +4223,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
                   <dxl:Ident ColId="8" ColName="order_datetime" TypeMdid="0.1114.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" DoubleValue="331171200000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                 </dxl:Comparison>
               </dxl:And>
               <dxl:LogicalGet>
@@ -4467,13 +4467,13 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                                 <dxl:And>
                                   <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
                                     <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="true"/>
-                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" DoubleValue="331171200000000.000000"/>
+                                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                                   </dxl:Comparison>
                                   <dxl:PartBoundInclusion Level="0" LowerBound="true"/>
                                 </dxl:And>
                                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.2371.1.0">
                                   <dxl:PartBound Level="0" Type="0.1114.1.0" LowerBound="true"/>
-                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" DoubleValue="331171200000000.000000"/>
+                                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                                 </dxl:Comparison>
                               </dxl:Or>
                             </dxl:And>
@@ -4500,7 +4500,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                             </dxl:Comparison>
                             <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
                               <dxl:Ident ColId="7" ColName="order_datetime" TypeMdid="0.1114.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" DoubleValue="331171200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                             </dxl:Comparison>
                           </dxl:And>
                         </dxl:PrintableFilter>
@@ -4528,7 +4528,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                             </dxl:Comparison>
                             <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.2372.1.0">
                               <dxl:Ident ColId="7" ColName="order_datetime" TypeMdid="0.1114.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" DoubleValue="331171200000000.000000"/>
+                              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="+Q4AAA==" LintValue="3833"/>
                             </dxl:Comparison>
                           </dxl:And>
                         </dxl:Filter>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-cast_boundary_value_to_date.mdp
@@ -295,7 +295,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
           <dxl:Ident ColId="3" ColName="p2" TypeMdid="0.1082.1.0"/>
-          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
           <dxl:TableDescriptor Mdid="0.651256.1.1" TableName="testpartitionfiltercasting">
@@ -362,7 +362,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
@@ -379,7 +379,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
             <dxl:PrintableFilter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               </dxl:Comparison>
             </dxl:PrintableFilter>
           </dxl:PartitionSelector>
@@ -404,7 +404,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a';
             <dxl:Filter>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                 <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               </dxl:Comparison>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.651256.1.1" TableName="testpartitionfiltercasting">

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-all-levels.mdp
@@ -297,7 +297,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
           </dxl:Comparison>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
             <dxl:Ident ColId="3" ColName="p2" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
           </dxl:Comparison>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
             <dxl:Ident ColId="4" ColName="p3" TypeMdid="0.1700.1.0"/>
@@ -369,7 +369,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
@@ -393,7 +393,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
                   <dxl:Ident ColId="3" ColName="p3" TypeMdid="0.1700.1.0"/>
@@ -430,7 +430,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
                   <dxl:Ident ColId="3" ColName="p3" TypeMdid="0.1700.1.0"/>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-leaf-levels.mdp
@@ -397,7 +397,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
           </dxl:Comparison>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
             <dxl:Ident ColId="3" ColName="p2" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
           </dxl:Comparison>
         </dxl:And>
         <dxl:LogicalGet>
@@ -465,7 +465,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABWE=" LintValue="160440876"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
@@ -489,7 +489,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
               </dxl:And>
             </dxl:PrintableFilter>
@@ -522,7 +522,7 @@ explain select * from TestPartitionFilterCasting where p1 = 'a' and p2 = '2015-0
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
               </dxl:And>
             </dxl:Filter>

--- a/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
+++ b/src/backend/gporca/data/dxl/multilevel-partitioning/Multilevel-Casting-predicate-on-non-root-levels.mdp
@@ -357,7 +357,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
         <dxl:And>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
             <dxl:Ident ColId="3" ColName="p2" TypeMdid="0.1082.1.0"/>
-            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+            <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
           </dxl:Comparison>
           <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
             <dxl:Ident ColId="4" ColName="p3" TypeMdid="0.1700.1.0"/>
@@ -429,7 +429,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
             <dxl:ProjList/>
             <dxl:PartEqFilters>
               <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+              <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
               <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAABAA==" DoubleValue="1.000000"/>
             </dxl:PartEqFilters>
             <dxl:PartFilters>
@@ -447,7 +447,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
               <dxl:And>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
                   <dxl:Ident ColId="3" ColName="p3" TypeMdid="0.1700.1.0"/>
@@ -478,7 +478,7 @@ explain select * from TestPartitionFilterCasting where p2 = '2015-01-01' and p3 
               <dxl:And>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
                   <dxl:Ident ColId="2" ColName="p2" TypeMdid="0.1082.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" DoubleValue="473385600000000.000000"/>
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" Value="ZxUAAA==" LintValue="5479"/>
                 </dxl:Comparison>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
                   <dxl:Ident ColId="3" ColName="p3" TypeMdid="0.1700.1.0"/>

--- a/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Input.xml
+++ b/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Input.xml
@@ -24,12 +24,12 @@
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.500000" DistinctValues="14.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" LintValue="4396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.500000" DistinctValues="8.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MxEAAA==" DoubleValue="380419200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" LintValue="4396"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MxEAAA==" LintValue="4403"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="5" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
+++ b/src/backend/gporca/data/dxl/statistics/Basic-Statistics-Output.xml
@@ -16,12 +16,12 @@
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">
         <dxl:StatsBucket Frequency="0.875000" DistinctValues="14.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" DoubleValue="378691200000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HxEAAA==" LintValue="4383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LBEAAA==" LintValue="4396"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.125000" DistinctValues="1.142857">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" DoubleValue="379814400000000.000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" DoubleValue="379900800000000.000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="LBEAAA==" LintValue="4396"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="LREAAA==" LintValue="4397"/>
         </dxl:StatsBucket>
       </dxl:DerivedColumnStats>
       <dxl:DerivedColumnStats ColId="5" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000">

--- a/src/backend/gporca/data/dxl/tpch/q1.mdp
+++ b/src/backend/gporca/data/dxl/tpch/q1.mdp
@@ -488,108 +488,108 @@
       <dxl:ColumnStatistics Mdid="1.17165.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" DoubleValue="-249436800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" LintValue="-2887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/b//w==" DoubleValue="-213321600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/b//w==" LintValue="-2469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/b//w==" DoubleValue="-213321600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/b//w==" LintValue="-2469"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvf//w==" DoubleValue="-181612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvf//w==" LintValue="-2102"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvf//w==" DoubleValue="-181612800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvf//w==" LintValue="-2102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/n//w==" DoubleValue="-147657600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/n//w==" LintValue="-1709"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/n//w==" DoubleValue="-147657600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/n//w==" LintValue="-1709"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fv3//w==" DoubleValue="-64454400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fv3//w==" LintValue="-746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fv3//w==" DoubleValue="-64454400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fv3//w==" LintValue="-746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -726,108 +726,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" DoubleValue="-251769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPX//w==" DoubleValue="-239155200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" LintValue="-2914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPX//w==" LintValue="-2768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPX//w==" DoubleValue="-239155200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPX//w==" LintValue="-2768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfr//w==" DoubleValue="-130204800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfr//w==" LintValue="-1507"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfr//w==" DoubleValue="-130204800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfr//w==" LintValue="-1507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPv//w==" DoubleValue="-97459200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPv//w==" LintValue="-1128"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPv//w==" DoubleValue="-97459200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPv//w==" LintValue="-1128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPz//w==" DoubleValue="-72921600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPz//w==" LintValue="-844"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPz//w==" DoubleValue="-72921600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ff3//w==" DoubleValue="-64540800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPz//w==" LintValue="-844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ff3//w==" LintValue="-747"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ff3//w==" DoubleValue="-64540800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ff3//w==" LintValue="-747"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.21" Name="tableoid" Width="4.000000"/>
@@ -852,108 +852,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofT//w==" DoubleValue="-251510400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofT//w==" LintValue="-2911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPX//w==" DoubleValue="-229824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPX//w==" LintValue="-2660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPX//w==" DoubleValue="-229824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPX//w==" LintValue="-2660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPj//w==" DoubleValue="-172108800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPj//w==" LintValue="-1992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPj//w==" DoubleValue="-172108800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvj//w==" DoubleValue="-163641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPj//w==" LintValue="-1992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvj//w==" LintValue="-1894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvj//w==" DoubleValue="-163641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvj//w==" LintValue="-1894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifr//w==" DoubleValue="-120873600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifr//w==" LintValue="-1399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifr//w==" DoubleValue="-120873600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/r//w==" DoubleValue="-112752000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifr//w==" LintValue="-1399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/r//w==" LintValue="-1305"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/r//w==" DoubleValue="-112752000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/r//w==" LintValue="-1305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvz//w==" DoubleValue="-87955200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvz//w==" LintValue="-1018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvz//w==" DoubleValue="-87955200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvz//w==" LintValue="-1018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv3//w==" DoubleValue="-63072000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv3//w==" LintValue="-730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv3//w==" DoubleValue="-63072000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iP3//w==" DoubleValue="-54604800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv3//w==" LintValue="-730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iP3//w==" LintValue="-632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iP3//w==" DoubleValue="-54604800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iP3//w==" LintValue="-632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/7//w==" DoubleValue="-33955200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/7//w==" LintValue="-393"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/7//w==" DoubleValue="-33955200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/7//w==" LintValue="-393"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.5" Name="l_extendedprice" Width="10.000000">

--- a/src/backend/gporca/data/dxl/tpch/q3.mdp
+++ b/src/backend/gporca/data/dxl/tpch/q3.mdp
@@ -1001,108 +1001,108 @@
       <dxl:ColumnStatistics Mdid="1.17165.1.1.18" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.11" Name="l_commitdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" DoubleValue="-249436800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ufT//w==" LintValue="-2887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" DoubleValue="-239241600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="L/X//w==" LintValue="-2769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" DoubleValue="-222566400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/b//w==" DoubleValue="-213321600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8PX//w==" LintValue="-2576"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="W/b//w==" LintValue="-2469"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/b//w==" DoubleValue="-213321600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="W/b//w==" LintValue="-2469"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" DoubleValue="-204508800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfb//w==" LintValue="-2367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" DoubleValue="-188870400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvf//w==" DoubleValue="-181612800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="dvf//w==" LintValue="-2186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="yvf//w==" LintValue="-2102"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvf//w==" DoubleValue="-181612800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="yvf//w==" LintValue="-2102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" DoubleValue="-165110400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifj//w==" LintValue="-1911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" DoubleValue="-156729600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/n//w==" DoubleValue="-147657600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6vj//w==" LintValue="-1814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/n//w==" LintValue="-1709"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/n//w==" DoubleValue="-147657600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/n//w==" LintValue="-1709"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" DoubleValue="-130377600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="G/r//w==" LintValue="-1509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" DoubleValue="-122342400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ePr//w==" LintValue="-1416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" DoubleValue="-113875200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2vr//w==" LintValue="-1318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" DoubleValue="-105667200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ofv//w==" LintValue="-1223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" DoubleValue="-97804800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lPv//w==" LintValue="-1132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" DoubleValue="-81561600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPz//w==" LintValue="-944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" DoubleValue="-73008000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fv3//w==" DoubleValue="-64454400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="s/z//w==" LintValue="-845"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Fv3//w==" LintValue="-746"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fv3//w==" DoubleValue="-64454400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Fv3//w==" LintValue="-746"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" DoubleValue="-55641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fP3//w==" LintValue="-644"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="94.384615">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" DoubleValue="-37929600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" DoubleValue="-37152000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Sf7//w==" LintValue="-439"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="Uv7//w==" LintValue="-430"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.3" Name="l_linenumber" Width="4.000000">
@@ -1239,108 +1239,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.10" Name="l_shipdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" DoubleValue="-251769600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPX//w==" DoubleValue="-239155200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nvT//w==" LintValue="-2914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="MPX//w==" LintValue="-2768"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPX//w==" DoubleValue="-239155200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="MPX//w==" LintValue="-2768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" DoubleValue="-231206400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="jPX//w==" LintValue="-2676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" DoubleValue="-222480000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8fX//w==" LintValue="-2575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" DoubleValue="-213408000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Wvb//w==" LintValue="-2470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" DoubleValue="-204681600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="v/b//w==" LintValue="-2369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" DoubleValue="-196387200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="H/f//w==" LintValue="-2273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" DoubleValue="-188784000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/f//w==" LintValue="-2185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" DoubleValue="-181526400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="y/f//w==" LintValue="-2101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" DoubleValue="-173404800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Kfj//w==" LintValue="-2007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" DoubleValue="-165024000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ivj//w==" LintValue="-1910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" DoubleValue="-156643200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="6/j//w==" LintValue="-1813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" DoubleValue="-147744000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Uvn//w==" LintValue="-1710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" DoubleValue="-139104000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfr//w==" DoubleValue="-130204800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tvn//w==" LintValue="-1610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfr//w==" LintValue="-1507"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfr//w==" DoubleValue="-130204800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfr//w==" LintValue="-1507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" DoubleValue="-122169600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="evr//w==" LintValue="-1414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" DoubleValue="-114134400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1/r//w==" LintValue="-1321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" DoubleValue="-105926400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPv//w==" DoubleValue="-97459200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Nvv//w==" LintValue="-1226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mPv//w==" LintValue="-1128"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPv//w==" DoubleValue="-97459200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mPv//w==" LintValue="-1128"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" DoubleValue="-89337600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="9vv//w==" LintValue="-1034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" DoubleValue="-81475200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPz//w==" DoubleValue="-72921600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ufz//w==" LintValue="-943"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPz//w==" LintValue="-844"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPz//w==" DoubleValue="-72921600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ff3//w==" DoubleValue="-64540800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPz//w==" LintValue="-844"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Ff3//w==" LintValue="-747"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ff3//w==" DoubleValue="-64540800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Ff3//w==" LintValue="-747"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" DoubleValue="-55900800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ef3//w==" LintValue="-647"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" DoubleValue="-47865600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="1v3//w==" LintValue="-554"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.538462">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" DoubleValue="-35683200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" DoubleValue="-34387200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Y/7//w==" LintValue="-413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="cv7//w==" LintValue="-398"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:RelationStatistics Mdid="2.17142.1.1" Name="orders" Rows="15040.000000"/>
@@ -1425,104 +1425,104 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17142.1.1.4" Name="o_orderdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" DoubleValue="-252460800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/T//w==" DoubleValue="-244425600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvT//w==" LintValue="-2922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8/T//w==" LintValue="-2829"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/T//w==" DoubleValue="-244425600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/X//w==" DoubleValue="-236131200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8/T//w==" LintValue="-2829"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="U/X//w==" LintValue="-2733"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/X//w==" DoubleValue="-236131200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfX//w==" DoubleValue="-227664000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="U/X//w==" LintValue="-2733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tfX//w==" LintValue="-2635"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfX//w==" DoubleValue="-227664000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPb//w==" DoubleValue="-218764800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tfX//w==" LintValue="-2635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="HPb//w==" LintValue="-2532"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPb//w==" DoubleValue="-218764800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="HPb//w==" LintValue="-2532"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" DoubleValue="-210124800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/b//w==" DoubleValue="-201916800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="gPb//w==" LintValue="-2432"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3/b//w==" LintValue="-2337"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/b//w==" DoubleValue="-201916800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pff//w==" DoubleValue="-193795200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3/b//w==" LintValue="-2337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Pff//w==" LintValue="-2243"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pff//w==" DoubleValue="-193795200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvf//w==" DoubleValue="-186105600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Pff//w==" LintValue="-2243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="lvf//w==" LintValue="-2154"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvf//w==" DoubleValue="-186105600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vf//w==" DoubleValue="-178156800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="lvf//w==" LintValue="-2154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="8vf//w==" LintValue="-2062"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vf//w==" DoubleValue="-178156800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPj//w==" DoubleValue="-170035200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="8vf//w==" LintValue="-2062"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="UPj//w==" LintValue="-1968"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPj//w==" DoubleValue="-170035200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPj//w==" DoubleValue="-161395200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="UPj//w==" LintValue="-1968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="tPj//w==" LintValue="-1868"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPj//w==" DoubleValue="-161395200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvn//w==" DoubleValue="-152582400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="tPj//w==" LintValue="-1868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Gvn//w==" LintValue="-1766"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvn//w==" DoubleValue="-152582400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Gvn//w==" LintValue="-1766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" DoubleValue="-143856000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pn//w==" DoubleValue="-135129600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="f/n//w==" LintValue="-1665"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5Pn//w==" LintValue="-1564"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pn//w==" DoubleValue="-135129600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qfr//w==" DoubleValue="-127094400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5Pn//w==" LintValue="-1564"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qfr//w==" LintValue="-1471"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qfr//w==" DoubleValue="-127094400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/r//w==" DoubleValue="-118627200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qfr//w==" LintValue="-1471"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="o/r//w==" LintValue="-1373"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/r//w==" DoubleValue="-118627200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="o/r//w==" LintValue="-1373"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" DoubleValue="-110332800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvv//w==" DoubleValue="-102470400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="A/v//w==" LintValue="-1277"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Xvv//w==" LintValue="-1186"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvv//w==" DoubleValue="-102470400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfv//w==" DoubleValue="-93916800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Xvv//w==" LintValue="-1186"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="wfv//w==" LintValue="-1087"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfv//w==" DoubleValue="-93916800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="wfv//w==" LintValue="-1087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" DoubleValue="-85968000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvz//w==" DoubleValue="-77587200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Hfz//w==" LintValue="-995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="fvz//w==" LintValue="-898"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvz//w==" DoubleValue="-77587200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fz//w==" DoubleValue="-69379200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="fvz//w==" LintValue="-898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="3fz//w==" LintValue="-803"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fz//w==" DoubleValue="-69379200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv3//w==" DoubleValue="-60652800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="3fz//w==" LintValue="-803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Qv3//w==" LintValue="-702"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv3//w==" DoubleValue="-60652800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/3//w==" DoubleValue="-52617600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Qv3//w==" LintValue="-702"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="n/3//w==" LintValue="-609"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.040000" DistinctValues="96.040000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/3//w==" DoubleValue="-52617600000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" DoubleValue="-44668800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="n/3//w==" LintValue="-609"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="+/3//w==" LintValue="-517"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17119.1.1.13" Name="tableoid" Width="4.000000"/>
@@ -1753,108 +1753,108 @@
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.12" Name="l_receiptdate" Width="4.000000">
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofT//w==" DoubleValue="-251510400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ofT//w==" LintValue="-2911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" DoubleValue="-237859200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPX//w==" DoubleValue="-229824000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="P/X//w==" LintValue="-2753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="nPX//w==" LintValue="-2660"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPX//w==" DoubleValue="-229824000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="nPX//w==" LintValue="-2660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" DoubleValue="-221097600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Afb//w==" LintValue="-2559"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" DoubleValue="-212112000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="afb//w==" LintValue="-2455"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" DoubleValue="-203126400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="0fb//w==" LintValue="-2351"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" DoubleValue="-195091200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvf//w==" LintValue="-2258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" DoubleValue="-187401600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="h/f//w==" LintValue="-2169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" DoubleValue="-180144000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPj//w==" DoubleValue="-172108800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="2/f//w==" LintValue="-2085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="OPj//w==" LintValue="-1992"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPj//w==" DoubleValue="-172108800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvj//w==" DoubleValue="-163641600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="OPj//w==" LintValue="-1992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="mvj//w==" LintValue="-1894"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvj//w==" DoubleValue="-163641600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="mvj//w==" LintValue="-1894"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" DoubleValue="-155433600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="+fj//w==" LintValue="-1799"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" DoubleValue="-146448000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yfn//w==" LintValue="-1695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" DoubleValue="-137635200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="x/n//w==" LintValue="-1593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" DoubleValue="-128736000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifr//w==" DoubleValue="-120873600000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Lvr//w==" LintValue="-1490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="ifr//w==" LintValue="-1399"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifr//w==" DoubleValue="-120873600000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/r//w==" DoubleValue="-112752000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="ifr//w==" LintValue="-1399"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5/r//w==" LintValue="-1305"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/r//w==" DoubleValue="-112752000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5/r//w==" LintValue="-1305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" DoubleValue="-104630400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Rfv//w==" LintValue="-1211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" DoubleValue="-96163200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvz//w==" DoubleValue="-87955200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="p/v//w==" LintValue="-1113"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Bvz//w==" LintValue="-1018"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvz//w==" DoubleValue="-87955200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Bvz//w==" LintValue="-1018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" DoubleValue="-80006400000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Yvz//w==" LintValue="-926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" DoubleValue="-71539200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv3//w==" DoubleValue="-63072000000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="xPz//w==" LintValue="-828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="Jv3//w==" LintValue="-730"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv3//w==" DoubleValue="-63072000000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iP3//w==" DoubleValue="-54604800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="Jv3//w==" LintValue="-730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="iP3//w==" LintValue="-632"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iP3//w==" DoubleValue="-54604800000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="iP3//w==" LintValue="-632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" DoubleValue="-46483200000000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/7//w==" DoubleValue="-33955200000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="5v3//w==" LintValue="-538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" Value="d/7//w==" LintValue="-393"/>
         </dxl:StatsBucket>
         <dxl:StatsBucket Frequency="0.038462" DistinctValues="96.653846">
-          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/7//w==" DoubleValue="-33955200000000"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" DoubleValue="-32140800000000"/>
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" Value="d/7//w==" LintValue="-393"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="jP7//w==" LintValue="-372"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.17165.1.1.5" Name="l_extendedprice" Width="10.000000">
@@ -2570,11 +2570,11 @@
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                 <dxl:Ident ColId="20" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" DoubleValue="-151459200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" LintValue="-1753"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                 <dxl:Ident ColId="42" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" DoubleValue="-151459200000000"/>
+                <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" LintValue="-1753"/>
               </dxl:Comparison>
             </dxl:And>
           </dxl:LogicalJoin>
@@ -2745,7 +2745,7 @@
                     <dxl:Filter>
                       <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
                         <dxl:Ident ColId="41" ColName="l_shipdate" TypeMdid="0.1082.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" DoubleValue="-151459200000000"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" LintValue="-1753"/>
                       </dxl:Comparison>
                     </dxl:Filter>
                     <dxl:TableDescriptor Mdid="0.17165.1.1" TableName="lineitem">
@@ -2820,7 +2820,7 @@
                       <dxl:Filter>
                         <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.1095.1.0">
                           <dxl:Ident ColId="19" ColName="o_orderdate" TypeMdid="0.1082.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" DoubleValue="-151459200000000"/>
+                          <dxl:ConstValue TypeMdid="0.1082.1.0" Value="J/n//w==" LintValue="-1753"/>
                         </dxl:Comparison>
                       </dxl:Filter>
                       <dxl:TableDescriptor Mdid="0.17142.1.1" TableName="orders">

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -317,6 +317,9 @@ public:
 	// is this a time-related type that is mappable to DOUBLE
 	static BOOL IsTimeRelatedTypeMappableToDouble(const IMDId *mdid);
 
+	// is this a time-related type that is mappable to LINT
+	static BOOL IsTimeRelatedTypeMappableToLint(const IMDId *mdid);
+
 	// is this a network-related type
 	static BOOL IsNetworkRelatedType(const IMDId *mdid);
 };

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -314,11 +314,15 @@ public:
 	// is this a time-related type
 	static BOOL IsTimeRelatedType(const IMDId *mdid);
 
-	// is this a time-related type that is mappable to DOUBLE
-	static BOOL IsTimeRelatedTypeMappableToDouble(const IMDId *mdid);
+	// is this a time-related type mappable to DOUBLE
+	static inline BOOL IsTimeRelatedTypeMappableToDouble(const IMDId *mdid) {
+		return IsTimeRelatedType(mdid) && !mdid->Equals(&CMDIdGPDB::m_mdid_date);
+	}
 
-	// is this a time-related type that is mappable to LINT
-	static BOOL IsTimeRelatedTypeMappableToLint(const IMDId *mdid);
+	// is this a time-related type mappable to LINT
+	static inline BOOL IsTimeRelatedTypeMappableToLint(const IMDId *mdid) {
+		return mdid->Equals(&CMDIdGPDB::m_mdid_date);
+	}
 
 	// is this a network-related type
 	static BOOL IsNetworkRelatedType(const IMDId *mdid);

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -316,7 +316,7 @@ public:
 
 	// is this a time-related type mappable to DOUBLE
 	static inline BOOL IsTimeRelatedTypeMappableToDouble(const IMDId *mdid) {
-		return IsTimeRelatedType(mdid) && !mdid->Equals(&CMDIdGPDB::m_mdid_date);
+		return IsTimeRelatedType(mdid) && !IsTimeRelatedTypeMappableToLint(mdid);
 	}
 
 	// is this a time-related type mappable to LINT

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -314,6 +314,9 @@ public:
 	// is this a time-related type
 	static BOOL IsTimeRelatedType(const IMDId *mdid);
 
+	// is this a time-related type that is mappable to DOUBLE
+	static BOOL IsTimeRelatedTypeMappableToDouble(const IMDId *mdid);
+
 	// is this a network-related type
 	static BOOL IsNetworkRelatedType(const IMDId *mdid);
 };

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -522,32 +522,6 @@ CMDTypeGenericGPDB::IsTimeRelatedType(const IMDId *mdid)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble
-//
-//	@doc:
-//		is this a time-related type that is mappable to double
-//---------------------------------------------------------------------------
-inline BOOL
-CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(const IMDId *mdid)
-{
-	return IsTimeRelatedType(mdid) && !mdid->Equals(&CMDIdGPDB::m_mdid_date);
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint
-//
-//	@doc:
-//		is this a time-related type that is mappable to lint
-//---------------------------------------------------------------------------
-inline BOOL
-CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(const IMDId *mdid)
-{
-	return mdid->Equals(&CMDIdGPDB::m_mdid_date);
-}
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CMDTypeGenericGPDB::IsNetworkRelatedType
 //
 //	@doc:

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -477,7 +477,8 @@ CMDTypeGenericGPDB::HasByte2IntMapping(const IMDType *mdtype)
 {
 	IMDId *mdid = mdtype->MDId();
 	return mdtype->IsTextRelated() || mdid->Equals(&CMDIdGPDB::m_mdid_uuid) ||
-		   mdid->Equals(&CMDIdGPDB::m_mdid_cash);
+		   mdid->Equals(&CMDIdGPDB::m_mdid_cash) ||
+		   mdid->Equals(&CMDIdGPDB::m_mdid_date);
 }
 
 //---------------------------------------------------------------------------
@@ -493,7 +494,8 @@ CMDTypeGenericGPDB::HasByte2DoubleMapping(const IMDId *mdid)
 {
 	return mdid->Equals(&CMDIdGPDB::m_mdid_numeric) ||
 		   mdid->Equals(&CMDIdGPDB::m_mdid_float4) ||
-		   mdid->Equals(&CMDIdGPDB::m_mdid_float8) || IsTimeRelatedType(mdid) ||
+		   mdid->Equals(&CMDIdGPDB::m_mdid_float8) ||
+		   IsTimeRelatedTypeMappableToDouble(mdid) ||
 		   IsNetworkRelatedType(mdid);
 }
 
@@ -516,6 +518,19 @@ CMDTypeGenericGPDB::IsTimeRelatedType(const IMDId *mdid)
 		   mdid->Equals(&CMDIdGPDB::m_mdid_relative_time) ||
 		   mdid->Equals(&CMDIdGPDB::m_mdid_interval) ||
 		   mdid->Equals(&CMDIdGPDB::m_mdid_time_interval);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble
+//
+//	@doc:
+//		is this a time-related type that is mappable to double
+//---------------------------------------------------------------------------
+inline BOOL
+CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(const IMDId *mdid)
+{
+	return IsTimeRelatedType(mdid) && !mdid->Equals(&CMDIdGPDB::m_mdid_date);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -478,7 +478,7 @@ CMDTypeGenericGPDB::HasByte2IntMapping(const IMDType *mdtype)
 	IMDId *mdid = mdtype->MDId();
 	return mdtype->IsTextRelated() || mdid->Equals(&CMDIdGPDB::m_mdid_uuid) ||
 		   mdid->Equals(&CMDIdGPDB::m_mdid_cash) ||
-		   mdid->Equals(&CMDIdGPDB::m_mdid_date);
+		   IsTimeRelatedTypeMappableToLint(mdid);
 }
 
 //---------------------------------------------------------------------------
@@ -531,6 +531,19 @@ inline BOOL
 CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(const IMDId *mdid)
 {
 	return IsTimeRelatedType(mdid) && !mdid->Equals(&CMDIdGPDB::m_mdid_date);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint
+//
+//	@doc:
+//		is this a time-related type that is mappable to lint
+//---------------------------------------------------------------------------
+inline BOOL
+CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(const IMDId *mdid)
+{
+	return mdid->Equals(&CMDIdGPDB::m_mdid_date);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -2466,7 +2466,7 @@ CDXLOperatorFactory::GetDatumVal(CDXLMemoryManager *dxl_memory_manager,
 		 &CDXLOperatorFactory::GetDatumStatsDoubleMappable},
 		// time-related types
 		{CMDIdGPDB::m_mdid_date.Oid(),
-		 &CDXLOperatorFactory::GetDatumStatsDoubleMappable},
+		 &CDXLOperatorFactory::GetDatumStatsLintMappable},
 		{CMDIdGPDB::m_mdid_time.Oid(),
 		 &CDXLOperatorFactory::GetDatumStatsDoubleMappable},
 		{CMDIdGPDB::m_mdid_timeTz.Oid(),

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -66,7 +66,7 @@ TranslateOneTimeFilterConjunctQuals TranslateFilterDisjunctQuals TranslateFilter
 InferPredicates InferPredicatesForLimit InferPredicatesBCC-vc-vc InferPredicatesBCC-vc-txt
 InferPredicatesBCC-txt-txt InferPredicatesBCC-oid-oid InferPredicatesBCC-vcpart-txt
 OR-WithIsNullPred Int2Predicate IN-Numeric DeduplicatePredicates
-AddEqualityPredicates AddPredsInSubqueries ExtractPredicateFromDisjWithComputedColumns
+AddEqualityPredicates EqualityPredicateOverDate AddPredsInSubqueries ExtractPredicateFromDisjWithComputedColumns
 Join-With-Subq-Preds-1 Non-Hashjoinable-Pred Non-Hashjoinable-Pred-2 Factorized-Preds IN OR AvoidConstraintDerivationForLike
 NLJ-DistCol-No-Broadcast NLJ-EqAllCol-No-Broadcast NLJ-EqDistCol-InEqNonDistCol-No-Broadcast
 NLJ-InEqDistCol-EqNonDistCol-Redistribute CorrelatedNLJWithTrueCondition InferPredicatesInnerOfLOJ

--- a/src/backend/gporca/server/src/unittest/CConstExprEvaluatorForDates.cpp
+++ b/src/backend/gporca/server/src/unittest/CConstExprEvaluatorForDates.cpp
@@ -33,7 +33,7 @@ using namespace gpopt;
 //
 //	@doc:
 //		It expects that the given expression is a scalar comparison between
-//		two date constants. It compares the two constants using their int64
+//		two date constants. It compares the two constants using their lint
 //		stats mapping, which in the case of the date type gives a correct result.
 //		If it gets an illegal expression, an assertion failure is raised in
 //		debug mode.

--- a/src/backend/gporca/server/src/unittest/CConstExprEvaluatorForDates.cpp
+++ b/src/backend/gporca/server/src/unittest/CConstExprEvaluatorForDates.cpp
@@ -33,7 +33,7 @@ using namespace gpopt;
 //
 //	@doc:
 //		It expects that the given expression is a scalar comparison between
-//		two date constants. It compares the two constants using their double
+//		two date constants. It compares the two constants using their int64
 //		stats mapping, which in the case of the date type gives a correct result.
 //		If it gets an illegal expression, an assertion failure is raised in
 //		debug mode.
@@ -58,8 +58,8 @@ CConstExprEvaluatorForDates::PexprEval(CExpression *pexpr)
 		CMDIdGPDB::m_mdid_date.Equals(popScalarRight->GetDatum()->MDId()));
 
 	CScalarCmp *popScCmp = dynamic_cast<CScalarCmp *>(pexpr->Pop());
-	CDouble dLeft = popScalarLeft->GetDatum()->GetDoubleMapping();
-	CDouble dRight = popScalarRight->GetDatum()->GetDoubleMapping();
+	LINT dLeft = popScalarLeft->GetDatum()->GetLINTMapping();
+	LINT dRight = popScalarRight->GetDatum()->GetLINTMapping();
 	BOOL result = false;
 	switch (popScCmp->ParseCmpType())
 	{

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3834,7 +3834,7 @@ CTestUtils::CreateGenericDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
 			ulbaSize, CDouble(value));
 	}
 	else if (pmdtype->IsTextRelated() ||
-			 mdid_type->Equals(&CMDIdGPDB::m_mdid_date))
+			 CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsLintMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3827,14 +3827,14 @@ CTestUtils::CreateGenericDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
 		CDXLUtils::DecodeByteArrayFromString(mp, pstrEncodedValue, &ulbaSize);
 
 	CDXLDatumGeneric *dxl_datum = NULL;
-	if (gpmd::CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(mdid_type))
+	if (CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsDoubleMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,
 			ulbaSize, CDouble(value));
 	}
 	else if (pmdtype->IsTextRelated() ||
-			 gpmd::CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(mdid_type))
+			 CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsLintMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3827,14 +3827,14 @@ CTestUtils::CreateGenericDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
 		CDXLUtils::DecodeByteArrayFromString(mp, pstrEncodedValue, &ulbaSize);
 
 	CDXLDatumGeneric *dxl_datum = NULL;
-	if (CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(mdid_type))
+	if (gpmd::CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsDoubleMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,
 			ulbaSize, CDouble(value));
 	}
 	else if (pmdtype->IsTextRelated() ||
-			 CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(mdid_type))
+			 gpmd::CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToLint(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsLintMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -3827,13 +3827,14 @@ CTestUtils::CreateGenericDatum(CMemoryPool *mp, CMDAccessor *md_accessor,
 		CDXLUtils::DecodeByteArrayFromString(mp, pstrEncodedValue, &ulbaSize);
 
 	CDXLDatumGeneric *dxl_datum = NULL;
-	if (CMDTypeGenericGPDB::IsTimeRelatedType(mdid_type))
+	if (CMDTypeGenericGPDB::IsTimeRelatedTypeMappableToDouble(mdid_type))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsDoubleMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,
 			ulbaSize, CDouble(value));
 	}
-	else if (pmdtype->IsTextRelated())
+	else if (pmdtype->IsTextRelated() ||
+			 mdid_type->Equals(&CMDIdGPDB::m_mdid_date))
 	{
 		dxl_datum = GPOS_NEW(mp) CDXLDatumStatsLintMappable(
 			mp, mdid_type, default_type_modifier, false /*is_const_null*/, data,

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -594,10 +594,8 @@ CStatisticsTest::Pdrgpstatspred2(CMemoryPool *mp)
 		GPOS_NEW(mp) CWStringDynamic(mp, GPOS_WSZ_LIT("HxEAAA=="));
 	CWStringDynamic *pstrUpperDate =
 		GPOS_NEW(mp) CWStringDynamic(mp, GPOS_WSZ_LIT("LREAAA=="));
-	LINT lLowerDate =
-		LINT(4383) * LINT(INT64_C(86400000000));  // microseconds per day
-	LINT lUpperDate =
-		LINT(4397) * LINT(INT64_C(86400000000));  // microseconds per day
+	LINT lLowerDate = LINT(4383);
+	LINT lUpperDate = LINT(4397);
 	StatsFilterGeneric(mp, 4, GPDB_DATE, pstrLowerDate, pstrUpperDate,
 					   lLowerDate, lUpperDate, pdrgpstatspred);
 


### PR DESCRIPTION
## Description
Details are in issue https://github.com/greenplum-db/gpdb/issues/11169

## Fix decription

The current patch replaces mapping for date values from DOUBLE number of microseconds to LINT number of days that is in its turns natural representation of date value in PostgreSQL. Such modification doesn't allow to compare dates with other time related typed values in the context of statistics estimation routines. But GPORCA in its current version (as opposed to PostgreSQL optimizer) doesn't consider comparisons between different time related types and assigns to such predicates dummy frequency value.

## Notes for reviewer

- All changes in *.h and *.cpp regard mapping logic

- `src/backend/gporca/server/CMakeLists.txt` and `src/backend/gporca/data/dxl/minidump/EqualityPredicateOverDate.mdp` add new test case for equality predicate where date type attribute participates

- in `src/backend/gporca/data/dxl/minidump/Select-Over-PartTbl.mdp` the cardinality of selection with predicate `date_attribute < constant` is repaired

- in all others *.mdp files including that was mentioned at previous point DoubleValue xml attributes for date type column statistics are rewritten to LintValue one with appropriate recalculation of attribute value