### PR TITLE
Send rows in binary mode for ANALYZE

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2841,7 +2841,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * Execute it.
 	 */
 	elog(elevel, "Executing SQL: %s", str.data);
-	CdbDispatchCommand(str.data, DF_WITH_SNAPSHOT, &cdb_pgresults);
+	CdbDispatchCommand(str.data, DF_WITH_SNAPSHOT | DF_IS_ANALYZE, &cdb_pgresults);
 
 	/*
 	 * Build a modified tuple descriptor for the table.

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2526,19 +2526,9 @@ parse_binary_record_to_values(char *string, TupleDesc tupdesc, char** values, bo
 		typeoid = htonl(*(int*)(currentBytePtr));
 		currentBytePtr += sizeof(int);
 
-/*
-		ereport(NOTICE,
-			(errmsg("typeoid: %u\n",
-					typeoid)));
-*/
 		int length = htonl(*(int*)(currentBytePtr));
 		currentBytePtr += sizeof(int);
 
-/*
-		ereport(NOTICE,
-			(errmsg("length: %u\n",
-					length)));
-*/
 #ifdef MY_DEBUG
 		ereport(NOTICE,
 			(errmsg("currentColumn: %u;	typeoid: %u; length: %u\n",

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2495,6 +2495,265 @@ parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nul
 }
 
 /*
+ * parse_binary_record_to_values
+ *
+ * CDB: a copy of record_in, but only parse the record binary
+ * into separate binary values for each column.
+ */
+static void
+parse_binary_record_to_values(char *string, TupleDesc tupdesc, char** values, bool *nulls)
+{
+
+	char *currentBytePtr = string;
+	int	ncolumns;
+	int currentColumn = 0;
+	
+	ncolumns = tupdesc->natts;
+
+	int numberOfAttributes = htonl(*(int*)currentBytePtr);
+	currentBytePtr += sizeof(int);
+
+#ifdef MY_DEBUG
+	ereport(NOTICE,
+		(errmsg("Number of attributes: %d and ncolumns: %d\n",
+				numberOfAttributes, ncolumns)));
+#endif
+
+	for (currentColumn = 0; currentColumn < ncolumns; currentColumn++)
+	{
+		Oid			typeoid;
+
+		typeoid = htonl(*(int*)(currentBytePtr));
+		currentBytePtr += sizeof(int);
+
+/*
+		ereport(NOTICE,
+			(errmsg("typeoid: %u\n",
+					typeoid)));
+*/
+		int length = htonl(*(int*)(currentBytePtr));
+		currentBytePtr += sizeof(int);
+
+/*
+		ereport(NOTICE,
+			(errmsg("length: %u\n",
+					length)));
+*/
+#ifdef MY_DEBUG
+		ereport(NOTICE,
+			(errmsg("currentColumn: %u;	typeoid: %u; length: %u\n",
+					currentColumn, typeoid, length)));
+#endif
+		if (length == 0xffffffff)
+		{
+			/* it means null value */
+#ifdef MY_DEBUG
+			ereport(NOTICE,
+			(errmsg("length is max - it means no value\n")));
+#endif
+			values[currentColumn] = NULL;
+			nulls[currentColumn] = true;
+		}
+		else
+		{
+			/* extract data for this column */
+			values[currentColumn] = palloc(length);
+
+			switch (typeoid)
+			{
+				case FLOAT8OID:
+					{
+						char *cPtrValue = values[currentColumn];
+						for (int i = sizeof(float8); i > 0; i--)
+						{
+							*cPtrValue = *(currentBytePtr + i - 1);
+							cPtrValue++;
+						}						
+					}
+					break;
+				default:
+					memcpy(values[currentColumn], currentBytePtr, length);			
+			}
+
+			nulls[currentColumn] = false;
+#ifdef MY_DEBUG
+
+			{
+				char *buf = palloc(length*3 + 1);
+				char *bufPtr = buf;
+				char *cptrValue = currentBytePtr;
+				for (int j = 0; j <  length; j++)
+				{
+					bufPtr += sprintf(bufPtr, "%02hhx ", *cptrValue++);
+				}
+
+				ereport(NOTICE,
+					(errmsg("%s\n",
+							buf)));
+			}
+
+			{
+				char *buf = palloc(length*3 + 1);
+				char *bufPtr = buf;
+				char *cptrValue = values[currentColumn];
+				for (int j = 0; j <  length; j++)
+				{
+					bufPtr += sprintf(bufPtr, "%02hhx ", *cptrValue++);
+				}
+
+				ereport(NOTICE,
+					(errmsg("%s\n",
+							buf)));
+			}
+#endif			
+			currentBytePtr += length;
+		}
+	}
+
+	return;
+#if 0
+	char	*ptr;
+	int	ncolumns;
+	int	i;
+	bool	needComma;
+	StringInfoData	buf;
+
+	Assert(string != NULL);
+	Assert(values != NULL);
+	Assert(nulls != NULL);
+	
+	ncolumns = tupdesc->natts;
+	needComma = false;
+
+	/*
+	 * Scan the string.  We use "buf" to accumulate the de-quoted data for
+	 * each column, which is then fed to the appropriate input converter.
+	 */
+	ptr = string;
+
+	/* Allow leading whitespace */
+	while (*ptr && isspace((unsigned char) *ptr))
+		ptr++;
+	if (*ptr++ != '(')
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Missing left parenthesis.")));
+	}
+
+	initStringInfo(&buf);
+
+	for (i = 0; i < ncolumns; i++)
+	{
+		/* Ignore dropped columns in datatype, but fill with nulls */
+		if (tupdesc->attrs[i]->attisdropped)
+		{
+			values[i] = NULL;
+			nulls[i] = true;
+			continue;
+		}
+
+		if (needComma)
+		{
+			/* Skip comma that separates prior field from this one */
+			if (*ptr == ',')
+				ptr++;
+			else
+			{
+				/* *ptr must be ')' */
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+						 errmsg("malformed record literal: \"%s\"", string),
+						 errdetail("Too few columns.")));
+			}
+		}
+
+		/* Check for null: completely empty input means null */
+		if (*ptr == ',' || *ptr == ')')
+		{
+			values[i] = NULL;
+			nulls[i] = true;
+		}
+		else
+		{
+			/* Extract string for this column */
+			bool		inquote = false;
+
+			resetStringInfo(&buf);
+			while (inquote || !(*ptr == ',' || *ptr == ')'))
+			{
+				char		ch = *ptr++;
+
+				if (ch == '\0')
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+							 errmsg("malformed record literal: \"%s\"",
+									string),
+							 errdetail("Unexpected end of input.")));
+				}
+				if (ch == '\\')
+				{
+					if (*ptr == '\0')
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+								 errmsg("malformed record literal: \"%s\"",
+										string),
+								 errdetail("Unexpected end of input.")));
+					}
+					appendStringInfoChar(&buf, *ptr++);
+				}
+				else if (ch == '"')
+				{
+					if (!inquote)
+						inquote = true;
+					else if (*ptr == '"')
+					{
+						/* doubled quote within quote sequence */
+						appendStringInfoChar(&buf, *ptr++);
+					}
+					else
+						inquote = false;
+				}
+				else
+					appendStringInfoChar(&buf, ch);
+			}
+
+			values[i] = palloc(strlen(buf.data) + 1);
+			memcpy(values[i], buf.data, strlen(buf.data) + 1);
+			nulls[i] = false;
+		}
+
+		/*
+		 * Prep for next column
+		 */
+		needComma = true;
+	}
+
+	if (*ptr++ != ')')
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Too many columns.")));
+	}
+	/* Allow trailing whitespace */
+	while (*ptr && isspace((unsigned char) *ptr))
+		ptr++;
+	if (*ptr)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("malformed record literal: \"%s\"", string),
+				 errdetail("Junk after right parenthesis.")));
+	}
+
+#endif
+}
+
+/*
  * Collect a sample from segments.
  *
  * Calls the gp_acquire_sample_rows() helper function on each segment,
@@ -2672,18 +2931,103 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 			if (rowStr == NULL)
 				elog(ERROR, "got NULL pointer from return value of gp_acquire_sample_rows");
 
-			parse_record_to_string(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
+			{
+#ifdef MY_DEBUG
+
+				int datalength = PQgetlength(pgresult, rowno, 0);
+				char *buf = palloc(datalength*3 + 1);
+				char *bufPtr = buf;
+
+
+				ereport(NOTICE,
+					(errmsg("resultno %d tuple %d length: %d\n",
+							resultno, rowno, datalength)));
+
+#endif
+#if 0
+				char *currentBytePtr = rowStr;
+				int numberOfAttributes = htonl(*(int*)currentBytePtr);
+				currentBytePtr += sizeof(int);
+
+
+				//memcpy(&numberOfAttributes, rowStr, sizeof(int));
+
+				ereport(NOTICE,
+					(errmsg("Number of attributes: %d\n",
+							numberOfAttributes)));
+
+				Oid			typoid;
+
+				char *typeidPtr = rowStr+4;
+				typoid = htonl(*(int*)(currentBytePtr));
+				currentBytePtr += sizeof(int);
+
+				ereport(NOTICE,
+					(errmsg("typoid: %u\n",
+							typoid)));
+
+				int length = htonl(*(int*)(currentBytePtr));
+				currentBytePtr += sizeof(int);
+
+				ereport(NOTICE,
+					(errmsg("length: %u\n",
+							length)));
+
+#endif								
+#ifdef MY_DEBUG
+				
+				char *cptrValue = rowStr;
+				for (int j = 0; j <  datalength; j++)
+				{
+					bufPtr += sprintf(bufPtr, "%02hhx ", *cptrValue++);
+				}
+
+				ereport(NOTICE,
+					(errmsg("Tuple %d: %s\n",
+							rowno, buf)));
+				pfree(buf);
+#endif
+			}	
+
+			{
+				Datum	   *relvalues = (Datum *) palloc(ncolumns * sizeof(Datum));
+				bool	   *relnulls = (bool *) palloc(ncolumns * sizeof(bool));
+				
+
+				//heap_deform_tuple(rowStr, funcTupleDesc, relvalues, relnulls);
+
+				//ereport(NOTICE,
+				//	(errmsg("sheap_deform_tuple done\n")));
+			}
+
+			parse_binary_record_to_values(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
+
+			//continue;
+
+			//parse_record_to_string(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
 
 			if (!funcRetNulls[0])
 			{
 				/* This is a summary row. */
 				if (got_summary)
 					elog(ERROR, "got duplicate summary row from gp_acquire_sample_rows");
+				
+				//memcpy(&this_totalrows, funcRetValues[0], sizeof(double));
 
+				this_totalrows = *(double*)funcRetValues[0];
+				this_totaldeadrows = *(double*)funcRetValues[1];
+
+#ifdef MY_DEBUG
+				ereport(NOTICE,
+					(errmsg("Got this_totalrows %f; this_totaldeadrows %f\n",
+							this_totalrows, this_totaldeadrows)));
+#endif
+/*
 				this_totalrows = DatumGetFloat8(DirectFunctionCall1(float8in,
 																	CStringGetDatum(funcRetValues[0])));
 				this_totaldeadrows = DatumGetFloat8(DirectFunctionCall1(float8in,
 																		CStringGetDatum(funcRetValues[1])));
+*/
 				got_summary = true;
 			}
 			else
@@ -2714,6 +3058,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					}
 				}
 
+#if 0
 				/* Process the columns */
 				index = 0;
 				for (i = 0; i < relDesc->natts; i++)
@@ -2731,6 +3076,8 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 				}
 
 				rows[sampleTuples] = BuildTupleFromCStrings(attinmeta, values);
+#endif
+				rows[sampleTuples] = BuildTupleFromValues(attinmeta, funcRetValues + 3);
 				sampleTuples++;
 
 				/*
@@ -2739,6 +3086,8 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 				 */
 			}
 		}
+
+		//continue;
 
 		if (!got_summary)
 			elog(ERROR, "did not get summary row from gp_acquire_sample_rows");
@@ -2757,6 +3106,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 		(*totalrows) += this_totalrows;
 		(*totaldeadrows) += this_totaldeadrows;
 	}
+
 	for (i = 0; i < funcTupleDesc->natts; i++)
 	{
 		if (funcRetValues[i])

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1382,6 +1382,73 @@ BuildTupleFromCStrings(AttInMetadata *attinmeta, char **values)
 }
 
 /*
+ * BuildTupleFromValues - build a HeapTuple given user data in binary form.
+ * values is an array binary data, one for each attribute of the return tuple.
+ * A NULL string pointer indicates we want to create a NULL field.
+ */
+HeapTuple
+BuildTupleFromValues(AttInMetadata *attinmeta, char **values)
+{
+	TupleDesc	tupdesc = attinmeta->tupdesc;
+	int			natts = tupdesc->natts;
+	Datum	   *dvalues;
+	bool	   *nulls;
+	int			i;
+	HeapTuple	tuple;
+
+	dvalues = (Datum *) palloc(natts * sizeof(Datum));
+	nulls = (bool *) palloc(natts * sizeof(bool));
+
+	/* Call the "in" function for each non-dropped attribute */
+	for (i = 0; i < natts; i++)
+	{
+		if (!tupdesc->attrs[i]->attisdropped)
+		{
+			/* Non-dropped attributes */
+			switch(tupdesc->attrs[i]->atttypid)
+			{
+				case FLOAT8OID:
+					dvalues[i] = Float8GetDatum(*(float8*)values[i]);
+					break;
+				default:
+						elog(ERROR, "Unsupported atttypid %u for attribute %d", tupdesc->attrs[i]->atttypid, i);
+
+			}
+#if 0
+			dvalues[i] = InputFunctionCall(&attinmeta->attinfuncs[i],
+										   values[i],
+										   attinmeta->attioparams[i],
+										   attinmeta->atttypmods[i]);
+#endif
+			if (values[i] != NULL)
+				nulls[i] = false;
+			else
+				nulls[i] = true;
+		}
+		else
+		{
+			/* Handle dropped attributes by setting to NULL */
+			dvalues[i] = (Datum) 0;
+			nulls[i] = true;
+		}
+	}
+
+	/*
+	 * Form a tuple
+	 */
+	tuple = heap_form_tuple(tupdesc, dvalues, nulls);
+
+	/*
+	 * Release locally palloc'd space.  XXX would probably be good to pfree
+	 * values of pass-by-reference datums, as well.
+	 */
+	pfree(dvalues);
+	pfree(nulls);
+
+	return tuple;
+}
+
+/*
  * HeapTupleHeaderGetDatum - convert a HeapTupleHeader pointer to a Datum.
  *
  * This must *not* get applied to an on-disk tuple; the tuple should be

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1419,10 +1419,7 @@ BuildTupleFromValues(AttInMetadata *attinmeta, char **values)
 					break;
 				case TEXTOID:
 					{
-						text *rawstr_text;
-
-						rawstr_text = cstring_to_text(values[i]);
-						dvalues[i] = PointerGetDatum(rawstr_text);
+						dvalues[i] = CStringGetTextDatum(values[i]);
 					}
 					break;
 				default:

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -33,6 +33,10 @@
  * indicate whether the command should be dispatched to qExecs along with a snapshot.
  */
 #define DF_WITH_SNAPSHOT  0x4
+/*
+ * indicate whether the command dispatched to qExecs is ANALYZE.
+ */
+#define DF_IS_ANALYZE  0x8
 
 struct QueryDesc;
 struct CdbDispatcherState;

--- a/src/include/funcapi.h
+++ b/src/include/funcapi.h
@@ -232,6 +232,7 @@ extern TupleDesc TypeGetTupleDesc(Oid typeoid, List *colaliases);
 extern TupleDesc BlessTupleDesc(TupleDesc tupdesc);
 extern AttInMetadata *TupleDescGetAttInMetadata(TupleDesc tupdesc);
 extern HeapTuple BuildTupleFromCStrings(AttInMetadata *attinmeta, char **values);
+extern HeapTuple BuildTupleFromValues(AttInMetadata *attinmeta, char **values);
 extern Datum HeapTupleHeaderGetDatum(HeapTupleHeader tuple);
 extern TupleTableSlot *TupleDescGetSlot(TupleDesc tupdesc);
 


### PR DESCRIPTION
Send results of 'select pg_catalog.gp_acquire_sample_rows' query in
binary mode.
That allows to avoid overflow for max double.

For text mode (default) when analyze for table is performed the master
segment calls gp_acquire_sample_rows() helper function on each
segment. That eventually calls float8out function on segment to
converts float8 number to a string with snprintf:

int	ndig = DBL_DIG + extra_float_digits;

snprintf(ascii, MAXDOUBLEWIDTH + 1, "%.*g", ndig, num);

When ndig is 15 the maximum float8 value 1.7976931348623157e+308 is
rounded to "1.79769313486232e+308" that has no representation.

And on master acquire_sample_rows_dispatcher function
process gp_acquire_sample_rows result and eventually float8in
function is called to convert string to float8 with strtold:
val = strtold(num, &endptr);

This is where overflow for "1.79769313486232e+308" happens but works
fine for "1.7976931348623157e+308".

Transferring in binary mode allows to avoid conversion from double to
string on segments and then back to double on master.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
