### PR TITLE
ADBDEV 1061

### DIFF
--- a/gpMgmt/bin/gppylib/logfilter.py
+++ b/gpMgmt/bin/gppylib/logfilter.py
@@ -42,10 +42,14 @@ Module contents:
     spiffInterval() - get begin/end datetime given any subset of begin/end/duration
 """
 
+import cStringIO
+import csv
 from datetime import date, datetime
 import re
 import sys
 import time
+
+csvDelimeter = '|'
 
 timestampPattern = re.compile(r'\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d*)?')
 # This pattern matches the date and time stamp at the beginning of a line
@@ -258,22 +262,28 @@ def FilterLogEntries(iterable,
 #------------------------------- Spying --------------------------------
 class CsvFlatten(object):
     """
-    Used to flatten a CSV parsed log line into something that looks like the 
+    Used to flatten a CSV parsed log line into something that looks like the
     old format.
     """
-    
+
     def __init__(self,iterable):
         self.source = iter(iterable)
-    
+        self.buffer = cStringIO.StringIO()
+        self.writer = csv.writer(self.buffer, delimiter=csvDelimeter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
+
     def __iter__(self):
         return self
-    
+
     def next(self):
         item = self.source.next()
         #we need to make a minor format change to the log level field so that
         # our single regex will match both.
         item[16] = item[16] + ": "
-        return '|'.join(item) + "\n"
+
+        self.buffer.truncate(0)
+        self.writer.writerow(item)
+
+        return self.buffer.getvalue()
 
 
 #------------------------------- Spying --------------------------------


### PR DESCRIPTION
`gplogfilter` outputs multiline text, which is ambiguously perceived by csv parsers.

`gplogfilter`'s result line:
```
2020-08-29 00:06:46.635873 UTC|data_mart|reporting|p158978|th1580669056|10.0.39.10|33084|2020-08-29 00:01:37 UTC|0|con750679|cmd6|seg8|slice1||||LOG: |00000|duration: 308909.520 ms||||||
SET optimizer=OFF;
INSERT INTO data_mart.volatility_15min(time_interval, active, instrument_type, volatility_date, volatility, volume, pnl)
WITH ti AS (
  SELECT generate_series(
            data_mart.get_last_volatility_date() - interval '1 hour',
            date_trunc('hour',now()) - INTERVAL '15 minutes',
            INTERVAL '15 minutes'
        ) time_interval
)
SELECT
    t.time_interval,
    t.active,
    d.instrument_type,
    date,
    volatility,
    sum(volume) / 1000000.0 volume,
    sum(pnl) / 1000000.0    pnl
FROM (
    SELECT
        time_interval,
        active,
        (VALUES->'900'->>'value')::numeric volatility,
        instant date,
        row_number() OVER (PARTITION BY active, time_interval ORDER BY instant DESC) r
       FROM volatility.history h
           JOIN ti ON
        h.instant > ti.time_interval and h.instant <= ti.time_interval + '15 minutes'
       ) t
    JOIN (
        SELECT
            ti.time_interval,
            instrument_active_id active,
            instrument|0||postgres.c|1421|
```
