### PR TITLE
Fix plpgsql test

### DIFF
--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -2338,7 +2338,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -2339,7 +2339,7 @@ begin
 			raise notice 'caught data_exception';
 			x := -1;
 		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
-			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
+			raise notice 'caught numeric_value_out_of_range or cardinality_violation or too_many_rows';
 			x := -2;
 	end;
 	return x;
@@ -2365,7 +2365,7 @@ NOTICE:  caught data_exception
 (1 row)
 
 select trap_matching_test(1);
-NOTICE:  caught numeric_value_out_of_range or cardinality_violation
+NOTICE:  caught numeric_value_out_of_range or cardinality_violation or too_many_rows
  trap_matching_test 
 --------------------
                  -2

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -2359,7 +2359,7 @@ begin
 			raise notice 'caught data_exception';
 			x := -1;
 		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
-			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
+			raise notice 'caught numeric_value_out_of_range or cardinality_violation or too_many_rows';
 			x := -2;
 	end;
 	return x;
@@ -2385,7 +2385,7 @@ NOTICE:  caught data_exception
 (1 row)
 
 select trap_matching_test(1);
-NOTICE:  caught numeric_value_out_of_range or cardinality_violation
+NOTICE:  caught numeric_value_out_of_range or cardinality_violation or too_many_rows
  trap_matching_test 
 --------------------
                  -2

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -2358,7 +2358,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;

--- a/src/test/regress/sql/plpgsql.sql
+++ b/src/test/regress/sql/plpgsql.sql
@@ -1734,7 +1734,7 @@ begin
 			raise notice 'caught data_exception';
 			x := -1;
 		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
-			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
+			raise notice 'caught numeric_value_out_of_range or cardinality_violation or too_many_rows';
 			x := -2;
 	end;
 	return x;

--- a/src/test/regress/sql/plpgsql.sql
+++ b/src/test/regress/sql/plpgsql.sql
@@ -1733,7 +1733,7 @@ begin
 		when data_exception then  -- category match
 			raise notice 'caught data_exception';
 			x := -1;
-		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then
+		when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION OR TOO_MANY_ROWS then
 			raise notice 'caught numeric_value_out_of_range or cardinality_violation';
 			x := -2;
 	end;


### PR DESCRIPTION
The `plpgsql` test fails on 5x.

`TOO_MANY_ROWS` exception is used i when optimizer enabled. I'm not quite sure why `NUMERIC_VALUE_OUT_OF_RANGE` is needed here, but I kept it to make it less different from upstream/.
