### PR TITLE
Don't choose indexscan when you need a motion for a subplan

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -353,7 +353,7 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	}
 
 	/* Consider sequential scan */
-	if (root->config->enable_seqscan)
+	if (enable_seqscan)
 		pathlist = lappend(pathlist, seqpath);
 
 	/* TODO: this might have been too ambitious of a re-ordering */
@@ -378,9 +378,9 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		rel->relstorage == RELSTORAGE_AOCOLS)
 		indexpathlist = NIL;
 
-	if (indexpathlist && root->config->enable_indexscan)
+	if (indexpathlist && enable_indexscan)
 		pathlist = list_concat(pathlist, indexpathlist);
-	if (bitmappathlist && root->config->enable_bitmapscan)
+	if (bitmappathlist && enable_bitmapscan)
 		pathlist = list_concat(pathlist, bitmappathlist);
 
 	/*
@@ -391,7 +391,7 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		rel->relstorage == RELSTORAGE_AOCOLS)
 		tidpathlist = NIL;
 
-	if (tidpathlist && root->config->enable_tidscan)
+	if (tidpathlist && enable_tidscan)
 		pathlist = list_concat(pathlist, tidpathlist);
 
 	/* If no enabled path was found, consider disabled paths. */

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -229,7 +229,7 @@ create_index_paths(PlannerInfo *root, RelOptInfo *rel,
 		/* Add index path to caller's list. */
 		*pindexpathlist = lappend(*pindexpathlist, ipath);
 
-		if (!root->config->enable_seqscan ||
+		if (!enable_seqscan ||
 			(ipath->indexselectivity < 1.0 &&
 			 !ScanDirectionIsBackward(ipath->indexscandir)))
 			bitindexpaths = lappend(bitindexpaths, ipath);
@@ -1855,7 +1855,7 @@ best_inner_indexscan(PlannerInfo *root, RelOptInfo *rel,
 	Assert(rel->relstorage != '\0');
 
 	/* Exclude plain index paths if user doesn't want them. */
-	if (!root->config->enable_indexscan && !root->config->mpp_trying_fallback_plan)
+	if (!enable_indexscan && !root->config->mpp_trying_fallback_plan)
 		indexpaths = NIL;
 
 	/* Exclude plain index paths if the relation is an append-only relation. */
@@ -1868,7 +1868,7 @@ best_inner_indexscan(PlannerInfo *root, RelOptInfo *rel,
 	 * promising combination of bitmap index paths.
 	 */
 	if (bitindexpaths != NIL &&
-		(root->config->enable_bitmapscan || root->config->mpp_trying_fallback_plan))
+		(enable_bitmapscan || root->config->mpp_trying_fallback_plan))
 	{
 		Path	   *bitmapqual;
 		Path	   *bpath;

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -536,6 +536,8 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->gp_cte_sharing = gp_cte_sharing;
 
+	c1->is_under_subplan = false;
+
 	return c1;
 }
 

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -498,10 +498,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 {
 	PlannerConfig *c1 = (PlannerConfig *) palloc(sizeof(PlannerConfig));
 	c1->cdbpath_segments = planner_segment_count();
-	c1->enable_seqscan = enable_seqscan;
-	c1->enable_indexscan = enable_indexscan;
-	c1->enable_bitmapscan = enable_bitmapscan;
-	c1->enable_tidscan = enable_tidscan;
 	c1->enable_sort = enable_sort;
 	c1->enable_hashagg = enable_hashagg;
 	c1->enable_groupagg = enable_groupagg;
@@ -526,7 +522,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->gp_eager_two_phase_agg = gp_eager_two_phase_agg;
 	c1->gp_enable_groupext_distinct_pruning = gp_enable_groupext_distinct_pruning;
 	c1->gp_enable_groupext_distinct_gather = gp_enable_groupext_distinct_gather;
-	c1->gp_enable_sort_limit = gp_enable_sort_limit;
 	c1->gp_enable_sort_distinct = gp_enable_sort_distinct;
 	c1->gp_enable_mk_sort = gp_enable_mk_sort;
 	c1->gp_enable_motion_mk_sort = gp_enable_motion_mk_sort;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -588,14 +588,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 		 */
 		config->gp_enable_direct_dispatch = false;
 		config->gp_enable_multiphase_agg = false;
-
-		/*
-		 * The MIN/MAX optimization works by inserting a subplan with LIMIT 1.
-		 * That effectively turns a correlated subquery into a multi-level
-		 * correlated subquery, which we don't currently support. (See check
-		 * above.)
-		 */
-		// config->gp_enable_minmax_optimization = false;
 	}
 
 	/*

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -420,24 +420,8 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 				 errmsg("correlated subquery with skip-level correlations is not supported")));
 	}
 
-	if ((Gp_role == GP_ROLE_DISPATCH)
-			&& IsSubqueryCorrelated(subquery)
-			&& QueryHasDistributedRelation(subquery))
-	{
-		/*
-		 * Generate the plan for the subquery with certain options disabled.
-		 */
-		config->gp_enable_direct_dispatch = false;
-		config->gp_enable_multiphase_agg = false;
-
-		/*
-		 * Only create subplans with sequential scans
-		 */
-		config->enable_indexscan = false;
-		config->enable_bitmapscan = false;
-		config->enable_tidscan = false;
-		config->enable_seqscan = true;
-	}
+	if (Gp_role == GP_ROLE_DISPATCH)
+		config->is_under_subplan = true;
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -52,6 +52,8 @@ typedef struct PlannerConfig
 
 	bool		gp_cte_sharing; /* Indicate whether sharing is to be disabled on any CTEs */
 
+	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
+
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
 	//int			gp_singleton_segindex; // TODO: change this.

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -13,10 +13,6 @@
  */
 typedef struct PlannerConfig
 {
-	bool		enable_seqscan;
-	bool		enable_indexscan;
-	bool		enable_bitmapscan;
-	bool		enable_tidscan;
 	bool		enable_sort;
 	bool		enable_hashagg;
 	bool		enable_groupagg;
@@ -42,7 +38,6 @@ typedef struct PlannerConfig
 	bool		gp_eager_two_phase_agg;
 	bool        gp_enable_groupext_distinct_pruning;
 	bool        gp_enable_groupext_distinct_gather;
-	bool		gp_enable_sort_limit;
 	bool		gp_enable_sort_distinct;
 	bool		gp_enable_mk_sort;
 	bool		gp_enable_motion_mk_sort;

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -263,6 +263,8 @@ typedef struct PlannerInfo
 	PlannerConfig *config;		/* Planner configuration */
 
 	List	   *dynamicScans;	/* DynamicScanInfos */
+
+	bool		is_correlated_subplan; /* true for correlated subqueries nested within subplans */
 } PlannerInfo;
 
 /*----------

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -494,8 +494,14 @@ NOTICE:  table "t1" does not exist, skipping
 NOTICE:  table "t2" does not exist, skipping
 NOTICE:  table "t3" does not exist, skipping
 CREATE TABLE t1 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t3 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 SELECT i, i, i FROM generate_series(1, 1000) i;
 INSERT INTO t2 SELECT i, i, i FROM generate_series(2, 1000) i; -- start from 2 so that one row from t1 doesn't match
 INSERT INTO t3 VALUES (1, 2, 3), (NULL, 2, 2);
@@ -818,27 +824,26 @@ set enable_nestloop to on;
 set enable_hashjoin to off;
 set enable_mergejoin to off;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
+                                                     QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.40 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.40 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.11..2.12 rows=1 width=8)
-                 ->  Aggregate  (cost=2.05..2.06 rows=1 width=8)
-                       ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
-                             Join Filter: a.a = b.x
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   Filter: a.b = $0
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
+                       Join Filter: a.a = b.x
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             Filter: a.b = $0
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on; optimizer=off
  Optimizer status: legacy query optimizer
-(18 rows)
+(17 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
  d 
@@ -851,31 +856,30 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
+                                                        QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.46 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.46 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
-                 ->  Aggregate  (cost=2.08..2.09 rows=1 width=8)
-                       ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
-                             Merge Cond: a.a = b.x
-                             ->  Sort  (cost=1.02..1.03 rows=1 width=4)
-                                   Sort Key: a.a
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         Filter: a.b = $0
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Sort  (cost=1.02..1.02 rows=1 width=4)
-                                   Sort Key: b.x
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.21..2.22 rows=1 width=8)
+                 ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
+                       Merge Cond: a.a = b.x
+                       ->  Sort  (cost=1.02..1.03 rows=1 width=4)
+                             Sort Key: a.a
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   Filter: a.b = $0
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+                             Sort Key: b.x
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off; optimizer=off
  Optimizer status: legacy query optimizer
-(22 rows)
+(21 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
  d 

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -494,14 +494,8 @@ NOTICE:  table "t1" does not exist, skipping
 NOTICE:  table "t2" does not exist, skipping
 NOTICE:  table "t3" does not exist, skipping
 CREATE TABLE t1 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t3 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 SELECT i, i, i FROM generate_series(1, 1000) i;
 INSERT INTO t2 SELECT i, i, i FROM generate_series(2, 1000) i; -- start from 2 so that one row from t1 doesn't match
 INSERT INTO t3 VALUES (1, 2, 3), (NULL, 2, 2);

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -7,20 +7,20 @@ create table nhtest (i numeric(10, 2)) distributed by (i);
 insert into nhtest values(100000.22);
 insert into nhtest values(300000.19);
 explain select * from nhtest a join nhtest b using (i);
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
+                                                      QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=11)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=11)
          Hash Cond: public.nhtest.i = public.nhtest.i
          ->  Table Scan on nhtest  (cost=0.00..431.00 rows=1 width=11)
          ->  Hash  (cost=431.00..431.00 rows=1 width=11)
                ->  Table Scan on nhtest  (cost=0.00..431.00 rows=1 width=11)
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
- Optimizer status: PQO version 2.39.2
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; gp_recursive_cte_prototype=on; optimizer=on
+ Optimizer status: PQO version 3.114.0
 (8 rows)
 
 select * from nhtest a join nhtest b using (i);
-     i     
+     i
 -----------
  100000.22
  300000.19
@@ -31,12 +31,12 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into l values (1), (1), (2);
 select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1.a = 2 order by 1,2,3;
- a | a | a 
+ a | a | a
 ---+---+---
- 1 | 1 |  
- 1 | 1 |  
- 1 | 1 |  
- 1 | 1 |  
+ 1 | 1 |
+ 1 | 1 |
+ 1 | 1 |
+ 1 | 1 |
  2 | 2 | 2
 (5 rows)
 
@@ -46,7 +46,7 @@ select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1
 create table hjtest (i int, j int) distributed by (i,j);
 insert into hjtest values(3, 4);
 select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j = 4;
- count 
+ count
 -------
      1
 (1 row)
@@ -73,7 +73,7 @@ SELECT *
 FROM gp_dist_random('alpha') FULL OUTER JOIN gp_dist_random('theta')
   ON (alpha.i = theta.i)
 WHERE (alpha.j IS NULL or theta.j IS NULL);
- i | j | i | j 
+ i | j | i | j
 ---+---+---+---
 (0 rows)
 
@@ -97,7 +97,7 @@ analyze t2;
 -- infer over equalities
 --
 explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
-                                                 QUERY PLAN                                                 
+                                                 QUERY PLAN
 ------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
@@ -111,12 +111,12 @@ explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: x = 100
- Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Settings:  gp_recursive_cte_prototype=on; optimizer=on
+ Optimizer status: PQO version 3.114.0
 (14 rows)
 
 select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
- count 
+ count
 -------
      1
 (1 row)
@@ -125,7 +125,7 @@ select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
 -- infer over >=
 --
 explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
-                                          QUERY PLAN                                          
+                                          QUERY PLAN
 ----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324039.56 rows=34 width=24)
    ->  Nested Loop  (cost=0.00..1324039.56 rows=12 width=24)
@@ -134,12 +134,12 @@ explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
                ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=12)
                      Filter: x = 100
          ->  Table Scan on t2  (cost=0.00..431.00 rows=34 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Settings:  gp_recursive_cte_prototype=on; optimizer=on
+ Optimizer status: PQO version 3.114.0
 (9 rows)
 
 select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
-  x  |  y  |  z  |  x  |  y  |  z  
+  x  |  y  |  z  |  x  |  y  |  z
 -----+-----+-----+-----+-----+-----
  100 | 100 | 100 | 100 | 100 | 100
 (1 row)
@@ -149,7 +149,7 @@ select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
 --
 set optimizer_segments=2;
 explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
-                                              QUERY PLAN                                               
+                                              QUERY PLAN
 -------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.01 rows=1 width=24)
    ->  Hash Join  (cost=0.00..862.01 rows=1 width=24)
@@ -164,13 +164,13 @@ explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
                      Hash Key: t2.y
                      ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=12)
                            Filter: y = 100
- Settings:  optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 2.39.2
+ Settings:  gp_recursive_cte_prototype=on; optimizer=on; optimizer_segments=2
+ Optimizer status: PQO version 3.114.0
 (15 rows)
 
 reset optimizer_segments;
 select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
-  x  |  y  |  z  |  x  |  y  |  z  
+  x  |  y  |  z  |  x  |  y  |  z
 -----+-----+-----+-----+-----+-----
  100 | 100 | 100 | 100 | 100 | 100
 (1 row)
@@ -183,37 +183,37 @@ insert into hjn_test values(3, 4);
 create table int4_tbl (f1 int) distributed by (f1);
 insert into int4_tbl values(123456), (-2147483647), (0), (-123456), (2147483647);
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,4) and hjn_test.j = 4;
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,(array[4])[1]) and hjn_test.j = (array[4])[1];
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where least (foo.bar,(array[4])[1]) = hjn_test.i and hjn_test.j = (array[4])[1];
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar, least(4,10)) and hjn_test.j = least(4,10);
- count 
+ count
 -------
      1
 (1 row)
 
 select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-     f1      |     f1      
+     f1      |     f1
 -------------+-------------
-  2147483647 |  2147483647
       123456 |      123456
  -2147483647 | -2147483647
            0 |           0
      -123456 |     -123456
+  2147483647 |  2147483647
 (5 rows)
 
 -- Same as the last query, but with a partitioned table (which requires a
@@ -229,11 +229,11 @@ insert into part4_tbl values
        (-1), (0), (1),
        (123455), (123456), (123457);
 select * from part4_tbl a join part4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-   f1    |   f1    
+   f1    |   f1
 ---------+---------
+ -123456 | -123456
        0 |       0
   123456 |  123456
- -123456 | -123456
 (3 rows)
 
 --
@@ -252,50 +252,50 @@ insert into tjoin3 values (1, 1, '1-1'), (2, 1, '2-1');
 select tjoin1.id, tjoin2.t, tjoin3.t
 from tjoin1
 left outer join (tjoin2 left outer join tjoin3 on tjoin2.id=tjoin3.id) on tjoin1.id=tjoin3.id;
- id |  t  |  t  
+ id |  t  |  t
 ----+-----+-----
-  3 |     | 
-  3 |     | 
   1 | 2-1 | 1-1
   1 | 2-1 | 2-1
   1 | 1-1 | 1-1
   1 | 1-1 | 2-1
-  2 |     | 
+  2 |     |
   1 | 2-1 | 1-1
   1 | 2-1 | 2-1
   1 | 1-1 | 1-1
   1 | 1-1 | 2-1
-  2 |     | 
+  2 |     |
+  3 |     |
+  3 |     |
 (12 rows)
 
 set enable_hashjoin to off;
 set optimizer_enable_hashjoin = off;
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,4) and hjn_test.j = 4;
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,(array[4])[1]) and hjn_test.j = (array[4])[1];
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where least (foo.bar,(array[4])[1]) = hjn_test.i and hjn_test.j = (array[4])[1];
- count 
+ count
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar, least(4,10)) and hjn_test.j = least(4,10);
- count 
+ count
 -------
      1
 (1 row)
 
 select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-     f1      |     f1      
+     f1      |     f1
 -------------+-------------
   2147483647 |  2147483647
       123456 |      123456
@@ -317,17 +317,17 @@ create table bar (c int, d int) distributed randomly;
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
 explain select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
-                   QUERY PLAN                   
-------------------------------------------------
+                       QUERY PLAN
+--------------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
    ->  Result  (cost=0.00..0.00 rows=0 width=4)
          One-Time Filter: false
- Settings:  optimizer=on
- Optimizer status: PQO version 2.39.2
+ Settings:  gp_recursive_cte_prototype=on; optimizer=on
+ Optimizer status: PQO version 3.114.0
 (5 rows)
 
 select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
- a 
+ a
 ---
 (0 rows)
 
@@ -339,13 +339,13 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 select * from foo where a not in (select c from bar where c <= 5);
- a  | b 
+ a  | b
 ----+---
-  7 |  
-  6 |  
-  8 |  
-  9 |  
- 10 |  
+  6 |
+  7 |
+ 10 |
+  8 |
+  9 |
 (5 rows)
 
 set enable_nestloop to off;
@@ -381,7 +381,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count 
+ count
 -------
     48
 (1 row)
@@ -398,7 +398,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count 
+ count
 -------
     48
 (1 row)
@@ -415,7 +415,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count 
+ count
 -------
     48
 (1 row)
@@ -435,7 +435,7 @@ set enable_nestloop to on;
 set enable_hashjoin to on;
 set enable_mergejoin to on;
 select count(*) from test_timestamp_t1 t1 ,test_timestamp_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
- count 
+ count
 -------
      2
 (1 row)
@@ -445,7 +445,7 @@ set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to on;
 select count(*) from test_timestamp_t1 t1 ,test_timestamp_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
- count 
+ count
 -------
      2
 (1 row)
@@ -460,10 +460,10 @@ insert into test_timestamp_t1 values(11 ,'2018-1-11');
 insert into test_timestamp_t2 values(10 ,'2018-1-10'::timestamp);
 insert into test_timestamp_t2 values(11 ,'2018-1-11'::timestamp);
 select * from test_timestamp_t1 t1 full outer join test_timestamp_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
- id |  field_dt  | id |        field_tms         
+ id |  field_dt  | id |        field_tms
 ----+------------+----+--------------------------
- 11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
  10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
+ 11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
 (2 rows)
 
 -- test float type
@@ -475,7 +475,7 @@ create table test_float2(id int, data float8)  DISTRIBUTED BY (data);
 insert into test_float1 values(1, 10), (2, 20);
 insert into test_float2 values(3, 10), (4, 20);
 select t1.id, t1.data, t2.id, t2.data from test_float1 t1, test_float2 t2 where t1.data = t2.data;
- id | data | id | data 
+ id | data | id | data
 ----+------+----+------
   1 |   10 |  3 |   10
   2 |   20 |  4 |   20
@@ -487,10 +487,10 @@ create table test_int2(id int, data int8)  DISTRIBUTED BY (data);
 insert into test_int1 values(1, 10), (2, 20);
 insert into test_int2 values(3, 10), (4, 20);
 select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
- id | data | id | data 
+ id | data | id | data
 ----+------+----+------
-  1 |   10 |  3 |   10
   2 |   20 |  4 |   20
+  1 |   10 |  3 |   10
 (2 rows)
 
 -- Cleanup
@@ -502,9 +502,18 @@ reset search_path;
 -- correct join predicates & residual filters
 reset all;
 drop table if exists t1, t2, t3;
+NOTICE:  table "t1" does not exist, skipping
+NOTICE:  table "t2" does not exist, skipping
+NOTICE:  table "t3" does not exist, skipping
 CREATE TABLE t1 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t3 (a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 SELECT i, i, i FROM generate_series(1, 1000) i;
 INSERT INTO t2 SELECT i, i, i FROM generate_series(2, 1000) i; -- start from 2 so that one row from t1 doesn't match
 INSERT INTO t3 VALUES (1, 2, 3), (NULL, 2, 2);
@@ -513,7 +522,7 @@ ANALYZE t2;
 ANALYZE t3;
 -- ensure plan has a filter over left outer join
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a IS NULL OR (t1.c = t3.c));
-                                                   QUERY PLAN                                                   
+                                                   QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.22 rows=3 width=36)
    ->  Result  (cost=0.00..1293.22 rows=1 width=36)
@@ -528,18 +537,19 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                                  ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Optimizer status: PQO version 3.24.0
-(14 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(15 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a IS NULL OR (t1.c = t3.c));
- a | b | c | a | b | c | a | b | c 
+ a | b | c | a | b | c | a | b | c
 ---+---+---+---+---+---+---+---+---
  2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
 (1 row)
 
 -- ensure plan has two inner joins with the where clause & join predicates ANDed
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
-                                     QUERY PLAN                                      
+                                     QUERY PLAN
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.21 rows=2 width=36)
    ->  Hash Join  (cost=0.00..1293.21 rows=1 width=36)
@@ -551,17 +561,18 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                            ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
- Optimizer status: PQO version 3.76.0
-(11 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(12 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
- a | b | c | a | b | c | a | b | c 
+ a | b | c | a | b | c | a | b | c
 ---+---+---+---+---+---+---+---+---
 (0 rows)
 
 -- ensure plan has a filter over left outer join
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a is distinct from t3.a);
-                                                   QUERY PLAN                                                   
+                                                   QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.22 rows=2 width=36)
    ->  Result  (cost=0.00..1293.22 rows=1 width=36)
@@ -576,19 +587,20 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                                  ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Optimizer status: PQO version 3.24.0
-(14 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(15 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a is distinct from t3.a);
- a | b | c | a | b | c | a | b | c 
+ a | b | c | a | b | c | a | b | c
 ---+---+---+---+---+---+---+---+---
- 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
  2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
+ 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
 (2 rows)
 
 -- ensure plan has a filter over left outer join
 explain select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2.b t2b, t2.c t2c from t1 left join t2 on (t1.a = t2.a)) t on (t1a = t3.a) WHERE (t2a IS NULL OR (t1c = t3.a));
-                                     QUERY PLAN                                      
+                                     QUERY PLAN
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.22 rows=4 width=36)
    ->  Result  (cost=0.00..1293.22 rows=2 width=36)
@@ -602,31 +614,32 @@ explain select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2
                            ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Optimizer status: PQO version 3.24.0
-(13 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(14 rows)
 
 select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2.b t2b, t2.c t2c from t1 left join t2 on (t1.a = t2.a)) t on (t1a = t3.a) WHERE (t2a IS NULL OR (t1c = t3.a));
- a | b | c | t1a | t1b | t1c | t2a | t2b | t2c 
+ a | b | c | t1a | t1b | t1c | t2a | t2b | t2c
 ---+---+---+-----+-----+-----+-----+-----+-----
- 1 | 2 | 3 |   1 |   1 |   1 |     |     |    
+ 1 | 2 | 3 |   1 |   1 |   1 |     |     |
 (1 row)
 
 -- ensure plan has a filter over left outer join
-explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
-  join t3 on tt.t1b = t3.b 
-  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
+explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt
+  join t3 on tt.t1b = t3.b
+  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
-                                                                  QUERY PLAN                                                                  
+                                                                  QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..2586.40 rows=8 width=56)
-   ->  Hash Join  (cost=0.00..2586.39 rows=3 width=56)
-         Hash Cond: public.t1.b = public.t3.b AND public.t1.b = public.t3.b AND public.t3.b = public.t3.b
-         ->  Result  (cost=0.00..2155.39 rows=2 width=44)
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..2586.37 rows=8 width=56)
+   ->  Hash Join  (cost=0.00..2586.37 rows=3 width=56)
+         Hash Cond: public.t1.b = public.t3.b
+         ->  Result  (cost=0.00..2155.36 rows=2 width=44)
                Filter: public.t2.a IS NULL OR public.t1.b = public.t3.b
-               ->  Hash Left Join  (cost=0.00..2155.39 rows=2 width=44)
+               ->  Hash Left Join  (cost=0.00..2155.36 rows=2 width=44)
                      Hash Cond: public.t1.a = public.t2.a
-                     ->  Hash Join  (cost=0.00..1724.29 rows=1 width=36)
-                           Hash Cond: public.t1.b = public.t3.b AND public.t1.b = public.t1.b
+                     ->  Hash Join  (cost=0.00..1724.26 rows=1 width=36)
+                           Hash Cond: public.t1.b = public.t3.b
                            ->  Table Scan on t1  (cost=0.00..431.01 rows=334 width=8)
                            ->  Hash  (cost=1293.18..1293.18 rows=3 width=28)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.18 rows=3 width=28)
@@ -645,19 +658,20 @@ explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 lef
          ->  Hash  (cost=431.00..431.00 rows=2 width=12)
                ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=12)
                      ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
- Optimizer status: PQO version 3.24.0
-(28 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(29 rows)
 
-select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
-  join t3 on tt.t1b = t3.b 
-  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
+select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt
+  join t3 on tt.t1b = t3.b
+  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
- t1a | t1b | t2a | t2b | a | b | c | t1a | t1b | t2a | t2b | a | b | c 
+ t1a | t1b | t2a | t2b | a | b | c | t1a | t1b | t2a | t2b | a | b | c
 -----+-----+-----+-----+---+---+---+-----+-----+-----+-----+---+---+---
-   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 | 1 | 2 | 3
-   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 |   | 2 | 2
-   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 | 1 | 2 | 3
    2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 |   | 2 | 2
+   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 | 1 | 2 | 3
+   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 |   | 2 | 2
+   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 | 1 | 2 | 3
 (4 rows)
 
 drop table t1, t2, t3;
@@ -668,7 +682,7 @@ INSERT INTO hexpr_t1 SELECT i, i::character varying FROM generate_series(1,10)i;
 INSERT INTO hexpr_t2 SELECT i::character varying FROM generate_series(1,10)i;
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -679,12 +693,13 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Optimizer status: PQO version 3.78.0
-(10 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(11 rows)
 
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -695,12 +710,13 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Optimizer status: PQO version 3.78.0
-(10 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(11 rows)
 
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -711,13 +727,17 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Optimizer status: PQO version 3.78.0
-(10 rows)
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.0
+(11 rows)
 
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo 
+ foo
 -----
+ 1
+ 4
+ 7
  2
  5
  8
@@ -725,41 +745,38 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  6
  9
  10
- 1
- 4
- 7
 (10 rows)
 
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo 
+ foo
 -----
- 8
- 2
- 5
- 9
- 10
- 3
- 6
  1
  4
  7
+ 2
+ 5
+ 8
+ 3
+ 6
+ 9
+ 10
 (10 rows)
 
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo 
+ foo
 -----
- 9
- 10
  3
  6
- 2
- 8
- 5
+ 9
+ 10
  1
  4
  7
+ 2
+ 5
+ 8
 (10 rows)
 
 -- test if subquery locus is general, then
@@ -776,7 +793,7 @@ select * from (
   select a from length('123')a
 ) t_subquery_general
 join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Hash Join  (cost=0.00..431.00 rows=1 width=8)
@@ -797,8 +814,8 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
                      Hash Key: c
                      ->  Table Scan on t_randomly_dist_table  (cost=0.00..431.00 rows=1 width=4)
                            Filter: c = 3
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
- Optimizer status: PQO version 3.86.0
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off
+ Optimizer status: PQO version 3.114.2
 (21 rows)
 
 reset enable_hashjoin;
@@ -829,30 +846,29 @@ set enable_nestloop to on;
 set enable_hashjoin to off;
 set enable_mergejoin to off;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
+                                                     QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.40 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.40 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.11..2.12 rows=1 width=8)
-                 ->  Aggregate  (cost=2.05..2.06 rows=1 width=8)
-                       ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
-                             Join Filter: a.a = b.x
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   Filter: a.b = $0
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
+                 ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
+                       Join Filter: a.a = b.x
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             Filter: a.b = $0
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on; optimizer=off
  Optimizer status: legacy query optimizer
-(18 rows)
+(17 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
- d 
+ d
 ---
  0
  1
@@ -862,34 +878,33 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
+                                                        QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.46 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.46 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
-                 ->  Aggregate  (cost=2.08..2.09 rows=1 width=8)
-                       ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
-                             Merge Cond: a.a = b.x
-                             ->  Sort  (cost=1.02..1.03 rows=1 width=4)
-                                   Sort Key: a.a
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         Filter: a.b = $0
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
-                             ->  Sort  (cost=1.02..1.02 rows=1 width=4)
-                                   Sort Key: b.x
-                                   ->  Result  (cost=1.01..1.02 rows=1 width=4)
-                                         ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
-                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
-                                                     ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
+           ->  Aggregate  (cost=2.21..2.22 rows=1 width=8)
+                 ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
+                       Merge Cond: a.a = b.x
+                       ->  Sort  (cost=1.02..1.03 rows=1 width=4)
+                             Sort Key: a.a
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   Filter: a.b = $0
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_a a  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Sort  (cost=1.02..1.02 rows=1 width=4)
+                             Sort Key: b.x
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off; optimizer=off
  Optimizer status: legacy query optimizer
-(22 rows)
+(21 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
- d 
+ d
 ---
  0
  1
@@ -919,7 +934,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
 explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.c > t2.c;
-                                                 QUERY PLAN                                                 
+                                                 QUERY PLAN
 ------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=3410.75..56612.58 rows=2022804 width=24)
    ->  Hash Join  (cost=3410.75..56612.58 rows=674268 width=24)
@@ -944,7 +959,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
 NOTICE:  prefetch join qual in slice 0 of plannode 2
-                                                      QUERY PLAN                                                       
+                                                      QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=3410.75..13213071198.52 rows=3034205 width=24)
    ->  Hash Join  (cost=3410.75..13213071198.52 rows=1011402 width=24)

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -7,20 +7,20 @@ create table nhtest (i numeric(10, 2)) distributed by (i);
 insert into nhtest values(100000.22);
 insert into nhtest values(300000.19);
 explain select * from nhtest a join nhtest b using (i);
-                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=11)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=11)
          Hash Cond: public.nhtest.i = public.nhtest.i
          ->  Table Scan on nhtest  (cost=0.00..431.00 rows=1 width=11)
          ->  Hash  (cost=431.00..431.00 rows=1 width=11)
                ->  Table Scan on nhtest  (cost=0.00..431.00 rows=1 width=11)
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; gp_recursive_cte_prototype=on; optimizer=on
- Optimizer status: PQO version 3.114.0
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
+ Optimizer status: PQO version 2.39.2
 (8 rows)
 
 select * from nhtest a join nhtest b using (i);
-     i
+     i     
 -----------
  100000.22
  300000.19
@@ -31,12 +31,12 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into l values (1), (1), (2);
 select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1.a = 2 order by 1,2,3;
- a | a | a
+ a | a | a 
 ---+---+---
- 1 | 1 |
- 1 | 1 |
- 1 | 1 |
- 1 | 1 |
+ 1 | 1 |  
+ 1 | 1 |  
+ 1 | 1 |  
+ 1 | 1 |  
  2 | 2 | 2
 (5 rows)
 
@@ -46,7 +46,7 @@ select * from l l1 join l l2 on l1.a = l2.a left join l l3 on l1.a = l3.a and l1
 create table hjtest (i int, j int) distributed by (i,j);
 insert into hjtest values(3, 4);
 select count(*) from hjtest a1, hjtest a2 where a2.i = least (a1.i,4) and a2.j = 4;
- count
+ count 
 -------
      1
 (1 row)
@@ -73,7 +73,7 @@ SELECT *
 FROM gp_dist_random('alpha') FULL OUTER JOIN gp_dist_random('theta')
   ON (alpha.i = theta.i)
 WHERE (alpha.j IS NULL or theta.j IS NULL);
- i | j | i | j
+ i | j | i | j 
 ---+---+---+---
 (0 rows)
 
@@ -97,7 +97,7 @@ analyze t2;
 -- infer over equalities
 --
 explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
-                                                 QUERY PLAN
+                                                 QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..862.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
@@ -111,12 +111,12 @@ explain select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: x = 100
- Settings:  gp_recursive_cte_prototype=on; optimizer=on
- Optimizer status: PQO version 3.114.0
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.39.2
 (14 rows)
 
 select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
- count
+ count 
 -------
      1
 (1 row)
@@ -125,7 +125,7 @@ select count(*) from t1,t2 where t1.x = 100 and t1.x = t2.x;
 -- infer over >=
 --
 explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
-                                          QUERY PLAN
+                                          QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324039.56 rows=34 width=24)
    ->  Nested Loop  (cost=0.00..1324039.56 rows=12 width=24)
@@ -134,12 +134,12 @@ explain select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
                ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=12)
                      Filter: x = 100
          ->  Table Scan on t2  (cost=0.00..431.00 rows=34 width=12)
- Settings:  gp_recursive_cte_prototype=on; optimizer=on
- Optimizer status: PQO version 3.114.0
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.39.2
 (9 rows)
 
 select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
-  x  |  y  |  z  |  x  |  y  |  z
+  x  |  y  |  z  |  x  |  y  |  z  
 -----+-----+-----+-----+-----+-----
  100 | 100 | 100 | 100 | 100 | 100
 (1 row)
@@ -149,7 +149,7 @@ select * from t1,t2 where t1.x = 100 and t2.x >= t1.x;
 --
 set optimizer_segments=2;
 explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
-                                              QUERY PLAN
+                                              QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.01 rows=1 width=24)
    ->  Hash Join  (cost=0.00..862.01 rows=1 width=24)
@@ -164,13 +164,13 @@ explain select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
                      Hash Key: t2.y
                      ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=12)
                            Filter: y = 100
- Settings:  gp_recursive_cte_prototype=on; optimizer=on; optimizer_segments=2
- Optimizer status: PQO version 3.114.0
+ Settings:  optimizer=on; optimizer_segments=2
+ Optimizer status: PQO version 2.39.2
 (15 rows)
 
 reset optimizer_segments;
 select * from t1,t2 where t1.x = 100 and t1.x = t2.y and t1.x <= t2.x;
-  x  |  y  |  z  |  x  |  y  |  z
+  x  |  y  |  z  |  x  |  y  |  z  
 -----+-----+-----+-----+-----+-----
  100 | 100 | 100 | 100 | 100 | 100
 (1 row)
@@ -183,37 +183,37 @@ insert into hjn_test values(3, 4);
 create table int4_tbl (f1 int) distributed by (f1);
 insert into int4_tbl values(123456), (-2147483647), (0), (-123456), (2147483647);
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,4) and hjn_test.j = 4;
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,(array[4])[1]) and hjn_test.j = (array[4])[1];
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where least (foo.bar,(array[4])[1]) = hjn_test.i and hjn_test.j = (array[4])[1];
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar, least(4,10)) and hjn_test.j = least(4,10);
- count
+ count 
 -------
      1
 (1 row)
 
 select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-     f1      |     f1
+     f1      |     f1      
 -------------+-------------
+  2147483647 |  2147483647
       123456 |      123456
  -2147483647 | -2147483647
            0 |           0
      -123456 |     -123456
-  2147483647 |  2147483647
 (5 rows)
 
 -- Same as the last query, but with a partitioned table (which requires a
@@ -229,11 +229,11 @@ insert into part4_tbl values
        (-1), (0), (1),
        (123455), (123456), (123457);
 select * from part4_tbl a join part4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-   f1    |   f1
+   f1    |   f1    
 ---------+---------
- -123456 | -123456
        0 |       0
   123456 |  123456
+ -123456 | -123456
 (3 rows)
 
 --
@@ -252,50 +252,50 @@ insert into tjoin3 values (1, 1, '1-1'), (2, 1, '2-1');
 select tjoin1.id, tjoin2.t, tjoin3.t
 from tjoin1
 left outer join (tjoin2 left outer join tjoin3 on tjoin2.id=tjoin3.id) on tjoin1.id=tjoin3.id;
- id |  t  |  t
+ id |  t  |  t  
 ----+-----+-----
+  3 |     | 
+  3 |     | 
   1 | 2-1 | 1-1
   1 | 2-1 | 2-1
   1 | 1-1 | 1-1
   1 | 1-1 | 2-1
-  2 |     |
+  2 |     | 
   1 | 2-1 | 1-1
   1 | 2-1 | 2-1
   1 | 1-1 | 1-1
   1 | 1-1 | 2-1
-  2 |     |
-  3 |     |
-  3 |     |
+  2 |     | 
 (12 rows)
 
 set enable_hashjoin to off;
 set optimizer_enable_hashjoin = off;
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,4) and hjn_test.j = 4;
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar,(array[4])[1]) and hjn_test.j = (array[4])[1];
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where least (foo.bar,(array[4])[1]) = hjn_test.i and hjn_test.j = (array[4])[1];
- count
+ count 
 -------
      1
 (1 row)
 
 select count(*) from hjn_test, (select 3 as bar) foo where hjn_test.i = least (foo.bar, least(4,10)) and hjn_test.j = least(4,10);
- count
+ count 
 -------
      1
 (1 row)
 
 select * from int4_tbl a join int4_tbl b on (a.f1 = (select f1 from int4_tbl c where c.f1=b.f1));
-     f1      |     f1
+     f1      |     f1      
 -------------+-------------
   2147483647 |  2147483647
       123456 |      123456
@@ -317,17 +317,17 @@ create table bar (c int, d int) distributed randomly;
 insert into foo select generate_series(1,10);
 insert into bar select generate_series(1,10);
 explain select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
-                       QUERY PLAN
---------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
    ->  Result  (cost=0.00..0.00 rows=0 width=4)
          One-Time Filter: false
- Settings:  gp_recursive_cte_prototype=on; optimizer=on
- Optimizer status: PQO version 3.114.0
+ Settings:  optimizer=on
+ Optimizer status: PQO version 2.39.2
 (5 rows)
 
 select a from foo where a<1 and a>1 and not exists (select c from bar where c=a);
- a
+ a 
 ---
 (0 rows)
 
@@ -339,13 +339,13 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 select * from foo where a not in (select c from bar where c <= 5);
- a  | b
+ a  | b 
 ----+---
-  6 |
-  7 |
- 10 |
-  8 |
-  9 |
+  7 |  
+  6 |  
+  8 |  
+  9 |  
+ 10 |  
 (5 rows)
 
 set enable_nestloop to off;
@@ -381,7 +381,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count
+ count 
 -------
     48
 (1 row)
@@ -398,7 +398,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count
+ count 
 -------
     48
 (1 row)
@@ -415,7 +415,7 @@ WITH RECURSIVE subdept(id, parent_department, name) AS
 		WHERE d.pid = sd.id
 )
 SELECT count(*) FROM subdept;
- count
+ count 
 -------
     48
 (1 row)
@@ -435,7 +435,7 @@ set enable_nestloop to on;
 set enable_hashjoin to on;
 set enable_mergejoin to on;
 select count(*) from test_timestamp_t1 t1 ,test_timestamp_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
- count
+ count 
 -------
      2
 (1 row)
@@ -445,7 +445,7 @@ set enable_nestloop to off;
 set enable_hashjoin to on;
 set enable_mergejoin to on;
 select count(*) from test_timestamp_t1 t1 ,test_timestamp_t2 t2 where T1.id = T2.id and T1.field_dt = t2.field_tms;
- count
+ count 
 -------
      2
 (1 row)
@@ -460,10 +460,10 @@ insert into test_timestamp_t1 values(11 ,'2018-1-11');
 insert into test_timestamp_t2 values(10 ,'2018-1-10'::timestamp);
 insert into test_timestamp_t2 values(11 ,'2018-1-11'::timestamp);
 select * from test_timestamp_t1 t1 full outer join test_timestamp_t2 t2 on T1.id = T2.id and T1.field_dt = t2.field_tms;
- id |  field_dt  | id |        field_tms
+ id |  field_dt  | id |        field_tms         
 ----+------------+----+--------------------------
- 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
  11 | 01-11-2018 | 11 | Thu Jan 11 00:00:00 2018
+ 10 | 01-10-2018 | 10 | Wed Jan 10 00:00:00 2018
 (2 rows)
 
 -- test float type
@@ -475,7 +475,7 @@ create table test_float2(id int, data float8)  DISTRIBUTED BY (data);
 insert into test_float1 values(1, 10), (2, 20);
 insert into test_float2 values(3, 10), (4, 20);
 select t1.id, t1.data, t2.id, t2.data from test_float1 t1, test_float2 t2 where t1.data = t2.data;
- id | data | id | data
+ id | data | id | data 
 ----+------+----+------
   1 |   10 |  3 |   10
   2 |   20 |  4 |   20
@@ -487,10 +487,10 @@ create table test_int2(id int, data int8)  DISTRIBUTED BY (data);
 insert into test_int1 values(1, 10), (2, 20);
 insert into test_int2 values(3, 10), (4, 20);
 select t1.id, t1.data, t2.id, t2.data from test_int1 t1, test_int2 t2 where t1.data = t2.data;
- id | data | id | data
+ id | data | id | data 
 ----+------+----+------
-  2 |   20 |  4 |   20
   1 |   10 |  3 |   10
+  2 |   20 |  4 |   20
 (2 rows)
 
 -- Cleanup
@@ -502,18 +502,9 @@ reset search_path;
 -- correct join predicates & residual filters
 reset all;
 drop table if exists t1, t2, t3;
-NOTICE:  table "t1" does not exist, skipping
-NOTICE:  table "t2" does not exist, skipping
-NOTICE:  table "t3" does not exist, skipping
 CREATE TABLE t1 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t3 (a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 SELECT i, i, i FROM generate_series(1, 1000) i;
 INSERT INTO t2 SELECT i, i, i FROM generate_series(2, 1000) i; -- start from 2 so that one row from t1 doesn't match
 INSERT INTO t3 VALUES (1, 2, 3), (NULL, 2, 2);
@@ -522,7 +513,7 @@ ANALYZE t2;
 ANALYZE t3;
 -- ensure plan has a filter over left outer join
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a IS NULL OR (t1.c = t3.c));
-                                                   QUERY PLAN
+                                                   QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.22 rows=3 width=36)
    ->  Result  (cost=0.00..1293.22 rows=1 width=36)
@@ -537,19 +528,18 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                                  ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(15 rows)
+ Optimizer status: PQO version 3.24.0
+(14 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a IS NULL OR (t1.c = t3.c));
- a | b | c | a | b | c | a | b | c
+ a | b | c | a | b | c | a | b | c 
 ---+---+---+---+---+---+---+---+---
  2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
 (1 row)
 
 -- ensure plan has two inner joins with the where clause & join predicates ANDed
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
-                                     QUERY PLAN
+                                     QUERY PLAN                                      
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.21 rows=2 width=36)
    ->  Hash Join  (cost=0.00..1293.21 rows=1 width=36)
@@ -561,18 +551,17 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                            ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(12 rows)
+ Optimizer status: PQO version 3.76.0
+(11 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a = t3.a);
- a | b | c | a | b | c | a | b | c
+ a | b | c | a | b | c | a | b | c 
 ---+---+---+---+---+---+---+---+---
 (0 rows)
 
 -- ensure plan has a filter over left outer join
 explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a is distinct from t3.a);
-                                                   QUERY PLAN
+                                                   QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.22 rows=2 width=36)
    ->  Result  (cost=0.00..1293.22 rows=1 width=36)
@@ -587,20 +576,19 @@ explain select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) 
                                  ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(15 rows)
+ Optimizer status: PQO version 3.24.0
+(14 rows)
 
 select * from t1 left join t2 on (t1.a = t2.a) join t3 on (t1.b = t3.b) where (t2.a is distinct from t3.a);
- a | b | c | a | b | c | a | b | c
+ a | b | c | a | b | c | a | b | c 
 ---+---+---+---+---+---+---+---+---
- 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
  2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | 3
+ 2 | 2 | 2 | 2 | 2 | 2 |   | 2 | 2
 (2 rows)
 
 -- ensure plan has a filter over left outer join
 explain select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2.b t2b, t2.c t2c from t1 left join t2 on (t1.a = t2.a)) t on (t1a = t3.a) WHERE (t2a IS NULL OR (t1c = t3.a));
-                                     QUERY PLAN
+                                     QUERY PLAN                                      
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.22 rows=4 width=36)
    ->  Result  (cost=0.00..1293.22 rows=2 width=36)
@@ -614,32 +602,31 @@ explain select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2
                            ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
                ->  Hash  (cost=431.01..431.01 rows=333 width=12)
                      ->  Table Scan on t2  (cost=0.00..431.01 rows=333 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(14 rows)
+ Optimizer status: PQO version 3.24.0
+(13 rows)
 
 select * from t3 join (select t1.a t1a, t1.b t1b, t1.c t1c, t2.a t2a, t2.b t2b, t2.c t2c from t1 left join t2 on (t1.a = t2.a)) t on (t1a = t3.a) WHERE (t2a IS NULL OR (t1c = t3.a));
- a | b | c | t1a | t1b | t1c | t2a | t2b | t2c
+ a | b | c | t1a | t1b | t1c | t2a | t2b | t2c 
 ---+---+---+-----+-----+-----+-----+-----+-----
- 1 | 2 | 3 |   1 |   1 |   1 |     |     |
+ 1 | 2 | 3 |   1 |   1 |   1 |     |     |    
 (1 row)
 
 -- ensure plan has a filter over left outer join
-explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt
-  join t3 on tt.t1b = t3.b
-  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b
+explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
+  join t3 on tt.t1b = t3.b 
+  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
-                                                                  QUERY PLAN
+                                                                  QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..2586.37 rows=8 width=56)
-   ->  Hash Join  (cost=0.00..2586.37 rows=3 width=56)
-         Hash Cond: public.t1.b = public.t3.b
-         ->  Result  (cost=0.00..2155.36 rows=2 width=44)
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..2586.40 rows=8 width=56)
+   ->  Hash Join  (cost=0.00..2586.39 rows=3 width=56)
+         Hash Cond: public.t1.b = public.t3.b AND public.t1.b = public.t3.b AND public.t3.b = public.t3.b
+         ->  Result  (cost=0.00..2155.39 rows=2 width=44)
                Filter: public.t2.a IS NULL OR public.t1.b = public.t3.b
-               ->  Hash Left Join  (cost=0.00..2155.36 rows=2 width=44)
+               ->  Hash Left Join  (cost=0.00..2155.39 rows=2 width=44)
                      Hash Cond: public.t1.a = public.t2.a
-                     ->  Hash Join  (cost=0.00..1724.26 rows=1 width=36)
-                           Hash Cond: public.t1.b = public.t3.b
+                     ->  Hash Join  (cost=0.00..1724.29 rows=1 width=36)
+                           Hash Cond: public.t1.b = public.t3.b AND public.t1.b = public.t1.b
                            ->  Table Scan on t1  (cost=0.00..431.01 rows=334 width=8)
                            ->  Hash  (cost=1293.18..1293.18 rows=3 width=28)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.18 rows=3 width=28)
@@ -658,20 +645,19 @@ explain select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 lef
          ->  Hash  (cost=431.00..431.00 rows=2 width=12)
                ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=12)
                      ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=12)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(29 rows)
+ Optimizer status: PQO version 3.24.0
+(28 rows)
 
-select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt
-  join t3 on tt.t1b = t3.b
-  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b
+select * from (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt 
+  join t3 on tt.t1b = t3.b 
+  join (select t1.a t1a, t1.b t1b, t2.a t2a, t2.b t2b from t1 left join t2 on t1.a = t2.a) tt1 on tt1.t1b = t3.b 
   join t3 t3_1 on tt1.t1b = t3_1.b and (tt1.t2a is NULL OR tt1.t1b = t3.b);
- t1a | t1b | t2a | t2b | a | b | c | t1a | t1b | t2a | t2b | a | b | c
+ t1a | t1b | t2a | t2b | a | b | c | t1a | t1b | t2a | t2b | a | b | c 
 -----+-----+-----+-----+---+---+---+-----+-----+-----+-----+---+---+---
-   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 |   | 2 | 2
-   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 | 1 | 2 | 3
-   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 |   | 2 | 2
    2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 | 1 | 2 | 3
+   2 |   2 |   2 |   2 |   | 2 | 2 |   2 |   2 |   2 |   2 |   | 2 | 2
+   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 | 1 | 2 | 3
+   2 |   2 |   2 |   2 | 1 | 2 | 3 |   2 |   2 |   2 |   2 |   | 2 | 2
 (4 rows)
 
 drop table t1, t2, t3;
@@ -682,7 +668,7 @@ INSERT INTO hexpr_t1 SELECT i, i::character varying FROM generate_series(1,10)i;
 INSERT INTO hexpr_t2 SELECT i::character varying FROM generate_series(1,10)i;
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN
+                                              QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -693,13 +679,12 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(11 rows)
+ Optimizer status: PQO version 3.78.0
+(10 rows)
 
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN
+                                              QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -710,13 +695,12 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(11 rows)
+ Optimizer status: PQO version 3.78.0
+(10 rows)
 
 EXPLAIN SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
-                                              QUERY PLAN
+                                              QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=5 width=8)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=14 width=2)
@@ -727,33 +711,13 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
                      ->  Table Scan on hexpr_t1  (cost=0.00..431.00 rows=4 width=2)
                ->  Hash  (cost=431.00..431.00 rows=4 width=2)
                      ->  Table Scan on hexpr_t2  (cost=0.00..431.00 rows=4 width=2)
- Settings:  optimizer=on
- Optimizer status: PQO version 3.114.0
-(11 rows)
-
-SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
-ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo
------
- 1
- 4
- 7
- 2
- 5
- 8
- 3
- 6
- 9
- 10
+ Optimizer status: PQO version 3.78.0
 (10 rows)
 
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo
+ foo 
 -----
- 1
- 4
- 7
  2
  5
  8
@@ -761,22 +725,41 @@ ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
  6
  9
  10
+ 1
+ 4
+ 7
 (10 rows)
 
 SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
 ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
- foo
+ foo 
 -----
- 3
- 6
+ 8
+ 2
+ 5
  9
  10
+ 3
+ 6
  1
  4
  7
+(10 rows)
+
+SELECT btrim(hexpr_t1.c2::text)::character varying AS foo FROM hexpr_t1 LEFT JOIN hexpr_t2
+ON hexpr_t2.c3::text = btrim(hexpr_t1.c2::text);
+ foo 
+-----
+ 9
+ 10
+ 3
+ 6
  2
- 5
  8
+ 5
+ 1
+ 4
+ 7
 (10 rows)
 
 -- test if subquery locus is general, then
@@ -793,7 +776,7 @@ select * from (
   select a from length('123')a
 ) t_subquery_general
 join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
-                                              QUERY PLAN
+                                              QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Hash Join  (cost=0.00..431.00 rows=1 width=8)
@@ -814,8 +797,8 @@ join t_randomly_dist_table on t_subquery_general.a = t_randomly_dist_table.c;
                      Hash Key: c
                      ->  Table Scan on t_randomly_dist_table  (cost=0.00..431.00 rows=1 width=4)
                            Filter: c = 3
- Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off
- Optimizer status: PQO version 3.114.2
+ Settings:  enable_hashjoin=on; enable_mergejoin=off; enable_nestloop=off; optimizer=on
+ Optimizer status: PQO version 3.86.0
 (21 rows)
 
 reset enable_hashjoin;
@@ -846,12 +829,12 @@ set enable_nestloop to on;
 set enable_hashjoin to off;
 set enable_mergejoin to off;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                     QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.40 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.40 rows=1 width=4)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.26 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.26 rows=1 width=4)
          SubPlan 1
-           ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
+          ->  Aggregate  (cost=2.18..2.19 rows=1 width=8)
                  ->  Nested Loop  (cost=0.00..2.04 rows=2 width=0)
                        Join Filter: a.a = b.x
                        ->  Result  (cost=1.01..1.02 rows=1 width=4)
@@ -865,10 +848,10 @@ explain select (select count(*) from (select 'random' from t_join_squelch_a a jo
                                          ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=off; enable_nestloop=on; optimizer=off
  Optimizer status: legacy query optimizer
-(17 rows)
+(18 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
- d
+ d 
 ---
  0
  1
@@ -878,10 +861,10 @@ set enable_nestloop to off;
 set enable_hashjoin to off;
 set enable_mergejoin to on;
 explain select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
-                                                        QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.46 rows=2 width=4)
-   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.46 rows=1 width=4)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..5.33 rows=2 width=4)
+   ->  Seq Scan on t_join_squelch_c c  (cost=0.00..5.33 rows=1 width=4)
          SubPlan 1
            ->  Aggregate  (cost=2.21..2.22 rows=1 width=8)
                  ->  Merge Join  (cost=2.04..2.07 rows=2 width=0)
@@ -901,10 +884,10 @@ explain select (select count(*) from (select 'random' from t_join_squelch_a a jo
                                                ->  Seq Scan on t_join_squelch_b b  (cost=0.00..1.01 rows=1 width=4)
  Settings:  enable_hashjoin=off; enable_mergejoin=on; enable_nestloop=off; optimizer=off
  Optimizer status: legacy query optimizer
-(21 rows)
+(22 rows)
 
 select (select count(*) from (select 'random' from t_join_squelch_a a join t_join_squelch_b b on a.a = b.x and a.b = c.i) x)d from t_join_squelch_c c;
- d
+ d 
 ---
  0
  1
@@ -934,7 +917,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- the join qual is t1.c > t2.c, it contains no motion, should not prefetch
 explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.c > t2.c;
-                                                 QUERY PLAN
+                                                 QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=3410.75..56612.58 rows=2022804 width=24)
    ->  Hash Join  (cost=3410.75..56612.58 rows=674268 width=24)
@@ -959,7 +942,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 explain select * from t1_test_pretch_join_qual t1 join t2_test_pretch_join_qual t2
 on t1.b = t2.b and t1.a > any (select sum(b) from t3_test_pretch_join_qual t3 where c > t2.a);
 NOTICE:  prefetch join qual in slice 0 of plannode 2
-                                                      QUERY PLAN
+                                                      QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=3410.75..13213071198.52 rows=3034205 width=24)
    ->  Hash Join  (cost=3410.75..13213071198.52 rows=1011402 width=24)

--- a/src/test/regress/expected/subselect_gp_indexes.out
+++ b/src/test/regress/expected/subselect_gp_indexes.out
@@ -1,0 +1,111 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+-- Check that Index Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+                                            QUERY PLAN
+--------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 1
+     ->  Result  (cost=274.00..274.01 rows=1 width=8)
+           Filter: subplan_motion_t.user_id = $0
+           ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+-- Check that TID Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
+HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..598.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 2
+     ->  Result  (cost=598.00..598.01 rows=1 width=8)
+           Filter: public.subplan_motion_t.ctid = $0 AND public.subplan_motion_t.user_id = $1
+           ->  Materialize  (cost=598.00..598.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=274.00..598.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=274.00..598.00 rows=1 width=8)
+                             InitPlan  (slice3)
+                               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=6)
+                                     ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=6)
+                                           Filter: user_id = 7
+ Settings:  optimizer=off
+ Optimizer status: legacy query optimizer
+(15 rows)
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+-- Check that Bitmap Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+        where(select u.user_id from (select * from subplan_motion_t) u
+              where u.user_id = cte."userId") is not null;
+                                            QUERY PLAN
+--------------------------------------------------------------------------------------------------
+ Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
+   Filter: ((subplan)) IS NOT NULL
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+   SubPlan 1
+     ->  Result  (cost=274.00..274.01 rows=1 width=8)
+           Filter: subplan_motion_t.user_id = $0
+           ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
+                       ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
+ Settings:  enable_bitmapscan=on; enable_indexscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore

--- a/src/test/regress/expected/subselect_gp_indexes.out
+++ b/src/test/regress/expected/subselect_gp_indexes.out
@@ -3,26 +3,26 @@
 --
 -- Given distributed table
 create table subplan_motion_t
-(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+(a bigint NOT NULL) DISTRIBUTED BY (a);
 -- with constraint
-alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
 NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
 -- and some data
 insert into subplan_motion_t
 select gen from generate_series(1, 20000) gen;
 -- Check that Index Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
- userId
---------
-      7
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
                                             QUERY PLAN
 --------------------------------------------------------------------------------------------------
  Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
@@ -30,31 +30,30 @@ where(select u.user_id from (select * from subplan_motion_t) u
    ->  Result  (cost=0.00..0.01 rows=1 width=0)
    SubPlan 1
      ->  Result  (cost=274.00..274.01 rows=1 width=8)
-           Filter: subplan_motion_t.user_id = $0
+           Filter: subplan_motion_t.a = $0
            ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
                        ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
- Settings:  optimizer=off
  Optimizer status: legacy query optimizer
-(11 rows)
+(10 rows)
 
 -- Check that TID Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
 NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
 HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
- userId
---------
-      7
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
 NOTICE:  SELECT uses system-defined column "subplan_motion_t.ctid" without the necessary companion column "subplan_motion_t.gp_segment_id"
 HINT:  To uniquely identify a row within a distributed table, use the "gp_segment_id" column together with the "ctid" column.
                                                    QUERY PLAN
@@ -64,33 +63,32 @@ HINT:  To uniquely identify a row within a distributed table, use the "gp_segmen
    ->  Result  (cost=0.00..0.01 rows=1 width=0)
    SubPlan 2
      ->  Result  (cost=598.00..598.01 rows=1 width=8)
-           Filter: public.subplan_motion_t.ctid = $0 AND public.subplan_motion_t.user_id = $1
+           Filter: public.subplan_motion_t.ctid = $0 AND public.subplan_motion_t.a = $1
            ->  Materialize  (cost=598.00..598.01 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=274.00..598.00 rows=1 width=8)
                        ->  Seq Scan on subplan_motion_t  (cost=274.00..598.00 rows=1 width=8)
                              InitPlan  (slice3)
                                ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=6)
                                      ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=6)
-                                           Filter: user_id = 7
- Settings:  optimizer=off
+                                           Filter: a = 7
  Optimizer status: legacy query optimizer
-(15 rows)
+(14 rows)
 
 set enable_indexscan = off;
 set enable_bitmapscan = on;
 -- Check that Bitmap Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
- userId
---------
-      7
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-        where(select u.user_id from (select * from subplan_motion_t) u
-              where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
                                             QUERY PLAN
 --------------------------------------------------------------------------------------------------
  Subquery Scan cte  (cost=0.00..274.02 rows=1 width=4)
@@ -98,11 +96,11 @@ explain select cte."userId" from (select 7 as "userId" ) cte
    ->  Result  (cost=0.00..0.01 rows=1 width=0)
    SubPlan 1
      ->  Result  (cost=274.00..274.01 rows=1 width=8)
-           Filter: subplan_motion_t.user_id = $0
+           Filter: subplan_motion_t.a = $0
            ->  Materialize  (cost=274.00..274.01 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..274.00 rows=1 width=8)
                        ->  Seq Scan on subplan_motion_t  (cost=0.00..274.00 rows=1 width=8)
- Settings:  enable_bitmapscan=on; enable_indexscan=off; optimizer=off
+ Settings:  enable_bitmapscan=on; enable_indexscan=off
  Optimizer status: legacy query optimizer
 (11 rows)
 

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -3,26 +3,26 @@
 --
 -- Given distributed table
 create table subplan_motion_t
-(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+(a bigint NOT NULL) DISTRIBUTED BY (a);
 -- with constraint
-alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
 NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
 -- and some data
 insert into subplan_motion_t
 select gen from generate_series(1, 20000) gen;
 -- Check that Index Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
- userId
---------
-      7
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
                                                        QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..447546.78 rows=1 width=4)
@@ -31,30 +31,30 @@ where(select u.user_id from (select * from subplan_motion_t) u
          ->  Result  (cost=0.00..0.00 rows=1 width=1)
    SubPlan 1
      ->  Result  (cost=0.00..6.00 rows=1 width=8)
-           Filter: user_id = $0
+           Filter: a = $0
            ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
                        ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
-                             Index Cond: user_id = 7
+                             Index Cond: a = 7
  Settings:  optimizer=on
  Optimizer status: PQO version 3.114.2
 (13 rows)
 
 -- Check that TID Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
- userId
---------
-      7
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
                                                                     QUERY PLAN
 --------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..464961450.41 rows=1 width=4)
@@ -63,19 +63,19 @@ where(select u.user_id from (select * from subplan_motion_t
          ->  Result  (cost=0.00..0.00 rows=1 width=1)
    SubPlan 2
      ->  Result  (cost=0.00..453632.86 rows=1 width=8)
-           Filter: public.subplan_motion_t.user_id = $0
+           Filter: public.subplan_motion_t.a = $0
            ->  Materialize  (cost=0.00..453632.86 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..453632.86 rows=1 width=8)
                        ->  Result  (cost=0.00..453632.86 rows=1 width=8)
                              ->  Result  (cost=0.00..453632.86 rows=1 width=8)
                                    Filter: public.subplan_motion_t.ctid = ((subplan))
                                    ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=14)
-                                         Index Cond: user_id = 7
+                                         Index Cond: a = 7
                                    SubPlan 1
                                      ->  Materialize  (cost=0.00..6.00 rows=1 width=6)
                                            ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=6)
                                                  ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=6)
-                                                       Index Cond: user_id = 7
+                                                       Index Cond: a = 7
  Settings:  optimizer=on
  Optimizer status: PQO version 3.114.2
 (21 rows)
@@ -83,18 +83,18 @@ where(select u.user_id from (select * from subplan_motion_t
 set enable_indexscan = off;
 set enable_bitmapscan = on;
 -- Check that Bitmap Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
- userId
---------
-      7
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
+ b
+---
+ 7
 (1 row)
 
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-        where(select u.user_id from (select * from subplan_motion_t) u
-              where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
                                                        QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..447546.78 rows=1 width=4)
@@ -103,11 +103,11 @@ explain select cte."userId" from (select 7 as "userId" ) cte
          ->  Result  (cost=0.00..0.00 rows=1 width=1)
    SubPlan 1
      ->  Result  (cost=0.00..6.00 rows=1 width=8)
-           Filter: user_id = $0
+           Filter: a = $0
            ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
                  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
                        ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
-                             Index Cond: user_id = 7
+                             Index Cond: a = 7
  Settings:  enable_bitmapscan=on; enable_indexscan=off; optimizer=on
  Optimizer status: PQO version 3.114.2
  (13 rows)

--- a/src/test/regress/expected/subselect_gp_indexes_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_indexes_optimizer.out
@@ -1,0 +1,117 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subplan_motion_t_pkey" for table "subplan_motion_t"
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+-- Check that Index Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..447546.78 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 1
+     ->  Result  (cost=0.00..6.00 rows=1 width=8)
+           Filter: user_id = $0
+           ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
+                       ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
+                             Index Cond: user_id = 7
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.2
+(13 rows)
+
+-- Check that TID Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+                                                                    QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..464961450.41 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 2
+     ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+           Filter: public.subplan_motion_t.user_id = $0
+           ->  Materialize  (cost=0.00..453632.86 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..453632.86 rows=1 width=8)
+                       ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+                             ->  Result  (cost=0.00..453632.86 rows=1 width=8)
+                                   Filter: public.subplan_motion_t.ctid = ((subplan))
+                                   ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=14)
+                                         Index Cond: user_id = 7
+                                   SubPlan 1
+                                     ->  Materialize  (cost=0.00..6.00 rows=1 width=6)
+                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=6)
+                                                 ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=6)
+                                                       Index Cond: user_id = 7
+ Settings:  optimizer=on
+ Optimizer status: PQO version 3.114.2
+(21 rows)
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+-- Check that Bitmap Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+ userId
+--------
+      7
+(1 row)
+
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+        where(select u.user_id from (select * from subplan_motion_t) u
+              where u.user_id = cte."userId") is not null;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..447546.78 rows=1 width=4)
+   Filter: NOT ((subplan)) IS NULL
+   ->  Result  (cost=0.00..0.00 rows=1 width=4)
+         ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   SubPlan 1
+     ->  Result  (cost=0.00..6.00 rows=1 width=8)
+           Filter: user_id = $0
+           ->  Materialize  (cost=0.00..6.00 rows=1 width=8)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
+                       ->  Index Scan using subplan_motion_t_pkey on subplan_motion_t  (cost=0.00..6.00 rows=1 width=8)
+                             Index Cond: user_id = 7
+ Settings:  enable_bitmapscan=on; enable_indexscan=off; optimizer=on
+ Optimizer status: PQO version 3.114.2
+ (13 rows)
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -62,7 +62,7 @@ test: dtm_retry
 
 # The appendonly test cannot be run concurrently with tests that have
 # serializable transactions (may conflict with AO vacuum operations).
-test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish
+test: rangefuncs_cdb gp_dqa subselect_gp subselect_gp2 olap_group olap_window_seq sirv_functions appendonly create_table_distpol alter_distpol_dropped query_finish subselect_gp_indexes
 
 # 'partition' runs for a long time, so try to keep it together with other
 # long-running tests.

--- a/src/test/regress/sql/subselect_gp_indexes.sql
+++ b/src/test/regress/sql/subselect_gp_indexes.sql
@@ -3,44 +3,44 @@
 --
 -- Given distributed table
 create table subplan_motion_t
-(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+(a bigint NOT NULL) DISTRIBUTED BY (a);
 -- with constraint
-alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (a);
 -- and some data
 insert into subplan_motion_t
 select gen from generate_series(1, 20000) gen;
 
 -- Check that Index Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
 
 -- Check that TID Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t
-                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
-      where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where a = 7)) u
+      where u.a = cte."b") is not null;
 
 set enable_indexscan = off;
 set enable_bitmapscan = on;
 
 -- Check that Bitmap Scan is not used
-select cte."userId" from (select 7 as "userId" ) cte
-where(select u.user_id from (select * from subplan_motion_t) u
-      where u.user_id = cte."userId") is not null;
+select cte."b" from (select 7 as "b" ) cte
+where(select u.a from (select * from subplan_motion_t) u
+      where u.a = cte."b") is not null;
 -- Plan
-explain select cte."userId" from (select 7 as "userId" ) cte
-        where(select u.user_id from (select * from subplan_motion_t) u
-              where u.user_id = cte."userId") is not null;
+explain select cte."b" from (select 7 as "b" ) cte
+        where(select u.a from (select * from subplan_motion_t) u
+              where u.a = cte."b") is not null;
 
 -- start_ignore
 drop table if exists subplan_motion_t;

--- a/src/test/regress/sql/subselect_gp_indexes.sql
+++ b/src/test/regress/sql/subselect_gp_indexes.sql
@@ -1,0 +1,47 @@
+--
+-- Test correlated subquery in subplan with motion chooses correct scan type
+--
+-- Given distributed table
+create table subplan_motion_t
+(user_id bigint NOT NULL) DISTRIBUTED BY (user_id);
+-- with constraint
+alter table only subplan_motion_t add constraint users_choose_tidscan_pkey primary key (user_id);
+-- and some data
+insert into subplan_motion_t
+select gen from generate_series(1, 20000) gen;
+
+-- Check that Index Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+
+-- Check that TID Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t
+                             where ctid = (select ctid from subplan_motion_t where user_id = 7)) u
+      where u.user_id = cte."userId") is not null;
+
+set enable_indexscan = off;
+set enable_bitmapscan = on;
+
+-- Check that Bitmap Scan is not used
+select cte."userId" from (select 7 as "userId" ) cte
+where(select u.user_id from (select * from subplan_motion_t) u
+      where u.user_id = cte."userId") is not null;
+-- Plan
+explain select cte."userId" from (select 7 as "userId" ) cte
+        where(select u.user_id from (select * from subplan_motion_t) u
+              where u.user_id = cte."userId") is not null;
+
+-- start_ignore
+drop table if exists subplan_motion_t;
+-- end_ignore


### PR DESCRIPTION
The problem is that `indexscan` cannot be used together with `Motion` node.  So we have to import a commit from 6x to fix it.
https://github.com/greenplum-db/gpdb/commit/cd055f999f87c8bd381cc3fd7a64ee94dfa46073

## Steps to reproduce 
1. Create table
```sql
CREATE SCHEMA test_schema;

CREATE TABLE test_schema.users_unmasked (
  user_id bigint NOT NULL,
  params text
) DISTRIBUTED BY (user_id);

ALTER TABLE ONLY test_schema.users_unmasked
ADD CONSTRAINT users_20171219_pkey PRIMARY KEY (user_id);

INSERT INTO test_schema.users_unmasked
SELECT
  gen,
  case when random() > 0.5 then 'A' else 'B' end
FROM generate_series(1,20000) gen;
```
2. Run two queries. The second one returns incorrect data? because of incorrect plan with indexscan node without Motion.
```sql
SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
  SELECT
      u.user_id
  FROM
      test_schema.users_unmasked u
  WHERE
      u.user_id = cte."userId"
) is not null;

SELECT cte."userId" FROM ( SELECT 7 as "userId" ) cte WHERE (
  SELECT
     u.user_id
  FROM
      (select * from test_schema.users_unmasked) u
  WHERE
      u.user_id = cte."userId"
) IS NOT NULL;
```