### PR TITLE
CI-1179 Run adb tests on ppc platform

### DIFF
--- a/arenadata/docker-compose.yaml
+++ b/arenadata/docker-compose.yaml
@@ -2,8 +2,10 @@
 
 version: "3"
 services:
+  #image can be either hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}-x86-64 or
+  #hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}-ppc64le depending on the arch
   mdw:
-    image: "hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}"
+    image: "${IMAGE}"
     working_dir: /home/gpadmin
     hostname: mdw
     volumes:
@@ -18,7 +20,7 @@ services:
       echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
       tail -f /home/gpadmin/gpdb_src/README.md"
   sdw1:
-    image: "hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}"
+    image: "${IMAGE}"
     privileged: true
     hostname: sdw1
     volumes:
@@ -33,7 +35,7 @@ services:
       echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
       tail -f /home/gpadmin/gpdb_src/README.md"
   sdw2:
-    image: "hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}"
+    image: "${IMAGE}"
     privileged: true
     hostname: sdw2
     volumes:
@@ -48,7 +50,7 @@ services:
       echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
       tail -f /home/gpadmin/gpdb_src/README.md"
   sdw3:
-    image: "hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}"
+    image: "${IMAGE}"
     privileged: true
     hostname: sdw3
     volumes:


### PR DESCRIPTION
Since tests have to be run on 2 different architectures, it was decided to use 2 different tags for the docker image. An IMAGE env variable will be used in pipelines.

