### PR TITLE
ADBDEV-2092: Different number of interfaces per host

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -620,7 +620,10 @@ END_PYTHON_CODE
 	done
 	. $CLUSTER_CONFIG
 	NUM_DATADIR=${#DATA_DIRECTORY[@]}
-	if [ `$ECHO ${M_HOST_ARRAY[@]}|$TR ' ' '\n'|$AWK -F"~" '{print $2}'|$SORT -u|$WC -l` -ne $MCOUNT ];then
+  COUNT_MHOST_NODES=`$ECHO ${M_HOST_ARRAY[@]}|$TR ' ' '\n'|$AWK -F"~" '{print $2}'|$UNIQ -c|$AWK '{print $1}'|$SORT -u`
+  if [ `$ECHO ${COUNT_MHOST_NODES}|$WC -w` -ne 1 ];then
+	  ERROR_EXIT "[FATAL]:-Uneven distribution of network interfaces by hosts" 2
+	elif [ $COUNT_MHOST_NODES -ne $MCOUNT ];then
 		LOG_MSG "[INFO]:-Configuring build for multi-home array" 1
 		MULTI_HOME=1
 		# Now make sure that we have same number of unique hostnames as there are data directories declared

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -100,6 +100,7 @@ TAIL=`findCmdInPath tail`
 TEE=`findCmdInPath tee`
 TOUCH=`findCmdInPath touch`
 TR=`findCmdInPath tr`
+UNIQ=`findCmdInPath uniq`
 WC=`findCmdInPath wc`
 WHICH=`findCmdInPath which`
 ZCAT=`findCmdInPath zcat`


### PR DESCRIPTION
At the moment there is a problem with the different number of interfaces per host. It has not been checked. 

Example host file:
```
sti-vm2-1
sti-vm3-1
sti-vm3-2
```
The `gpinitsystem` didn't check the different number of interfaces. It only used the first host as a template for counting, assuming that the others had same number.  