### PR TITLE
[5X backport] Fix aocsseg inconsistency when rollback add column

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -97,9 +97,11 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 
     segrel = heap_open(prel->rd_appendonly->segrelid, RowExclusiveLock);
 
-	InsertFastSequenceEntry(prel->rd_appendonly->segrelid,
-							(int64)segno,
-							0);
+	/*
+	 * Create a new entry in gp_fastsequence or increment
+	 * an existing one (it can exist after transaction rollback).
+	 */
+	GetFastSequences(prel->rd_appendonly->segrelid, (int64) segno, 1, 0);
 
     values[Anum_pg_aocs_segno-1] = Int32GetDatum(segno);
     values[Anum_pg_aocs_vpinfo-1] = PointerGetDatum(vpinfo);
@@ -110,11 +112,13 @@ InsertInitialAOCSFileSegInfo(Relation prel, int4 segno, int4 nvp)
 
     segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
 
-    frozen_heap_insert(segrel, segtup);
+    simple_heap_insert(segrel, segtup);
     CatalogUpdateIndexes(segrel, segtup);
 
     heap_freetuple(segtup);
     heap_close(segrel, RowExclusiveLock);
+
+    CommandCounterIncrement();
 
     pfree(vpinfo);
     pfree(nulls);

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -783,3 +783,22 @@ alter table aocs_with_compress drop column b;
 alter table aocs_with_compress set with (reorganize=true);
 -- The following operation must not fail
 alter table aocs_with_compress alter column c type integer;
+--
+-- Test case: validate pg_aocsseg consistency after alter table
+-- add column with rollback.
+--
+-- pg_aocsseg stores vpinfo structure with serialized EOF information
+-- for every column in AOCS table. If transaction adds new columns,
+-- spawns new pg_aocsseg entries and rollbacks, check there is no
+-- inconsistency in pg_aocsseg after it (with vacuum).
+--
+SET gp_default_storage_options='appendonly=true, orientation=column';
+CREATE TABLE aocs_alter_add_col_no_compress AS
+   SELECT g AS a, g AS b FROM generate_series(1, 10) AS g DISTRIBUTED BY (a);
+BEGIN;
+ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN c int;
+UPDATE aocs_alter_add_col_no_compress SET c = 1;
+ROLLBACK;
+VACUUM aocs_alter_add_col_no_compress;
+DROP TABLE aocs_alter_add_col_no_compress;
+RESET gp_default_storage_options;


### PR DESCRIPTION
Before current commit we initailized pg_aocsseg entries with frozen
tuples to make these entries implicitly visible even after rollback.
It is a working approach for AO tables, but AOC tables store additional
"vpinfo" structure with serialized information about every column EOF.
This can cause inconsistency between "vpinfo" structure in pg_aocsseg
entries and the actual number of columns in a table when we modify the
amount of columns under explicit transaction and rollback it later.
As a result we fail on asserts in "GetAllAOCSFileSegInfo_pg_aocsseg_rel()"
or (in a case of a build without asserts) in some unpredictable places
in the code when retrieve metadata from pg_aocsseg.

As a fix this commit inserts simple tuples to pg_aocsseg but still insert
frozen tuples to gp_fastsequence (as it generates row numbers for segment
files and should never be rollbacked to avoid inconsistency in index pointers
of the AO/AOC tables).

Backport of a5e28ec66dd07b4e1863bff785c951ffbd74aa52

Co-authored-by: Vasiliy Ivanov <ivi@arenadata.io>