### PR TITLE
Set 'extra_float_digits' to 2 to avoid float8 overflow

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2571,7 +2571,9 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * may result in different behaviour under different acl configuration.
 	 */
 	initStringInfo(&str);
-	appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s');",
+	appendStringInfo(&str, "select gp_acquire_sample_rows from "
+				"(select set_config('extra_float_digits', '2', true)) sc,"
+				"(select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s')) asr;",
 					 RelationGetRelid(onerel),
 					 perseg_targrows,
 					 inh ? "t" : "f");

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1696,7 +1696,7 @@ INSERT INTO foo SELECT i, i%9, i%100 FROM generate_series(1,500)i;
 ANALYZE VERBOSE rootpartition foo;
 INFO:  analyzing "public.foo" inheritance tree
 INFO:  column c of partition foo_1_prt_1 is not analyzed, so ANALYZE will collect sample for stats calculation
-INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(17861, 400, 't')
+INFO:  Executing SQL: select gp_acquire_sample_rows from (select set_config('extra_float_digits', '2', true)) sc,(select pg_catalog.gp_acquire_sample_rows(17861, 400, 't')) asr;
 -- Testing auto merging root statistics for all columns
 -- where column attnums are differents due to dropped columns
 -- and split partitions.


### PR DESCRIPTION
When analyze for table is performed master segment calls
gp_acquire_sample_rows() helper function on each segment.
That eventually calls float8out function on segment to
converts float8 number to a string with snprintf:

int	ndig = DBL_DIG + extra_float_digits;

snprintf(ascii, MAXDOUBLEWIDTH + 1, "%.*g", ndig, num);

When ndig is 15 the maximum float8 value 1.7976931348623157e+308 is
rounded to "1.79769313486232e+308" that has no representation.
This why extra_float_digits should be set at least to 2.

And on master acquire_sample_rows_dispatcher function
process gp_acquire_sample_rows result and eventually float8in
function is called to convert string to float8 with strtold:
val = strtold(num, &endptr);

This is where overflow for "1.79769313486232e+308" happens but works
fine for "1.7976931348623157e+308".

If table has a filed of double precision type like below:

# create table t (a double precision);

Insert of maximum float8 value 1.7976931348623157e+308 fails as
it is rounded to 1.79769313486232e+308 that has no representation.

# insert into t values (1.7976931348623157e+308);
ERROR:  value out of range: overflow
#

The workaround is to set 'extra_float_digits' GUC value to 2.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
