### PR TITLE
ORCA: reduce column list for which statistics is gathered for UNION ALL operation

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnionAll.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUnionAll.h
@@ -91,6 +91,13 @@ public:
 	// Derived Relational Properties
 	//-------------------------------------------------------------------------------------
 
+	// compute required stat columns of the n-th child
+	virtual CColRefSet *PcrsStat(CMemoryPool *mp,
+								 CExpressionHandle &,  // exprhdl
+								 CColRefSet *pcrsInput,
+								 ULONG child_index
+	) const;
+
 	// derive max card
 	virtual CMaxCard DeriveMaxCard(CMemoryPool *mp,
 								   CExpressionHandle &exprhdl) const;

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSetOp.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSetOp.cpp
@@ -475,24 +475,13 @@ CLogicalSetOp::PpcDeriveConstraintIntersectUnion(CMemoryPool *mp,
 //
 //---------------------------------------------------------------------------
 CColRefSet *
-CLogicalSetOp::PcrsStat(CMemoryPool *mp,
+CLogicalSetOp::PcrsStat(CMemoryPool *,		  // mp
 						CExpressionHandle &,  //exprhdl,
-						CColRefSet *pcrsInput,
+						CColRefSet *,		  //pcrsInput
 						ULONG child_index) const
 {
-	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
-	const ULONG length = m_pdrgpcrOutput->Size();
-
-	for (ULONG ul = 0; ul < length; ul++)
-	{
-		CColRef *outputColref = (*m_pdrgpcrOutput)[ul];
-
-		if (!pcrsInput->FMember(outputColref))
-			continue;
-
-		CColRef *childColref = (*(*m_pdrgpdrgpcrInput)[child_index])[ul];
-		pcrs->Include(childColref);
-	}
+	CColRefSet *pcrs = (*m_pdrgpcrsInput)[child_index];
+	pcrs->AddRef();
 
 	return pcrs;
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalSetOp.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalSetOp.cpp
@@ -475,13 +475,24 @@ CLogicalSetOp::PpcDeriveConstraintIntersectUnion(CMemoryPool *mp,
 //
 //---------------------------------------------------------------------------
 CColRefSet *
-CLogicalSetOp::PcrsStat(CMemoryPool *,		  // mp
+CLogicalSetOp::PcrsStat(CMemoryPool *mp,
 						CExpressionHandle &,  //exprhdl,
-						CColRefSet *,		  //pcrsInput
+						CColRefSet *pcrsInput,
 						ULONG child_index) const
 {
-	CColRefSet *pcrs = (*m_pdrgpcrsInput)[child_index];
-	pcrs->AddRef();
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+	const ULONG length = m_pdrgpcrOutput->Size();
+
+	for (ULONG ul = 0; ul < length; ul++)
+	{
+		CColRef *outputColref = (*m_pdrgpcrOutput)[ul];
+
+		if (!pcrsInput->FMember(outputColref))
+			continue;
+
+		CColRef *childColref = (*(*m_pdrgpdrgpcrInput)[child_index])[ul];
+		pcrs->Include(childColref);
+	}
 
 	return pcrs;
 }

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
@@ -162,6 +162,9 @@ CLogicalUnionAll::PstatsDeriveUnionAll(CMemoryPool *mp,
 	GPOS_ASSERT(NULL != pdrgpcrOutput);
 	GPOS_ASSERT(NULL != pdrgpdrgpcrInput);
 
+	CReqdPropRelational *prprel = dynamic_cast<CReqdPropRelational *>(exprhdl.Prp());
+	GPOS_ASSERT(NULL != prprel);
+
 	IStatistics *result_stats = exprhdl.Pstats(0);
 	result_stats->AddRef();
 	const ULONG arity = exprhdl.Arity();
@@ -173,7 +176,8 @@ CLogicalUnionAll::PstatsDeriveUnionAll(CMemoryPool *mp,
 			dynamic_cast<CStatistics *>(child_stats),
 			CColRef::Pdrgpul(mp, pdrgpcrOutput),
 			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[0]),
-			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[ul]));
+			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[ul]),
+			prprel->PcrsStat());
 		result_stats->Release();
 		result_stats = stats;
 	}
@@ -197,6 +201,37 @@ CLogicalUnionAll::PstatsDerive(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	GPOS_ASSERT(EspNone < Esp(exprhdl));
 
 	return PstatsDeriveUnionAll(mp, exprhdl);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CLogicalUnionAll::PcrsStat
+//
+//	@doc:
+//		Compute required stats columns
+//
+//---------------------------------------------------------------------------
+CColRefSet *
+CLogicalUnionAll::PcrsStat(CMemoryPool *mp,
+						   CExpressionHandle &,  //exprhdl,
+						   CColRefSet *pcrsInput,
+						   ULONG child_index) const
+{
+	CColRefSet *pcrs = GPOS_NEW(mp) CColRefSet(mp);
+	const ULONG length = m_pdrgpcrOutput->Size();
+
+	for (ULONG ul = 0; ul < length; ul++)
+	{
+		CColRef *outputColref = (*m_pdrgpcrOutput)[ul];
+
+		if (!pcrsInput->FMember(outputColref))
+			continue;
+
+		CColRef *childColref = (*(*m_pdrgpdrgpcrInput)[child_index])[ul];
+		pcrs->Include(childColref);
+	}
+
+	return pcrs;
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CUnionAllStatsProcessor.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CUnionAllStatsProcessor.h
@@ -22,7 +22,8 @@ public:
 	static CStatistics *CreateStatsForUnionAll(
 		CMemoryPool *mp, const CStatistics *stats_first_child,
 		const CStatistics *stats_second_child, ULongPtrArray *output_colids,
-		ULongPtrArray *first_child_colids, ULongPtrArray *second_child_colids);
+		ULongPtrArray *first_child_colids, ULongPtrArray *second_child_colids,
+		CColRefSet *output_pcrsStat);
 };
 }  // namespace gpnaucrates
 

--- a/src/backend/gporca/libnaucrates/src/statistics/CUnionAllStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CUnionAllStatsProcessor.cpp
@@ -20,7 +20,8 @@ CStatistics *
 CUnionAllStatsProcessor::CreateStatsForUnionAll(
 	CMemoryPool *mp, const CStatistics *stats_first_child,
 	const CStatistics *stats_second_child, ULongPtrArray *output_colids,
-	ULongPtrArray *first_child_colids, ULongPtrArray *second_child_colids)
+	ULongPtrArray *first_child_colids, ULongPtrArray *second_child_colids,
+	CColRefSet *output_pcrsStat)
 {
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != stats_second_child);
@@ -54,17 +55,15 @@ CUnionAllStatsProcessor::CreateStatsForUnionAll(
 			ULONG first_child_colid = *(*first_child_colids)[ul];
 			ULONG second_child_colid = *(*second_child_colids)[ul];
 
+			if (!output_pcrsStat->CBitSet::Get(output_colid))
+				continue;
+
 			const CHistogram *first_child_histogram =
 				stats_first_child->GetHistogram(first_child_colid);
+			GPOS_ASSERT(NULL != first_child_histogram);
 			const CHistogram *second_child_histogram =
 				stats_second_child->GetHistogram(second_child_colid);
-
-			/*
-			 * Neccessary columns on which statistics is delivered to upper plan
-			 * nodes already have to have statistics in child nodes
-			 */
-			if (first_child_histogram == NULL || second_child_histogram == NULL)
-				continue;
+			GPOS_ASSERT(NULL != second_child_histogram);
 
 			if (first_child_histogram->IsWellDefined() ||
 				second_child_histogram->IsWellDefined())

--- a/src/backend/gporca/libnaucrates/src/statistics/CUnionAllStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CUnionAllStatsProcessor.cpp
@@ -56,10 +56,15 @@ CUnionAllStatsProcessor::CreateStatsForUnionAll(
 
 			const CHistogram *first_child_histogram =
 				stats_first_child->GetHistogram(first_child_colid);
-			GPOS_ASSERT(NULL != first_child_histogram);
 			const CHistogram *second_child_histogram =
 				stats_second_child->GetHistogram(second_child_colid);
-			GPOS_ASSERT(NULL != second_child_histogram);
+
+			/*
+			 * Neccessary columns on which statistics is delivered to upper plan
+			 * nodes already have to have statistics in child nodes
+			 */
+			if (first_child_histogram == NULL || second_child_histogram == NULL)
+				continue;
 
 			if (first_child_histogram->IsWellDefined() ||
 				second_child_histogram->IsWellDefined())

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -145,7 +145,7 @@ CStatisticsTest::EresUnittest_UnionAll()
 		CStatistics *pstatsOutput =
 			CUnionAllStatsProcessor::CreateStatsForUnionAll(
 				mp, pstats1, pstats2, pdrgpulColIdOutput, pdrgpulColIdInput1,
-				pdrgpulColIdInput2);
+				pdrgpulColIdInput2, GPOS_NEW(mp) CColRefSet(mp));
 
 		GPOS_ASSERT(NULL != pstatsOutput);
 
@@ -519,7 +519,7 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	colids->AddRef();
 
 	CStatistics *pstats6 = CUnionAllStatsProcessor::CreateStatsForUnionAll(
-		mp, stats, stats, colids, colids, colids);
+		mp, stats, stats, colids, colids, colids, GPOS_NEW(mp) CColRefSet(mp));
 
 	GPOS_TRACE(GPOS_WSZ_LIT("pstats6 = pstats1 union all pstats1"));
 	CCardinalityTestUtils::PrintStats(mp, pstats6);


### PR DESCRIPTION
## Motivation

Currently for UNION ALL (as for other set operations) ORCA requests statistics for all columns defined in target column list of this op. And if subrelations participating in UNION ALL have very wide target column list themself and UNION ALL doesn't reduce this return column list then ORCA planing time becomes very high especially compared with postgres optimizer. The following example shows this anomaly:
```SQL
-- Generate two tables with 10^3 column
do $$
declare
    i int;
begin
    create table test1();
    create table test2();
    for i in 1..1000 loop
        execute format('alter table test1 add column a%s int', i);
        execute format('alter table test2 add column a%s int', i);
    end loop;
end;
$$ language plpgsql;

-- Fill in these tables by random data from 0 up to 1000
do $$
declare
    i int;
    tlist text;
begin
    tlist = '';
    for i in 1..1000 loop
        tlist = tlist || 'random() * 1000, ';
    end loop;
    tlist = substring(tlist for char_length(tlist)-2);
    execute format('insert into test1 select %s from generate_series(1, 1000)', tlist);
    execute format('insert into test2 select %s from generate_series(1, 1000)', tlist);
end;
$$ language plpgsql;

-- Perform analyze
analyze test1;
analyze test2;

-- Measure the first planning time (with cold cache warmup). It's about 40.874 sec.
explain (costs off, analyze)
select *
from test1
where a1 = 0
union all
select *
from test2
where a1 = 0;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1) (actual time=8.186..8.186 rows=1 loops=1)
   ->  Append (actual time=0.508..0.972 rows=1 loops=1)
         ->  Seq Scan on test1 (never executed)
               Filter: (a1 = 0)
         ->  Seq Scan on test2 (actual time=0.010..0.474 rows=1 loops=1)
               Filter: (a1 = 0)
 Planning time: 40874.113 ms
   (slice0)    Executor memory: 3728K bytes.
   (slice1)    Executor memory: 1918K bytes (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 20.940 ms

-- The second planning time (realistic). It's about 6 sec.
explain (costs off, analyze)
select *
from test1
where a1 = 0
union all
select *
from test2
where a1 = 0;
                                        QUERY PLAN                                     
------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1) (actual time=7.850..7.850 rows=1 loops=1)
   ->  Append (actual time=0.462..0.887 rows=1 loops=1)
         ->  Seq Scan on test1 (never executed)
               Filter: (a1 = 0)
         ->  Seq Scan on test2 (actual time=0.011..0.435 rows=1 loops=1)
               Filter: (a1 = 0)
 Planning time: 6047.823 ms
   (slice0)    Executor memory: 3728K bytes.
   (slice1)    Executor memory: 1918K bytes (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 18.661 ms

set optimizer to off;

 -- Postgres planner case. Planning time is about 0.027 sec.
explain (costs off, analyze)
select *
from test1
where a1 = 0
union all
select *
from test2
where a1 = 0;
                                     QUERY PLAN                                     
------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1) (actual time=9.475..9.476 rows=1 loops=1)
   ->  Append (actual time=0.566..1.071 rows=1 loops=1)
         ->  Seq Scan on test1 (never executed)
               Filter: (a1 = 0)
         ->  Seq Scan on test2 (actual time=0.011..0.516 rows=1 loops=1)
               Filter: (a1 = 0)
 Planning time: 27.260 ms
   (slice0)    Executor memory: 3750K bytes.
   (slice1)    Executor memory: 1918K bytes (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution time: 17.686 ms
```

The main reason of such slowdown in ORCA optimizer is in gathering statistics over columns for each node participating in query plan. Flamegraph below shows this slowdown for upper query:
![Screenshot from 2021-09-02 22-38-26](https://user-images.githubusercontent.com/2855994/131905825-17450fb6-d114-4ef0-bb9a-a3feb7ed2eb3.png)
The `gpopt::CEngine::DeriveStats` routine that performs calculating statistics for plan nodes spends about 97.5% full planning time. And most of this is wasted on building of column histograms for plain tables (`gpopt::CMDAccessor::GetHistogram` call) and building histogram for UNION ALL result columns (`gpnaucrates::CHistogram::MakeUnionAllHistogramNormalize` call).

The `Append` node that is implemented by `CLogicalUnionAll` ORCA-specific logical node [requests](https://github.com/arenadata/gpdb/blob/a211f82e01e8585d8661772cbd53f3f5358dc194/src/backend/gporca/libgpopt/src/operators/CLogicalSetOp.cpp#L470-L488) statistics for the full list of columns incoming from child nodes. It's 2*1000 statistics objects all of which includes histogram of values distribution for target column. No one of these statistics objects are [needed](https://github.com/arenadata/gpdb/blob/a211f82e01e8585d8661772cbd53f3f5358dc194/src/backend/gporca/libnaucrates/src/statistics/CUnionAllStatsProcessor.cpp#L94) for calculating cardinality of `CLogicalUnionAll` node also upper node nohow uses their. Therefore, such heavy statistics calculating is completely redundant.

## Patch details
In current implementation `CLogicalUnionAll` node requests column statistics that is requested from it from upper node, i.e. it merely retransmits request from upper node to corresponding columns of child nodes.