### PR TITLE
Fixup snapshoot_eof

### DIFF
--- a/src/test/isolation2/output/uao/snapshot_eof.source
+++ b/src/test/isolation2/output/uao/snapshot_eof.source
@@ -53,7 +53,7 @@ ROLLBACK
 COPY 10
 -- Resume VACUUM.
 -- start_ignore
-3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -73,7 +73,7 @@ VACUUM
 (1 row)
 -- Cleanup.
 -- start_ignore
-3:SELECT gp_inject_fault('ao_column_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+3:SELECT gp_inject_fault('ao_@orientation@_truncate_to_eof', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
  gp_inject_fault 
 -----------------
  Success:        


### PR DESCRIPTION
A copy-past inaccuracy was found in snapshot_eof test. It uses
preprocessing of the isolation framework to unify tests for row
and column oriented tables. So in two places "column" orientation
was used instead of "@orientation@" template. It didn't affect
test itself as it is about manipulations with fault injector under
"ignore". Though it is the only test uses this fault and this
inaccuracy doesn't influence any other test, it can become a problem
in future. So, fix it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
