### PR TITLE
Fix segfault when trying to reindex partitioned table inside transaction block or function.

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2788,7 +2788,7 @@ RangeVarCallbackForReindexIndex(const RangeVar *relation,
  *		Recreate all indexes of a table (and of its toast table, if any)
  */
 Oid
-ReindexTable(ReindexStmt *stmt)
+ReindexTable(ReindexStmt *stmt, bool isTopLevel)
 {
 	RangeVar   *relation = stmt->relation;
 	int			options = stmt->options;
@@ -2819,7 +2819,8 @@ ReindexTable(ReindexStmt *stmt)
 	 */
 	if (get_rel_relkind(heapOid) == RELKIND_PARTITIONED_TABLE)
 	{
-		// FIXME transasction block check?
+		if (Gp_role == GP_ROLE_DISPATCH)
+			PreventInTransactionBlock(isTopLevel, "REINDEX PARTITIONED TABLE");
 		List	   *prels;
 
 		prels = find_all_inheritors(heapOid,

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -948,7 +948,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 						ReindexIndex(stmt);
 						break;
 					case REINDEX_OBJECT_TABLE:
-						ReindexTable(stmt);
+						ReindexTable(stmt, isTopLevel);
 						break;
 					case REINDEX_OBJECT_SCHEMA:
 					case REINDEX_OBJECT_SYSTEM:

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -38,7 +38,7 @@ extern ObjectAddress DefineIndex(Oid relationId,
 								 bool quiet,
 								 bool is_new_table);
 extern void ReindexIndex(ReindexStmt *stmt);
-extern Oid	ReindexTable(ReindexStmt *stmt);
+extern Oid	ReindexTable(ReindexStmt *stmt, bool isTopLevel);
 extern void ReindexMultipleTables(const char *objectName, ReindexObjectType objectKind,
 								  int options, bool concurrent);
 extern char *makeObjectName(const char *name1, const char *name2,

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -1431,6 +1431,16 @@ COMMIT;
 BEGIN;
 CREATE INDEX std_index on concur_heap(f2);
 COMMIT;
+-- But can't do a regular index build in a transaction over partitioned table
+CREATE TABLE reindex_xact_part(i int) PARTITION BY RANGE(i);
+DO
+$$BEGIN
+REINDEX TABLE reindex_xact_part;
+END$$;
+ERROR:  REINDEX PARTITIONED TABLE cannot be executed from a function
+CONTEXT:  SQL statement "REINDEX TABLE reindex_xact_part"
+PL/pgSQL function inline_code_block line 2 at SQL statement
+DROP TABLE reindex_xact_part;
 -- Failed builds are left invalid by VACUUM FULL, fixed by REINDEX
 VACUUM FULL concur_heap;
 REINDEX TABLE concur_heap;

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -1431,7 +1431,7 @@ COMMIT;
 BEGIN;
 CREATE INDEX std_index on concur_heap(f2);
 COMMIT;
--- But can't do a regular index build in a transaction over partitioned table
+-- But can't do the same over partitioned table
 CREATE TABLE reindex_xact_part(i int) PARTITION BY RANGE(i);
 DO
 $$BEGIN

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -490,6 +490,14 @@ BEGIN;
 CREATE INDEX std_index on concur_heap(f2);
 COMMIT;
 
+-- But can't do the same over partitioned table
+CREATE TABLE reindex_xact_part(i int) PARTITION BY RANGE(i);
+DO
+$$BEGIN
+REINDEX TABLE reindex_xact_part;
+END$$;
+DROP TABLE reindex_xact_part;
+
 -- Failed builds are left invalid by VACUUM FULL, fixed by REINDEX
 VACUUM FULL concur_heap;
 REINDEX TABLE concur_heap;


### PR DESCRIPTION
Unlike Postgres 12, GP has additional function ([ReindexRelationList](https://github.com/greenplum-db/gpdb/blob/0276a90cbb493af1356d076800d53e4d4b90822a/src/backend/commands/indexcmds.c#L3064)) for relation list reindexing, which used for partitioned table [reindexing](https://github.com/greenplum-db/gpdb/blob/0276a90cbb493af1356d076800d53e4d4b90822a/src/backend/commands/indexcmds.c#L2829) as well. This function creates it's own [transaction](https://github.com/greenplum-db/gpdb/blob/0276a90cbb493af1356d076800d53e4d4b90822a/src/backend/commands/indexcmds.c#L3076) for each reindex partition call, which makes impossible to use it inside transaction block. Each call to such functions should be guarded by [PreventInTransactionBlock](https://github.com/greenplum-db/gpdb/blob/0276a90cbb493af1356d076800d53e4d4b90822a/src/backend/access/transam/xact.c#L4297) function call, like it was already [done](https://github.com/greenplum-db/gpdb/blob/0276a90cbb493af1356d076800d53e4d4b90822a/src/backend/tcop/utility.c#L963) for database, schema and system reindexing.
This commit adds a call to PreventInTransactionBlock guard function for partitioned tables and brings reindexing logic closer to Postgres [master](https://github.com/postgres/postgres/blob/master/src/backend/commands/indexcmds.c#L2717). Reindex of non-partitioned tables still can be done inside transaction block like before. Additionally, commit contains new regression test, which can be considered as current bug-proof. Ordinary "begin-end" block not causing any error, which should be threated as incorrect, so "do" block is used.

