### PR TITLE
add ppc64le specific build options

### DIFF
--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -41,7 +41,7 @@ function build_arch() {
 	*) ;;
 	esac
 
-	echo "${id}${version}_x86_64"
+	echo "${id}${version}_$(uname -p)"
 }
 
 ## ----------------------------------------------------------------------

--- a/concourse/scripts/unit_tests_gporca.bash
+++ b/concourse/scripts/unit_tests_gporca.bash
@@ -27,7 +27,6 @@ function test_orca
 function _main
 {
   mkdir gpdb_src/gpAux/ext
-  build_xerces
   test_orca
 }
 

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -126,6 +126,7 @@ ORCA_CONFIG=--enable-orca
 
 rhel6_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 rhel7_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
+rhel7_ppc64le_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 rhel8_x86_64_CONFIGFLAGS=--disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml
 linux_x86_64_CONFIGFLAGS=${ORCA_CONFIG} --with-libxml
 ubuntu18.04_x86_64_CONFIGFLAGS=--enable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy ${ORCA_CONFIG} --with-libxml

--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -46,6 +46,7 @@ export NO_M64=1
 rhel6_x86_64_BLD_CFLAGS=-m64 -gdwarf-2 -gstrict-dwarf
 rhel7_x86_64_BLD_CFLAGS=-m64
 rhel8_x86_64_BLD_CFLAGS=-m64
+rhel7_ppc64le_BLD_CFLAGS=-m64 -fasynchronous-unwind-tables
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 
 BLD_LDFLAGS=$($(BLD_ARCH)_BLD_LDFLAGS)


### PR DESCRIPTION
upstream has hardcoded value for architecture - x86_64
we need a possibility to pass ppc64le specific configuration variables
to support this architecture

e.g. we must build postgres binaries with `-fasynchronous-unwind-tables`
that disabled on power by default. It leads to fails to unwind
stack during exception handling for stacks that contains mixed
C/C++ frames (ORCA does it).

Also, disable xerces build for ORCA unittests because we use it
from CentOS repos
