### PR TITLE
Fixed bug related to incorrect use of WaitLatchOrSocket function.

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -124,10 +124,12 @@ libpqrcv_connect(char *conninfo)
 		int			io_flag;
 		int			rc;
 
-		if (status == PGRES_POLLING_READING)
-			io_flag = WL_SOCKET_READABLE;
-		else
-			io_flag = WL_SOCKET_WRITEABLE;
+		/*
+		 * This flag has to be setup for the further call of WaitLatchOrSocket.
+		 */
+		io_flag = WL_SOCKET_READABLE;
+		if (status == PGRES_POLLING_WRITING)
+			io_flag |= WL_SOCKET_WRITEABLE;
 
 		rc = WaitLatchOrSocket(&MyProc->procLatch,
 							   WL_POSTMASTER_DEATH | WL_LATCH_SET | io_flag,

--- a/src/test/walrep/expected/walreceiver.out
+++ b/src/test/walrep/expected/walreceiver.out
@@ -1,8 +1,8 @@
 -- negative cases
 SELECT test_receive();
-ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:600)
+ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:602)
 SELECT test_send();
-ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:619)
+ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:621)
 SELECT test_disconnect();
  test_disconnect 
 -----------------


### PR DESCRIPTION
We always have to pass the `WL_SOCKET_READABLE` flag to `WaitLatchOrSocket` function when we waiting on sockets. The reason for this is that `EOF` and error conditions are reported only via `WL_SOCKET_READABLE`.