### PR TITLE
Check if any of join path contains other path's relids before applying motion.

### DIFF
--- a/src/test/regress/expected/rpt_joins.out
+++ b/src/test/regress/expected/rpt_joins.out
@@ -2153,10 +2153,49 @@ select max(c1) from pg_class left join t_5628 on true;
    2
 (1 row)
 
+--
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+--
+create table test_tz(tz interval) distributed replicated;
+insert into test_tz
+select i * '1 hour'::interval
+from generate_series(0,23) i;
+create index test_tz_idx on test_tz(tz);
+set optimizer=off;
+set enable_hashjoin=off;
+set enable_seqscan=off;
+EXPLAIN (costs off)
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Nested Loop
+   Join Filter: (tst.tz = pg_timezone_names.utc_offset)
+   ->  Function Scan on pg_timezone_names
+         Filter: (name = 'UTC'::text)
+   ->  Materialize
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Index Only Scan using test_tz_idx on test_tz tst
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+ name | tz  
+------+-----
+ UTC  | @ 0
+(1 row)
+
+reset optimizer;
+reset enable_hashjoin;
+reset enable_seqscan;
 drop schema rpt_joins cascade;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table j1_tbl
 drop cascades to table j2_tbl
 drop cascades to table rpt_joins.t1
 drop cascades to table rpt_joins.t2
 drop cascades to table rpt_joins.t3
+drop cascades to table test_tz

--- a/src/test/regress/sql/rpt_joins.sql
+++ b/src/test/regress/sql/rpt_joins.sql
@@ -450,4 +450,30 @@ insert into t_5628 values (1,1), (2,2);
 explain (costs off) select max(c1) from pg_class left join t_5628 on true;
 select max(c1) from pg_class left join t_5628 on true;
 
+--
+-- regression test for nest loop join of indexed rpt and entry, segment should not fall with segfault
+--
+create table test_tz(tz interval) distributed replicated;
+insert into test_tz
+select i * '1 hour'::interval
+from generate_series(0,23) i;
+create index test_tz_idx on test_tz(tz);
+
+set optimizer=off;
+set enable_hashjoin=off;
+set enable_seqscan=off;
+
+EXPLAIN (costs off)
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+
+SELECT tzn.name, tst.tz
+FROM test_tz tst
+JOIN pg_timezone_names tzn ON tzn.name = 'UTC' AND tst.tz = tzn.utc_offset;
+
+reset optimizer;
+reset enable_hashjoin;
+reset enable_seqscan;
+
 drop schema rpt_joins cascade;


### PR DESCRIPTION
Join clauses should not use any of relids, that are not available on current slice. Using of unavailable relation on index scan leads to segfault.
To check this we've implemented additional walker function, which recursively compares one path's relids with other path's relids.
Additional regression test included. Related to issue [#12228](https://github.com/greenplum-db/gpdb/issues/12228).

_Why fix it here?_
`cdbpath_motion_for_join` function doesn't necessarily create motion node. It's OK if it returns untouched plan - we shouldn't do anything with plan in this case, because it's valid. We can't prohibit just all joins or just all nodes containing quals doing it on somewhere higher levels. Another point: Am I right such bug can affect any type of join(nested, merge, hash) or last two join types not affected by design somehow?

_Should we scan another nodes for relids?_
Don't know. We've found a bug on index nodes only.

P.S. Don't know why, but I feel this fix _ugly_. Is there any better way to apply the same filtering logic?
