### PR TITLE
Avoid usage of pivotaldata docker images in own pipelines

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -6,7 +6,7 @@ RUN yum makecache && \
     yum -y install epel-release java-1.8.0-openjdk-devel && \
     yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
                    ant-junit autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
-                   krb5-server krb5-workstation && \
+                   krb5-server krb5-workstation xerces-c-devel && \
     yum clean all
 
 # install all software we need

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -6,7 +6,7 @@ RUN yum makecache && \
     yum -y install epel-release java-1.8.0-openjdk-devel && \
     yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
                    ant-junit autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
-                   krb5-server && \
+                   krb5-server krb5-workstation && \
     yum clean all
 
 # install all software we need

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -4,8 +4,9 @@ FROM centos:centos7 as base
 RUN yum makecache && \
     rpm --import http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7 && \
     yum -y install epel-release java-1.8.0-openjdk-devel && \
-    yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip && \
-    yum -y install ant-junit autoconf bison cmake3 flex gperf indent jq libtool && \
+    yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
+                   ant-junit autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
+                   krb5-server && \
     yum clean all
 
 # install all software we need

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,18 +1,50 @@
-FROM pivotaldata/centos-gpdb-dev:7-gcc6.2-llvm3.7 as base
+FROM centos:centos7 as base
 
-RUN rm -rf /opt/cmake* \
-    && yum remove -y cmake \
-    && yum install -y epel-release \
-    && yum install -y cmake3 \
-                    libzstd-devel \
-                    apr-util-devel \
-                    libuv-devel \
-                    perl-IPC-Run \
-                    perl-Test-Base \
-                    wget \
-    && yum clean all \
-    && ln -s /usr/bin/cmake3 /usr/bin/cmake \
-    && ln -s /usr/bin/ctest3 /usr/bin/ctest
+# Install some basic utilities and build tools
+RUN yum makecache && \
+    rpm --import http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7 && \
+    yum -y install epel-release java-1.8.0-openjdk-devel && \
+    yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip && \
+    yum -y install ant-junit autoconf bison cmake3 flex gperf indent jq libtool && \
+    yum clean all
+
+# install all software we need
+RUN yum makecache && \
+    yum -y install python2-pip && \
+    yum -y install python-devel python-psutil python-setuptools && \
+    yum -y install apr-devel apr-util-devel bzip2-devel expat-devel libcurl-devel && \
+    yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
+    yum -y install openssl-devel pam-devel readline-devel snappy-devel libuv-devel && \
+    yum -y install apache-ivy libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
+    yum -y install perl-IPC-Run perl-Test-Base && \
+    pip install psi && \
+    yum clean all
+
+# setup ssh configuration
+RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
+    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
+    chmod 0600 /root/.ssh/authorized_keys && \
+    echo -e "password\npassword" | passwd 2> /dev/null && \
+    { ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /root/.ssh/known_hosts && \
+    #
+    ssh-keygen -f /etc/ssh/ssh_host_key -N '' -t rsa1 && \
+    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \
+    ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa && \
+    sed -i -e 's|Defaults    requiretty|#Defaults    requiretty|' /etc/sudoers && \
+    sed -ri 's/UsePAM yes/UsePAM no/g;s/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
+    sed -ri 's@^HostKey /etc/ssh/ssh_host_ecdsa_key$@#&@;s@^HostKey /etc/ssh/ssh_host_ed25519_key$@#&@' /etc/ssh/sshd_config
+
+# newer version of gcc and run environment for gpdb
+RUN yum -y install centos-release-scl && \
+    yum -y install --nogpgcheck devtoolset-7-gcc devtoolset-7-gcc-c++ && yum clean all && \
+    pip --no-cache-dir install psi && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake && \
+    ln -s /usr/bin/ctest3 /usr/bin/ctest && \
+    echo -e 'source /opt/rh/devtoolset-7/enable' >> /opt/gcc_env.sh && \
+    echo -e 'source /opt/gcc_env.sh' >> /root/.bashrc && \
+    echo -e '#!/bin/sh' >> /etc/profile.d/jdk_home.sh && \
+    echo -e 'export JAVA_HOME=/etc/alternatives/java_sdk' >> /etc/profile.d/jdk_home.sh && \
+    echo -e 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
 
 WORKDIR /home/gpadmin
 

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -198,8 +198,6 @@ function _main() {
 
 	prep_env
 
-	build_xerces
-	#link_python
 	generate_build_number
 	build_gpdb "${BLD_TARGET_OPTION[@]}"
 	git_info
@@ -207,11 +205,6 @@ function _main() {
 	if [[ -z "${SKIP_UNITTESTS}" ]]; then
 		unittest_check_gpdb
 	fi
-
-	include_zstd
-	#include_quicklz
-	include_libuv
-	#include_libstdcxx
 
 	export_gpdb
 	export_gpdb_extensions

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -211,7 +211,7 @@ function _main() {
 	include_zstd
 	#include_quicklz
 	include_libuv
-	include_libstdcxx
+	#include_libstdcxx
 
 	export_gpdb
 	export_gpdb_extensions


### PR DESCRIPTION
Pivotal has migrated its test images to gcr.io and removed them from Docker HUB
So to avoid such situation replace the base image with centos:7
Dependencies fetched from src/tools/docker/centos7/Dockerfile
GCC 6 wanted by concourse scripts isn't available now
and we don't use them for release build and don't vendor in own
distribution. So I've commented it too.