### PR TITLE
ADBDEV-1683. Remove Gpmon_Incr_Rows_Out() from tuplesort.c & tuplesort_mk.c

### DIFF
--- a/src/backend/utils/sort/tuplesort.c
+++ b/src/backend/utils/sort/tuplesort.c
@@ -1810,8 +1810,6 @@ tuplesort_gettupleslot_pos(Tuplesortstate *state, TuplesortPos *pos,
 	if (stup.tuple)
 	{
 		ExecStoreMinimalTuple(stup.tuple, slot, should_free);
-		if (state->gpmon_pkt)
-			Gpmon_Incr_Rows_Out(state->gpmon_pkt);
 		return true;
 	}
 	else

--- a/src/backend/utils/sort/tuplesort_mk.c
+++ b/src/backend/utils/sort/tuplesort_mk.c
@@ -1702,9 +1702,6 @@ tuplesort_gettupleslot_pos_mk(Tuplesortstate_mk *state, TuplesortPos_mk *pos,
 
 #endif
 
-		if (state->gpmon_pkt)
-			Gpmon_Incr_Rows_Out(state->gpmon_pkt);
-
 		return true;
 	}
 


### PR DESCRIPTION
Remove `Gpmon_Incr_Rows_Out()` calls from `tuplesort_gettupleslot_pos()` and `tuplesort_gettupleslot_pos_mk()`. The calls to `Gpmon_Incr_Rows_Out()` from these methods are redundant, as both of them are called only from `ExecProcNode()`, which [calls `Gpmon_Incr_Rows_Out()` itself](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/backend/executor/execProcnode.c#L1158-L1162).

`ExecProcNode()` calls `Gpmon_Incr_Rows_Out()` since https://github.com/greenplum-db/gpdb/commit/c16900105465fb0a89ddca416d603759a14357f9. Note that it removed a lot of `Gpmon_Incr_Rows_Out` calls, among others.

Current redundant calls make `gpperfmon` `qexec` packets' [`rowsout`](https://github.com/greenplum-db/gpdb/blob/e4986e82c293aa6e132f1e8b47a65ec4ff25d7bd/src/include/gpmon/gpmon.h#L205) field incorrect for `Sort` nodes: this field contains value twice greater than the actual one.
