### PR TITLE
ADBDEV-1567. Initialize all subplans in ValuesScanState (backport)

### DIFF
--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -28,7 +28,8 @@
 #include "cdb/cdbvars.h"
 #include "executor/executor.h"
 #include "executor/nodeValuesscan.h"
-#include "optimizer/var.h"              /* CDB: contain_var_reference() */
+#include "optimizer/var.h"		/* CDB: contain_var_reference() */
+#include "optimizer/clauses.h"
 #include "parser/parsetree.h"
 
 
@@ -53,7 +54,7 @@ ValuesNext(ValuesScanState *node)
 	EState	   *estate;
 	ExprContext *econtext;
 	ScanDirection direction;
-	List	   *exprlist;
+	int			curr_idx;
 
 	/*
 	 * get information from the estate and scan state
@@ -70,19 +71,11 @@ ValuesNext(ValuesScanState *node)
 	{
 		if (node->curr_idx < node->array_len)
 			node->curr_idx++;
-		if (node->curr_idx < node->array_len)
-			exprlist = node->exprlists[node->curr_idx];
-		else
-			exprlist = NIL;
 	}
 	else
 	{
 		if (node->curr_idx >= 0)
 			node->curr_idx--;
-		if (node->curr_idx >= 0)
-			exprlist = node->exprlists[node->curr_idx];
-		else
-			exprlist = NIL;
 	}
 
 	/*
@@ -93,11 +86,12 @@ ValuesNext(ValuesScanState *node)
 	 */
 	ExecClearTuple(slot);
 
-	if (exprlist)
+	curr_idx = node->curr_idx;
+	if (curr_idx >= 0 && curr_idx < node->array_len)
 	{
+		List	   *exprlist = node->exprlists[curr_idx];
+		List	   *exprstatelist = node->exprstatelists[curr_idx];
 		MemoryContext oldContext;
-		List	   *oldsubplans;
-		List	   *exprstatelist;
 		Datum	   *values;
 		bool	   *isnull;
 		ListCell   *lc;
@@ -111,30 +105,28 @@ ValuesNext(ValuesScanState *node)
 		ReScanExprContext(econtext);
 
 		/*
-		 * Build the expression eval state in the econtext's per-tuple memory.
-		 * This is a tad unusual, but we want to delete the eval state again
-		 * when we move to the next row, to avoid growth of memory
-		 * requirements over a long values list.
+		 * Do per-VALUES-row work in the per-tuple context.
 		 */
 		oldContext = MemoryContextSwitchTo(econtext->ecxt_per_tuple_memory);
 
 		/*
-		 * The expressions might contain SubPlans (this is currently only
-		 * possible if there's a sub-select containing a LATERAL reference,
-		 * otherwise sub-selects in a VALUES list should be InitPlans). Those
-		 * subplans will want to hook themselves into our subPlan list, which
-		 * would result in a corrupted list after we delete the eval state. We
-		 * can work around this by saving and restoring the subPlan list.
-		 * (There's no need for the functionality that would be enabled by
-		 * having the list entries, since the SubPlans aren't going to be
-		 * re-executed anyway.)
+		 * Unless we already made the expression eval state for this row,
+		 * build it in the econtext's per-tuple memory.  This is a tad
+		 * unusual, but we want to delete the eval state again when we move to
+		 * the next row, to avoid growth of memory requirements over a long
+		 * values list.  For rows in which that won't work, we already built
+		 * the eval state at plan startup.
 		 */
-		oldsubplans = node->ss.ps.subPlan;
-		node->ss.ps.subPlan = NIL;
-
-		exprstatelist = (List *) ExecInitExpr((Expr *) exprlist, &node->ss.ps);
-
-		node->ss.ps.subPlan = oldsubplans;
+		if (exprstatelist == NIL)
+		{
+			/*
+			 * Pass parent as NULL, not my plan node, because we don't want
+			 * anything in this transient state linking into permanent state.
+			 * The only expression type that might wish to do so is a SubPlan,
+			 * and we already checked that there aren't any.
+			 */
+			exprstatelist = (List *) ExecInitExpr((Expr *) exprlist, NULL);
+		}
 
 		/* parser should have checked all sublists are the same length */
 		Assert(list_length(exprstatelist) == slot->tts_tupleDescriptor->natts);
@@ -285,13 +277,38 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 	scanstate->curr_idx = -1;
 	scanstate->array_len = list_length(node->values_lists);
 
-	/* convert list of sublists into array of sublists for easy addressing */
+	/*
+	 * Convert the list of expression sublists into an array for easier
+	 * addressing at runtime.  Also, detect whether any sublists contain
+	 * SubPlans; for just those sublists, go ahead and do expression
+	 * initialization.  (This avoids problems with SubPlans wanting to connect
+	 * themselves up to the outer plan tree.  Notably, EXPLAIN won't see the
+	 * subplans otherwise; also we will have troubles with dangling pointers
+	 * and/or leaked resources if we try to handle SubPlans the same as
+	 * simpler expressions.)
+	 */
 	scanstate->exprlists = (List **)
 		palloc(scanstate->array_len * sizeof(List *));
+	scanstate->exprstatelists = (List **)
+		palloc0(scanstate->array_len * sizeof(List *));
 	i = 0;
 	foreach(vtl, node->values_lists)
 	{
-		scanstate->exprlists[i++] = (List *) lfirst(vtl);
+		List	   *exprs = castNode(List, lfirst(vtl));
+
+		scanstate->exprlists[i] = exprs;
+
+		/*
+		 * We can avoid the cost of a contain_subplans() scan in the simple
+		 * case where there are no SubPlans anywhere.
+		 */
+		if (estate->es_subplanstates &&
+			contain_subplans((Node *) exprs))
+		{
+			scanstate->exprstatelists[i] = (List *)
+				ExecInitExpr((Expr *) exprs, &scanstate->ss.ps);
+		}
+		i++;
 	}
 
 	/*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2105,7 +2105,8 @@ typedef struct TableFunctionState
  *
  *		rowcontext			per-expression-list context
  *		exprlists			array of expression lists being evaluated
- *		array_len			size of array
+ *		exprstatelists		array of expression state lists, for SubPlans only
+ *		array_len			size of above arrays
  *		curr_idx			current array index (0-based)
  *		marked_idx			marked position (for mark/restore)
  *
@@ -2114,6 +2115,12 @@ typedef struct TableFunctionState
  *	rowcontext, in which to build the executor expression state for each
  *	Values sublist.  Resetting this context lets us get rid of expression
  *	state for each row, avoiding major memory leakage over a long values list.
+ *	However, that doesn't work for sublists containing SubPlans, because a
+ *	SubPlan has to be connected up to the outer plan tree to work properly.
+ *	Therefore, for only those sublists containing SubPlans, we do expression
+ *	state construction at executor start, and store those pointers in
+ *	exprstatelists[].  NULL entries in that array correspond to simple
+ *	subexpressions that are handled as described above.
  * ----------------
  */
 typedef struct ValuesScanState
@@ -2125,6 +2132,8 @@ typedef struct ValuesScanState
 	int			curr_idx;
 	int			marked_idx;
 	bool		cdb_want_ctid;	/* true => ctid is referenced in targetlist */
+	/* in back branches, put this at the end to avoid ABI break: */
+	List	  **exprstatelists;
 } ValuesScanState;
 
 /* ----------------

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -749,6 +749,33 @@ where s.i < 10 and (select val.x) < 110;
   10
 (17 rows)
 
+-- another variant of that (bug #16213)
+explain (verbose, costs off)
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+               QUERY PLAN               
+----------------------------------------
+ Values Scan on "*VALUES*"
+   Output: "*VALUES*".column1
+   SubPlan 1
+     ->  Values Scan on "*VALUES*_1"
+           Output: "*VALUES*_1".column1
+(5 rows)
+
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+ column1 
+---------
+ t
+ f
+(2 rows)
+
 --
 -- Check sane behavior with nested IN SubLinks
 -- GPDB_94_MERGE_FIXME: ORCA plan is correct but very pricy. Should we fallback to planner?

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -756,14 +756,17 @@ select * from
   (3 not in (select * from (values (1), (2)) ss1)),
   (false)
 ) ss;
-               QUERY PLAN               
-----------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Values Scan on "*VALUES*"
    Output: "*VALUES*".column1
    SubPlan 1
-     ->  Values Scan on "*VALUES*_1"
+     ->  Materialize
            Output: "*VALUES*_1".column1
-(5 rows)
+           ->  Values Scan on "*VALUES*_1"
+                 Output: "*VALUES*_1".column1
+ Optimizer: Postgres query optimizer
+(8 rows)
 
 select * from
 (values

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -777,6 +777,36 @@ where s.i < 10 and (select val.x) < 110;
   10
 (17 rows)
 
+-- another variant of that (bug #16213)
+explain (verbose, costs off)
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+                  QUERY PLAN                  
+----------------------------------------------
+ Values Scan on "*VALUES*"
+   Output: "*VALUES*".column1
+   SubPlan 1
+     ->  Materialize
+           Output: "*VALUES*_1".column1
+           ->  Values Scan on "*VALUES*_1"
+                 Output: "*VALUES*_1".column1
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+ column1 
+---------
+ t
+ f
+(2 rows)
+
 --
 -- Check sane behavior with nested IN SubLinks
 -- GPDB_94_MERGE_FIXME: ORCA plan is correct but very pricy. Should we fallback to planner?

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -433,6 +433,20 @@ select val.x
   ) as val(x)
 where s.i < 10 and (select val.x) < 110;
 
+-- another variant of that (bug #16213)
+explain (verbose, costs off)
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+
+select * from
+(values
+  (3 not in (select * from (values (1), (2)) ss1)),
+  (false)
+) ss;
+
 --
 -- Check sane behavior with nested IN SubLinks
 -- GPDB_94_MERGE_FIXME: ORCA plan is correct but very pricy. Should we fallback to planner?


### PR DESCRIPTION
This is a backport of https://github.com/postgres/postgres/commit/2e2646060e18461de24e3585344095664dc7727b.

`EXPLAIN` output is incorrect in [current GPDB 7](https://github.com/greenplum-db/gpdb/tree/fc4b84d2e0de28b4637eb95646f7c49e17e0bbbd). Compare the following queries:

* [Current `adb-6.x`](https://github.com/greenplum-db/gpdb/tree/fc4b84d2e0de28b4637eb95646f7c49e17e0bbbd)
```
EXPLAIN select val.x
  from generate_series(1,10) as s(i),
  lateral (
    values ((select s.i + 1)), (s.i + 101)
  ) as val(x)
where s.i < 10 and (select val.x) < 110;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Nested Loop  (cost=10000000000.00..10000000032.50 rows=112 width=4)
   ->  Function Scan on generate_series s  (cost=0.00..12.50 rows=112 width=4)
         Filter: (i < 10)
   ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=1 width=4)
         Filter: ((SubPlan 1) < 110)
         SubPlan 1
           ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres query optimizer
(8 rows)
```

* PostgreSQL 9.4.26
```
EXPLAIN select val.x
  from generate_series(1,10) as s(i),
  lateral (
    values ((select s.i + 1)), (s.i + 101)
  ) as val(x)
where s.i < 10 and (select val.x) < 110;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Nested Loop  (cost=0.00..32.48 rows=333 width=4)
   ->  Function Scan on generate_series s  (cost=0.00..12.50 rows=333 width=4)
         Filter: (i < 10)
   ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=1 width=4)
         Filter: ((SubPlan 1) < 110)
         SubPlan 1
           ->  Result  (cost=0.00..0.01 rows=1 width=0)
         SubPlan 2
           ->  Result  (cost=0.00..0.01 rows=1 width=0)
(9 rows)
```

`SubPlan 2` is missing in `adb-6.x` output.

* `adb-6.x` with this PR applied
```
EXPLAIN select val.x
  from generate_series(1,10) as s(i),
  lateral (
    values ((select s.i + 1)), (s.i + 101)
  ) as val(x)
where s.i < 10 and (select val.x) < 110;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Nested Loop  (cost=10000000000.00..10000000032.50 rows=112 width=4)
   ->  Function Scan on generate_series s  (cost=0.00..12.50 rows=112 width=4)
         Filter: (i < 10)
   ->  Values Scan on "*VALUES*"  (cost=0.00..0.05 rows=1 width=4)
         Filter: ((SubPlan 1) < 110)
         SubPlan 1
           ->  Result  (cost=0.00..0.01 rows=1 width=0)
         SubPlan 2
           ->  Result  (cost=0.00..0.01 rows=1 width=0)
 Optimizer: Postgres query optimizer
(10 rows)
```

## Extra changes compared to upstream commit
`subselect` test is updated with corresponding output from GPDB: there are differences in `EXPLAIN` output; there is a variant of `subselect` result file for ORCA.
