### PR TITLE
Release 6.16.3 arenadata22

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -914,6 +914,45 @@ include_dir 'conf.d'
       </listitem>
      </varlistentry>
 
+     <varlistentry id="guc-client-connection-check-interval" xreflabel="client_connection_check_interval">
+      <term><varname>client_connection_check_interval</varname> (<type>integer</type>)
+      <indexterm>
+       <primary><varname>client_connection_check_interval</varname> configuration parameter</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+        Sets the time interval between optional checks that the client is still
+        connected, while running queries.  The check is performed by polling
+        the socket, and allows long running queries to be aborted sooner if
+        the kernel reports that the connection is closed.
+       </para>
+       <para>
+        This option is currently available only on systems that support the
+        non-standard <symbol>POLLRDHUP</symbol> extension to the
+        <symbol>poll</symbol> system call, including Linux, or are able to
+        detect client disconnection using POLLHUP option defined by POSIX,
+        including OSX.
+       </para>
+       <para>
+        If the value is specified without units, it is taken as milliseconds.
+        The default value is <literal>0</literal>, which disables connection
+        checks.  Without connection checks, the server will detect the loss of
+        the connection only at the next interaction with the socket, when it
+        waits for, receives or sends data.
+       </para>
+       <para>
+        For the kernel itself to detect lost TCP connections reliably and within
+        a known timeframe in all scenarios including network failure, it may
+        also be necessary to adjust the TCP keepalive settings of the operating
+        system, or the <xref linkend="guc-tcp-keepalives-idle"/>,
+        <xref linkend="guc-tcp-keepalives-interval"/> and
+        <xref linkend="guc-tcp-keepalives-count"/> settings of
+        <productname>PostgreSQL</productname>.
+       </para>
+      </listitem>
+     </varlistentry>
+
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-connection-security">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -34,6 +34,9 @@
               <xref href="#check_function_bodies"/>
             </li>
             <li>
+              <xref href="#client_connection_check_interval"/>
+            </li>
+            <li>
               <xref href="#client_encoding"/>
             </li>
             <li>
@@ -888,6 +891,34 @@
             <row>
               <entry colname="col1">Boolean</entry>
               <entry colname="col2">on</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="client_connection_check_interval">
+      <title>client_connection_check_interval</title>
+    <body>
+      <p>Sets the time interval between optional checks that the client is still
+        connected, while running queries. 0 disables connection checks. </p>
+      <table id="client_connection_check_interval_table">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">number of milliseconds</entry>
+              <entry colname="col2">0</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -76,6 +76,10 @@
           <strow>
             <stentry>
               <p>
+                <xref href="guc-list.xml#client_connection_check_interval" type="section"
+                  >client_connection_check_interval</xref>
+              </p>
+              <p>
                 <xref href="guc-list.xml#gp_connection_send_timeout" type="section"
                   >gp_connection_send_timeout</xref>
               </p>

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -182,7 +182,7 @@ AOCSTruncateToEOF(Relation aorel)
 				segno;
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_column_truncate_to_eof");
@@ -246,7 +246,6 @@ AOCSTruncateToEOF(Relation aorel)
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 static void
@@ -441,7 +440,7 @@ AOCSDrop(Relation aorel,
 	int			i,
 				segno;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(RelationIsAoCols(aorel));
@@ -491,7 +490,6 @@ AOCSDrop(Relation aorel,
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 
@@ -521,7 +519,7 @@ AOCSCompact(Relation aorel,
 				segno;
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_column_compact");
@@ -611,6 +609,4 @@ AOCSCompact(Relation aorel,
 		FreeAllAOCSSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }

--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -31,6 +31,7 @@
 #include "executor/executor.h"
 #include "nodes/execnodes.h"
 #include "storage/lmgr.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
@@ -182,6 +183,10 @@ AOCSTruncateToEOF(Relation aorel)
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_column_truncate_to_eof");
+#endif
 
 	Assert(RelationIsAoCols(aorel));
 
@@ -517,6 +522,10 @@ AOCSCompact(Relation aorel,
 	LockAcquireResult acquireResult;
 	AOCSFileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_column_compact");
+#endif
 
 	Assert(RelationIsAoCols(aorel));
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -830,6 +830,13 @@ aocs_insert_init(Relation rel, int segno, bool update_mode)
 	desc->aoi_rel = rel;
 	desc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("ao_column_insert_init_1") == FaultInjectorTypeSkip)
+	{
+		SIMPLE_FAULT_INJECTOR("ao_column_insert_init_2");
+	}
+#endif
+
 	/*
 	 * Writers uses this since they have exclusive access to the lock acquired
 	 * with LockRelationAppendOnlySegmentFile for the segment-file.

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -828,7 +828,7 @@ aocs_insert_init(Relation rel, int segno, bool update_mode)
 
 	desc = (AOCSInsertDesc) palloc0(sizeof(AOCSInsertDescData));
 	desc->aoi_rel = rel;
-	desc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	desc->appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("ao_column_insert_init_1") == FaultInjectorTypeSkip)
@@ -1014,8 +1014,6 @@ aocs_insert_finish(AOCSInsertDesc idesc)
 	AppendOnlyBlockDirectory_End_forInsert(&(idesc->blockDirectory));
 
 	UpdateAOCSFileSegInfo(idesc);
-
-	UnregisterSnapshot(idesc->appendOnlyMetaDataSnapshot);
 
 	pfree(idesc->fsInfo);
 

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -519,7 +519,7 @@ AppendOnlyDrop(Relation aorel, List *compaction_segno)
 	int			i,
 				segno;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(RelationIsAoRows(aorel));
@@ -572,7 +572,6 @@ AppendOnlyDrop(Relation aorel, List *compaction_segno)
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*
@@ -590,7 +589,7 @@ AppendOnlyTruncateToEOF(Relation aorel)
 				segno;
 	LockAcquireResult acquireResult;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_row_truncate_to_eof");
@@ -654,7 +653,6 @@ AppendOnlyTruncateToEOF(Relation aorel)
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*
@@ -682,7 +680,7 @@ AppendOnlyCompact(Relation aorel,
 	int			i,
 				segno;
 	FileSegInfo *fsinfo;
-	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	Snapshot	appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	SIMPLE_FAULT_INJECTOR("ao_row_compact");
@@ -762,7 +760,6 @@ AppendOnlyCompact(Relation aorel,
 		FreeAllSegFileInfo(segfile_array, total_segfiles);
 		pfree(segfile_array);
 	}
-	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 
 /*

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -40,6 +40,7 @@
 #include "nodes/execnodes.h"
 #include "storage/procarray.h"
 #include "storage/lmgr.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
@@ -591,6 +592,10 @@ AppendOnlyTruncateToEOF(Relation aorel)
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_row_truncate_to_eof");
+#endif
+
 	Assert(RelationIsAoRows(aorel));
 
 	relname = RelationGetRelationName(aorel);
@@ -678,6 +683,10 @@ AppendOnlyCompact(Relation aorel,
 				segno;
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("ao_row_compact");
+#endif
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
 	Assert(insert_segno >= 0);

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2622,6 +2622,13 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 	 */
 	aoInsertDesc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("ao_row_insert_init_1") == FaultInjectorTypeSkip)
+	{
+		SIMPLE_FAULT_INJECTOR("ao_row_insert_init_2");
+	}
+#endif
+
 	aoInsertDesc->mt_bind = create_memtuple_binding(RelationGetDescr(rel));
 
 	aoInsertDesc->appendFile = -1;

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2620,7 +2620,7 @@ appendonly_insert_init(Relation rel, int segno, bool update_mode)
 	 * Writers uses this since they have exclusive access to the lock acquired
 	 * with LockRelationAppendOnlySegmentFile for the segment-file.
 	 */
-	aoInsertDesc->appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+	aoInsertDesc->appendOnlyMetaDataSnapshot = SnapshotSelf;
 
 #ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("ao_row_insert_init_1") == FaultInjectorTypeSkip)
@@ -3099,8 +3099,6 @@ appendonly_insert_finish(AppendOnlyInsertDesc aoInsertDesc)
 	AppendOnlyBlockDirectory_End_forInsert(&(aoInsertDesc->blockDirectory));
 
 	AppendOnlyStorageWrite_FinishSession(&aoInsertDesc->storageWrite);
-
-	UnregisterSnapshot(aoInsertDesc->appendOnlyMetaDataSnapshot);
 
 	pfree(aoInsertDesc->title);
 	pfree(aoInsertDesc);

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -1125,6 +1125,13 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 	AORelHashEntryData *aoentry = NULL;
 	TransactionId CurrentXid = GetTopTransactionId();
 
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("reserved_segno") == FaultInjectorTypeSkip)
+	{
+		return RESERVED_SEGNO;
+	}
+#endif
+
 	switch (Gp_role)
 	{
 		case GP_ROLE_EXECUTE:
@@ -1141,6 +1148,7 @@ SetSegnoForWrite(Relation rel, int existingsegno)
 		case GP_ROLE_DISPATCH:
 
 			Assert(existingsegno == InvalidFileSegNumber);
+
 
 			ereportif(Debug_appendonly_print_segfile_choice, LOG,
 					  (errmsg("SetSegnoForWrite: Choosing a segno for append-only "

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5888,16 +5888,12 @@ dispatcherAYT(void)
 static void
 checkQDConnectionAlive(void)
 {
-	if (!dispatcherAYT())
+	if (Gp_role == GP_ROLE_EXECUTE)
 	{
-		if (Gp_role == GP_ROLE_EXECUTE)
+		if (!dispatcherAYT())
 			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					 errmsg("interconnect error segment lost contact with master (recv)")));
-		else
-			ereport(ERROR,
-					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
-					 errmsg("interconnect error master lost contact with client (recv)")));
 	}
 }
 

--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -69,6 +69,9 @@
 #include "postgres.h"
 #include <pthread.h>
 
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
 #include <signal.h>
 #include <fcntl.h>
 #include <grp.h>
@@ -2079,4 +2082,54 @@ pq_setkeepalivescount(int count, Port *port)
 #endif
 
 	return STATUS_OK;
+}
+
+/*
+ * Check if the client is still connected.
+ */
+bool
+pq_check_connection(void)
+{
+	struct pollfd pollfd;
+	int         rc;
+	short		poll_ev_aux;
+
+#if defined(POLLRDHUP)
+	/*
+	 * POLLRDHUP is a Linux extension to poll(2) to detect sockets closed by the
+	 * other end.
+	 * We don't have a portable way to do that without actually trying to read
+	 * or write data on other systems. We don't want to read because that would
+	 * be confused by pipelined queries and COPY data. Perhaps in future we'll
+	 * try to write a heartbeat message instead.
+	 */
+	poll_ev_aux = POLLRDHUP;
+#elif defined(__darwin__)
+	/*
+	 * OSX is able to detect closed sockets via single POSIX-compliant POLLHUP
+	 * option
+	 */
+	poll_ev_aux = 0;
+#else
+	return true;
+#endif
+
+	pollfd.fd = MyProcPort->sock;
+	pollfd.events = POLLOUT | POLLIN | poll_ev_aux;
+
+	pollfd.revents = 0;
+
+	rc = poll(&pollfd, 1, 0);
+
+	if (rc < 0)
+	{
+		ereport(COMMERROR,
+				(errcode_for_socket_access(),
+				 errmsg("could not poll socket: %m")));
+		return false;
+	}
+	else if (rc == 1 && (pollfd.revents & (POLLHUP | poll_ev_aux)))
+		return false;
+
+	return true;
 }

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -417,13 +417,18 @@ get_first_col_type(Plan *plan, Oid *coltype, int32 *coltypmod,
 /**
  * Returns true if query refers to a distributed table.
  */
-bool QueryHasDistributedRelation(Query *q)
+bool QueryHasDistributedRelation(Query *q, bool recursive)
 {
 	ListCell   *rt = NULL;
 
 	foreach(rt, q->rtable)
 	{
 		RangeTblEntry *rte = (RangeTblEntry *) lfirst(rt);
+
+		if (rte->rtekind == RTE_SUBQUERY
+				&& recursive
+				&& QueryHasDistributedRelation(rte->subquery, true))
+			return true;
 
 		if (rte->relid != InvalidOid
 				&& rte->rtekind == RTE_RELATION)
@@ -590,7 +595,7 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 
 	if ((Gp_role == GP_ROLE_DISPATCH)
 			&& IsSubqueryMultiLevelCorrelated(subquery)
-			&& QueryHasDistributedRelation(subquery))
+			&& QueryHasDistributedRelation(subquery, root->is_correlated_subplan))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -121,6 +121,9 @@ int			max_stack_depth = 100;
 /* wait N seconds to allow attach from a debugger */
 int			PostAuthDelay = 0;
 
+/* Time between checks that the client is still connected. */
+int         client_connection_check_interval = 0;
+
 
 /*
  * Hook for extensions, to get notified when query cancel or DIE signal is
@@ -3212,6 +3215,15 @@ start_xact_command(void)
 		else
 			disable_timeout(STATEMENT_TIMEOUT, false);
 
+		/* Start timeout for checking if the client has gone away if necessary. */
+		if (client_connection_check_interval > 0 &&
+			Gp_role != GP_ROLE_EXECUTE &&
+			IsUnderPostmaster &&
+			MyProcPort &&
+			!get_timeout_active(CLIENT_CONNECTION_CHECK_TIMEOUT))
+			enable_timeout_after(CLIENT_CONNECTION_CHECK_TIMEOUT,
+								 client_connection_check_interval);
+
 		xact_started = true;
 	}
 }
@@ -3775,6 +3787,27 @@ ProcessInterrupts(const char* filename, int lineno)
 						 errmsg("terminating connection due to administrator command")));
 		}
 	}
+
+	if (CheckClientConnectionPending)
+	{
+		CheckClientConnectionPending = false;
+
+		/*
+		 * Check for lost connection and re-arm, if still configured, but not
+		 * if we've arrived back at DoingCommandRead state.  We don't want to
+		 * wake up idle sessions, and they already know how to detect lost
+		 * connections.
+		 */
+		if (!DoingCommandRead && client_connection_check_interval > 0)
+		{
+			if (!pq_check_connection())
+				ClientConnectionLost = true;
+			else
+				enable_timeout_after(CLIENT_CONNECTION_CHECK_TIMEOUT,
+									 client_connection_check_interval);
+		}
+	}
+
 	if (ClientConnectionLost)
 	{
 		QueryCancelPending = false;		/* lost connection trumps QueryCancel */

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -32,6 +32,7 @@ volatile bool QueryCancelPending = false;
 volatile bool QueryCancelCleanup = false;
 volatile bool QueryFinishPending = false;
 volatile bool ProcDiePending = false;
+volatile sig_atomic_t CheckClientConnectionPending = false;
 volatile bool ClientConnectionLost = false;
 volatile bool ImmediateInterruptOK = false;
 /* Make these signed integers (instead of uint32) to detect garbage negative values. */

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -22,6 +22,9 @@
 #include <float.h>
 #include <math.h>
 #include <limits.h>
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
 #include <unistd.h>
 #include <sys/stat.h>
 #ifdef HAVE_SYSLOG
@@ -205,6 +208,7 @@ static bool check_max_worker_processes(int *newval, void **extra, GucSource sour
 static bool check_autovacuum_max_workers(int *newval, void **extra, GucSource source);
 static bool check_autovacuum_work_mem(int *newval, void **extra, GucSource source);
 static bool check_effective_io_concurrency(int *newval, void **extra, GucSource source);
+static bool check_client_connection_check_interval(int *newval, void **extra, GucSource source);
 static void assign_effective_io_concurrency(int newval, void *extra);
 static void assign_pgstat_temp_directory(const char *newval, void *extra);
 static bool check_application_name(char **newval, void **extra, GucSource source);
@@ -2628,6 +2632,17 @@ static struct config_int ConfigureNamesInt[] =
 		&pgstat_track_activity_query_size,
 		1024, 100, 102400,
 		NULL, NULL, NULL
+	},
+
+	{
+		{"client_connection_check_interval", PGC_USERSET, CLIENT_CONN_OTHER,
+			gettext_noop("Sets the time interval between checks for disconnection while running queries."),
+			NULL,
+			GUC_UNIT_MS
+		},
+		&client_connection_check_interval,
+		0, 0, INT_MAX,
+		check_client_connection_check_interval, NULL, NULL
 	},
 
 	/* End-of-list marker */
@@ -10070,6 +10085,20 @@ assign_effective_io_concurrency(int newval, void *extra)
 #ifdef USE_PREFETCH
 	target_prefetch_pages = *((int *) extra);
 #endif   /* USE_PREFETCH */
+}
+
+static bool
+check_client_connection_check_interval(int *newval, void **extra, GucSource source)
+{
+#if !(defined(POLLRDHUP) || defined(__darwin__))
+	/* Linux and OSX only, for now.  See pq_check_connection(). */
+	if (*newval != 0)
+	{
+		GUC_check_errdetail("client_connection_check_interval must be set to 0 on platforms that lack POLLRDHUP and not OSX.";
+		return false;
+	}
+#endif
+	return true;
 }
 
 static void

--- a/src/backend/utils/misc/timeout.c
+++ b/src/backend/utils/misc/timeout.c
@@ -27,7 +27,8 @@ typedef struct timeout_params
 {
 	TimeoutId	index;			/* identifier of timeout reason */
 
-	/* volatile because it may be changed from the signal handler */
+	/* volatile because these may be changed from the signal handler */
+	volatile bool active;       /* true if timeout is in active_timeouts[] */
 	volatile bool indicator;	/* true if timeout has occurred */
 
 	/* callback function for timeout, or NULL if timeout not registered */
@@ -105,6 +106,9 @@ insert_timeout(TimeoutId id, int index)
 		elog(FATAL, "timeout index %d out of range 0..%d", index,
 			 num_active_timeouts);
 
+	Assert(!all_timeouts[id].active);
+	all_timeouts[id].active = true;
+
 	for (i = num_active_timeouts - 1; i >= index; i--)
 		active_timeouts[i + 1] = active_timeouts[i];
 
@@ -124,6 +128,9 @@ remove_timeout_index(int index)
 	if (index < 0 || index >= num_active_timeouts)
 		elog(FATAL, "timeout index %d out of range 0..%d", index,
 			 num_active_timeouts - 1);
+
+	Assert(active_timeouts[index]->active);
+	active_timeouts[index]->active = false;
 
 	for (i = index + 1; i < num_active_timeouts; i++)
 		active_timeouts[i - 1] = active_timeouts[i];
@@ -147,9 +154,8 @@ enable_timeout(TimeoutId id, TimestampTz now, TimestampTz fin_time)
 	 * If this timeout was already active, momentarily disable it.  We
 	 * interpret the call as a directive to reschedule the timeout.
 	 */
-	i = find_active_timeout(id);
-	if (i >= 0)
-		remove_timeout_index(i);
+	if (all_timeouts[id].active)
+		remove_timeout_index(find_active_timeout(id));
 
 	/*
 	 * Find out the index where to insert the new timeout.  We sort by
@@ -383,6 +389,7 @@ InitializeTimeouts(void)
 	for (i = 0; i < MAX_TIMEOUTS; i++)
 	{
 		all_timeouts[i].index = i;
+		all_timeouts[i].active = false;
 		all_timeouts[i].indicator = false;
 		all_timeouts[i].timeout_handler = NULL;
 		all_timeouts[i].start_time = 0;
@@ -558,7 +565,6 @@ enable_timeouts(const EnableTimeoutParams *timeouts, int count)
 void
 disable_timeout(TimeoutId id, bool keep_indicator)
 {
-	int			i;
 
 	/* Assert request is sane */
 	Assert(all_timeouts_initialized);
@@ -568,9 +574,8 @@ disable_timeout(TimeoutId id, bool keep_indicator)
 	disable_alarm();
 
 	/* Find the timeout and remove it from the active list. */
-	i = find_active_timeout(id);
-	if (i >= 0)
-		remove_timeout_index(i);
+	if (all_timeouts[id].active)
+		remove_timeout_index(find_active_timeout(id));
 
 	/* Mark it inactive, whether it was active or not. */
 	if (!keep_indicator)
@@ -605,13 +610,11 @@ disable_timeouts(const DisableTimeoutParams *timeouts, int count)
 	for (i = 0; i < count; i++)
 	{
 		TimeoutId	id = timeouts[i].id;
-		int			idx;
 
 		Assert(all_timeouts[id].timeout_handler != NULL);
 
-		idx = find_active_timeout(id);
-		if (idx >= 0)
-			remove_timeout_index(idx);
+		if (all_timeouts[id].active)
+			remove_timeout_index(find_active_timeout(id));
 
 		if (!timeouts[i].keep_indicator)
 			all_timeouts[id].indicator = false;
@@ -629,6 +632,8 @@ disable_timeouts(const DisableTimeoutParams *timeouts, int count)
 void
 disable_all_timeouts(bool keep_indicators)
 {
+	int i;
+
 	disable_alarm();
 
 	/*
@@ -647,13 +652,24 @@ disable_all_timeouts(bool keep_indicators)
 
 	num_active_timeouts = 0;
 
-	if (!keep_indicators)
+	for (i = 0; i < MAX_TIMEOUTS; i++)
 	{
-		int			i;
-
-		for (i = 0; i < MAX_TIMEOUTS; i++)
+		all_timeouts[i].active = false;
+		if (!keep_indicators)
 			all_timeouts[i].indicator = false;
 	}
+}
+
+/*
+ * Return true if the timeout is active (enabled and not yet fired)
+ *
+ * This is, of course, subject to race conditions, as the timeout could fire
+ * immediately after we look.
+ */
+bool
+get_timeout_active(TimeoutId id)
+{
+	return all_timeouts[id].active;
 }
 
 /*

--- a/src/include/libpq/libpq.h
+++ b/src/include/libpq/libpq.h
@@ -56,6 +56,7 @@ extern void pq_putmessage_noblock(char msgtype, const char *s, size_t len);
 extern void pq_startcopyout(void);
 extern void pq_endcopyout(bool errorAbort);
 extern bool pq_waitForDataUsingSelect(void);                /* GPDB only */
+extern bool pq_check_connection(void);
 
 /*
  * prototypes for functions in be-secure.c

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -87,6 +87,7 @@ extern PGDLLIMPORT volatile bool QueryFinishPending;
 extern PGDLLIMPORT volatile bool ProcDiePending;
 extern PGDLLIMPORT volatile sig_atomic_t ConfigReloadPending;
 
+extern PGDLLIMPORT volatile sig_atomic_t CheckClientConnectionPending;
 extern volatile bool ClientConnectionLost;
 
 /* these are marked volatile because they are examined by signal handlers: */

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -49,6 +49,6 @@ extern bool IsSubqueryMultiLevelCorrelated(Query *sq);
 
 extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);
-extern bool QueryHasDistributedRelation(Query *q);
+extern bool QueryHasDistributedRelation(Query *q, bool recursive);
 
 #endif   /* SUBSELECT_H */

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -33,6 +33,7 @@ extern CommandDest whereToSendOutput;
 extern PGDLLIMPORT const char *debug_query_string;
 extern int	max_stack_depth;
 extern int	PostAuthDelay;
+extern int  client_connection_check_interval;
 
 /* GUC-configurable parameters */
 

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -1,5 +1,6 @@
 		"bytea_output",
 		"check_function_bodies",
+		"client_connection_check_interval",
 		"client_min_messages",
 		"commit_delay",
 		"commit_siblings",

--- a/src/include/utils/timeout.h
+++ b/src/include/utils/timeout.h
@@ -30,6 +30,7 @@ typedef enum TimeoutId
 	STANDBY_DEADLOCK_TIMEOUT,
 	STANDBY_TIMEOUT,
 	GANG_TIMEOUT,
+	CLIENT_CONNECTION_CHECK_TIMEOUT,
 	/* First user-definable timeout reason */
 	USER_TIMEOUT,
 	/* Maximum number of timeout reasons */
@@ -79,6 +80,7 @@ extern void disable_timeouts(const DisableTimeoutParams *timeouts, int count);
 extern void disable_all_timeouts(bool keep_indicators);
 
 /* accessors */
+extern bool get_timeout_active(TimeoutId id);
 extern bool get_timeout_indicator(TimeoutId id, bool reset_indicator);
 extern TimestampTz get_timeout_start_time(TimeoutId id);
 extern TimestampTz get_timeout_finish_time(TimeoutId id);

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -1,0 +1,137 @@
+-- @Description Tests segment file logical EOF.
+--
+
+-- start_matchsubs
+--
+-- # create a match/subs expression
+--
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- end_matchsubs
+1:CREATE extension if NOT EXISTS gp_inject_fault;
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+1:BEGIN;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 30);
+1:ROLLBACK;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM truncate_eof;
+-- Commit new data and move eof.
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+0U<:
+-- Validate that segment file is not corrupted.
+1:SELECT count(*) FROM truncate_eof;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE truncate_eof;
+1:RESET gp_default_storage_options;
+
+--
+-- Check that VACUUM compaction uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires compaction.
+1:SET gp_appendonly_compaction_threshold = 10;
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE compact (a int);
+1:INSERT INTO compact SELECT generate_series(1, 100);
+1:DELETE FROM compact WHERE a > 1;
+1:ANALYZE compact;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM compact;
+-- Commit new data and move eof.
+1:INSERT INTO compact SELECT generate_series(1, 100);
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+0U<:
+-- Validate that a new segment file has a correct amount of rows.
+1:SELECT count(*) FROM compact;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE compact;
+1:RESET gp_appendonly_compaction_threshold;
+1:RESET gp_default_storage_options;
+
+
+--
+-- Check that COPY uses the latest committed segment eof.
+--
+-- Isolation framework doesn't allow us to emulate concurrent utility
+-- mode sessions. So we use 'reserved_segno' fault to make COPY on QD
+-- use the same 0 segment as utility mode does.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('reserved_segno', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Emulate concurrent segment file modification with COPY command.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+0U&:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+1:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5"';
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+0U<:
+-- Validate that segment file has a correct amount of rows.
+1:SELECT count(*) FROM insert_eof;
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p';
+-- end_ignore
+1:DROP TABLE insert_eof;
+1:RESET gp_default_storage_options;

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -22,6 +22,48 @@ FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
 -- end_ignore
 -- Create segment file that requires eof truncate.
 1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED BY (a);
+1:BEGIN;
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+1:ROLLBACK;
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+2&:VACUUM truncate_eof;
+-- Commit new data in two parallel sessions and move eof.
+-- start_ignore
+1&:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- end_ignore
+3:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+-- Resume VACUUM.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1<:
+-- end_ignore
+2<:
+-- Validate that segment file is not corrupted.
+3:SELECT count(*) FROM truncate_eof;
+-- Cleanup.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+3:DROP TABLE truncate_eof;
+3:RESET gp_default_storage_options;
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+-- Test with VACUUM in utility mode.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
 1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
 1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
 1:BEGIN;

--- a/src/test/isolation2/input/uao/snapshot_eof.source
+++ b/src/test/isolation2/input/uao/snapshot_eof.source
@@ -177,3 +177,35 @@ FROM gp_segment_configuration WHERE role = 'p';
 -- end_ignore
 1:DROP TABLE insert_eof;
 1:RESET gp_default_storage_options;
+
+--
+-- Check that we don't have anomalies on concurrent segment file
+-- modifications during prepared phase.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+-- Emulate concurrent segment file modification.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1&:INSERT INTO insert_eof SELECT generate_series(1, 10);
+-- Validate that segment file has a correct amount of rows.
+2:SELECT count(*) FROM insert_eof;
+-- start_ignore
+2:SELECT gp_inject_fault('after_commit_prepared', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1<:
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+-- end_ignore
+1:DROP TABLE insert_eof;
+1:RESET gp_default_storage_options;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -129,6 +129,7 @@ test: uao/select_while_vacuum_serializable2_row
 test: uao/selectinsert_while_vacuum_row
 test: uao/selectinsertupdate_while_vacuum_row
 test: uao/selectupdate_while_vacuum_row
+test: uao/snapshot_eof_row
 test: uao/update_while_vacuum_row
 test: uao/vacuum_self_serializable_row
 test: uao/vacuum_self_serializable2_row
@@ -179,6 +180,7 @@ test: uao/select_while_vacuum_serializable2_column
 test: uao/selectinsert_while_vacuum_column
 test: uao/selectinsertupdate_while_vacuum_column
 test: uao/selectupdate_while_vacuum_column
+test: uao/snapshot_eof_column
 test: uao/update_while_vacuum_column
 test: uao/vacuum_self_serializable_column
 test: uao/vacuum_self_serializable2_column

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -1,0 +1,273 @@
+-- @Description Tests segment file logical EOF.
+--
+
+-- start_matchsubs
+--
+-- # create a match/subs expression
+--
+-- m/ERROR:.*server closed the connection unexpectedly/
+-- s/ERROR:.*server closed the connection unexpectedly/ERROR: server closed the connection unexpectedly/gm
+-- end_matchsubs
+1:CREATE extension if NOT EXISTS gp_inject_fault;
+CREATE
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
+CREATE
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+1:BEGIN;
+BEGIN
+1:INSERT INTO truncate_eof SELECT generate_series(1, 30);
+INSERT 30
+1:ROLLBACK;
+ROLLBACK
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM truncate_eof;  <waiting ...>
+-- Commit new data and move eof.
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+0U<:  <... completed>
+VACUUM
+-- Validate that segment file is not corrupted.
+1:SELECT count(*) FROM truncate_eof;
+ count 
+-------
+ 20    
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1:DROP TABLE truncate_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET
+
+--
+-- Check that VACUUM compaction uses the latest committed segment eof.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires compaction.
+1:SET gp_appendonly_compaction_threshold = 10;
+SET
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE compact (a int);
+CREATE
+1:INSERT INTO compact SELECT generate_series(1, 100);
+INSERT 100
+1:DELETE FROM compact WHERE a > 1;
+DELETE 99
+1:ANALYZE compact;
+ANALYZE
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+0U&:VACUUM compact;  <waiting ...>
+-- Commit new data and move eof.
+1:INSERT INTO compact SELECT generate_series(1, 100);
+INSERT 100
+-- Resume VACUUM.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+0U<:  <... completed>
+VACUUM
+-- Validate that a new segment file has a correct amount of rows.
+1:SELECT count(*) FROM compact;
+ count 
+-------
+ 101   
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_compact', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1:DROP TABLE compact;
+DROP
+1:RESET gp_appendonly_compaction_threshold;
+RESET
+1:RESET gp_default_storage_options;
+RESET
+
+
+--
+-- Check that COPY uses the latest committed segment eof.
+--
+-- Isolation framework doesn't allow us to emulate concurrent utility
+-- mode sessions. So we use 'reserved_segno' fault to make COPY on QD
+-- use the same 0 segment as utility mode does.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('reserved_segno', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Emulate concurrent segment file modification with COPY command.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+CREATE
+0U&:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';  <waiting ...>
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_1', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+1:COPY insert_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5"';
+COPY 5
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+0U<:  <... completed>
+COPY 10
+-- Validate that segment file has a correct amount of rows.
+1:SELECT count(*) FROM insert_eof;
+ count 
+-------
+ 15    
+(1 row)
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_insert_init_2', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+1:SELECT gp_inject_fault('reserved_segno', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+-- end_ignore
+1:DROP TABLE insert_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -34,6 +34,82 @@ CREATE
 -- Create segment file that requires eof truncate.
 1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
 SET
+1:CREATE TABLE truncate_eof (a int) DISTRIBUTED BY (a);
+CREATE
+1:BEGIN;
+BEGIN
+1:INSERT INTO truncate_eof SELECT generate_series(1, 10);
+INSERT 10
+1:ROLLBACK;
+ROLLBACK
+-- Pause VACUUM after an appendonly metadata snapshot has been acquired
+-- but before segment file has been locked.
+2&:VACUUM truncate_eof;  <waiting ...>
+-- Commit new data in two parallel sessions and move eof.
+-- start_ignore
+1&:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';  <waiting ...>
+-- end_ignore
+3:COPY truncate_eof FROM PROGRAM 'printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"';
+COPY 10
+-- Resume VACUUM.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+COPY 10
+-- end_ignore
+2<:  <... completed>
+VACUUM
+-- Validate that segment file is not corrupted.
+3:SELECT count(*) FROM truncate_eof;
+ count 
+-------
+ 20    
+(1 row)
+-- Cleanup.
+-- start_ignore
+3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+3:DROP TABLE truncate_eof;
+DROP
+3:RESET gp_default_storage_options;
+RESET
+
+--
+-- Check that VACUUM truncate uses the latest committed segment eof.
+-- Test with VACUUM in utility mode.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Create segment file that requires eof truncate.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
 1:CREATE TABLE truncate_eof (a int) DISTRIBUTED RANDOMLY;
 CREATE
 1:INSERT INTO truncate_eof SELECT generate_series(1, 10);

--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -347,3 +347,64 @@ COPY 10
 DROP
 1:RESET gp_default_storage_options;
 RESET
+
+--
+-- Check that we don't have anomalies on concurrent segment file
+-- modifications during prepared phase.
+--
+-- Configure fault injection.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+-- Emulate concurrent segment file modification.
+1:SET gp_default_storage_options = "appendonly=true, orientation=@orientation@";
+SET
+1:CREATE TABLE insert_eof(a int) DISTRIBUTED RANDOMLY;
+CREATE
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1&:INSERT INTO insert_eof SELECT generate_series(1, 10);  <waiting ...>
+-- Validate that segment file has a correct amount of rows.
+2:SELECT count(*) FROM insert_eof;
+ count 
+-------
+ 0     
+(1 row)
+-- start_ignore
+2:SELECT gp_inject_fault('after_commit_prepared', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+-- end_ignore
+1<:  <... completed>
+INSERT 10
+-- Cleanup.
+-- start_ignore
+1:SELECT gp_inject_fault('after_commit_prepared', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:               
+(3 rows)
+-- end_ignore
+1:DROP TABLE insert_eof;
+DROP
+1:RESET gp_default_storage_options;
+RESET

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -1670,6 +1670,12 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
  4.0000000000000000
 (4 rows)
 
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+ERROR:  correlated subquery with skip-level correlations is not supported
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1795,6 +1795,12 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
  4.0000000000000000
 (4 rows)
 
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+ERROR:  correlated subquery with skip-level correlations is not supported
+-- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+ERROR:  correlated subquery with skip-level correlations is not supported
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -342,6 +342,10 @@ SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a
 select A.i, (select C.j from C group by C.j having max(C.j) = any (select min(B.j) from B)) as C_j from A,B,C where A.i = 99 order by A.i, C_j limit 10;
 select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select x)) as avg_x from qp_csq_t1 order by 1;
 
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
+-- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
+select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
 
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)


### PR DESCRIPTION
PR to 6X master to test fixes together.

Fixed:

1. ADBDEV-1710 Fix catalog snapshot AO/AOCO data corruption
2. ADBDEV-1532 Detect client disconnection while running query and immediately interrupt its execution
3. ADBDEV-1729 Fix segfault on execution of multilevel correlated queries