### PR TITLE
Check if index pathkeys list is empty in find_usable_indexes() function

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -62,7 +62,7 @@ RUN rpm -i $sigar && rpm -i $sigar_headers && mkdir -p /home/gpadmin/bin_gpdb
 ENV TARGET_OS_VERSION=7
 ENV TARGET_OS=centos
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--with-gssapi --enable-debug --enable-depend \
+ENV CONFIGURE_FLAGS="--with-gssapi --enable-debug --enable-depend --enable-cassert \
     --with-libraries=/home/gpadmin/bin_orca/lib \
     --with-includes=/home/gpadmin/bin_orca/include"
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/gpadmin/bin_orca/lib:/usr/lib64:/usr/local/lib

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -402,6 +402,12 @@ find_usable_indexes(PlannerInfo *root, RelOptInfo *rel,
 		if (index_is_ordered && possibly_useful_pathkeys &&
 			istoplevel && outer_rel == NULL)
 		{
+			/*
+			 * index_pathkeys might be NULL when target index does not provide
+			 * a desired sort order in query or when useful for sorting
+			 * index corresponding to inherited or child relation does not
+			 * participate in join.
+			 */
 			index_pathkeys = build_index_pathkeys(root, index,
 												  ForwardScanDirection);
 
@@ -410,7 +416,7 @@ find_usable_indexes(PlannerInfo *root, RelOptInfo *rel,
 			 * of the child's baserel.  Transform the pathkey list to refer to
 			 * columns of the appendrel.
 			 */
-			if (rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
+			if (index_pathkeys && rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
 			{
 				AppendRelInfo *appinfo = NULL;
 				RelOptInfo *appendrel = NULL;


### PR DESCRIPTION
index_pathkeys might be NULL when target index does not provide
a desired sort order in query or when useful for sorting index
corresponding to inherited or child relation does not participate
in join.

Due to that the following fragment fails:
```
    CREATE TABLE clstr_tst (a int, b INT) DISTRIBUTED BY (a);
    CREATE INDEX clstr_tst_b_c ON clstr_tst (b);
    CREATE TABLE clstr_tst_inh () INHERITS (clstr_tst);
    SELECT a FROM clstr_tst ORDER BY 1
```

The solution is to check if index_pathkeys list is empty before using it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
