### PR TITLE
ADBDEV-1892. Custom `float8` test output for ppc64le

### DIFF
--- a/src/backend/utils/adt/float.c
+++ b/src/backend/utils/adt/float.c
@@ -374,9 +374,8 @@ float8in(PG_FUNCTION_ARGS)
 {
 	char	   *num = PG_GETARG_CSTRING(0);
 	char	   *orig_num;
-	long double val;
+	double		val;
 	char	   *endptr;
-	bool 		literal_inf = true;
 
 	/*
 	 * endptr points to the first character _after_ the sequence we recognized
@@ -400,7 +399,7 @@ float8in(PG_FUNCTION_ARGS)
 					orig_num)));
 
 	errno = 0;
-	val = strtold(num, &endptr);
+	val = strtod(num, &endptr);
 
 	/* did we not see anything that looks like a double? */
 	if (endptr == num || errno != 0)
@@ -422,7 +421,7 @@ float8in(PG_FUNCTION_ARGS)
 			val = get_float8_nan();
 			endptr = num + 3;
 		}
-		else if (pg_strncasecmp(num, "Infinity", 8) == 0 || pg_strncasecmp(num, "+Infinity", 9) == 0)
+		else if (pg_strncasecmp(num, "Infinity", 8) == 0)
 		{
 			val = get_float8_infinity();
 			endptr = num + 8;
@@ -497,32 +496,7 @@ float8in(PG_FUNCTION_ARGS)
 			 errmsg("invalid input syntax for type double precision: \"%s\"",
 					orig_num)));
 
-	/*
-	 * strtod does not support values from 1e-323 to 1e-308 for double datatype in rhel6
-	 * due to changes in glibc. In order to overcome this issue we use strtold to parse
-	 * the string and store it in long double so that we get higher precision. We check if
-	 * this value is within allowed range for double using the below two checks:- 
-	 *
-	 * 1) Overflow - When we try to store a value > 1e308 in a double datatype, it gets represented 
-	 * internally as "inf". Hence in order to check for overflow, we use the isinf() method in order
-	 * to check if (double) val has overflowed. But "inf" is a legitimate value for float8, hence if the
-	 * user entered "inf"/"Infinity" we allow it. Otherwise we treat it as overflow.
-	 *
-	 * 2) Underflow - When we try to store a value < 1e-323, it gets converted to a 0.0. But "0.0" is a 
-	 * legitimate value allowed by float8 datatype. Hence we examine if the val is > 0 or < 0 with higher 
-	 * precision (as long double). Again, 0.0 is allowed for float8. If the user entered 0.0, val will be 0.0
-	 * in both higher precision and when rounded down and we allow it. Otherwise in higher precision, 
-	 * val will be > 0 or < 0 and when rounded down to double it will be 0 which is treated as underflow.
-	 */
-
-	if ( pg_strncasecmp(num, "Infinity", 8) != 0  && pg_strncasecmp(num, "-Infinity", 9) != 0 &&\
-		 pg_strncasecmp(num, "Inf", 3) != 0 && pg_strncasecmp(num, "-Inf", 4) != 0 &&\
-		 pg_strncasecmp(num, "+Infinity", 9) != 0 && pg_strncasecmp(num, "+Inf", 4) != 0 )
-		literal_inf = false;
-
-	CHECKFLOATVAL((double) val, literal_inf, !(val > 0 || val < 0));
-
-	PG_RETURN_FLOAT8((double) val);
+	PG_RETURN_FLOAT8(val);
 }
 
 /*

--- a/src/test/regress/expected/float8.out
+++ b/src/test/regress/expected/float8.out
@@ -9,27 +9,27 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e+200');
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e-200');
 -- test for underflow and overflow handling
 SELECT '10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: SELECT '10e400'::float8;
                ^
 SELECT '-10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: SELECT '-10e400'::float8;
                ^
 SELECT '1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: SELECT '1e309'::float8;
                ^
 SELECT '10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: SELECT '10e-400'::float8;
                ^
 SELECT '-10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: SELECT '-10e-400'::float8;
                ^
 SELECT '1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: SELECT '1e-324'::float8;
                ^
 SELECT '1e308'::float8;
@@ -467,27 +467,27 @@ SELECT '' AS five, f1 FROM FLOAT8_TBL ORDER BY 2;
 
 -- test for over- and underflow
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e308');
@@ -503,19 +503,19 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('+naN'::float8);
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-naN'::float8);
 -- test for over- and underflow with update statement
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='0.0'::float8;
@@ -529,19 +529,19 @@ UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='+naN'::float8;
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='-naN'::float8;
 -- test for over- and underflow with delete statement
 DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='0.0'::float8;


### PR DESCRIPTION
Add a file with custom `float8` regression test output for PowerPC-64-little-endian architecture.

Add this to `src/test/regress/resultmap`.