### PR TITLE
fix remove duplicate declaration caused by mistake

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/utils.h
+++ b/src/backend/gporca/libgpos/include/gpos/utils.h
@@ -41,21 +41,6 @@
 
 #define ALIGN_STORAGE __attribute__((aligned(8)))
 
-#define GPOS_GET_FRAME_POINTER(x) \
-	do                            \
-	{                             \
-		ULONG_PTR ulp;            \
-		GPOS_ASMFP;               \
-		x = ulp;                  \
-	} while (0)
-#define GPOS_GET_STACK_POINTER(x) \
-	do                            \
-	{                             \
-		ULONG_PTR ulp;            \
-		GPOS_ASMSP;               \
-		x = ulp;                  \
-	} while (0)
-
 #define GPOS_MSEC_IN_SEC ((ULLONG) 1000)
 #define GPOS_USEC_IN_MSEC ((ULLONG) 1000)
 #define GPOS_USEC_IN_SEC (((ULLONG) 1000) * 1000)


### PR DESCRIPTION
We've hiden part of directives under preprocessing in 70e444e3f53ec8cf534d689c837c5b3fcf28f35b (ADBDEV-796)
Theese directives are unavailable on power
But later we've recreated them during conflict resolution in
ca42bb7749e4f8c6ceea076be80deec5b3b42d25 (6.11.2 release)
Now them are blocking build for power

The build went successful with this changes: https://ci.arenadata.io/job/adb-6.x-build-project/493/console