### PR TITLE
ADBDEV-1930: Correct plan with volatile functions

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2177,6 +2177,12 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 		result_plan->flow = pull_up_Flow(result_plan,
 										 result_plan->lefttree,
 										 true);
+
+		if (result_plan->flow->locustype == CdbLocusType_General)
+		{
+			result_plan->flow->locustype = CdbLocusType_SingleQE;
+			result_plan->flow->flotype = FLOW_SINGLETON;
+		}
 	}
 
 	Insist(result_plan->flow);

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -446,6 +446,15 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 			&subroot,
 			config);
 
+	if (plan->flow->locustype == CdbLocusType_General &&
+		(contain_volatile_functions((Node *) plan->targetlist) ||
+		 contain_volatile_functions(subquery->havingQual)))
+	{
+		plan->flow->segindex = 0;
+		plan->flow->locustype = CdbLocusType_SingleQE;
+		plan->flow->flotype = FLOW_SINGLETON;
+	}
+
 	/* And convert to SubPlan or InitPlan format. */
 	Node	   *result = build_subplan(root,
 										plan,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1000,6 +1000,11 @@ contain_volatile_functions_walker(Node *node, void *context)
 			if (op_volatile(lfirst_oid(opid)) == PROVOLATILE_VOLATILE)
 				return true;
 		}
+	}
+	else if (IsA(node, RestrictInfo))
+	{
+		RestrictInfo * info = (RestrictInfo *) node;
+		return contain_volatile_functions_walker((Node*)info->clause, context);
 		/* else fall through to check args */
 	}
 	return expression_tree_walker(node, contain_volatile_functions_walker,

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -2621,6 +2621,12 @@ create_nestloop_path(PlannerInfo *root,
 		}
     }
 
+	if (CdbPathLocus_IsGeneral(join_locus) &&
+			contain_volatile_functions((Node *) restrict_clauses))
+	{
+			CdbPathLocus_MakeSingleQE(&(join_locus));
+	}
+
     pathnode = makeNode(NestPath);
 	pathnode->path.pathtype = T_NestLoop;
 	pathnode->path.parent = joinrel;
@@ -2793,6 +2799,12 @@ create_mergejoin_path(PlannerInfo *root,
 		}
 	}
 
+	if (CdbPathLocus_IsGeneral(join_locus) &&
+			contain_volatile_functions((Node *) restrict_clauses))
+	{
+			CdbPathLocus_MakeSingleQE(&(join_locus));
+	}
+
 	pathnode->jpath.path.pathtype = T_MergeJoin;
 	pathnode->jpath.path.parent = joinrel;
 	pathnode->jpath.jointype = jointype;
@@ -2856,6 +2868,12 @@ create_hashjoin_path(PlannerInfo *root,
 										 false);
 	if (CdbPathLocus_IsNull(join_locus))
 		return NULL;
+
+	if (CdbPathLocus_IsGeneral(join_locus) &&
+			contain_volatile_functions((Node *) restrict_clauses))
+	{
+			CdbPathLocus_MakeSingleQE(&(join_locus));
+	}
 
 	pathnode = makeNode(HashPath);
 

--- a/src/test/regress/expected/bfv_planner.out
+++ b/src/test/regress/expected/bfv_planner.out
@@ -353,6 +353,184 @@ PL/pgSQL function "volatilefunc" line 4 at assignment
             0
 (3 rows)
 
+-- volatile general
+-- General locus imply that if the corresponding slice
+-- is executed in many different segments should provide the
+-- same result data set. Thus, in some cases, General
+-- can be treated like broadcast. But if the general
+-- locus path contain volatile functions, they lose the property and
+-- can only be treated as singleQE. The following cases are to check that
+-- we correctly handle all these cases.
+-- FIXME: for ORCA the following SQL does not consider this. We should
+-- fix them when ORCA changes.
+set optimizer = off;
+create table t_hashdist(a int, b int, c int) distributed by (a);
+---- pushed down filter
+explain select * from
+        (select a from generate_series(1, 10)a) x, t_hashdist
+        where x.a > random();
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=34.33..1558913.33 rows=25966667 width=16)
+   ->  Nested Loop  (cost=34.33..1558913.33 rows=8655556 width=16)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=34.33..44.33 rows=334 width=4)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..33.33 rows=1000 width=4)
+                     ->  Function Scan on generate_series a  (cost=0.00..20.00 rows=334 width=4)
+                           Filter: a::double precision > random()
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(9 rows)
+
+---- join qual
+explain select * from
+                    t_hashdist,
+                    (select a from generate_series(1, 10) a) x,
+                    (select a from generate_series(1, 10) a) y
+                    where x.a + y.a > random();
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=2528.40..519365874.23 rows=25966666667 width=20)
+   ->  Nested Loop  (cost=13.50..30026.00 rows=333334 width=8)
+         Join Filter: (a.a + a.a)::double precision > random()
+         ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+         ->  Materialize  (cost=13.50..23.50 rows=334 width=4)
+               ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+   ->  Materialize  (cost=2514.90..3293.90 rows=25967 width=12)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2437.00 rows=77900 width=12)
+               ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(11 rows)
+
+---- sublink & subquery
+explain select * from t_hashdist where a > All (select random() from generate_series(1, 10));
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=68.00..5843447.00 rows=25967 width=12)
+   ->  Nested Loop Left Anti Semi Join (Not-In)  (cost=68.00..5843447.00 rows=8656 width=12)
+         Join Filter: t_hashdist.a::double precision <= "NotIn_SUBQUERY".random
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=68.00..98.00 rows=1000 width=8)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..65.00 rows=3000 width=8)
+                     ->  Subquery Scan "NotIn_SUBQUERY"  (cost=0.00..25.00 rows=1000 width=8)
+                           ->  Function Scan on generate_series  (cost=0.00..15.00 rows=1000 width=0)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+explain select * from t_hashdist where a in (select random()::int from generate_series(1, 10));
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=60.00..2107.50 rows=77900 width=12)
+   ->  Hash EXISTS Join  (cost=60.00..2107.50 rows=25967 width=12)
+         Hash Cond: t_hashdist.a = (random()::integer)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Hash  (cost=47.50..47.50 rows=334 width=4)
+               ->  Redistribute Motion 1:3  (slice1)  (cost=0.00..47.50 rows=1000 width=4)
+                     Hash Key: (random()::integer)
+                     ->  Function Scan on generate_series  (cost=0.00..17.50 rows=1000 width=0)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+-- subplan
+explain select * from
+    t_hashdist left join (select a from generate_series(1, 10) a) x on t_hashdist.a > any (select random() from generate_series(1, 10));
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=55.50..2050718434.50 rows=38950000 width=16)
+   ->  Nested Loop Left Join  (cost=55.50..2050718434.50 rows=12983334 width=16)
+         Join Filter: (subplan)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=55.50..85.50 rows=1000 width=4)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..52.50 rows=3000 width=4)
+                     ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+         SubPlan 1
+           ->  Materialize  (cost=16.00..26.00 rows=1000 width=0)
+                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..15.00 rows=1000 width=0)
+                       ->  Function Scan on generate_series  (cost=0.00..15.00 rows=1000 width=0)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+-- targetlist
+explain select * from t_hashdist cross join (select random () from generate_series(1, 10))x;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=68.00..4674947.00 rows=77900000 width=20)
+   ->  Nested Loop  (cost=68.00..4674947.00 rows=25966667 width=20)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=68.00..98.00 rows=1000 width=8)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..65.00 rows=3000 width=8)
+                     ->  Function Scan on generate_series  (cost=0.00..15.00 rows=1000 width=0)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+explain select * from t_hashdist cross join (select a, sum(random()) from generate_series(1, 10) a group by a) x;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=85.50..4674964.50 rows=77900000 width=24)
+   ->  Nested Loop  (cost=85.50..4674964.50 rows=25966667 width=24)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=85.50..115.50 rows=1000 width=12)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=17.50..82.50 rows=3000 width=12)
+                     ->  HashAggregate  (cost=17.50..32.50 rows=1000 width=12)
+                           Group By: a.a
+                           ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+explain select * from t_hashdist cross join (select random() as k, sum(a) from generate_series(1, 10) a group by k) x;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=88.00..4674967.00 rows=77900000 width=28)
+   ->  Nested Loop  (cost=88.00..4674967.00 rows=25966667 width=28)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=88.00..118.00 rows=1000 width=16)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=20.00..85.00 rows=3000 width=16)
+                     ->  HashAggregate  (cost=20.00..35.00 rows=1000 width=16)
+                           Group By: random()
+                           ->  Function Scan on generate_series a  (cost=0.00..15.00 rows=1000 width=4)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+explain select * from t_hashdist cross join (select a, count(1) as s from generate_series(1, 10) a group by a having count(1) > random() order by a) x ;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=147.83..4675026.83 rows=77900000 width=24)
+   ->  Nested Loop  (cost=147.83..4675026.83 rows=25966667 width=24)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+         ->  Materialize  (cost=147.83..177.83 rows=1000 width=12)
+               ->  Broadcast Motion 1:3  (slice1)  (cost=62.33..144.83 rows=3000 width=12)
+                     ->  GroupAggregate  (cost=62.33..94.83 rows=1000 width=12)
+                           Filter: count(1)::double precision > random()
+                           Group By: a.a
+                           ->  Sort  (cost=62.33..64.83 rows=1000 width=4)
+                                 Sort Key: a.a
+                                 ->  Function Scan on generate_series a  (cost=0.00..12.50 rows=1000 width=4)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(13 rows)
+
+-- limit
+explain select * from t_hashdist cross join (select * from generate_series(1, 10) limit 1) x;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..4974.06 rows=77900 width=16)
+   ->  Nested Loop  (cost=0.00..4974.06 rows=25967 width=16)
+         ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..0.06 rows=3 width=4)
+               ->  Limit  (cost=0.00..0.01 rows=1 width=4)
+                     ->  Function Scan on generate_series  (cost=0.00..12.50 rows=1000 width=4)
+         ->  Seq Scan on t_hashdist  (cost=0.00..879.00 rows=25967 width=12)
+ Settings:  enable_bitmapscan=off; enable_seqscan=off; optimizer=off
+ Optimizer status: legacy query optimizer
+(8 rows)
+
+reset optimizer;
 -- start_ignore
 drop table if exists bfv_planner_x;
 drop table if exists testbadsql;


### PR DESCRIPTION
General locus imply that if the corresponding slice is executed in many different segments should provide the same result data set. Thus, in some cases, General can be treated like broadcast.

But what if the general locus path contain volatile functions? volatile functions, by definition, do not guarantee results of different invokes. So for such cases, they lose the property and cannot be treated as *general. Previously, Greenplum planner does not handle these cases correctly. Limit general path also has such issue.

Backport of https://github.com/greenplum-db/gpdb/commit/5b4c4f59016f01868ebc7b7c94aae5892ef0629e

###  Test case
```sql
create table test1(a int) distributed by (a);
insert into  test1 select * from generate_series(1, 5);

explain select * from (select gp_execution_segment()) as t, test1;
```