### PR TITLE
Fix preprocessing of NOT IN to LAS-Apply

### DIFF
--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -684,9 +684,10 @@ splitJoinQualExpr(List *joinqual, List **inner_join_keys_p, List **outer_join_ke
 				}
 				break;
 
+			case T_DistinctExpr:
 			case T_Const:
 				/*
-				 * Constant expressions do not need to be splitted into left and
+				 * Distinct and constant expressions do not need to be splitted into left and
 				 * right as they don't need to be considered for NULL value special
 				 * cases
 				 */

--- a/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -351,7 +351,7 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false">
+        <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="2155.000479" Rows="1.000000" Width="4"/>
           </dxl:Properties>
@@ -400,17 +400,20 @@
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="1293.000409" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:JoinFilter>
-                  <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
+                  <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                  </dxl:IsDistinctFrom>
                 </dxl:JoinFilter>
                 <dxl:Assert ErrorCode="P0003">
                   <dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
@@ -341,10 +341,13 @@
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Not>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:IsDistinctFrom>
               </dxl:Not>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
@@ -341,10 +341,13 @@
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Not>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:IsDistinctFrom>
               </dxl:Not>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.32780.1.1" TableName="x">

--- a/src/backend/gporca/data/dxl/minidump/NotInToLASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NotInToLASJ.mdp
@@ -1,0 +1,463 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  create table t1(a int) distributed by (a);
+  insert into t1 values (1), (2), (3);
+  explain select * from t1 where a not in (select b.a from t1 a left join t1 b on false);
+                                            QUERY PLAN
+  ---------------------------------------------------------------------------------------------
+  Hash Left Anti Semi (Not-In) Join  (cost=0.00..883119.02 rows=1 width=4)
+    Hash Cond: (t1.a = (NULL::integer))
+    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+    ->  Hash  (cost=882688.02..882688.02 rows=2 width=4)
+          ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..882688.02 rows=2 width=4)
+                ->  Nested Loop Left Join  (cost=0.00..882688.02 rows=1 width=4)
+                      Join Filter: true
+                      ->  Seq Scan on t1 t1_1  (cost=0.00..431.00 rows=1 width=1)
+                      ->  Result  (cost=0.00..0.00 rows=0 width=4)
+                            One-Time Filter: false
+  Optimizer: Pivotal Optimizer (GPORCA)
+  (12 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,103001,103014,103022,103026,103027,103029,103038,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.144.1.0"/>
+        <dxl:Commutator Mdid="0.518.1.0"/>
+        <dxl:InverseOp Mdid="0.96.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16436.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16436.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16436.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.60.1.0"/>
+        <dxl:Commutator Mdid="0.91.1.0"/>
+        <dxl:InverseOp Mdid="0.85.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7124.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.2222.1.0"/>
+          <dxl:Opfamily Mdid="0.7124.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Not>
+          <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="17">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:LogicalJoin JoinType="Left">
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.16436.1.0" TableName="t1" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.16436.1.0" TableName="t1" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+            </dxl:LogicalJoin>
+          </dxl:SubqueryAny>
+        </dxl:Not>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16436.1.0" TableName="t1" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="883119.022535" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:JoinFilter/>
+        <dxl:HashCondList>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:HashCondList>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.16436.1.0" TableName="t1" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="882688.021892" Rows="2.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="16" Alias="a">
+              <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="882688.021862" Rows="2.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="16" Alias="a">
+                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16436.1.0" TableName="t1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="16" Alias="a">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="ctid">
+                  <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="xmin">
+                  <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="cmin">
+                  <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="xmax">
+                  <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="cmax">
+                  <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="tableoid">
+                  <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+              </dxl:OneTimeFilter>
+            </dxl:Result>
+          </dxl:NestedLoopJoin>
+        </dxl:GatherMotion>
+      </dxl:HashJoin>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
@@ -933,7 +933,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.060573" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.061098" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -946,7 +946,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.060572" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.061097" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="ColRef_0026">
@@ -957,7 +957,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.060536" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.061061" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -968,7 +968,7 @@
             <dxl:Filter/>
             <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.060536" Rows="200.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.061061" Rows="500.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -26,21 +26,21 @@
 
     explain
     select dervd_tbl.s1, dervd_tbl.s2, coalesce(p3.id3,0)
-    from 
-    	(select coalesce(trim(p2.id),trim(substr(p1.id,1,5)))::varchar(50) as s1
-    	,  trim(p2.descr)::varchar(255) as s2
-    	, '9' ::varchar(50) s3
-    	from
-    	t1 p1
-    	left outer join T1 p2
-    			on (trim(substr(p1.id,1,5)) ::text = trim(p2.id)::text
-    			and trim(coalesce(p2.att,'')) <> 'Y' and trim(p2.id) <> '')      		
-    	where trim(coalesce(p1.att,'')) <> 'Y' and trim(p1.id) <> ''
-    	and trim(p2.id) not in ( select trim(id2) from T2 where trim(coalesce(att2,'')) <> 'Y' and trim(id2) <> '')
-    	) dervd_tbl
-    	left join t3 p3
-    		on (dervd_tbl.s3::text = p3.desc3::text
-    		and p3.to_dt3 = '9999-12-31 00:00:00'::timestamp)
+    from
+       (select coalesce(trim(p2.id),trim(substr(p1.id,1,5)))::varchar(50) as s1
+       ,  trim(p2.descr)::varchar(255) as s2
+       , '9' ::varchar(50) s3
+       from
+       t1 p1
+       left outer join T1 p2
+                       on (trim(substr(p1.id,1,5)) ::text = trim(p2.id)::text
+                       and trim(coalesce(p2.att,'')) <> 'Y' and trim(p2.id) <> '')
+       where trim(coalesce(p1.att,'')) <> 'Y' and trim(p1.id) <> ''
+       and trim(p2.id) not in ( select trim(id2) from T2 where trim(coalesce(att2,'')) <> 'Y' and trim(id2) <> '')
+       ) dervd_tbl
+       left join t3 p3
+               on (dervd_tbl.s3::text = p3.desc3::text
+               and p3.to_dt3 = '9999-12-31 00:00:00'::timestamp)
     group by 1,2,3
     ;
 
@@ -53,16 +53,18 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102113,102120,102144,102147,103001,103014,103015,103022,103027,103029,103033,103037,104003,104004,104005,104006,105000"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16451.1.0.1" Name="desc3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16451.1.0.0" Name="id3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBScalarOp Mdid="0.2060.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.1114.1.0"/>
         <dxl:RightType Mdid="0.1114.1.0"/>
@@ -70,16 +72,22 @@
         <dxl:OpFunc Mdid="0.2052.1.0"/>
         <dxl:Commutator Mdid="0.2060.1.0"/>
         <dxl:InverseOp Mdid="0.2061.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7111.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.2040.1.0"/>
-          <dxl:Opfamily Mdid="0.3041.1.0"/>
+          <dxl:Opfamily Mdid="0.4059.1.0"/>
+          <dxl:Opfamily Mdid="0.7111.1.0"/>
+          <dxl:Opfamily Mdid="0.10006.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.401.1.0" Name="text" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
+      <dxl:GPDBFunc Mdid="0.401.1.0" Name="text" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="true" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.25.1.0"/>
       </dxl:GPDBFunc>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -94,8 +102,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.368662.1.0" Name="t2" Rows="0.000000" EmptyRelation="true"/>
       <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
         <dxl:EqualityOp Mdid="0.98.1.0"/>
         <dxl:InequalityOp Mdid="0.531.1.0"/>
         <dxl:LessThanOp Mdid="0.664.1.0"/>
@@ -110,40 +119,6 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Relation Mdid="0.368662.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="id2" Attno="1" Mdid="0.1042.1.0" TypeModifier="11" Nullable="false" ColWidth="7">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="att2" Attno="2" Mdid="0.1042.1.0" TypeModifier="5" Nullable="false" ColWidth="1">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.531.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>
@@ -153,6 +128,8 @@
         <dxl:InverseOp Mdid="0.98.1.0"/>
       </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.1042.1.0" Name="bpchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.427.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7106.1.0"/>
         <dxl:EqualityOp Mdid="0.1054.1.0"/>
         <dxl:InequalityOp Mdid="0.1057.1.0"/>
         <dxl:LessThanOp Mdid="0.1058.1.0"/>
@@ -168,6 +145,8 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.410.1.0"/>
         <dxl:InequalityOp Mdid="0.411.1.0"/>
         <dxl:LessThanOp Mdid="0.412.1.0"/>
@@ -182,8 +161,9 @@
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.368659.1.0" Name="t1" Rows="0.000000" EmptyRelation="true"/>
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -198,43 +178,6 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Relation Mdid="0.368659.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="id" Attno="1" Mdid="0.1042.1.0" TypeModifier="11" Nullable="false" ColWidth="7">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="descr" Attno="2" Mdid="0.1042.1.0" TypeModifier="179" Nullable="true" ColWidth="175">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="att" Attno="3" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
       <dxl:GPDBScalarOp Mdid="0.664.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>
@@ -244,11 +187,15 @@
         <dxl:InverseOp Mdid="0.667.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
-          <dxl:Opfamily Mdid="0.3035.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
       <dxl:MDCast Mdid="3.25.1.0;1043.1.0" Name="varchar" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.1043.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
         <dxl:EqualityOp Mdid="0.98.1.0"/>
         <dxl:InequalityOp Mdid="0.531.1.0"/>
         <dxl:LessThanOp Mdid="0.664.1.0"/>
@@ -263,7 +210,11 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16448.1.0.1" Name="att2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16448.1.0.0" Name="id2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -278,7 +229,9 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -302,12 +255,13 @@
         <dxl:InverseOp Mdid="0.415.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.3028.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:RelationStatistics Mdid="2.368665.1.0" Name="t3" Rows="0.000000" EmptyRelation="true"/>
       <dxl:MDCast Mdid="3.1042.1.0;25.1.0" Name="text" BinaryCoercible="false" SourceTypeId="0.1042.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.401.1.0" CoercePathType="1"/>
-      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
         <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
@@ -322,9 +276,10 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -337,7 +292,55 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Relation Mdid="0.368665.1.0" Name="t3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+      <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.1043.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.16451.1.0.2" Name="to_dt3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:RelationStatistics Mdid="2.16445.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16445.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.1042.1.0" TypeModifier="11" Nullable="false" ColWidth="7">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="descr" Attno="2" Mdid="0.1042.1.0" TypeModifier="179" Nullable="true" ColWidth="175">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="att" Attno="3" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.427.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16451.1.0" Name="t3" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16451.1.0" Name="t3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="id3" Attno="1" Mdid="0.20.1.0" Nullable="false" ColWidth="8">
             <dxl:DefaultValue/>
@@ -351,41 +354,90 @@
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList/>
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
-        <dxl:ResultType Mdid="0.1043.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:ColumnStatistics Mdid="1.368662.1.0.1" Name="att2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.368662.1.0.0" Name="id2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.368659.1.0.2" Name="att" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:ColumnStatistics Mdid="1.368659.1.0.1" Name="descr" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.368659.1.0.0" Name="id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.368665.1.0.2" Name="to_dt3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16448.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16448.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="id2" Attno="1" Mdid="0.1042.1.0" TypeModifier="11" Nullable="false" ColWidth="7">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="att2" Attno="2" Mdid="0.1042.1.0" TypeModifier="5" Nullable="false" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.427.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16445.1.0.2" Name="att" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.60.1.0"/>
+        <dxl:Commutator Mdid="0.91.1.0"/>
+        <dxl:InverseOp Mdid="0.85.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7124.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.2222.1.0"/>
+          <dxl:Opfamily Mdid="0.7124.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2040.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7111.1.0"/>
         <dxl:EqualityOp Mdid="0.2060.1.0"/>
         <dxl:InequalityOp Mdid="0.2061.1.0"/>
         <dxl:LessThanOp Mdid="0.2062.1.0"/>
@@ -407,20 +459,28 @@
         <dxl:OpFunc Mdid="0.67.1.0"/>
         <dxl:Commutator Mdid="0.98.1.0"/>
         <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
           <dxl:Opfamily Mdid="0.1995.1.0"/>
-          <dxl:Opfamily Mdid="0.3035.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+          <dxl:Opfamily Mdid="0.10018.1.0"/>
+          <dxl:Opfamily Mdid="0.10022.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBFunc Mdid="0.877.1.0" Name="substr" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false">
+      <dxl:GPDBFunc Mdid="0.877.1.0" Name="substr" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.25.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:ColumnStatistics Mdid="1.368665.1.0.1" Name="desc3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.368665.1.0.0" Name="id3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:GPDBFunc Mdid="0.885.1.0" Name="btrim" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="true">
+      <dxl:GPDBFunc Mdid="0.885.1.0" Name="btrim" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="true" IsAllowedForPS="false">
         <dxl:ResultType Mdid="0.25.1.0"/>
       </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.16445.1.0.1" Name="descr" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16445.1.0.0" Name="id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -486,7 +546,7 @@
                   </dxl:FuncExpr>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="33" Alias="s3">
-                  <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="54" Value="AAAABTk=" LintValue="2767856619"/>
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="54" Value="AAAABTk=" LintValue="3757101760"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:LogicalSelect>
@@ -496,11 +556,11 @@
                       <dxl:FuncExpr FuncId="0.401.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                         <dxl:Coalesce TypeMdid="0.1042.1.0">
                           <dxl:Ident ColId="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                          <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                          <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                         </dxl:Coalesce>
                       </dxl:FuncExpr>
                     </dxl:FuncExpr>
-                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                   </dxl:Comparison>
                   <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                     <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -508,7 +568,7 @@
                         <dxl:Ident ColId="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                       </dxl:FuncExpr>
                     </dxl:FuncExpr>
-                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                   </dxl:Comparison>
                   <dxl:Not>
                     <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.98.1.0" ColId="30">
@@ -534,11 +594,11 @@
                                 <dxl:FuncExpr FuncId="0.401.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                                   <dxl:Coalesce TypeMdid="0.1042.1.0">
                                     <dxl:Ident ColId="22" ColName="att2" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                   </dxl:Coalesce>
                                 </dxl:FuncExpr>
                               </dxl:FuncExpr>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                             </dxl:Comparison>
                             <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                               <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -546,21 +606,21 @@
                                   <dxl:Ident ColId="21" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                 </dxl:FuncExpr>
                               </dxl:FuncExpr>
-                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                              <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                             </dxl:Comparison>
                           </dxl:And>
                           <dxl:LogicalGet>
-                            <dxl:TableDescriptor Mdid="0.368662.1.0" TableName="t2">
+                            <dxl:TableDescriptor Mdid="0.16448.1.0" TableName="t2" LockMode="1">
                               <dxl:Columns>
                                 <dxl:Column ColId="21" Attno="1" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                                 <dxl:Column ColId="22" Attno="2" ColName="att2" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                                 <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="24" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="25" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="26" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="27" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="28" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="29" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:LogicalGet>
@@ -571,34 +631,34 @@
                 </dxl:And>
                 <dxl:LogicalJoin JoinType="Left">
                   <dxl:LogicalGet>
-                    <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                    <dxl:TableDescriptor Mdid="0.16445.1.0" TableName="t1" LockMode="1">
                       <dxl:Columns>
                         <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                         <dxl:Column ColId="2" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
                         <dxl:Column ColId="3" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                         <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:LogicalGet>
                   <dxl:LogicalGet>
-                    <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                    <dxl:TableDescriptor Mdid="0.16445.1.0" TableName="t1" LockMode="1">
                       <dxl:Columns>
                         <dxl:Column ColId="11" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                         <dxl:Column ColId="12" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
                         <dxl:Column ColId="13" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                         <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="16" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="18" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="20" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:LogicalGet>
@@ -624,11 +684,11 @@
                         <dxl:FuncExpr FuncId="0.401.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
                           <dxl:Coalesce TypeMdid="0.1042.1.0">
                             <dxl:Ident ColId="13" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                            <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                            <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                           </dxl:Coalesce>
                         </dxl:FuncExpr>
                       </dxl:FuncExpr>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                     </dxl:Comparison>
                     <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                       <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -636,25 +696,25 @@
                           <dxl:Ident ColId="11" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                         </dxl:FuncExpr>
                       </dxl:FuncExpr>
-                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                      <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                     </dxl:Comparison>
                   </dxl:And>
                 </dxl:LogicalJoin>
               </dxl:LogicalSelect>
             </dxl:LogicalProject>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.368665.1.0" TableName="t3">
+              <dxl:TableDescriptor Mdid="0.16451.1.0" TableName="t3" LockMode="1">
                 <dxl:Columns>
                   <dxl:Column ColId="34" Attno="1" ColName="id3" TypeMdid="0.20.1.0" ColWidth="8"/>
                   <dxl:Column ColId="35" Attno="2" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54" ColWidth="50"/>
                   <dxl:Column ColId="36" Attno="3" ColName="to_dt3" TypeMdid="0.1114.1.0" ColWidth="8"/>
                   <dxl:Column ColId="37" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="38" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="39" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="40" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="41" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="38" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="39" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="40" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="41" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="42" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="43" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:LogicalGet>
@@ -676,10 +736,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1680">
+    <dxl:Plan Id="0" SpaceSize="2240">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.003881" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.004176" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="30" Alias="s1">
@@ -696,7 +756,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.003792" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.004087" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="30"/>
@@ -717,7 +777,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.004058" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="30" Alias="s1">
@@ -740,7 +800,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.003763" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.004058" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="s1">
@@ -756,19 +816,19 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr>
+                <dxl:HashExpr Opfamily="0.1995.1.0">
                   <dxl:Ident ColId="30" ColName="s1" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr>
+                <dxl:HashExpr Opfamily="0.1995.1.0">
                   <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr>
+                <dxl:HashExpr Opfamily="0.1977.1.0">
                   <dxl:Ident ColId="43" ColName="coalesce" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.003725" Rows="1.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.004020" Rows="1.000000" Width="24"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="30"/>
@@ -789,7 +849,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.004000" Rows="2.000000" Width="24"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -812,7 +872,7 @@
                   <dxl:LimitOffset/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1724.003705" Rows="2.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1724.004000" Rows="2.000000" Width="24"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="43" Alias="coalesce">
@@ -830,9 +890,9 @@
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
-                    <dxl:HashJoin JoinType="Left">
+                    <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1724.003689" Rows="2.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1724.003984" Rows="2.000000" Width="24"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="30" Alias="s1">
@@ -846,20 +906,10 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:JoinFilter/>
-                      <dxl:HashCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:Cast>
-                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:Cast>
-                        </dxl:Comparison>
-                      </dxl:HashCondList>
-                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:SortingColumnList/>
+                      <dxl:HashJoin JoinType="Left">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.002612" Rows="2.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1724.003859" Rows="2.000000" Width="24"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="30" Alias="s1">
@@ -868,20 +918,25 @@
                           <dxl:ProjElem ColId="31" Alias="s2">
                             <dxl:Ident ColId="31" ColName="s2" TypeMdid="0.1043.1.0" TypeModifier="259"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="32" Alias="s3">
-                            <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                          <dxl:ProjElem ColId="33" Alias="id3">
+                            <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="32" ColName="s3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                            </dxl:Cast>
+                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                            </dxl:Cast>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.002462" Rows="2.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.002542" Rows="2.000000" Width="24"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="30" Alias="s1">
@@ -922,14 +977,14 @@
                               </dxl:FuncExpr>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="32" Alias="s3">
-                              <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="54" Value="AAAABTk=" LintValue="2767856619"/>
+                              <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="54" Value="AAAABTk=" LintValue="3757101760"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:OneTimeFilter/>
                           <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.002414" Rows="2.000000" Width="24"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.002494" Rows="2.000000" Width="24"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="id">
@@ -956,7 +1011,7 @@
                             </dxl:HashCondList>
                             <dxl:HashJoin JoinType="Left">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="862.001325" Rows="2.000000" Width="24"/>
+                                <dxl:Cost StartupCost="0" TotalCost="862.001518" Rows="2.000000" Width="24"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="0" Alias="id">
@@ -989,9 +1044,9 @@
                                   </dxl:FuncExpr>
                                 </dxl:Comparison>
                               </dxl:HashCondList>
-                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000238" Rows="1.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000302" Rows="1.000000" Width="8"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="0" Alias="id">
@@ -1000,19 +1055,6 @@
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:SortingColumnList/>
-                                <dxl:HashExprList>
-                                  <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                          <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                        </dxl:Cast>
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                                      </dxl:FuncExpr>
-                                    </dxl:FuncExpr>
-                                  </dxl:HashExpr>
-                                </dxl:HashExprList>
                                 <dxl:TableScan>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000213" Rows="1.000000" Width="8"/>
@@ -1029,11 +1071,11 @@
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="2" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                             </dxl:Coalesce>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                                         <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -1041,28 +1083,28 @@
                                             <dxl:Ident ColId="0" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                       </dxl:Comparison>
                                     </dxl:And>
                                   </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                                  <dxl:TableDescriptor Mdid="0.16445.1.0" TableName="t1" LockMode="1">
                                     <dxl:Columns>
                                       <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                                       <dxl:Column ColId="2" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                                       <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
-                              </dxl:RedistributeMotion>
-                              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              </dxl:GatherMotion>
+                              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000278" Rows="1.000000" Width="16"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000406" Rows="1.000000" Width="16"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="10" Alias="id">
@@ -1074,15 +1116,6 @@
                                 </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:SortingColumnList/>
-                                <dxl:HashExprList>
-                                  <dxl:HashExpr>
-                                    <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
-                                        <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
-                                      </dxl:Cast>
-                                    </dxl:FuncExpr>
-                                  </dxl:HashExpr>
-                                </dxl:HashExprList>
                                 <dxl:TableScan>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000228" Rows="1.000000" Width="16"/>
@@ -1102,11 +1135,11 @@
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="12" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                             </dxl:Coalesce>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                                         <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -1114,30 +1147,30 @@
                                             <dxl:Ident ColId="10" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                       </dxl:Comparison>
                                     </dxl:And>
                                   </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368659.1.0" TableName="t1">
+                                  <dxl:TableDescriptor Mdid="0.16445.1.0" TableName="t1" LockMode="1">
                                     <dxl:Columns>
                                       <dxl:Column ColId="10" Attno="1" ColName="id" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                                       <dxl:Column ColId="11" Attno="2" ColName="descr" TypeMdid="0.1042.1.0" TypeModifier="179" ColWidth="175"/>
                                       <dxl:Column ColId="12" Attno="3" ColName="att" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                                       <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
-                              </dxl:RedistributeMotion>
+                              </dxl:GatherMotion>
                             </dxl:HashJoin>
-                            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000262" Rows="3.000000" Width="8"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000149" Rows="1.000000" Width="8"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="29" Alias="btrim">
@@ -1177,11 +1210,11 @@
                                           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.401.1.0">
                                             <dxl:Coalesce TypeMdid="0.1042.1.0">
                                               <dxl:Ident ColId="21" ColName="att2" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                              <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                             </dxl:Coalesce>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3870055082"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABVk=" LintValue="3341433612"/>
                                       </dxl:Comparison>
                                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
                                         <dxl:FuncExpr FuncId="0.885.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
@@ -1189,51 +1222,31 @@
                                             <dxl:Ident ColId="20" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11"/>
                                           </dxl:Cast>
                                         </dxl:FuncExpr>
-                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="3739851654"/>
+                                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAABA==" LintValue="2817148525"/>
                                       </dxl:Comparison>
                                     </dxl:And>
                                   </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.368662.1.0" TableName="t2">
+                                  <dxl:TableDescriptor Mdid="0.16448.1.0" TableName="t2" LockMode="1">
                                     <dxl:Columns>
                                       <dxl:Column ColId="20" Attno="1" ColName="id2" TypeMdid="0.1042.1.0" TypeModifier="11" ColWidth="7"/>
                                       <dxl:Column ColId="21" Attno="2" ColName="att2" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
                                       <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="23" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="24" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="25" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="26" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="27" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="28" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                     </dxl:Columns>
                                   </dxl:TableDescriptor>
                                 </dxl:TableScan>
                               </dxl:Result>
-                            </dxl:BroadcastMotion>
+                            </dxl:GatherMotion>
                           </dxl:HashJoin>
                         </dxl:Result>
-                      </dxl:RedistributeMotion>
-                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000180" Rows="1.000000" Width="16"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="33" Alias="id3">
-                            <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="34" Alias="desc3">
-                            <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
+                        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000130" Rows="1.000000" Width="16"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="1.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="33" Alias="id3">
@@ -1243,29 +1256,44 @@
                               <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2060.1.0">
-                              <dxl:Ident ColId="35" ColName="to_dt3" TypeMdid="0.1114.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.1114.1.0" Value="ACBkc/fmgAM=" DoubleValue="252455529600000000.000000"/>
-                            </dxl:Comparison>
-                          </dxl:Filter>
-                          <dxl:TableDescriptor Mdid="0.368665.1.0" TableName="t3">
-                            <dxl:Columns>
-                              <dxl:Column ColId="33" Attno="1" ColName="id3" TypeMdid="0.20.1.0" ColWidth="8"/>
-                              <dxl:Column ColId="34" Attno="2" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54" ColWidth="50"/>
-                              <dxl:Column ColId="35" Attno="3" ColName="to_dt3" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                              <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="37" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="38" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="39" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="40" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
-                    </dxl:HashJoin>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000130" Rows="1.000000" Width="16"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="33" Alias="id3">
+                                <dxl:Ident ColId="33" ColName="id3" TypeMdid="0.20.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="34" Alias="desc3">
+                                <dxl:Ident ColId="34" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.2060.1.0">
+                                <dxl:Ident ColId="35" ColName="to_dt3" TypeMdid="0.1114.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.1114.1.0" Value="ACBkc/fmgAM=" DoubleValue="252455529600000000.000000"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:TableDescriptor Mdid="0.16451.1.0" TableName="t3" LockMode="1">
+                              <dxl:Columns>
+                                <dxl:Column ColId="33" Attno="1" ColName="id3" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="34" Attno="2" ColName="desc3" TypeMdid="0.1043.1.0" TypeModifier="54" ColWidth="50"/>
+                                <dxl:Column ColId="35" Attno="3" ColName="to_dt3" TypeMdid="0.1114.1.0" ColWidth="8"/>
+                                <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="37" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="38" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="39" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="40" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="41" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="42" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:GatherMotion>
+                      </dxl:HashJoin>
+                    </dxl:RandomMotion>
                   </dxl:Result>
                 </dxl:Sort>
               </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
@@ -327,7 +327,7 @@
     <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000299" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000329" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1659,8 +1659,6 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 	// generate a select with the inverse predicate as the selection predicate
 	// TODO: Handle the case where pexprInversePred == NULL
 	pexprPredicate = pexprInversePred;
-	pexprInnerSelect =
-		CUtils::PexprLogicalSelect(mp, pexprInner, pexprPredicate);
 
 	if (EsqctxtValue == esqctxt)
 	{
@@ -1679,11 +1677,8 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 				fUseCorrelated = true;
 		}
 
-		CExpression *pexprNewInnerSelect = PexprInnerSelect(
+		pexprInnerSelect = PexprInnerSelect(
 			mp, colref, pexprInner, pexprPredicate, &fUseNotNullOptimization);
-
-		pexprInnerSelect->Release();
-		pexprInnerSelect = pexprNewInnerSelect;
 
 		if (!fUseCorrelated)
 		{
@@ -1699,10 +1694,35 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 				mp, pexprOuter, pexprSubquery, esqctxt, ppexprNewOuter,
 				ppexprResidualScalar);
 		}
+		pexprInner->Release();
+		pexprPredicate->Release();
 	}
 	else
 	{
 		GPOS_ASSERT(EsqctxtFilter == esqctxt);
+
+		// check that inner row in filter is nullable
+		CColRefSet *pcrsNotNullInner = GPOS_NEW(mp) CColRefSet(mp);
+		pcrsNotNullInner->Include(pexprInner->DeriveNotNullColumns());
+		CColRefSet *pcrsUsedInner = GPOS_NEW(mp) CColRefSet(mp);
+		pcrsUsedInner->Include(colref);
+		pcrsUsedInner->Intersection(pexprPredicate->DeriveUsedColumns());
+		pcrsNotNullInner->Intersection(pcrsUsedInner);
+		BOOL fInnerUsesNullableCol =
+			pcrsNotNullInner->Size() != pcrsUsedInner->Size();
+		pcrsNotNullInner->Release();
+		pcrsUsedInner->Release();
+
+		if (fInnerUsesNullableCol)
+		{
+			pexprInnerSelect = CUtils::PexprLogicalSelect(
+				mp, pexprInner, CUtils::PexprIsNotFalse(mp, pexprPredicate));
+		}
+		else
+		{
+			pexprInnerSelect =
+				CUtils::PexprLogicalSelect(mp, pexprInner, pexprPredicate);
+		}
 
 		*ppexprResidualScalar = CUtils::PexprScalarConstBool(mp, true);
 		*ppexprNewOuter =

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -324,22 +324,21 @@ select c1 from t1 where c1 > 6 and c1 not in
 --
 explain select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
-   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
-         Hash Cond: (t2.c2 = t1.c1)
-         ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-         ->  Hash  (cost=862.00..862.00 rows=2 width=4)
-               ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=2 width=4)
-                     Hash Cond: (t1.c1 = t3.c3)
-                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                 ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(13 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=6 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..1293.00 rows=2 width=4)
+         Hash Cond: (t1.c1 = t3.c3)
+         ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+               Hash Cond: (t1.c1 = t2.c2)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
@@ -825,23 +824,22 @@ select c1 from t1 where c1 not in (select c2 from t2 order by c2 limit 3) order 
 --q32
 --
 explain select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
-                                                                                                                                                                     QUERY PLAN                                                                                                                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324032.85 rows=4 width=4)
-   Filter: (SubPlan 1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
-         ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-   SubPlan 1
-     ->  Result  (cost=0.00..431.00 rows=1 width=1)
-           Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-           ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                 ->  Result  (cost=0.00..431.00 rows=2 width=8)
-                       ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
-                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
-                                         Filter: ((c2 > '-1'::integer) AND (c2 <= 1))
+                                                                                                                                                                        QUERY PLAN                                                                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.88 rows=10 width=4)
+   ->  Seq Scan on t1  (cost=0.00..1324032.88 rows=4 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                 Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 <> t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..431.00 rows=2 width=8)
+                             ->  Materialize  (cost=0.00..431.00 rows=2 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                               Filter: ((c2 > '-1'::integer) AND (c2 <= 1))
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 select c1 from t1 where c1 =all (select c2 from t2 where c2 > -1 and c2 <= 1);
  c1 
@@ -880,26 +878,27 @@ select c1 from t1 where c1 <>all (select c2 from t2);
 --q34
 --
 explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
-                                                                                                                                                                       QUERY PLAN                                                                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1765379.01 rows=4 width=4)
-   ->  Seq Scan on t1  (cost=0.00..1765379.01 rows=2 width=4)
-         Filter: (SubPlan 1)
-         SubPlan 1
-           ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                 Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                 ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
-                       ->  Result  (cost=0.00..862.00 rows=2 width=8)
-                             ->  Materialize  (cost=0.00..862.00 rows=2 width=4)
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-                                         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                               Hash Cond: (t2.c2 = t1n.c1n)
-                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-                                               ->  Hash  (cost=431.00..431.00 rows=7 width=4)
-                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                           ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(17 rows)
+                                                                                                                                                                    QUERY PLAN                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1765379.24 rows=10 width=4)
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+   SubPlan 1
+     ->  Result  (cost=0.00..862.00 rows=1 width=1)
+           Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
+                 ->  Result  (cost=0.00..862.00 rows=5 width=8)
+                       ->  Materialize  (cost=0.00..862.00 rows=5 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=5 width=4)
+                                   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=2 width=4)
+                                         Hash Cond: (t2.c2 = t1n.c1n)
+                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                         ->  Hash  (cost=431.00..431.00 rows=7 width=4)
+                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                                     ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
  c1 


### PR DESCRIPTION
`NOT IN` is equivalent to `<> ALL` SQL expression and should be replaced with `LAS-Apply` in `CSubqueryHandler::FRemoveAllSubquery()`. The problem was that ORCA transformed `<> ALL` subquery in filter incorrectly: instead of a [correct description](https://github.com/greenplum-db/gpdb/blob/6987e210b2cfbaa0d213382363a6a6e09cb7051f/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp#L1573) in a comment for `FRemoveAllSubquery()` function, the real plan didn't try to add
`IS_NOT_NULL` node for `R.a` and `IS_NOT_FALSE` for `R.a = S.b`. As a
result ORCA returned incorrect results on some queries.

For example in https://github.com/greenplum-db/gpdb/issues/10967
```sql
create table t1(a int) distributed by (a);
insert into t1 values (1), (2), (3);
select * from t1 where a not in (
    select b.a from t1 a left join t1 b on false
);
```
returned incorrect `(1), (2), (3)` result for ORCA and correct empty result on postgres planner. The root of it was in `FRemoveAllSubquery()`. Previously this function transformed
```
+--CScalarSubqueryAll(<>)["a" (16)]   origin: [Grp:6, GrpExpr:0]
   |--CLogicalLeftOuterJoin   origin: [Grp:4, GrpExpr:0]
   |  |--CLogicalGet "t1" ("t1"), Columns: ["a" (8),..]
   |  |--CLogicalConstTableGet Columns: ["a" (16),..]
   |  +--CScalarConst (1)   origin: [Grp:3, GrpExpr:0]
   +--CScalarIdent "a" (0)   origin: [Grp:5, GrpExpr:0]
```
to
```
+--CLogicalLeftAntiSemiApplyNotIn (Reqd Inner Cols: "a" (16))
   |--CLogicalGet "t1" ("t1"), Columns: ["a" (0),..]
   |--CLogicalSelect
   |  |--CLogicalLeftOuterJoin   origin: [Grp:4, GrpExpr:0]
   |  |  |--CLogicalGet "t1" ("t1"), Columns: ["a" (8),..]
   |  |  |--CLogicalConstTableGet Columns: ["a" (16),..]
   |  |  +--CScalarConst (1)   origin: [Grp:3, GrpExpr:0]
   |  +--CScalarCmp (=)
   |     |--CScalarIdent "a" (0)   origin: [Grp:5, GrpExpr:0]
   |     +--CScalarIdent "a" (16)
   +--CScalarConst (1)
```
and didn't add `IS_NOT_FALSE` and `IS_NOT_NULL` checks as we should expect.
Now we get a correct logical tree with empty result:
```
+--CLogicalLeftAntiSemiApplyNotIn (Reqd Inner Cols: "a" (16))
   |--CLogicalSelect
   |  |--CLogicalGet "t1" ("t1"), Columns: ["a" (0),..]
   |  +--CScalarBoolOp (EboolopNot)
   |     +--CScalarNullTest
   |        +--CScalarIdent "a" (0)   origin: [Grp:5, GrpExpr:0]
   |--CLogicalSelect
   |  |--CLogicalLeftOuterJoin   origin: [Grp:4, GrpExpr:0]
   |  |  |--CLogicalGet "t1" ("t1"), Columns: ["a" (8),..]
   |  |  |--CLogicalConstTableGet Columns: ["a" (16),..]
   |  |  +--CScalarConst (1)   origin: [Grp:3, GrpExpr:0]
   |  +--CScalarIsDistinctFrom (=)
   |     |--CScalarCmp (=)
   |     |  |--CScalarIdent "a" (0)   origin: [Grp:5, GrpExpr:0]
   |     |  +--CScalarIdent "a" (16)
   |     +--CScalarConst (0)
   +--CScalarConst (1)
```