### PR TITLE
Introduce contentId parameter for WAL archiving

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -31,6 +31,12 @@
 #include "storage/pmsignal.h"
 
 /*
+ * GPDB specific imports:
+ */
+#include "cdb/cdbvars.h"
+#include "utils/builtins.h"
+
+/*
  * Attempt to retrieve the specified file from off-line archival storage.
  * If successful, fill "path" with its complete path (note that this will be
  * a temp file name that doesn't follow the normal naming convention), and
@@ -65,6 +71,8 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	XLogSegNo	restartSegNo;
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
+
+	char        contentid[12];  /* sign, 10 digits and '\0' */
 
 	/* In standby mode, restore_command might not be supplied */
 	if (recoveryRestoreCommand == NULL)
@@ -173,6 +181,14 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 					/* %r: filename of last restartpoint */
 					sp++;
 					StrNCpy(dp, lastRestartPointFname, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.segindex, contentid);
+					StrNCpy(dp, contentid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -49,6 +49,11 @@
 #include "utils/guc.h"
 #include "utils/ps_status.h"
 
+/*
+ * GPDB specific imports:
+ */
+#include "cdb/cdbvars.h"
+#include "utils/builtins.h"
 
 /* ----------
  * Timer definitions.
@@ -534,6 +539,8 @@ pgarch_archiveXlog(char *xlog)
 	const char *sp;
 	int			rc;
 
+	char		contentid[12];	/* sign, 10 digits and '\0' */
+
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
 	/*
@@ -560,6 +567,14 @@ pgarch_archiveXlog(char *xlog)
 					/* %f: filename of source file */
 					sp++;
 					strlcpy(dp, xlog, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.segindex, contentid);
+					strlcpy(dp, contentid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -34,10 +34,7 @@ REPLICA_PRIMARY1=$TEMP_DIR/replica_p1
 REPLICA_PRIMARY2=$TEMP_DIR/replica_p2
 REPLICA_PRIMARY3=$TEMP_DIR/replica_p3
 
-ARCHIVE_MASTER=$TEMP_DIR/archive_m
-ARCHIVE_PRIMARY1=$TEMP_DIR/archive_p1
-ARCHIVE_PRIMARY2=$TEMP_DIR/archive_p2
-ARCHIVE_PRIMARY3=$TEMP_DIR/archive_p3
+ARCHIVE_PREFIX=$TEMP_DIR/archive_seg
 
 REPLICA_MASTER_DBID=10
 REPLICA_PRIMARY1_DBID=11
@@ -76,13 +73,12 @@ run_test_isolation2()
 # the new settings.
 echo "Setting up WAL Archiving configurations..."
 for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
-  ARCHIVE_VAR=ARCHIVE_$segment_role
   DATADIR_VAR=$segment_role
   echo "wal_level = hot_standby
 archive_mode = on
-archive_command = 'cp %p ${!ARCHIVE_VAR}/%f'" >> ${!DATADIR_VAR}/postgresql.conf
-  mkdir -p ${!ARCHIVE_VAR}
+archive_command = 'cp %p ${ARCHIVE_PREFIX}%c/%f'" >> ${!DATADIR_VAR}/postgresql.conf
 done
+mkdir -p ${ARCHIVE_PREFIX}{-1,0,1,2}
 gpstop -ar -q
 
 # Create the basebackups which will be our replicas for Point-In-Time
@@ -115,10 +111,9 @@ gpstop -a -q
 # mirrors to replicate to.
 echo "Creating recovery.conf files in the replicas and starting them up..."
 for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
-  ARCHIVE_VAR=ARCHIVE_$segment_role
   REPLICA_VAR=REPLICA_$segment_role
   echo "standby_mode = 'on'
-restore_command = 'cp ${!ARCHIVE_VAR}/%f %p'
+restore_command = 'cp ${ARCHIVE_PREFIX}%c/%f %p'
 recovery_target_name = 'test_restore_point'
 primary_conninfo = ''" > ${!REPLICA_VAR}/recovery.conf
   echo "" > ${!REPLICA_VAR}/postgresql.auto.conf


### PR DESCRIPTION
This commit introduces the contentId (%c) parameter to archive_command
and restore_command. It will be substituted with the contentId of the
segment involved in the archival/recovery process.
Thus, an archive_command = 'cp %p /tmp/archive/seg%c/%f' might be
substituted by (for a 3 segment cluster):

cp pg_wal/00000001000000A900000065 /tmp/archive/seg-1/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg0/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg1/00000001000000A900000065
cp pg_wal/00000001000000A900000065 /tmp/archive/seg2/00000001000000A900000065

The param will serve as a piece of identifying information for a WAL
stream from a given segment.

test_gpdb_pitr.sh updated to exercise the (%c) substitution.

Co-authored-by: Kevin Yeap <kyeap@vmware.com>

(cherry picked from commit 96b9844bc803162edded0fe39755e2f97178c45d)