### PR TITLE
ADBDEV-1198 Fix Notice messages handling in fts

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -676,15 +676,9 @@ ftsReceive(fts_context *context)
 				/* Parse the response. */
 				if (PQisBusy(ftsInfo->conn))
 				{
-					elog(LOG, "FTS: error parsing response from (content=%d, "
-						 "dbid=%d) state=%d, retry_count=%d, "
-						 "conn->asyncStatus=%d %s",
-						 ftsInfo->primary_cdbinfo->config->segindex,
-						 ftsInfo->primary_cdbinfo->config->dbid,
-						 ftsInfo->state, ftsInfo->retry_count,
-						 ftsInfo->conn->asyncStatus,
-						 PQerrorMessage(ftsInfo->conn));
-					ftsInfo->state = nextFailedState(ftsInfo->state);
+					/*
+					 * There is not enough data in the buffer.
+					 */
 					break;
 				}
 

--- a/src/test/regress/expected/fts_error.out
+++ b/src/test/regress/expected/fts_error.out
@@ -81,6 +81,39 @@ where content = 0 and mode = 's';
  t
 (1 row)
 
+alter system set gp_fts_probe_retries to 0;
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+set optimizer = off;
+-- start_ignore
+\! gpconfig -c client_min_messages -v DEBUG1
+\! gpstop -u
+-- end_ignore
+select gp_request_fts_probe_scan();
+DEBUG1:  Message type Q received by from libpq, len = 36
+LOG:  statement: select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t
+(1 row)
+
+select count(*) from gp_segment_configuration where status = 'd';
+DEBUG1:  Message type Q received by from libpq, len = 66
+LOG:  statement: select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+     0
+(1 row)
+
+-- start_ignore
+\! gpconfig -r client_min_messages
+\! gpstop -u
+-- end_ignore
+reset optimizer;
 alter system reset gp_fts_probe_interval;
 alter system reset gp_fts_probe_retries;
 select pg_reload_conf();

--- a/src/test/regress/sql/fts_error.sql
+++ b/src/test/regress/sql/fts_error.sql
@@ -41,6 +41,27 @@ relation = 'gp_configuration_history'::regclass;
 select count(*) = 2 as in_sync from gp_segment_configuration
 where content = 0 and mode = 's';
 
+alter system set gp_fts_probe_retries to 0;
+select pg_reload_conf();
+
+set optimizer = off;
+
+-- start_ignore
+\! gpconfig -c client_min_messages -v DEBUG1
+\! gpstop -u
+-- end_ignore
+
+select gp_request_fts_probe_scan();
+
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- start_ignore
+\! gpconfig -r client_min_messages
+\! gpstop -u
+-- end_ignore
+
+reset optimizer;
+
 alter system reset gp_fts_probe_interval;
 alter system reset gp_fts_probe_retries;
 select pg_reload_conf();


### PR DESCRIPTION
Current fts implementation doesn't take Notice response messages into
account and thus fails on PQisBusy evaluation every time such message
is received (asyncStatus is not changed from PGASYNC_BUSY during Notice
repsponse messages processing).
The described behavior reproduces for client_min_messages set to DEBUG*
and causes an unexpected fail of PROBE cycle and consequent marking
primary down in configuration.