### PR TITLE
Fixup! gpinitsystem backout script creation

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -80,6 +80,7 @@ Feature: gpinitsystem tests
         And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
         And the user waits 10 second
         Then gpintsystem logs should not contain lines about running backout script
+        And all files in gpAdminLogs directory are deleted
         And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
 


### PR DESCRIPTION
Commit 39bd1ccfc77cf180cc3a79f68075cc4ae05070fd introduced a new `gpinitsystem` behave test. It has an inaccuracy in error status validation logic - test always failed before the current fix. We need to clean `FATAL` message from `gpAdminLogs` from the first killed `gpinitsystem` run before we check the next `gpinitsystem` status. Otherwise previous FATAL fails the results.