### PR TITLE
Send rows in binary mode for ANALYZE

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2557,11 +2557,6 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	*totalrows = 0;
 	*totaldeadrows = 0;
 
-	if (!portal->holdStore)
-	{
-		elog(ERROR, "No tuples received.");
-	}
-
 	slot = MakeSingleTupleTableSlot(queryDesc->tupDesc);
 	while (tuplestore_gettupleslot(portal->holdStore, true, false, slot))
 	{

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2469,6 +2469,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 */
 
 	/* There is only one element in list due to simple select. */
+	Assert(linitial(raw_parsetree_list) == llast(raw_parsetree_list));
 	parsetree = (Node *) linitial(raw_parsetree_list);
 
 	querytree_list = pg_analyze_and_rewrite(parsetree,
@@ -2478,6 +2479,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	plantree_list = pg_plan_queries(querytree_list, 0, NULL);
 
 	/* There is only one statement in list due to simple select. */
+	Assert(linitial(plantree_list) == llast(plantree_list));
 	plan_stmt = (PlannedStmt *) linitial(plantree_list);
 
 	queryDesc = CreateQueryDesc(plan_stmt,

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2560,7 +2560,6 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	slot = MakeSingleTupleTableSlot(queryDesc->tupDesc);
 	for (;;)
 	{
-		MemoryContext oldcontext;
 		bool		ok;
 		TupleDesc	typeinfo;
 		int			natts;
@@ -2569,11 +2568,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 		double		this_totalrows = 0;
 		double		this_totaldeadrows = 0;
 
-		oldcontext = MemoryContextSwitchTo(portal->holdContext);
-
 		ok = tuplestore_gettupleslot(portal->holdStore, true, false, slot);
-
-		MemoryContextSwitchTo(oldcontext);
 
 		if (!ok)
 			break;

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -923,6 +923,14 @@ create table test_tr (totalrows int4);
 analyze test_tr;
 drop table test_tr;
 --
+-- Test analyze for table with maximum float8 value 1.7976931348623157e+308
+-- There should be no "ERROR:  value out of range: overflow"
+--
+create table test_max_float8(a double precision);
+insert into test_max_float8 values(1.7976931348623157e+308);
+analyze test_max_float8;
+drop table test_max_float8;
+--
 -- Test with both a dropped column and an oversized column
 -- (github issue https://github.com/greenplum-db/gpdb/issues/9503)
 --

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -926,10 +926,12 @@ drop table test_tr;
 -- Test analyze for table with maximum float8 value 1.7976931348623157e+308
 -- There should be no "ERROR:  value out of range: overflow"
 --
+set extra_float_digits to 0;
 create table test_max_float8(a double precision);
 insert into test_max_float8 values(1.7976931348623157e+308);
 analyze test_max_float8;
 drop table test_max_float8;
+reset extra_float_digits;
 --
 -- Test with both a dropped column and an oversized column
 -- (github issue https://github.com/greenplum-db/gpdb/issues/9503)

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -19,6 +19,7 @@ insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -324,7 +325,9 @@ insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
@@ -373,6 +376,7 @@ insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
@@ -461,6 +465,12 @@ insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -506,6 +516,7 @@ insert into dd_multicol_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_multicol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 select count(*) from dd_multicol_idx;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  count 
@@ -654,7 +665,19 @@ insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_part_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -29,6 +29,7 @@ insert into dd_multicol_1 values(null, 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_multicol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
@@ -31,6 +31,7 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 analyze dd_multicol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -18,6 +18,7 @@ insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -318,7 +319,9 @@ insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -366,6 +369,7 @@ insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -453,6 +457,12 @@ insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -498,6 +508,7 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 analyze dd_multicol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 select count(*) from dd_multicol_idx;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  count 
@@ -643,7 +654,19 @@ insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_part_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -872,6 +872,7 @@ savepoint sp1;
 insert into distxact1_4 values (2),(1);
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 release sp1;
 end;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/gp_copy_dtx.out
+++ b/src/test/regress/expected/gp_copy_dtx.out
@@ -4,6 +4,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SET Test_print_direct_dispatch_info = ON;
 COPY test_copy_from_dtx (c1, c2) FROM stdin;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 SELECT * FROM test_copy_from_dtx;

--- a/src/test/regress/expected/qp_targeted_dispatch.out
+++ b/src/test/regress/expected/qp_targeted_dispatch.out
@@ -674,6 +674,7 @@ Create table zoompp7620 as select * from mpp7620 where key=200;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'key' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into mpp7620 values (200, 200);

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -664,6 +664,7 @@ Create table zoompp7620 as select * from mpp7620 where key=200;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 insert into mpp7620 values (200, 200);

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -456,6 +456,15 @@ analyze test_tr;
 drop table test_tr;
 
 --
+-- Test analyze for table with maximum float8 value 1.7976931348623157e+308
+-- There should be no "ERROR:  value out of range: overflow"
+--
+create table test_max_float8(a double precision);
+insert into test_max_float8 values(1.7976931348623157e+308);
+analyze test_max_float8;
+drop table test_max_float8;
+
+--
 -- Test with both a dropped column and an oversized column
 -- (github issue https://github.com/greenplum-db/gpdb/issues/9503)
 --

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -459,10 +459,12 @@ drop table test_tr;
 -- Test analyze for table with maximum float8 value 1.7976931348623157e+308
 -- There should be no "ERROR:  value out of range: overflow"
 --
+set extra_float_digits to 0;
 create table test_max_float8(a double precision);
 insert into test_max_float8 values(1.7976931348623157e+308);
 analyze test_max_float8;
 drop table test_max_float8;
+reset extra_float_digits;
 
 --
 -- Test with both a dropped column and an oversized column


### PR DESCRIPTION
Send results of 'select pg_catalog.gp_acquire_sample_rows' query in
binary mode.
That allows to avoid overflow for max double.

For text mode (default) when analyze for table is performed the master
segment calls `gp_acquire_sample_rows()` helper function on each
segment. That eventually calls `float8out` function on segment to
converts float8 number to a string with `snprintf`:

`int	ndig = DBL_DIG + extra_float_digits;
`
`snprintf(ascii, MAXDOUBLEWIDTH + 1, "%.*g", ndig, num);
`

When `ndig` is 15 the maximum float8 value 1.7976931348623157e+308 is
rounded to "1.79769313486232e+308" that has no representation.

And on master acquire_sample_rows_dispatcher function
process gp_acquire_sample_rows result and eventually float8in
function is called to convert string to float8 with strtold:
`val = strtold(num, &endptr);
`

This is where overflow for "1.79769313486232e+308" happens but works
fine for "1.7976931348623157e+308".

Transferring in binary mode allows to avoid conversion from double to
string on segments and then back to double on master.

Using `CdbDispatchPlan` instead of `CdbDispatchCommand` allows
to receive data in binary mode in `MemTuple`.

As `acquire_sample_rows_dispatcher` executes
`select pg_catalog.gp_acquire_sample_rows` with `CdbDispatchPlan`
when **Test_print_direct_dispatch_info** is enabled `cdbdisp_dispatchX`
prints `INFO` message ` "(slice %d) Dispatch command to %s"`.
This has to be added to expected tests output.

> (gdb) list
> 1143						primaryGang->type == GANGTYPE_PRIMARY_READER ||
> 1144						primaryGang->type == GANGTYPE_SINGLETON_READER ||
> 1145						primaryGang->type == GANGTYPE_ENTRYDB_READER);
> 1146
> 1147			if (Test_print_direct_dispatch_info)
> 1148				elog(INFO, "(slice %d) Dispatch command to %s", slice->sliceIndex,
> 1149					 		segmentsToContentStr(slice->directDispatch.isDirectDispatch ?
> 1150												slice->directDispatch.contentIds : slice->segments));
> 1151
> 1152			/*
> (gdb) bt 5
> #0  cdbdisp_dispatchX (queryDesc=0x5601ebd98dc0, planRequiresTxn=1 '\001', cancelOnError=1 '\001') at cdbdisp_query.c:1148
> #1  0x00005601e9c6368e in CdbDispatchPlan (queryDesc=0x5601ebd98dc0, planRequiresTxn=1 '\001', cancelOnError=1 '\001') at cdbdisp_query.c:234
> #2  0x00005601e97a7740 in standard_ExecutorStart (queryDesc=0x5601ebd98dc0, eflags=16) at execMain.c:721
> #3  0x00005601e97a6686 in ExecutorStart (queryDesc=0x5601ebd98dc0, eflags=0) at execMain.c:262
> #4  0x00005601e96d14d0 in acquire_sample_rows_dispatcher (onerel=0x7fe0829d6388, inh=0 '\000', elevel=13, rows=0x7fe082975058, targrows=30000, totalrows=0x7ffdbc341458,
>     totaldeadrows=0x7ffdbc341460) at analyze.c:2492
> (More stack frames follow...)
> (gdb)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
