### PR TITLE
Backport synchronization of amgetbitmap definition with upstream

### DIFF
--- a/src/backend/access/gist/gistget.c
+++ b/src/backend/access/gist/gistget.c
@@ -553,21 +553,31 @@ Datum
 gistgetbitmap(PG_FUNCTION_ARGS)
 {
 	IndexScanDesc scan = (IndexScanDesc) PG_GETARG_POINTER(0);
-	Node	   *n = (Node *) PG_GETARG_POINTER(1);
+	Node	  **bmNodeP = (Node *) PG_GETARG_POINTER(1);
 	TIDBitmap  *tbm;
 	GISTScanOpaque so = (GISTScanOpaque) scan->opaque;
 	int64		ntids = 0;
 	GISTSearchItem fakeItem;
 
-	if (n == NULL)
+	/*
+	 * GPDB specific code. Since GPDB also support StreamBitmap
+	 * in bitmap index. So normally we need to create specific bitmap
+	 * node in the amgetbitmap AM.
+	 */
+	Assert(bmNodeP);
+	if (*bmNodeP == NULL)
+	{
+		/* XXX should we use less than work_mem for this? */
 		tbm = tbm_create(work_mem * 1024L);
-	else if (!IsA(n, TIDBitmap))
-		elog(ERROR, "non hash bitmap");
+		*bmNodeP = (Node *) tbm;
+	}
+	else if (!IsA(*bmNodeP, TIDBitmap))
+		elog(ERROR, "non gist bitmap");
 	else
-		tbm = (TIDBitmap *) n;
+		tbm = (TIDBitmap *) *bmNodeP;
 
 	if (!so->qual_ok)
-		PG_RETURN_POINTER(tbm);
+		PG_RETURN_INT64(0);
 
 	pgstat_count_index_scan(scan->indexRelation);
 
@@ -597,5 +607,5 @@ gistgetbitmap(PG_FUNCTION_ARGS)
 		pfree(item);
 	}
 
-	PG_RETURN_POINTER(tbm);
+	PG_RETURN_INT64(ntids);
 }

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -148,7 +148,7 @@ extern ItemPointer index_getnext_tid(IndexScanDesc scan,
 				  ScanDirection direction);
 extern HeapTuple index_fetch_heap(IndexScanDesc scan);
 extern HeapTuple index_getnext(IndexScanDesc scan, ScanDirection direction);
-extern Node *index_getbitmap(IndexScanDesc scan, Node *bitmap);
+extern int64 index_getbitmap(IndexScanDesc scan, Node **bitmapP);
 
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,
 				  IndexBulkDeleteResult *stats,

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -432,7 +432,7 @@ from get_explain_analyze_xml_output($$
  {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
 (1 row)
 
--- gist spgist test case
+-- spgist index test case
 create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
 with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
@@ -457,7 +457,7 @@ from get_explain_analyze_xml_output($$
  {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
 (1 row)
 
--- gist gin test case
+-- gin index test case
 create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
 with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -365,11 +365,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(idx_col) 
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_btree_test_idx on bitmap_btree_test
-using btree(idx_col);
 insert into bitmap_btree_test
 select i, i % 1000
 from generate_series(0,10000) i;
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
@@ -389,11 +389,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(idx_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_bitmap_test_idx on bitmap_bitmap_test
-using bitmap(idx_col);
 insert into bitmap_bitmap_test
 select i, i % 1000
 from generate_series(0,10000) i;
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
 --both optimizers should show 1 row actually processed, because bitmap index
 --doesn't have a precise idea of the number of heap tuples involved
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -414,11 +414,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_gist_test_idx on bitmap_gist_test
-using gist(idx_col);
 insert into bitmap_gist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
@@ -438,11 +438,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_spgist_test_idx on bitmap_spgist_test
-using spgist(idx_col);
 insert into bitmap_spgist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
 --both optimizers should show more than 1 row actually processed
 --spgist index is not supported by ORCA, falling back to Postgres optimizer
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -463,11 +463,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_gin_test_idx on bitmap_gin_test
-using gin(idx_col);
 insert into bitmap_gin_test
 select i, i % 1000, array[(i % 1000)]
 from generate_series(0,10000) i;
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -333,3 +333,153 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+--
+-- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
+--
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
+-- force (Dynamic) Bitmap Index Scan
+set optimizer_enable_dynamictablescan=off;
+set enable_seqscan=off;
+-- Each test case below creates partitioned table with index atop of it.
+-- Each test case covers its own index type supported by GPDB and shows actual
+-- number of rows processed. This number should be more than 1 after fix
+-- (except bitmap, see below).
+-- The final call to get_explain_analyze_xml_output finds xml node with
+-- "Bitmap Index Scan" value, then goes to parent node (..), and finally
+-- extracts "Node-Type" and "Actual-Rows" nodes values. Additionally,
+-- "Optimizer" value extracted.
+-- btree index test case
+create table bitmap_btree_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col) 
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
+insert into bitmap_btree_test
+select i, i % 1000
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_btree_test where idx_col = 900;
+    $$) as x;
+       type_n_rows       |             opt              
+-------------------------+------------------------------
+ {"Bitmap Index Scan",5} | {"Postgres query optimizer"}
+(1 row)
+
+-- bitmap index test case
+create table bitmap_bitmap_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
+insert into bitmap_bitmap_test
+select i, i % 1000
+from generate_series(0,10000) i;
+--both optimizers should show 1 row actually processed, because bitmap index
+--doesn't have a precise idea of the number of heap tuples involved
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_bitmap_test where idx_col = 900;
+    $$) as x;
+       type_n_rows       |             opt              
+-------------------------+------------------------------
+ {"Bitmap Index Scan",1} | {"Postgres query optimizer"}
+(1 row)
+
+-- gist index test case
+create table bitmap_gist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
+insert into bitmap_gist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gist_test where idx_col @> 900;
+    $$) as x;
+                  type_n_rows                  |             opt              
+-----------------------------------------------+------------------------------
+ {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
+(1 row)
+
+-- gist spgist test case
+create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
+insert into bitmap_spgist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+--spgist index is not supported by ORCA, falling back to Postgres optimizer
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_spgist_test where idx_col @> 900;
+    $$) as x;
+                  type_n_rows                  |             opt              
+-----------------------------------------------+------------------------------
+ {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
+(1 row)
+
+-- gist gin test case
+create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
+insert into bitmap_gin_test
+select i, i % 1000, array[(i % 1000)]
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gin_test where idx_col @> array[900];
+    $$) as x;
+                  type_n_rows                  |             opt              
+-----------------------------------------------+------------------------------
+ {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
+(1 row)
+
+reset optimizer_enable_dynamictablescan;
+reset enable_seqscan;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -364,3 +364,153 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_allstat=DEFAULT;
+--
+-- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
+--
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
+-- force (Dynamic) Bitmap Index Scan
+set optimizer_enable_dynamictablescan=off;
+set enable_seqscan=off;
+-- Each test case below creates partitioned table with index atop of it.
+-- Each test case covers its own index type supported by GPDB and shows actual
+-- number of rows processed. This number should be more than 1 after fix
+-- (except bitmap, see below).
+-- The final call to get_explain_analyze_xml_output finds xml node with
+-- "Bitmap Index Scan" value, then goes to parent node (..), and finally
+-- extracts "Node-Type" and "Actual-Rows" nodes values. Additionally,
+-- "Optimizer" value extracted.
+-- btree index test case
+create table bitmap_btree_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col) 
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
+insert into bitmap_btree_test
+select i, i % 1000
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_btree_test where idx_col = 900;
+    $$) as x;
+           type_n_rows           |              opt               
+---------------------------------+--------------------------------
+ {"Dynamic Bitmap Index Scan",5} | {"Pivotal Optimizer (GPORCA)"}
+(1 row)
+
+-- bitmap index test case
+create table bitmap_bitmap_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
+insert into bitmap_bitmap_test
+select i, i % 1000
+from generate_series(0,10000) i;
+--both optimizers should show 1 row actually processed, because bitmap index
+--doesn't have a precise idea of the number of heap tuples involved
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_bitmap_test where idx_col = 900;
+    $$) as x;
+           type_n_rows           |              opt               
+---------------------------------+--------------------------------
+ {"Dynamic Bitmap Index Scan",1} | {"Pivotal Optimizer (GPORCA)"}
+(1 row)
+
+-- gist index test case
+create table bitmap_gist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
+insert into bitmap_gist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gist_test where idx_col @> 900;
+    $$) as x;
+           type_n_rows           |              opt               
+---------------------------------+--------------------------------
+ {"Dynamic Bitmap Index Scan",2} | {"Pivotal Optimizer (GPORCA)"}
+(1 row)
+
+-- gist spgist test case
+create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
+insert into bitmap_spgist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+--spgist index is not supported by ORCA, falling back to Postgres optimizer
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_spgist_test where idx_col @> 900;
+    $$) as x;
+                  type_n_rows                  |             opt              
+-----------------------------------------------+------------------------------
+ {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
+(1 row)
+
+-- gist gin test case
+create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
+insert into bitmap_gin_test
+select i, i % 1000, array[(i % 1000)]
+from generate_series(0,10000) i;
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gin_test where idx_col @> array[900];
+    $$) as x;
+           type_n_rows           |              opt               
+---------------------------------+--------------------------------
+ {"Dynamic Bitmap Index Scan",2} | {"Pivotal Optimizer (GPORCA)"}
+(1 row)
+
+reset optimizer_enable_dynamictablescan;
+reset enable_seqscan;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -396,11 +396,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(idx_col) 
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_btree_test_idx on bitmap_btree_test
-using btree(idx_col);
 insert into bitmap_btree_test
 select i, i % 1000
 from generate_series(0,10000) i;
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
@@ -420,11 +420,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(idx_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_bitmap_test_idx on bitmap_bitmap_test
-using bitmap(idx_col);
 insert into bitmap_bitmap_test
 select i, i % 1000
 from generate_series(0,10000) i;
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
 --both optimizers should show 1 row actually processed, because bitmap index
 --doesn't have a precise idea of the number of heap tuples involved
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -445,11 +445,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_gist_test_idx on bitmap_gist_test
-using gist(idx_col);
 insert into bitmap_gist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
@@ -469,11 +469,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_spgist_test_idx on bitmap_spgist_test
-using spgist(idx_col);
 insert into bitmap_spgist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
 --both optimizers should show more than 1 row actually processed
 --spgist index is not supported by ORCA, falling back to Postgres optimizer
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -494,11 +494,11 @@ with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
-create index bitmap_gin_test_idx on bitmap_gin_test
-using gin(idx_col);
 insert into bitmap_gin_test
 select i, i % 1000, array[(i % 1000)]
 from generate_series(0,10000) i;
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
               /*[local-name()="Node-Type" or local-name()="Actual-Rows"]

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -463,7 +463,7 @@ from get_explain_analyze_xml_output($$
  {"Dynamic Bitmap Index Scan",2} | {"Pivotal Optimizer (GPORCA)"}
 (1 row)
 
--- gist spgist test case
+-- spgist index test case
 create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
 with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
@@ -488,7 +488,7 @@ from get_explain_analyze_xml_output($$
  {"Bitmap Index Scan",0,"Bitmap Index Scan",5} | {"Postgres query optimizer"}
 (1 row)
 
--- gist gin test case
+-- gin index test case
 create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
 with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -256,7 +256,7 @@ from get_explain_analyze_xml_output($$
     select * from bitmap_gist_test where idx_col @> 900;
     $$) as x;
 
--- gist spgist test case
+-- spgist index test case
 create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
 with (appendonly=true, compresslevel=5, compresstype=zlib)
 distributed by (dist_col)
@@ -280,7 +280,7 @@ from get_explain_analyze_xml_output($$
     select * from bitmap_spgist_test where idx_col @> 900;
     $$) as x;
 
--- gist gin test case
+-- gin index test case
 
 create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
 with (appendonly=true, compresslevel=5, compresstype=zlib)

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -193,12 +193,12 @@ distributed by (dist_col)
 partition by range(idx_col) 
 (start (0) inclusive end (999) inclusive every (500));
 
-create index bitmap_btree_test_idx on bitmap_btree_test
-using btree(idx_col);
-
 insert into bitmap_btree_test
 select i, i % 1000
 from generate_series(0,10000) i;
+
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
 
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -216,12 +216,12 @@ distributed by (dist_col)
 partition by range(idx_col)
 (start (0) inclusive end (999) inclusive every (500));
 
-create index bitmap_bitmap_test_idx on bitmap_bitmap_test
-using bitmap(idx_col);
-
 insert into bitmap_bitmap_test
 select i, i % 1000
 from generate_series(0,10000) i;
+
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
 
 --both optimizers should show 1 row actually processed, because bitmap index
 --doesn't have a precise idea of the number of heap tuples involved
@@ -240,12 +240,12 @@ distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
 
-create index bitmap_gist_test_idx on bitmap_gist_test
-using gist(idx_col);
-
 insert into bitmap_gist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
 
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
@@ -263,12 +263,12 @@ distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
 
-create index bitmap_spgist_test_idx on bitmap_spgist_test
-using spgist(idx_col);
-
 insert into bitmap_spgist_test
 select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
 from generate_series(0,10000) i;
+
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
 
 --both optimizers should show more than 1 row actually processed
 --spgist index is not supported by ORCA, falling back to Postgres optimizer
@@ -288,12 +288,12 @@ distributed by (dist_col)
 partition by range(part_col)
 (start (0) inclusive end (999) inclusive every (500));
 
-create index bitmap_gin_test_idx on bitmap_gin_test
-using gin(idx_col);
-
 insert into bitmap_gin_test
 select i, i % 1000, array[(i % 1000)]
 from generate_series(0,10000) i;
+
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
 
 --both optimizers should show more than 1 row actually processed
 select xpath('//*[contains(text(), "Bitmap Index Scan")]/..

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -155,3 +155,154 @@ explain SELECT * from information_schema.key_column_usage;
 set gp_enable_explain_allstat=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_allstat=DEFAULT;
+
+--
+-- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
+--
+
+-- Return EXPLAIN ANALYZE result as xml to manipulate it further.
+create or replace function get_explain_analyze_xml_output(explain_query text)
+returns xml as
+$$
+declare
+  x xml;
+begin
+  execute 'EXPLAIN (ANALYZE, VERBOSE, FORMAT XML) ' || explain_query
+  into x;
+  return x;
+end;
+$$ language plpgsql;
+
+-- force (Dynamic) Bitmap Index Scan
+set optimizer_enable_dynamictablescan=off;
+set enable_seqscan=off;
+
+-- Each test case below creates partitioned table with index atop of it.
+-- Each test case covers its own index type supported by GPDB and shows actual
+-- number of rows processed. This number should be more than 1 after fix
+-- (except bitmap, see below).
+-- The final call to get_explain_analyze_xml_output finds xml node with
+-- "Bitmap Index Scan" value, then goes to parent node (..), and finally
+-- extracts "Node-Type" and "Actual-Rows" nodes values. Additionally,
+-- "Optimizer" value extracted.
+
+-- btree index test case
+create table bitmap_btree_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col) 
+(start (0) inclusive end (999) inclusive every (500));
+
+create index bitmap_btree_test_idx on bitmap_btree_test
+using btree(idx_col);
+
+insert into bitmap_btree_test
+select i, i % 1000
+from generate_series(0,10000) i;
+
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_btree_test where idx_col = 900;
+    $$) as x;
+
+-- bitmap index test case
+create table bitmap_bitmap_test(dist_col int, idx_col int)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(idx_col)
+(start (0) inclusive end (999) inclusive every (500));
+
+create index bitmap_bitmap_test_idx on bitmap_bitmap_test
+using bitmap(idx_col);
+
+insert into bitmap_bitmap_test
+select i, i % 1000
+from generate_series(0,10000) i;
+
+--both optimizers should show 1 row actually processed, because bitmap index
+--doesn't have a precise idea of the number of heap tuples involved
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_bitmap_test where idx_col = 900;
+    $$) as x;
+
+-- gist index test case
+create table bitmap_gist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+
+create index bitmap_gist_test_idx on bitmap_gist_test
+using gist(idx_col);
+
+insert into bitmap_gist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gist_test where idx_col @> 900;
+    $$) as x;
+
+-- gist spgist test case
+create table bitmap_spgist_test(dist_col int, part_col int, idx_col int4range)
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+
+create index bitmap_spgist_test_idx on bitmap_spgist_test
+using spgist(idx_col);
+
+insert into bitmap_spgist_test
+select i, i % 1000, int4range(i % 1000, i % 1000, '[]')
+from generate_series(0,10000) i;
+
+--both optimizers should show more than 1 row actually processed
+--spgist index is not supported by ORCA, falling back to Postgres optimizer
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_spgist_test where idx_col @> 900;
+    $$) as x;
+
+-- gist gin test case
+
+create table bitmap_gin_test(dist_col int, part_col int, idx_col int[])
+with (appendonly=true, compresslevel=5, compresstype=zlib)
+distributed by (dist_col)
+partition by range(part_col)
+(start (0) inclusive end (999) inclusive every (500));
+
+create index bitmap_gin_test_idx on bitmap_gin_test
+using gin(idx_col);
+
+insert into bitmap_gin_test
+select i, i % 1000, array[(i % 1000)]
+from generate_series(0,10000) i;
+
+--both optimizers should show more than 1 row actually processed
+select xpath('//*[contains(text(), "Bitmap Index Scan")]/..
+              /*[local-name()="Node-Type" or local-name()="Actual-Rows"]
+              /text()', x) type_n_rows,
+       xpath('//*[local-name()="Optimizer"]/text()', x) opt
+from get_explain_analyze_xml_output($$
+    select * from bitmap_gin_test where idx_col @> array[900];
+    $$) as x;
+
+reset optimizer_enable_dynamictablescan;
+reset enable_seqscan;


### PR DESCRIPTION
GPDB has a different definition of amgetbitmap with upstream.
Since GPDB also supports StreamBitmap in bitmap index. So normally
we need to create a specific bitmap node in the amgetbitmap AM.
We used to return the created node, this leads to losing the tuples
matched in the bitmap.
So I refactor the amgetbitmap function definition to set bitmap
through pointer and then return the tuples matched in the bitmap.

For GPDB specific bitmap index, it's hard to get matched tuples
in amgetbitmap AM, so ignore it for now.

(backported from 3245d17937bf990ea00689770ec068b12e400eb8)