### PR TITLE
Clarify IS DISTINCT FROM FALSE three valued logic

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2748,6 +2748,10 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 		{
 			CExpression *pexprEquality = NULL;
 			CExpression *pexprFalse = NULL;
+
+			// LASJ with Not-In in GPDB returns nothing, if a NULL was
+			// produced by the inner-outer tuple match. So, we should
+			// check NOT NULL for the inner and outer sides only for LASJ.
 			if (FExtractEquality(
 					pexprPred, &pexprEquality,
 					&pexprFalse) &&	 // extracted equality expression
@@ -2759,12 +2763,17 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 				CPhysicalJoin::FHashJoinCompatible(
 					pexprEquality, pexprOuter,
 					pexprInner) &&	// equality is hash-join compatible
-				!CUtils::FUsesNullableCol(
-					mp, pexprEquality,
-					pexprInner) &&	// equality uses an inner NOT NULL column
-				!CUtils::FUsesNullableCol(
-					mp, pexprEquality,
-					pexprOuter))  // equality uses an outer NOT NULL column
+				((COperator::EopLogicalLeftAntiSemiJoin ==
+					  pexpr->Pop()->Eopid() &&
+				  !CUtils::FUsesNullableCol(
+					  mp, pexprEquality,
+					  pexprInner) &&  // equality uses an inner NOT NULL column
+				  !CUtils::FUsesNullableCol(
+					  mp, pexprEquality,
+					  pexprOuter)  // equality uses an outer NOT NULL column
+				  ) ||
+				 (COperator::EopLogicalLeftAntiSemiJoinNotIn ==
+				  pexpr->Pop()->Eopid())))
 			{
 				pexprEquality->AddRef();
 				pdrgpexprNew->Append(pexprEquality);


### PR DESCRIPTION
Commit e4173271a1f5e250b87ed37e02c8a462627d4029 fixed three valued logic for IS DISTINCT FROM FALSE transformation of the LASHJ to HJ.

The problem was, that this commit created too general restriction for the inner and outer sides of the LASJ: they had to be exactly NOT NULL for any type of LASJ. But it is redundant for LASJ Not-In case, as it returns nothing if the inner-outer tuple match status is NULL.

The reason we have to care about this clarification is that we have our own implementation of a preprocessing fix for NOT NULL in LASJ filter (90afebcd9404a87ab1c4e95b17a6f6a2734b4d63). It differs form the Pivotal's realization (ee9dc5d21c7e2f4b38dfa80900f56ff518047acf) and adds IS DISTINCT FROM FALSE for joins during transformation. Before current patch some joins produced non-effective plans due to e4173271a1f5e250b87ed37e02c8a462627d4029.
