### PR TITLE
Fix initialization of GPDB-specific extra column values for system relations

### DIFF
--- a/src/backend/catalog/Catalog.pm
+++ b/src/backend/catalog/Catalog.pm
@@ -92,6 +92,9 @@ sub Catalogs
 				$bki_values = ProcessDataLine(\%catalog, $bki_values, \%coldefaults, \%extra_values);
 
 				push @{ $catalog{data} }, { oid => $2, bki_values => $bki_values };
+
+				# Clear GPDB_EXTRA_COL settings to further reinitialize their for successive DATA definitions
+				%extra_values = ();
 			}
 			elsif (/^DESCR\(\"(.*)\"\)$/)
 			{


### PR DESCRIPTION
## Problem description

The perl module [catalog/Catalog.pm](https://github.com/greenplum-db/gpdb/blob/6.13.0/src/backend/catalog/Catalog.pm) parses different header files that describe system relations and their predefined rows and generates .bki files that later are used for system catalog initialization. Some header's entries, e.g. GPDB_COLUMN_DEFAULT, once established later are used for successive DATA definitions, but others, e.g. GPDB_EXTRA_COL, are used only for the next DATA entry. But [Catalog](https://github.com/greenplum-db/gpdb/blob/6.13.0/src/backend/catalog/Catalog.pm#L39-L230) function call defined inside `catalog/Catalog.pm` accounts the second kind of entries as first ones. As result, some `pg_proc` entries get invalid prodataaccess values after cluster initialization:
```sql
# the `bitand` function is defined as modifiable that is kind of absurd
select
    oid, proname,
    pg_get_function_arguments(oid) as "Argument data types",
    pg_get_function_result(oid) as "Result data type",
    obj_description(oid, 'pg_proc'),
    prosrc, prodataaccess
from pg_proc
where oid = 1673;
                                                                 
 oid  | proname | Argument data types | Result data type |       obj_description        | prosrc  | prodataaccess 
------+---------+---------------------+------------------+------------------------------+---------+---------------
 1673 | bitand  | bit, bit            | bit              | implementation of & operator | bit_and | m           

```
This leads to some restrictions in query optimizations, e.g. ORCA inhibits LOJ->Inner Join transformation when function with incorrectly assigned prodataaccess value that disallow the null-rejecting property is used inside outer predicate.

## Patch description

In fact the current patch clears GPDB_EXTRA_COL settings after processing of DATA assigned to it in catalog/Catalog.pm file.