### PR TITLE
pg_rewind: avoid removing "pg_log" files

### DIFF
--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -253,10 +253,11 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	 * from the target data folder all paths which have been filtered out from
 	 * the source data folder when processing the source files.
 	 *
-	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME is in the excluded file list.
-	 * It should not be copied but also should not be removed. In the future,
-	 * if there are more files that should not be copied but also should not be
-	 * removed, then a separate function for those files would be better.
+	 * GPDB: GP_INTERNAL_AUTO_CONF_FILE_NAME and "pg_log" are in the excluded
+	 * file list.  These should not be copied but also should not be
+	 * removed. In the future, if there are more files or directories that
+	 * should not be copied but also should not be removed, then a separate
+	 * function for those would be better.
 	 */
 	{
 		const char *filename = last_dir_separator(path);
@@ -265,6 +266,15 @@ process_target_file(const char *path, file_type_t type, size_t size,
 		else
 			filename++;
 		if (strcmp(filename, GP_INTERNAL_AUTO_CONF_FILE_NAME) == 0)
+			return;
+
+		/*
+		 * While `log_directory` guc is declared inside DEFUNCT_OPTIONS group
+		 * (see corresponding entry inside `ConfigureNamesString` global array),
+		 * this guc will preserve its default value 'pg_log' without any
+		 * possibility to change it externally
+		 */
+		if (strstr(path, "pg_log/") == path)
 			return;
 	}
 


### PR DESCRIPTION
## Problem description
"pg_log" is part of excluded directory list. The semantics of exclude file/directory list is to avoid copy from source to target. But also as side effect if those files are present in target, they are removed as well.

This semantic is good for most of things but for "pg_log" directory don't wish to get them removed. Hence, adding logic to add this exception.

Backport 6f29a6f to 6X.

## Steps to reproduce

1. Increase `wal_keep_segments` up to, e.g., 1000 so that new primary doesn’t rotate its wal segments after point of divergence and hence `pg_rewind` would run well.
2. Make some modifications to DB:
  ```sql
  create table test as select i from generate_series(1, 1000) i;
  ```
3. Immediately stop primary segment:
  ```bash
  kill -QUIT <primary_postmaster_pid>
  ```
4. Check that old mirror becomes primary
5. Run `gprecoverseg -s` to restore old primary and track progress of `pg_rewind`
6. After successful completion of previous command all old files inside `pg_log` directory have to be removed.