### PR TITLE
ADBDEV-1897. Refactor stack unwind in GPDB

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -99,11 +99,11 @@ SERVER_PLATFORMS=rhel7_x86_64 rhel6_x86_64 rhel8_x86_64 linux_x86_64 photon3_x86
 # Compiler options
 #---------------------------------------------------------------------
 
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
 
 ifeq (on, ${GPDBGOPT})
-CFLAGS_OPT=-O1 -fno-omit-frame-pointer
+CFLAGS_OPT=-O1
 else
 CFLAGS_OPT=-O0
 endif

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -139,6 +139,7 @@ FtsProbeMain(Datum main_arg)
 	main_tid = pthread_self();
 
 #ifdef SIGSEGV
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 	pqsignal(SIGSEGV, CdbProgramErrorHandler);
 #endif
 

--- a/src/backend/gporca/CMakeLists.txt
+++ b/src/backend/gporca/CMakeLists.txt
@@ -58,14 +58,6 @@ if (COMPILER_HAS_G3)
   SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g3")
 endif()
 
-# Do not omit frame pointer. Even with RELEASE builds, it is used for
-# backtracing.
-check_cxx_compiler_flag("-fno-omit-frame-pointer"
-                        COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
-if (COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
-endif()
-
 # Turn on GPOS_DEBUG define for DEBUG builds.
 cmake_policy(SET CMP0043 NEW)
 

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -2,7 +2,5 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPF
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-# Do not omit frame pointer. Even with RELEASE builds, it is used for
-# backtracing.
-override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
+override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros $(CPPFLAGS)
 override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)

--- a/src/backend/gporca/libgpos/include/gpos/utils.h
+++ b/src/backend/gporca/libgpos/include/gpos/utils.h
@@ -19,17 +19,6 @@
 #include "gpos/io/COstreamBasic.h"
 #include "gpos/types.h"
 
-// These fallback is similar to the one used in Postgres 'elog.c'
-#if defined(__x86_64__)
-#define GPOS_ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
-#define GPOS_GET_FRAME_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMFP; x = ulp; } while (0)
-#elif defined(__i386)
-#define GPOS_ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
-#define GPOS_GET_FRAME_POINTER(x) do { ULONG_PTR ulp; GPOS_ASMFP; x = ulp; } while (0)
-#else
-#include <execinfo.h>
-#endif
-
 #define ALIGNED_16(x) \
 	(((ULONG_PTR) x >> 1) << 1 == (ULONG_PTR) x)  // checks 16-bit alignment
 #define ALIGNED_32(x) \

--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -15,6 +15,8 @@
 #include "gpos/task/IWorker.h"
 #include "gpos/utils.h"
 
+#include <execinfo.h>
+
 #define GPOS_STACK_DESCR_TRACE_BUF (4096)
 
 using namespace gpos;
@@ -30,61 +32,20 @@ using namespace gpos;
 void
 CStackDescriptor::BackTrace(ULONG top_frames_to_skip)
 {
-	// get base pointer of current frame
-
 	ULONG gpos_stack_trace_depth_actual;
-	#ifdef GPOS_GET_FRAME_POINTER
-	ULONG_PTR current_frame;
-	GPOS_GET_FRAME_POINTER(current_frame);
-	gpos_stack_trace_depth_actual = GPOS_STACK_TRACE_DEPTH;
-	#else
-	void *current_frame[GPOS_STACK_TRACE_DEPTH];
-	gpos_stack_trace_depth_actual = backtrace(current_frame, GPOS_STACK_TRACE_DEPTH);
-	#endif
+	void *raddrs[GPOS_STACK_TRACE_DEPTH];
+
+	// get the backtrace in platform-independent way
+	gpos_stack_trace_depth_actual = backtrace(raddrs, GPOS_STACK_TRACE_DEPTH);
 
 	// reset stack depth
 	Reset();
 
-	// pointer to next frame in stack
-	void **next_frame = (void **) current_frame;
-
-	// get stack start address
-	ULONG_PTR stack_start = 0;
-	IWorker *worker = IWorker::Self();
-	if (NULL == worker)
+	// skip the first top_frames_to_skip
+	for (ULONG i = top_frames_to_skip; i < gpos_stack_trace_depth_actual; i++)
 	{
-		// no worker in stack, return immediately
-		return;
-	}
-
-	// get address from worker
-	stack_start = worker->GetStackStart();
-
-	// consider the first GPOS_STACK_TRACE_DEPTH frames below worker object
-	for (ULONG frame_counter = 0; frame_counter < gpos_stack_trace_depth_actual;
-		 frame_counter++)
-	{
-		// check if the frame pointer is after stack start and before previous frame
-		if ((ULONG_PTR) *next_frame > stack_start ||
-			(ULONG_PTR) *next_frame < (ULONG_PTR) next_frame)
-		{
-			break;
-		}
-
-		// skip top frames
-		if (0 < top_frames_to_skip)
-		{
-			top_frames_to_skip--;
-		}
-		else
-		{
-			// get return address (one above the base pointer)
-			ULONG_PTR *frame_address = (ULONG_PTR *) (next_frame + 1);
-			m_array_of_addresses[m_depth++] = (void *) *frame_address;
-		}
-
-		// move to next frame
-		next_frame = (void **) *next_frame;
+		// backtrace() produces pure return addresses, so just copy them
+		m_array_of_addresses[m_depth++] = raddrs[i];
 	}
 }
 

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -13,7 +13,7 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPP
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # FIXME: Would be better to include gporca.mk, but hitting a warning
-override CPPFLAGS := -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
+override CPPFLAGS := -Wno-variadic-macros $(CPPFLAGS)
 override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
 
 OBJS        = CAutoTimer.o \

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -206,6 +206,7 @@ StartupProcessMain(void)
 	pqsignal(SIGUSR1, StartupProcSigUsr1Handler);
 	pqsignal(SIGUSR2, StartupProcTriggerHandler);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGBUS
 	pqsignal(SIGBUS, HandleCrash);
 #endif

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -277,6 +277,7 @@ WalReceiverMain(void)
 	pqsignal(SIGCONT, SIG_DFL);
 	pqsignal(SIGWINCH, SIG_DFL);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGILL
 	pqsignal(SIGILL, WalRcvCrashHandler);
 #endif

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2865,6 +2865,7 @@ WalSndSignals(void)
 	pqsignal(SIGCONT, SIG_DFL);
 	pqsignal(SIGWINCH, SIG_DFL);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGILL
 	pqsignal(SIGILL, WalSndCrashHandler);
 #endif

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4782,6 +4782,8 @@ PostgresMain(int argc, char *argv[],
 		 */
 		pqsignal(SIGCHLD, SIG_DFL);		/* system() requires this on some
 										 * platforms */
+
+		InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifndef _WIN32
 #ifdef SIGILL
 		pqsignal(SIGILL, CdbProgramErrorHandler);

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -192,24 +192,6 @@ static void write_eventlog(int level, const char *line, int len);
 #define ADDRESS_SIZE     20
 #define STACK_DEPTH_MAX  100
 
-/*
- * Assembly code, gets the values of the frame pointer.
- * It only works for x86 processors.
- */
-#if defined(__i386)
-#define ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) ((uint32)value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#elif defined(__x86_64__)
-#define ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#else
-#define ASMFP
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x)
-#endif
-
 
 static ErrorData errordata[ERRORDATA_STACK_SIZE];
 
@@ -5384,59 +5366,9 @@ debug_backtrace(void)
  */
 uint32 gp_backtrace(void **stackAddresses, uint32 maxStackDepth)
 {
-#if defined(__i386) || defined(__x86_64__)
-
-	/*
-	 * Stack base pointer has not been initialized by PostmasterMain,
-	 * or PostgresMain/AuxiliaryProcessMain is called directly by main
-	 * rather than forked by PostmasterMain (such as when initdb).
-	 *
-	 * In this case, just return depth as 0 to indicate that we have not
-	 * stored any frame addresses.
-	 */
-	if (stack_base_ptr == NULL)
-		return 0;
-
-	/* get base pointer of current frame */
-	uint64 framePtrValue = 0;
-	GET_FRAME_POINTER(framePtrValue);
-
-	uint32 depth = 0;
-	void **pFramePtr = (void**) GET_PTR_FROM_VALUE(framePtrValue);
-
-	/* check if the frame pointer is valid */
-	if (pFramePtr != NULL && (void *) &depth < (void *) pFramePtr)
-	{
-		/* consider the first maxStackDepth frames only, below the stack base pointer */
-		for (depth = 0; depth < maxStackDepth; depth++)
-		{
-			/* check if next frame is within stack */
-			if (pFramePtr == NULL ||
-				(void *) pFramePtr > *pFramePtr ||
-				(void *) stack_base_ptr < *pFramePtr)
-			{
-				break;
-			}
-
-			/* get return address (one above the frame pointer) */
-			const uintptr_t *returnAddr = (uintptr_t *)(pFramePtr + 1);
-
-			/* store return address */
-			stackAddresses[depth] = (void *) *returnAddr;
-
-			/* move to next frame */
-			pFramePtr = (void**)*pFramePtr;
-		}
-	}
-	else
-	{
-		depth  = backtrace(stackAddresses, maxStackDepth);
-	}
-
-	Assert(depth > 0);
-
-	return depth;
-
+#ifdef WIN32
+	/* backtrace is not available for this platform */
+	return 0;
 #else
 	return backtrace(stackAddresses, maxStackDepth);
 #endif
@@ -5495,6 +5427,22 @@ SegvBusIllName(int signal)
 	}
 
 	return NULL;
+}
+
+/*
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread must be async-safe to be
+ * used as a signal handler. Under hood it calls backtrace() to collect frame
+ * addresses, that is known to be async-unsafe on the first run, while all the
+ * next runs are async-safe. This function must be called before setting
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread as a signal handler.
+ */
+void
+InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void)
+{
+	void *singleFrame[1];
+
+	/* Make gp_backtrace() async-safe */
+	gp_backtrace(singleFrame, 1);
 }
 
 /*

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -641,6 +641,7 @@ extern char *stack_base_ptr;
 extern bool gp_log_stack_trace_lines;   /* session GUC, controls line info in stack traces */
 
 extern const char *SegvBusIllName(int signal);
+extern void InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void);
 extern void StandardHandlerForSigillSigsegvSigbus_OnMainThread(char * processName, SIGNAL_ARGS);
 
 #endif   /* ELOG_H */


### PR DESCRIPTION
Implement an additional version of `CStackDescriptor::BackTrace()`. The new implementation is to be used when x86 assembly instructions are not available, and pure `backtrace()` is used instead. In this case, frames are traversed in a different fashion, and there is no need in complex return address calculation algorithm (relying on x86 implementation details).

Previously, a common implementation for both "backtrace" and "assembly" case was used. In the "backtrace" case it performed completely wrong pointer arithmetics operations.

The new implementation passes the test (described in [ADBDEV-1889](https://arenadata.atlassian.net/browse/ADBDEV-1889)) without modifications of the test itself.