### PR TITLE
Wrong snapshot for EOF corrupts data in AO/AOCO

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -182,7 +182,7 @@ AOCSTruncateToEOF(Relation aorel)
 				segno;
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_column_truncate_to_eof");
@@ -246,7 +246,6 @@ AOCSTruncateToEOF(Relation aorel)
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 static void
@@ -441,7 +440,7 @@ AOCSDrop(Relation aorel,
 	int			i,
 				segno;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(RelationIsAoCols(aorel));
@@ -491,7 +490,6 @@ AOCSDrop(Relation aorel,
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 
@@ -521,7 +519,7 @@ AOCSCompact(Relation aorel,
 				segno;
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_column_compact");
@@ -611,6 +609,4 @@ AOCSCompact(Relation aorel,
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -31,6 +31,7 @@
 #include "executor/executor.h"
 #include "nodes/execnodes.h"
 #include "storage/lmgr.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
@@ -182,6 +183,10 @@ AOCSTruncateToEOF(Relation aorel)
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_column_truncate_to_eof");
+#endif
 
 	Assert(RelationIsAoCols(aorel));
 
@@ -517,6 +522,10 @@ AOCSCompact(Relation aorel,
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_column_compact");
+#endif
 
 	Assert(RelationIsAoCols(aorel));
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -830,6 +830,13 @@ aocs_insert_init(Relation rel, int segno, bool update_mode)
 	desc->aoi_rel = rel;
 	desc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("ao_column_insert_init_1") == FaultInjectorTypeSkip)
+	{
+		SIMPLE_FAULT_INJECTOR("ao_column_insert_init_2");
+	}
+#endif
+
 	/*
 	 * Writers uses this since they have exclusive access to the lock acquired
 	 * with LockRelationAppendOnlySegmentFile for the segment-file.

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -828,7 +828,7 @@ aocs_insert_init(Relation rel, int segno, bool update_mode)
 
 	desc = (AOCSInsertDesc) palloc0(sizeof(AOCSInsertDescData));
 	desc->aoi_rel = rel;
-	desc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	desc->appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("ao_column_insert_init_1") == FaultInjectorTypeSkip)
@@ -1014,8 +1014,6 @@ aocs_insert_finish(AOCSInsertDesc idesc)
 	AppendOnlyBlockDirectory_End_forInsert(&(idesc->blockDirectory));
 
 	UpdateAOCSFileSegInfo(idesc);
-
-	UnregisterSnapshot(idesc->appendOnlyMetaDataSnapshot);
 
 	pfree(idesc->fsInfo);
 

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -519,7 +519,7 @@ AppendOnlyDrop(Relation aorel, List *compaction_segno)
 	int			i,
 				segno;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(RelationIsAoRows(aorel));
@@ -572,7 +572,6 @@ AppendOnlyDrop(Relation aorel, List *compaction_segno)
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*
@@ -590,7 +589,7 @@ AppendOnlyTruncateToEOF(Relation aorel)
 				segno;
 	LockAcquireResult acquireResult;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_row_truncate_to_eof");
@@ -654,7 +653,6 @@ AppendOnlyTruncateToEOF(Relation aorel)
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*
@@ -682,7 +680,7 @@ AppendOnlyCompact(Relation aorel,
 	int			i,
 				segno;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_row_compact");
@@ -762,7 +760,6 @@ AppendOnlyCompact(Relation aorel,
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -40,6 +40,7 @@
 #include "nodes/execnodes.h"
 #include "storage/procarray.h"
 #include "storage/lmgr.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
@@ -591,6 +592,10 @@ AppendOnlyTruncateToEOF(Relation aorel)
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_row_truncate_to_eof");
+#endif
+
 	Assert(RelationIsAoRows(aorel));
 
 	relname = RelationGetRelationName(aorel);
@@ -678,6 +683,10 @@ AppendOnlyCompact(Relation aorel,
 				segno;
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_row_compact");
+#endif
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(insert_segno >= 0);

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2622,6 +2622,13 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 	 */
 	aoInsertDesc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("ao_row_insert_init_1") == FaultInjectorTypeSkip)
+	{
+		SIMPLE_FAULT_INJECTOR("ao_row_insert_init_2");
+	}
+#endif
+
 	aoInsertDesc->mt_bind = create_memtuple_binding(RelationGetDescr(rel));
 
 	aoInsertDesc->appendFile = -1;

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2620,7 +2620,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 	 * Writers uses this since they have exclusive access to the lock acquired
 	 * with LockRelationAppendOnlySegmentFile for the segment-file.
 	 */
-	aoInsertDesc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	aoInsertDesc->appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("ao_row_insert_init_1") == FaultInjectorTypeSkip)
@@ -3099,8 +3099,6 @@ appendonly_insert_finish(AppendOnlyInsertDesc aoInsertDesc)
 	AppendOnlyBlockDirectory_End_forInsert(&(aoInsertDesc->blockDirectory));
 
 	AppendOnlyStorageWrite_FinishSession(&aoInsertDesc->storageWrite);
-
-	UnregisterSnapshot(aoInsertDesc->appendOnlyMetaDataSnapshot);
 
 	pfree(aoInsertDesc->title);
 	pfree(aoInsertDesc);

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1125,6 +1125,13 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 	AORelHashEntryData *aoentry = NULL;
 	TransactionId CurrentXid = GetTopTransactionId();
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("reserved_segno") == FaultInjectorTypeSkip)
+	{
+		return RESERVED_SEGNO;
+	}
+#endif
+
 	switch (Gp_role)
 	{
 		case GP_ROLE_EXECUTE:
@@ -1141,6 +1148,7 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 		case GP_ROLE_DISPATCH:
 
 			Assert(existingsegno == InvalidFileSegNumber);
+
 
 			ereportif(Debug_appendonly_print_segfile_choice, LOG,
 					  (errmsg("SetSegnoForWrite: Choosing a segno for append-only "

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -1,0 +1,137 @@
+-- @Description Tests segment file logical EOF.
+--
+
+-- start_matchsubs
+--
+-- # create a match/subs expression
+--
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- end_matchsubs
+1:CREATE extension if NOT EXISTS gp_inject_fault;
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+1:BEGIN;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 30);
+1:ROLLBACK;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM truncate_eof;
+-- Commit new data and move eof.
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+0U<:
+-- Validate that segment file is not corrupted.
+1:SELECT count(*) FROM truncate_eof;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE truncate_eof;
+1:RESET gp_default_storage_options;
+
+--
+-- Check that VACUUM compaction uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires compaction.
+1:SET gp_appendonly_compaction_threshold = 10;
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE compact (a int);
+1:INSERT INTO compact SELECT generate_series(1, 100);
+1:DELETE FROM compact WHERE a > 1;
+1:ANALYZE compact;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM compact;
+-- Commit new data and move eof.
+1:INSERT INTO compact SELECT generate_series(1, 100);
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+0U<:
+-- Validate that a new segment file has a correct amount of rows.
+1:SELECT count(*) FROM compact;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE compact;
+1:RESET gp_appendonly_compaction_threshold;
+1:RESET gp_default_storage_options;
+
+
+--
+-- Check that COPY uses the latest committed segment eof.
+--
+-- Isolation framework doesn't allow us to emulate concurrent utility
+-- mode sessions. So we use 'reserved_segno' fault to make COPY on QD
+-- use the same 0 segment as utility mode does.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('reserved_segno', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Emulate concurrent segment file modification with COPY command.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+0U&:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+1:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5"';
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+0U<:
+-- Validate that segment file has a correct amount of rows.
+1:SELECT count(*) FROM insert_eof;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+1:DROP TABLE insert_eof;
+1:RESET gp_default_storage_options;

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -22,6 +22,48 @@ FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
 -- end_ignore
 -- Create segment file that requires eof truncate.
 1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED BY (a);
+1:BEGIN;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+1:ROLLBACK;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+2&:VACUUM truncate_eof;
+-- Commit new data in two parallel sessions and move eof.
+-- start_ignore
+1&:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- end_ignore
+3:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- Resume VACUUM.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1<:
+-- end_ignore
+2<:
+-- Validate that segment file is not corrupted.
+3:SELECT count(*) FROM truncate_eof;
+-- Cleanup.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+3:DROP TABLE truncate_eof;
+3:RESET gp_default_storage_options;
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+-- Test with VACUUM in utility mode.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
 1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
 1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
 1:BEGIN;

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -177,3 +177,35 @@ FROM gp_segment_configuration WHERE role = 'p';
 -- end_ignore
 1:DROP TABLE insert_eof;
 1:RESET gp_default_storage_options;
+
+--
+-- Check that we don't have anomalies on concurrent segment file
+-- modifications during prepared phase.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Emulate concurrent segment file modification.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1&:INSERT INTO insert_eof SELECT generate_series(1, 10);
+-- Validate that segment file has a correct amount of rows.
+2:SELECT count(*) FROM insert_eof;
+-- start_ignore
+2:SELECT gp_inject_fault('after_commit_prepared', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1<:
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE insert_eof;
+1:RESET gp_default_storage_options;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -129,6 +129,7 @@ test: uao/select_while_vacuum_serializable2_row
 test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
+test: uao/snapshot_eof_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -179,6 +180,7 @@ test: uao/select_while_vacuum_serializable2_column
 test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
+test: uao/snapshot_eof_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -1,0 +1,273 @@
+-- @Description Tests segment file logical EOF.
+--
+
+-- start_matchsubs
+--
+-- # create a match/subs expression
+--
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- end_matchsubs
+1:CREATE extension if NOT EXISTS gp_inject_fault;
+CREATE
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
+CREATE
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+1:BEGIN;
+BEGIN
+1:INSERT INTO truncate_eof SELECT generate_series(1, 30);
+INSERT 30
+1:ROLLBACK;
+ROLLBACK
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM truncate_eof;  <waiting ...>
+-- Commit new data and move eof.
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+0U<:  <... completed>
+VACUUM
+-- Validate that segment file is not corrupted.
+1:SELECT count(*) FROM truncate_eof;
+ count 
+-------
+ 20    
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1:DROP TABLE truncate_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET
+
+--
+-- Check that VACUUM compaction uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires compaction.
+1:SET gp_appendonly_compaction_threshold = 10;
+SET
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE compact (a int);
+CREATE
+1:INSERT INTO compact SELECT generate_series(1, 100);
+INSERT 100
+1:DELETE FROM compact WHERE a > 1;
+DELETE 99
+1:ANALYZE compact;
+ANALYZE
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM compact;  <waiting ...>
+-- Commit new data and move eof.
+1:INSERT INTO compact SELECT generate_series(1, 100);
+INSERT 100
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+0U<:  <... completed>
+VACUUM
+-- Validate that a new segment file has a correct amount of rows.
+1:SELECT count(*) FROM compact;
+ count 
+-------
+ 101   
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1:DROP TABLE compact;
+DROP
+1:RESET gp_appendonly_compaction_threshold;
+RESET
+1:RESET gp_default_storage_options;
+RESET
+
+
+--
+-- Check that COPY uses the latest committed segment eof.
+--
+-- Isolation framework doesn't allow us to emulate concurrent utility
+-- mode sessions. So we use 'reserved_segno' fault to make COPY on QD
+-- use the same 0 segment as utility mode does.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('reserved_segno', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Emulate concurrent segment file modification with COPY command.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+CREATE
+0U&:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';  <waiting ...>
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+1:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5"';
+COPY 5
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+0U<:  <... completed>
+COPY 10
+-- Validate that segment file has a correct amount of rows.
+1:SELECT count(*) FROM insert_eof;
+ count 
+-------
+ 15    
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+1:DROP TABLE insert_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -34,6 +34,82 @@ CREATE
 -- Create segment file that requires eof truncate.
 1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
 SET
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED BY (a);
+CREATE
+1:BEGIN;
+BEGIN
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+1:ROLLBACK;
+ROLLBACK
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+2&:VACUUM truncate_eof;  <waiting ...>
+-- Commit new data in two parallel sessions and move eof.
+-- start_ignore
+1&:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';  <waiting ...>
+-- end_ignore
+3:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+COPY 10
+-- Resume VACUUM.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+COPY 10
+-- end_ignore
+2<:  <... completed>
+VACUUM
+-- Validate that segment file is not corrupted.
+3:SELECT count(*) FROM truncate_eof;
+ count 
+-------
+ 20    
+(1 row)
+-- Cleanup.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+3:DROP TABLE truncate_eof;
+DROP
+3:RESET gp_default_storage_options;
+RESET
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+-- Test with VACUUM in utility mode.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
 1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
 CREATE
 1:INSERT INTO truncate_eof SELECT generate_series(1, 10);

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -347,3 +347,64 @@ COPY 10
 DROP
 1:RESET gp_default_storage_options;
 RESET
+
+--
+-- Check that we don't have anomalies on concurrent segment file
+-- modifications during prepared phase.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Emulate concurrent segment file modification.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+CREATE
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1&:INSERT INTO insert_eof SELECT generate_series(1, 10);  <waiting ...>
+-- Validate that segment file has a correct amount of rows.
+2:SELECT count(*) FROM insert_eof;
+ count 
+-------
+ 0     
+(1 row)
+-- start_ignore
+2:SELECT gp_inject_fault('after_commit_prepared', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1<:  <... completed>
+INSERT 10
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:               
+(3 rows)
+-- end_ignore
+1:DROP TABLE insert_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET


### PR DESCRIPTION
In 5X a snapshot satisfies "now" was used when transaction extracted AO/AOCO segment file eof. In other words "now" allowed us to see all committed transactions. When this code was ported to 6X a catalog snapshot was chosen for this purpose. As a result we don't see committed transactions that started after the snapshot has been taken. As a result a transaction can change segment file eof between the moment a snapshot was taken and an exclusive file segment lock was hold. So AO/AOCO in 6X suffers from data corruption in concurrent DML queries.

This PR consists of two commits. The first one demonstrates the problem (all added tests should fail). The second one fixes the problem using snapshot self instead of catalog snapshot - it allows us to see all committed data as "now" in 5X did.

5X and 7X (thanks to a [big refactoring](https://github.com/greenplum-db/gpdb/commit/5778f31124d5737e18d76f8d06f07f96c31c8be7)) do not face this problem.
