### PR TITLE
[6X Backport] Segfault when trying to select from view with JOIN and table with dropped column

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3826,6 +3826,9 @@ CTranslatorQueryToDXL::TranslateJoinExprInFromToDXL(JoinExpr *join_expr)
 	ForBoth(lc_node, rte->joinaliasvars, lc_col_name, alias->colnames)
 	{
 		Node *join_alias_node = (Node *) lfirst(lc_node);
+		// rte->joinaliasvars may contain NULL ptrs which indicates dropped columns
+		if (!join_alias_node)
+			continue;
 		GPOS_ASSERT(IsA(join_alias_node, Var) ||
 					IsA(join_alias_node, CoalesceExpr));
 		Value *value = (Value *) lfirst(lc_col_name);

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -271,3 +271,13 @@ ALTER TABLE test_part_col ADD COLUMN f int;
 ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
 ALTER TABLE test_part_col DROP COLUMN f;
 DROP TABLE test_part_col;
+-- Create view with JOIN clause, drop column, check select to view not causing segfault
+CREATE TABLE dropped_col_t1(i1 int, i2 int);
+CREATE TABLE dropped_col_t2(i1 int, i2 int);
+CREATE VIEW dropped_col_v AS SELECT dropped_col_t1.i1 FROM dropped_col_t1 JOIN dropped_col_t2 ON dropped_col_t1.i1=dropped_col_t2.i1;
+ALTER TABLE dropped_col_t1 DROP COLUMN i2;
+SELECT * FROM dropped_col_v;
+ i1 
+----
+(0 rows)
+

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -223,3 +223,10 @@ ALTER TABLE test_part_col ALTER COLUMN f TYPE TEXT;
 ALTER TABLE test_part_col DROP COLUMN f;
 
 DROP TABLE test_part_col;
+
+-- Create view with JOIN clause, drop column, check select to view not causing segfault
+CREATE TABLE dropped_col_t1(i1 int, i2 int);
+CREATE TABLE dropped_col_t2(i1 int, i2 int);
+CREATE VIEW dropped_col_v AS SELECT dropped_col_t1.i1 FROM dropped_col_t1 JOIN dropped_col_t2 ON dropped_col_t1.i1=dropped_col_t2.i1;
+ALTER TABLE dropped_col_t1 DROP COLUMN i2;
+SELECT * FROM dropped_col_v;


### PR DESCRIPTION
ORCA falls with segfault when trying to select from view:
- With JOIN clause
- With table which column was dropped after view creation

`RangeTblEntry::joinaliasvars` alias list can contain pointers to NULL node if correspond column was dropped ([rewriteHandler.c#L296](https://github.com/greenplum-db/gpdb/blob/23814da5b0eb50a4c3957f1d95ab54a9f72e25b5/src/backend/rewrite/rewriteHandler.c#L296)).

Postgres planner itself can handle such values ([var.c#L878](https://github.com/greenplum-db/gpdb/blob/23814da5b0eb50a4c3957f1d95ab54a9f72e25b5/src/backend/optimizer/util/var.c#L878)) and the logic of NULL pointers is legit.

ORCA doesn't respect NULL pointers when loop over them ([CTranslatorQueryToDXL.cpp#L3854](https://github.com/greenplum-db/gpdb/blob/23814da5b0eb50a4c3957f1d95ab54a9f72e25b5/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp#L3854)), which cause segfault on [CTranslatorScalarToDXL.cpp#L274](https://github.com/greenplum-db/gpdb/blob/23814da5b0eb50a4c3957f1d95ab54a9f72e25b5/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp#L274).

PR includes small code fix and additional regression test.

(cherry picked from commit [f46a6f4](https://github.com/arenadata/gpdb/commit/f46a6f460f740ec0e990272aca606cdea1e8a3e1))