### PR TITLE
ADBDEV-1691. Refactor query_info_collect_hook call site in ExecProcNode

### DIFF
--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -955,10 +955,10 @@ ExecProcNode(PlanState *node)
 
 	if(!node->fHadSentNodeStart)
 	{
+		node->fHadSentNodeStart = true;
 		/* GPDB hook for collecting query info */
 		if (query_info_collect_hook)
 			(*query_info_collect_hook)(METRICS_PLAN_NODE_EXECUTING, node);
-		node->fHadSentNodeStart = true;
 	}
 
 	switch (nodeTag(node))
@@ -1200,10 +1200,10 @@ MultiExecProcNode(PlanState *node)
 	
 	if (!node->fHadSentNodeStart)
 	{
+		node->fHadSentNodeStart = true;
 		/* GPDB hook for collecting query info */
 		if (query_info_collect_hook)
 			(*query_info_collect_hook)(METRICS_PLAN_NODE_EXECUTING, node);
-		node->fHadSentNodeStart = true;
 	}
 
 	if (node->chgParam != NULL) /* something changed */


### PR DESCRIPTION
Set `node->fHadSentNodeStart = true` before `query_info_collect_hook` is called.

This allows `query_info_collect_hook` to modify `node->fHadSentNodeStart`, so that it could request repeatable calls of the hook from `MultiExecProcNode` / `ExecProcNode`.