### PR TITLE
[Backport 5x] Fix resource group waiting queue corruption

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1848,8 +1848,17 @@ groupAcquireSlot(ResGroupInfo *pGroupInfo)
 		}
 	}
 
-	/* add into group wait queue */
-	groupWaitQueuePush(group, MyProc);
+	/*
+	 * Add into group wait queue (if not waiting yet).
+	 *
+	 * Need to handle a special case, when MyProc was interrupted
+	 * by SIGTERM while waiting for resource group slot.
+	 * Some callbacks - RemoveTempRelationsCallback for example -
+	 * open new transactions on proc exit. It can cause a double
+	 * add of MyProc to the waiting queue (and its corruption).
+	 */
+	if (!procIsWaiting(MyProc))
+		groupWaitQueuePush(group, MyProc);
 
 	if (!group->lockedForDrop)
 		group->totalQueued++;

--- a/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cancel_terminate_concurrency.out
@@ -243,5 +243,65 @@ DROP
 DROP RESOURCE GROUP rg_concurrency_test;
 DROP
 
+-- test5: terminate a query waiting for a slot, that opens a transaction on exit callback
+DROP ROLE IF EXISTS role_concurrency_test;
+DROP
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+ERROR:  resource group "rg_concurrency_test" does not exist
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+CREATE
+1:SET ROLE role_concurrency_test;
+SET
+1:CREATE TEMP TABLE tmp(a INT);
+CREATE
+2:SET ROLE role_concurrency_test;
+SET
+2:BEGIN;
+BEGIN
+1&:SELECT 1;  <waiting ...>
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query        |rsgname            
+-------+--------------+---------------------+-------------------
+t      |resgroup      |SELECT 1;            |rg_concurrency_test
+f      |              |<IDLE> in transaction|rg_concurrency_test
+(2 rows)
+-- Upon receiving the terminate request, session 1 should start a new transaction to cleanup temp table.
+-- Note, that session 1 has already been waiting for resource group slot, so its new transaction also
+-- waits for the slot (until session 2 commits). We check that session 1 should not add its proc to the
+-- wait queue again. Such double addition of the same proc to the wait queue leads to the queue corruption
+-- (was found to occur previously).
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+pg_terminate_backend
+--------------------
+t                 
+(1 row)
+2:COMMIT;
+COMMIT
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+SELECT * FROM rg_concurrency_view;
+waiting|waiting_reason|current_query|rsgname
+-------+--------------+-------------+-------
+(0 rows)
+1q: ... <quitting>
+2q: ... <quitting>
+SELECT pg_sleep(1);
+pg_sleep
+--------
+        
+(1 row)
+DROP ROLE role_concurrency_test;
+DROP
+DROP RESOURCE GROUP rg_concurrency_test;
+DROP
+
 DROP VIEW rg_concurrency_view;
 DROP

--- a/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cancel_terminate_concurrency.sql
@@ -115,4 +115,33 @@ SELECT * FROM rg_concurrency_view;
 DROP ROLE role_concurrency_test;
 DROP RESOURCE GROUP rg_concurrency_test;
 
+-- test5: terminate a query waiting for a slot, that opens a transaction on exit callback
+DROP ROLE IF EXISTS role_concurrency_test;
+-- start_ignore
+DROP RESOURCE GROUP rg_concurrency_test;
+-- end_ignore
+
+CREATE RESOURCE GROUP rg_concurrency_test WITH (concurrency=1, cpu_rate_limit=20, memory_limit=20);
+CREATE ROLE role_concurrency_test RESOURCE GROUP rg_concurrency_test;
+1:SET ROLE role_concurrency_test;
+1:CREATE TEMP TABLE tmp(a INT);
+2:SET ROLE role_concurrency_test;
+2:BEGIN;
+1&:SELECT 1;
+SELECT * FROM rg_concurrency_view;
+-- Upon receiving the terminate request, session 1 should start a new transaction to cleanup temp table.
+-- Note, that session 1 has already been waiting for resource group slot, so its new transaction also
+-- waits for the slot (until session 2 commits). We check that session 1 should not add its proc to the
+-- wait queue again. Such double addition of the same proc to the wait queue leads to the queue corruption
+-- (was found to occur previously).
+SELECT pg_terminate_backend(procpid) FROM pg_stat_activity WHERE waiting_reason='resgroup' AND rsgname='rg_concurrency_test';
+2:COMMIT;
+1<:
+SELECT * FROM rg_concurrency_view;
+1q:
+2q:
+SELECT pg_sleep(1);
+DROP ROLE role_concurrency_test;
+DROP RESOURCE GROUP rg_concurrency_test;
+
 DROP VIEW rg_concurrency_view;


### PR DESCRIPTION
This commit fixes a situation, when a process waiting for resource
group slot receives SIGTERM. Some callbacks - RemoveTempRelationsCallback
for example - try to open new transactions on proc exit. It caused
an attempt to add the process to the waiting queue for the second
time (and queue corruption). Now we don't add process to the queue
if it is already waiting for the slot.

Backport of 810ede554208e8486c3ade3c1906f2e897b05424