### PR TITLE
Fix SELECT over DML queries

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -617,7 +617,8 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 			{
 				if ((plan->flow->flotype == FLOW_PARTITIONED ||
 					(plan->flow->flotype == FLOW_SINGLETON &&
-					 plan->flow->locustype == CdbLocusType_SegmentGeneral)) &&
+					 plan->flow->locustype == CdbLocusType_SegmentGeneral) ||
+					 query->hasModifyingCTE) &&
 					 !root->glob->is_parallel_cursor)
 					bringResultToDispatcher = true;
 

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -69,6 +69,22 @@ cdbpath_cost_motion(PlannerInfo *root, CdbMotionPath *motionpath)
 	motionpath->path.memory = subpath->memory;
 }								/* cdbpath_cost_motion */
 
+/*
+ * Check if current root or any root's parent has SELECT query with modifying
+ * CTE inside.
+ */
+static bool
+hasModifyingCTESelectRecur(PlannerInfo *root)
+{
+	while (root)
+	{
+		if (root->parse->hasModifyingCTE &&
+			root->parse->commandType == CMD_SELECT)
+			return true;
+		root = root->parent_root;
+	}
+	return false;
+}
 
 /*
  * cdbpath_create_motion_path
@@ -218,9 +234,17 @@ cdbpath_create_motion_path(PlannerInfo *root,
 			return (Path *) pathnode;
 		}
 
-		/* replicated-->singleton would give redundant copies of the rows. */
+		/*
+		 * replicated-->singleton would give redundant copies of the rows.
+		 * But there is an exception - DML over replicated table should pass
+		 * the check and add motion.
+		 */
 		if (CdbPathLocus_IsReplicated(subpath->locus))
-			goto invalid_motion_request;
+		{
+			if (root->upd_del_replicated_table == 0 &&
+				!hasModifyingCTESelectRecur(root))
+				goto invalid_motion_request;
+		}
 
 		/*
 		 * Must be partitioned-->singleton. If caller gave pathkeys, they'll
@@ -228,7 +252,7 @@ cdbpath_create_motion_path(PlannerInfo *root,
 		 * arbitrarily interleave the rows from the subpath partitions in no
 		 * special order.
 		 */
-		if (!CdbPathLocus_IsPartitioned(subpath->locus))
+		else if (!CdbPathLocus_IsPartitioned(subpath->locus))
 			goto invalid_motion_request;
 	}
 
@@ -337,11 +361,9 @@ cdbpath_create_motion_path(PlannerInfo *root,
 		}
 		else if (CdbPathLocus_IsReplicated(locus))
 		{
-			/*
-			 * Assume that this case only can be generated in
-			 * UPDATE/DELETE statement
-			 */
-			if (root->upd_del_replicated_table == 0)
+			/* Assume that this case only can be generated in DML statement. */
+			if (root->upd_del_replicated_table == 0 &&
+				!hasModifyingCTESelectRecur(root))
 				goto invalid_motion_request;
 
 		}
@@ -1103,7 +1125,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 			if (CdbPathLocus_IsReplicated(other->locus))
 			{
 				Assert(root->upd_del_replicated_table > 0 ||
-					   (root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT));
+					   hasModifyingCTESelectRecur(root));
 
 				/*
 				 * It only appear when we UPDATE a replicated table.
@@ -1262,7 +1284,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	else if (CdbPathLocus_IsReplicated(outer.locus))
 	{
 		if (root->upd_del_replicated_table > 0 ||
-			(root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT))
+			hasModifyingCTESelectRecur(root))
 			CdbPathLocus_MakeReplicated(&inner.move_to,
 										CdbPathLocus_NumSegments(outer.locus));
 		else
@@ -1274,7 +1296,7 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	else if (CdbPathLocus_IsReplicated(inner.locus))
 	{
 		if (root->upd_del_replicated_table > 0 ||
-			(root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT))
+			hasModifyingCTESelectRecur(root))
 			CdbPathLocus_MakeReplicated(&outer.move_to,
 										CdbPathLocus_NumSegments(inner.locus));
 		else

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -1102,7 +1102,8 @@ cdbpath_motion_for_join(PlannerInfo *root,
 
 			if (CdbPathLocus_IsReplicated(other->locus))
 			{
-				Assert(root->upd_del_replicated_table > 0);
+				Assert(root->upd_del_replicated_table > 0 ||
+					   (root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT));
 
 				/*
 				 * It only appear when we UPDATE a replicated table.
@@ -1112,6 +1113,15 @@ cdbpath_motion_for_join(PlannerInfo *root,
 				 * table, we can not execute the plan correctly.
 				 *
 				 * TODO:Can we modify(or add) the broadcast motion for this case?
+				 *
+				 * Another case - DML over replicated table inside CTE with
+				 * SELECT above. If we joining the result of DML with another
+				 * table, which is too replicated, but has less numsegments,
+				 * then we want DML part of query be executed on all, but
+				 * SELECT part of query be executed on less numsegments.
+				 * "Explicit Gather Motion" will use less numsegments in
+				 * execMotionSender(), so our result will not be flacky
+				 * because of new segments without a data.
 				 */
 				Assert(CdbPathLocus_NumSegments(segGeneral->locus) <=
 					   CdbPathLocus_NumSegments(other->locus));
@@ -1232,10 +1242,27 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	}
 	/*
 	 * Replicated paths shouldn't occur except UPDATE/DELETE on replicated table.
+	 *
+	 * Another case - DML over replicated table inside CTE with SELECT above.
+	 * As an easy solution we want to make another part of join replicated,
+	 * but it may be sub-optimal in several cases: 1) Joining something from
+	 * CdbPathLocus_IsBottleneck (for example CdbLocusType_Entry, like joining
+	 * with LIMIT'ed table) with DML over replicated table. 2) Joining
+	 * something from CdbPathLocus_IsPartitioned (for example
+	 * CdbLocusType_Hashed, like joining with distributed by key table) with
+	 * DML over replicated table.
+	 *
+	 * Making this parts replicated will create unnecessary broadcast motion
+	 * to all segments and execution of non-DML part of query on all segments.
+	 * So, as TODO we should think about all the cases and make the logic
+	 * above locus-dependent. We probably shouldn't touch another part of
+	 * join, but change the current one. To support this solution we should
+	 * add more cases to cdbpath_create_motion_path().
 	 */
 	else if (CdbPathLocus_IsReplicated(outer.locus))
 	{
-		if (root->upd_del_replicated_table > 0)
+		if (root->upd_del_replicated_table > 0 ||
+			(root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT))
 			CdbPathLocus_MakeReplicated(&inner.move_to,
 										CdbPathLocus_NumSegments(outer.locus));
 		else
@@ -1246,7 +1273,8 @@ cdbpath_motion_for_join(PlannerInfo *root,
 	}
 	else if (CdbPathLocus_IsReplicated(inner.locus))
 	{
-		if (root->upd_del_replicated_table > 0)
+		if (root->upd_del_replicated_table > 0 ||
+			(root->parse->hasModifyingCTE && root->parse->commandType == CMD_SELECT))
 			CdbPathLocus_MakeReplicated(&outer.move_to,
 										CdbPathLocus_NumSegments(inner.locus));
 		else

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -323,8 +323,7 @@ make_motion_gather(PlannerInfo *root, Plan *subplan, List *sortPathKeys, CdbLocu
 	Motion	   *motion;
 
 	Assert(subplan->flow != NULL);
-	Assert(subplan->flow->flotype == FLOW_PARTITIONED ||
-		   subplan->flow->flotype == FLOW_SINGLETON);
+	Assert(subplan->flow->flotype != FLOW_UNDEFINED);
 
 	if (sortPathKeys)
 	{

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2013,7 +2013,12 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 		config->honor_order_by = false;
 
-		if (!cte->cterecursive)
+		/*
+		 * Additionally to recursive CTE queries, don't try to push down quals
+		 * to non-SELECT queries. There can be DML operation with RETURNING
+		 * clause, and it's incorrect to push down upper quals to it.
+		 */
+		if (!cte->cterecursive && subquery->commandType == CMD_SELECT)
 		{
 			/*
 			 * Adjust the subquery so that 'root', i.e. this subquery, is the

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1949,6 +1949,17 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	Assert(IsA(cte->ctequery, Query));
 
 	/*
+	 * We can't do DML for each subplan. It'll cause duplicated DML operations
+	 * or mutation errors during apply_motion() of cdbparallelize().
+	 *
+	 * TODO: Better workaround using materialization or something else if
+	 * possible.
+	 */
+	if (cte->cterefcount > 1 &&
+		((Query *) cte->ctequery)->commandType != CMD_SELECT)
+		elog(ERROR, "too much refs to non-SELECT CTE");
+
+	/*
 	 * In PostgreSQL, we use the index to look up the plan ID in the
 	 * cteroot->cte_plan_ids list. In GPDB, CTE plans work differently, and
 	 * we look up the CtePlanInfo struct in the list_cteplaninfo instead.

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2530,25 +2530,25 @@ with cte as (
 
 -- Test joining of replicated table (as CdbLocusType_Replicated) with various
 -- CdbLocusType_Entry scenarios.
-explain (costs off) with cte as (
+explain with cte as (
     insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
     returning i
 ) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Explicit Gather Motion 3:1  (slice3; segments: 3)
-   ->  Aggregate
-         ->  Hash Left Join
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice3; segments: 3)  (cost=39.34..39.35 rows=1 width=8)
+   ->  Aggregate  (cost=39.34..39.35 rows=1 width=8)
+         ->  Hash Left Join  (cost=0.59..36.84 rows=334 width=0)
                Hash Cond: (with_dml_dr.i = lmt.i)
-               ->  Insert on with_dml_dr
-                     ->  Function Scan on generate_series i
-               ->  Hash
-                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                           ->  Subquery Scan on lmt
-                                 ->  Limit
-                                       ->  Gather Motion 3:1  (slice1; segments: 3)
-                                             ->  Limit
-                                                   ->  Seq Scan on with_dml
+               ->  Insert on with_dml_dr  (cost=0.00..12.50 rows=334 width=4)
+                     ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=334 width=4)
+               ->  Hash  (cost=0.41..0.41 rows=5 width=4)
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..0.41 rows=15 width=4)
+                           ->  Subquery Scan on lmt  (cost=0.00..0.21 rows=5 width=4)
+                                 ->  Limit  (cost=0.00..0.16 rows=5 width=8)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.16 rows=5 width=8)
+                                             ->  Limit  (cost=0.00..0.06 rows=2 width=8)
+                                                   ->  Seq Scan on with_dml  (cost=0.00..961.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (14 rows)
 
@@ -2624,3 +2624,195 @@ with cte as (
 (1 row)
 
 truncate with_dml_dr;
+-- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
+-- INSERT caused filtering of inserting dataset, which may lead to incomplete
+-- dataset inserted. Pushing down of quals to UPDATE and DELETE caused
+-- "could not find replacement targetlist entry for attno 1 (rewriteManip.c:1409)"
+-- error.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i > 2)
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) c from with_dml;
+ c 
+---
+ 5
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) c from with_dml_dr;
+ c 
+---
+ 5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i = 1)
+                     ->  Update on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i = 5)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) c from with_dml where j = 1000;
+ c 
+---
+ 1
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i = 1)
+               ->  Update on with_dml_dr
+                     ->  Seq Scan on with_dml_dr
+                           Filter: (i = 5)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) c from with_dml_dr where j = 1000;
+ c 
+---
+ 1
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i < 2)
+                     ->  Delete on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) c from with_dml;
+ c 
+---
+ 0
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i < 2)
+               ->  Delete on with_dml_dr
+                     ->  Seq Scan on with_dml_dr
+                           Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) c from with_dml_dr;
+ c 
+---
+ 0
+(1 row)
+

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2214,3 +2214,413 @@ select * from rcte limit 10;
 ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 5:   select first_value(c) over (partition by b), a+x
                  ^
+--
+-- Test various SELECT statements over DML operations
+--
+create table with_dml(i integer, j integer) distributed by(i);
+create table with_dml_dr(i integer, j integer) distributed replicated;
+-- Test select over DML queries. Gather motion should be there, no matter
+-- what type of distribution is used. Before fix, motion was missed for
+-- distributed replicated table, which caused count(*) to return zero rows.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Update on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Update on with_dml_dr
+               ->  Seq Scan on with_dml_dr
+                     Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Delete on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Delete on with_dml_dr
+               ->  Seq Scan on with_dml_dr
+                     Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+-- Test joining, which caused "!(root->upd_del_replicated_table > 0)"
+-- (cdbpath.c:1105) or "!(((bool) 0))" (cdbpath.c:1243) assertion errors due
+-- to incompatibility of CdbLocusType_Replicated with select statements.
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Insert on with_dml_dr
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Insert on with_dml_dr with_dml_dr_1
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Update on with_dml_dr
+                           ->  Seq Scan on with_dml_dr
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Update on with_dml_dr with_dml_dr_1
+                           ->  Seq Scan on with_dml_dr with_dml_dr_1
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+    20
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Delete on with_dml_dr
+                           ->  Seq Scan on with_dml_dr
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Delete on with_dml_dr with_dml_dr_1
+                           ->  Seq Scan on with_dml_dr with_dml_dr_1
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+     0
+(1 row)
+
+-- Test joining of replicated table (as CdbLocusType_Replicated) with various
+-- CdbLocusType_Entry scenarios.
+explain (costs off) with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice3; segments: 3)
+   ->  Aggregate
+         ->  Hash Left Join
+               Hash Cond: (with_dml_dr.i = lmt.i)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+               ->  Hash
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                           ->  Subquery Scan on lmt
+                                 ->  Limit
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Limit
+                                                   ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+ count 
+-------
+     5
+(1 row)
+
+-- execution(not planning) of this will raise:
+-- ERROR:  INSERT/UPDATE/DELETE must be executed by a writer segworker group
+explain (costs off) with cte as (                                                                                                                                                                
+    insert into with_dml_dr select i, i * 100 from generate_series(2658,2664) i
+    returning i
+) select count(*) from cte join pg_class on cte.i = oid;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: ((with_dml_dr.i)::oid = pg_class.oid)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+               ->  Hash
+                     ->  Broadcast Motion 1:3  (slice1)
+                           ->  Seq Scan on pg_class
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- Test joining of one replicated table with another replicated table
+-- propagated on less segments.
+select gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
+create table with_dml_dr_seg1(i integer, j integer) distributed replicated;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 1:1  (slice1; segments: 1)
+   ->  Aggregate
+         ->  Hash Right Join
+               Hash Cond: (with_dml_dr_seg1.i = with_dml_dr.i)
+               ->  Seq Scan on with_dml_dr_seg1
+               ->  Hash
+                     ->  Insert on with_dml_dr
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+ count 
+-------
+     5
+(1 row)
+
+truncate with_dml_dr;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2816,3 +2822,38 @@ select count(*) c from with_dml_dr;
  0
 (1 row)
 
+-- Test we can't use DML CTE if multiple CTE references found.
+-- Otherwise it'll cause duplicated DML operations or apply_motion() errors, like
+-- "!(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist))" (cdbmutate.c:1203)
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2630,6 +2630,7 @@ with cte as (
 (1 row)
 
 truncate with_dml_dr;
+drop table with_dml_dr_seg1;
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete
 -- dataset inserted. Pushing down of quals to UPDATE and DELETE caused

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -3,6 +3,12 @@
 -- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
 -- s/\d+/XXX/g
 --
+-- m/ERROR:  unexpected arguments to set operation \(cdbsetop\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- m/ERROR:  unexpected input locus to distinct \(planner\.c:\d+\)/
+-- s/\d+/XXX/g
+--
 -- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
@@ -2631,6 +2637,169 @@ with cte as (
 
 truncate with_dml_dr;
 drop table with_dml_dr_seg1;
+-- Test UNION ALL of CTE over replicated table with another table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Append
+   ->  Explicit Gather Motion 3:1  (slice1; segments: 3)
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(5 rows)
+
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Append
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               ->  Seq Scan on with_dml_dr with_dml_dr_1
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(10 rows)
+
+truncate with_dml_dr;
+-- Test ORDER BY of CTE over replicated table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: with_dml_dr.i
+   ->  Sort
+         Sort Key: with_dml_dr.i
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(5 rows)
+
+truncate with_dml_dr;
+-- Test select from CTE used as a part of subquery. Recursive iteration by
+-- roots helps us to detect modifying CTE and create valid plan.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (d.i = cte.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml d
+               ->  Hash
+                     ->  Subquery Scan on cte
+                           ->  Insert on with_dml_dr
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (d.i = cte.i)
+               ->  Seq Scan on with_dml_dr d
+               ->  Hash
+                     ->  Subquery Scan on cte
+                           ->  Insert on with_dml_dr
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+ count 
+-------
+     5
+(1 row)
+
+truncate with_dml_dr;
+-- Test still not working cases, which shows some user-friendly errors and not
+-- stopping cluster.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union select * from with_dml;
+ERROR:  unexpected arguments to set operation (cdbsetop.c:229)
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select distinct count(*) from cte;
+ERROR:  unexpected input locus to distinct (planner.c:3025)
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete
 -- dataset inserted. Pushing down of quals to UPDATE and DELETE caused

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2215,3 +2215,413 @@ select * from rcte limit 10;
 ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 5:   select first_value(c) over (partition by b), a+x
                  ^
+--
+-- Test various SELECT statements over DML operations
+--
+create table with_dml(i integer, j integer) distributed by(i);
+create table with_dml_dr(i integer, j integer) distributed replicated;
+-- Test select over DML queries. Gather motion should be there, no matter
+-- what type of distribution is used. Before fix, motion was missed for
+-- distributed replicated table, which caused count(*) to return zero rows.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Update on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Update on with_dml_dr
+               ->  Seq Scan on with_dml_dr
+                     Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     ->  Delete on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Delete on with_dml_dr
+               ->  Seq Scan on with_dml_dr
+                     Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+ count 
+-------
+     5
+(1 row)
+
+-- Test joining, which caused "!(root->upd_del_replicated_table > 0)"
+-- (cdbpath.c:1105) or "!(((bool) 0))" (cdbpath.c:1243) assertion errors due
+-- to incompatibility of CdbLocusType_Replicated with select statements.
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Insert on with_dml_dr
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Insert on with_dml_dr with_dml_dr_1
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Update on with_dml_dr
+                           ->  Seq Scan on with_dml_dr
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Update on with_dml_dr with_dml_dr_1
+                           ->  Seq Scan on with_dml_dr with_dml_dr_1
+                                 Filter: (i <= 5)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+    20
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml.i = with_dml_dr.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml
+               ->  Hash
+                     ->  Delete on with_dml_dr
+                           ->  Seq Scan on with_dml_dr
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (with_dml_dr.i = with_dml_dr_1.i)
+               ->  Seq Scan on with_dml_dr
+               ->  Hash
+                     ->  Delete on with_dml_dr with_dml_dr_1
+                           ->  Seq Scan on with_dml_dr with_dml_dr_1
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+ count 
+-------
+     0
+(1 row)
+
+-- Test joining of replicated table (as CdbLocusType_Replicated) with various
+-- CdbLocusType_Entry scenarios.
+explain (costs off) with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice3; segments: 3)
+   ->  Aggregate
+         ->  Hash Left Join
+               Hash Cond: (with_dml_dr.i = lmt.i)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+               ->  Hash
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                           ->  Subquery Scan on lmt
+                                 ->  Limit
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Limit
+                                                   ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+ count 
+-------
+     5
+(1 row)
+
+-- execution(not planning) of this will raise:
+-- ERROR:  INSERT/UPDATE/DELETE must be executed by a writer segworker group
+explain (costs off) with cte as (                                                                                                                                                                
+    insert into with_dml_dr select i, i * 100 from generate_series(2658,2664) i
+    returning i
+) select count(*) from cte join pg_class on cte.i = oid;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: ((with_dml_dr.i)::oid = pg_class.oid)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+               ->  Hash
+                     ->  Broadcast Motion 1:3  (slice1)
+                           ->  Seq Scan on pg_class
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- Test joining of one replicated table with another replicated table
+-- propagated on less segments.
+select gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
+create table with_dml_dr_seg1(i integer, j integer) distributed replicated;
+select gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Explicit Gather Motion 1:1  (slice1; segments: 1)
+   ->  Aggregate
+         ->  Hash Right Join
+               Hash Cond: (with_dml_dr_seg1.i = with_dml_dr.i)
+               ->  Seq Scan on with_dml_dr_seg1
+               ->  Hash
+                     ->  Insert on with_dml_dr
+                           ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+ count 
+-------
+     5
+(1 row)
+
+truncate with_dml_dr;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2817,3 +2823,38 @@ select count(*) c from with_dml_dr;
  0
 (1 row)
 
+-- Test we can't use DML CTE if multiple CTE references found.
+-- Otherwise it'll cause duplicated DML operations or apply_motion() errors, like
+-- "!(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist))" (cdbmutate.c:1203)
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  too much refs to non-SELECT CTE (allpaths.c:1960)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2531,25 +2531,25 @@ with cte as (
 
 -- Test joining of replicated table (as CdbLocusType_Replicated) with various
 -- CdbLocusType_Entry scenarios.
-explain (costs off) with cte as (
+explain with cte as (
     insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
     returning i
 ) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Explicit Gather Motion 3:1  (slice3; segments: 3)
-   ->  Aggregate
-         ->  Hash Left Join
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice3; segments: 3)  (cost=39.34..39.35 rows=1 width=8)
+   ->  Aggregate  (cost=39.34..39.35 rows=1 width=8)
+         ->  Hash Left Join  (cost=0.59..36.84 rows=334 width=0)
                Hash Cond: (with_dml_dr.i = lmt.i)
-               ->  Insert on with_dml_dr
-                     ->  Function Scan on generate_series i
-               ->  Hash
-                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                           ->  Subquery Scan on lmt
-                                 ->  Limit
-                                       ->  Gather Motion 3:1  (slice1; segments: 3)
-                                             ->  Limit
-                                                   ->  Seq Scan on with_dml
+               ->  Insert on with_dml_dr  (cost=0.00..12.50 rows=334 width=4)
+                     ->  Function Scan on generate_series i  (cost=0.00..12.50 rows=334 width=4)
+               ->  Hash  (cost=0.41..0.41 rows=5 width=4)
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..0.41 rows=15 width=4)
+                           ->  Subquery Scan on lmt  (cost=0.00..0.21 rows=5 width=4)
+                                 ->  Limit  (cost=0.00..0.16 rows=5 width=8)
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.16 rows=5 width=8)
+                                             ->  Limit  (cost=0.00..0.06 rows=2 width=8)
+                                                   ->  Seq Scan on with_dml  (cost=0.00..961.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (14 rows)
 
@@ -2625,3 +2625,195 @@ with cte as (
 (1 row)
 
 truncate with_dml_dr;
+-- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
+-- INSERT caused filtering of inserting dataset, which may lead to incomplete
+-- dataset inserted. Pushing down of quals to UPDATE and DELETE caused
+-- "could not find replacement targetlist entry for attno 1 (rewriteManip.c:1409)"
+-- error.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i > 2)
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) c from with_dml;
+ c 
+---
+ 5
+(1 row)
+
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i > 2)
+               ->  Insert on with_dml_dr
+                     ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) c from with_dml_dr;
+ c 
+---
+ 5
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i = 1)
+                     ->  Update on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i = 5)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) c from with_dml where j = 1000;
+ c 
+---
+ 1
+(1 row)
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i = 1)
+               ->  Update on with_dml_dr
+                     ->  Seq Scan on with_dml_dr
+                           Filter: (i = 5)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) c from with_dml_dr where j = 1000;
+ c 
+---
+ 1
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i < 2)
+                     ->  Delete on with_dml
+                           ->  Seq Scan on with_dml
+                                 Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) c from with_dml;
+ c 
+---
+ 0
+(1 row)
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Subquery Scan on cte
+               Filter: (cte.i < 2)
+               ->  Delete on with_dml_dr
+                     ->  Seq Scan on with_dml_dr
+                           Filter: (i > 0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) c from with_dml_dr;
+ c 
+---
+ 0
+(1 row)
+

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2631,6 +2631,7 @@ with cte as (
 (1 row)
 
 truncate with_dml_dr;
+drop table with_dml_dr_seg1;
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete
 -- dataset inserted. Pushing down of quals to UPDATE and DELETE caused

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -3,6 +3,12 @@
 -- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
 -- s/\d+/XXX/g
 --
+-- m/ERROR:  unexpected arguments to set operation \(cdbsetop\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- m/ERROR:  unexpected input locus to distinct \(planner\.c:\d+\)/
+-- s/\d+/XXX/g
+--
 -- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
@@ -2632,6 +2638,169 @@ with cte as (
 
 truncate with_dml_dr;
 drop table with_dml_dr_seg1;
+-- Test UNION ALL of CTE over replicated table with another table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Append
+   ->  Explicit Gather Motion 3:1  (slice1; segments: 3)
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(5 rows)
+
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Append
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               ->  Seq Scan on with_dml_dr with_dml_dr_1
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(10 rows)
+
+truncate with_dml_dr;
+-- Test ORDER BY of CTE over replicated table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: with_dml_dr.i
+   ->  Sort
+         Sort Key: with_dml_dr.i
+         ->  Insert on with_dml_dr
+               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+ i |  j  
+---+-----
+ 1 | 100
+ 2 | 200
+ 3 | 300
+ 4 | 400
+ 5 | 500
+(5 rows)
+
+truncate with_dml_dr;
+-- Test select from CTE used as a part of subquery. Recursive iteration by
+-- roots helps us to detect modifying CTE and create valid plan.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice2; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (d.i = cte.i)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Seq Scan on with_dml d
+               ->  Hash
+                     ->  Subquery Scan on cte
+                           ->  Insert on with_dml_dr
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+ count 
+-------
+     0
+(1 row)
+
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Explicit Gather Motion 3:1  (slice1; segments: 3)
+   ->  Aggregate
+         ->  Hash Join
+               Hash Cond: (d.i = cte.i)
+               ->  Seq Scan on with_dml_dr d
+               ->  Hash
+                     ->  Subquery Scan on cte
+                           ->  Insert on with_dml_dr
+                                 ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+ count 
+-------
+     5
+(1 row)
+
+truncate with_dml_dr;
+-- Test still not working cases, which shows some user-friendly errors and not
+-- stopping cluster.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union select * from with_dml;
+ERROR:  unexpected arguments to set operation (cdbsetop.c:229)
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select distinct count(*) from cte;
+ERROR:  unexpected input locus to distinct (planner.c:3025)
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete
 -- dataset inserted. Pushing down of quals to UPDATE and DELETE caused

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -508,7 +508,7 @@ with cte as (
 
 -- Test joining of replicated table (as CdbLocusType_Replicated) with various
 -- CdbLocusType_Entry scenarios.
-explain (costs off) with cte as (
+explain with cte as (
     insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
     returning i
 ) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
@@ -538,3 +538,63 @@ with cte as (
     returning i
 ) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
 truncate with_dml_dr;
+
+-- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
+-- INSERT caused filtering of inserting dataset, which may lead to incomplete
+-- dataset inserted. Pushing down of quals to UPDATE and DELETE caused
+-- "could not find replacement targetlist entry for attno 1 (rewriteManip.c:1409)"
+-- error.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+select count(*) c from with_dml;
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+select count(*) c from with_dml_dr;
+
+explain (costs off)
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+with cte as (
+    update with_dml set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+select count(*) c from with_dml where j = 1000;
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+with cte as (
+    update with_dml_dr set j = 1000 where i = 5 returning i
+) select count(*) from cte where i = 1;
+select count(*) c from with_dml_dr where j = 1000;
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < 2;
+select count(*) c from with_dml;
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < 2;
+select count(*) c from with_dml_dr;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -3,6 +3,13 @@ create extension if not exists gp_debug_numsegments;
 create language plpythonu;
 -- end_ignore
 
+-- start_matchsubs
+--
+-- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
+
 drop table if exists with_test1 cascade;
 create table with_test1 (i int, t text, value int) distributed by (i);
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
@@ -598,3 +605,35 @@ with cte as (
     delete from with_dml_dr where i > 0 returning i
 ) select count(*) from cte where i < 2;
 select count(*) c from with_dml_dr;
+
+-- Test we can't use DML CTE if multiple CTE references found.
+-- Otherwise it'll cause duplicated DML operations or apply_motion() errors, like
+-- "!(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist))" (cdbmutate.c:1203)
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte where i < (select avg(i) from cte);

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -1,3 +1,8 @@
+-- start_ignore
+create extension if not exists gp_debug_numsegments;
+create language plpythonu;
+-- end_ignore
+
 drop table if exists with_test1 cascade;
 create table with_test1 (i int, t text, value int) distributed by (i);
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
@@ -390,3 +395,146 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
+
+--
+-- Test various SELECT statements over DML operations
+--
+create table with_dml(i integer, j integer) distributed by(i);
+create table with_dml_dr(i integer, j integer) distributed replicated;
+
+-- Test select over DML queries. Gather motion should be there, no matter
+-- what type of distribution is used. Before fix, motion was missed for
+-- distributed replicated table, which caused count(*) to return zero rows.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte;
+
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+with cte as (
+    update with_dml set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning j
+) select count(*) from cte;
+
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+with cte as (
+    delete from with_dml where i > 0 returning i
+) select count(*) from cte;
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte;
+
+-- Test joining, which caused "!(root->upd_del_replicated_table > 0)"
+-- (cdbpath.c:1105) or "!(((bool) 0))" (cdbpath.c:1243) assertion errors due
+-- to incompatibility of CdbLocusType_Replicated with select statements.
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+explain (costs off)
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+with cte as (
+    update with_dml_dr set j = j + 1 where i <= 5 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml on cte.i = with_dml.i;
+explain (costs off)
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+with cte as (
+    delete from with_dml_dr where i > 0 returning i
+) select count(*) from cte join with_dml_dr on cte.i = with_dml_dr.i;
+
+-- Test joining of replicated table (as CdbLocusType_Replicated) with various
+-- CdbLocusType_Entry scenarios.
+explain (costs off) with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join (select * from with_dml limit 5) lmt on cte.i = lmt.i;
+-- execution(not planning) of this will raise:
+-- ERROR:  INSERT/UPDATE/DELETE must be executed by a writer segworker group
+explain (costs off) with cte as (                                                                                                                                                                
+    insert into with_dml_dr select i, i * 100 from generate_series(2658,2664) i
+    returning i
+) select count(*) from cte join pg_class on cte.i = oid;
+
+-- Test joining of one replicated table with another replicated table
+-- propagated on less segments.
+select gp_debug_set_create_table_default_numsegments(1);
+create table with_dml_dr_seg1(i integer, j integer) distributed replicated;
+select gp_debug_reset_create_table_default_numsegments();
+explain (costs off)
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+with cte as (
+    insert into with_dml_dr select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
+truncate with_dml_dr;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -8,6 +8,12 @@ create language plpythonu;
 -- m/ERROR:  too much refs to non-SELECT CTE \(allpaths\.c:\d+\)/
 -- s/\d+/XXX/g
 --
+-- m/ERROR:  unexpected arguments to set operation \(cdbsetop\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- m/ERROR:  unexpected input locus to distinct \(planner\.c:\d+\)/
+-- s/\d+/XXX/g
+--
 -- end_matchsubs
 
 drop table if exists with_test1 cascade;
@@ -546,6 +552,67 @@ with cte as (
 ) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
 truncate with_dml_dr;
 drop table with_dml_dr_seg1;
+
+-- Test UNION ALL of CTE over replicated table with another table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml;
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union all select * from with_dml_dr;
+truncate with_dml_dr;
+
+-- Test ORDER BY of CTE over replicated table.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte order by i;
+truncate with_dml_dr;
+
+-- Test select from CTE used as a part of subquery. Recursive iteration by
+-- roots helps us to detect modifying CTE and create valid plan.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml d on d.i = cte.i) t;
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select count(*) from (select d.i from cte join with_dml_dr d on d.i = cte.i) t;
+truncate with_dml_dr;
+
+-- Test still not working cases, which shows some user-friendly errors and not
+-- stopping cluster.
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select * from cte union select * from with_dml;
+explain (costs off) with cte as ( 
+    insert into with_dml_dr select i, i * 100  from generate_series(1,5) i 
+    returning i, j
+) select distinct count(*) from cte;
 
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -545,6 +545,7 @@ with cte as (
     returning i
 ) select count(*) from cte left join with_dml_dr_seg1 on cte.i = with_dml_dr_seg1.i;
 truncate with_dml_dr;
+drop table with_dml_dr_seg1;
 
 -- Test quals not pushing down to CTE with DML. Previosuly, pushing down to
 -- INSERT caused filtering of inserting dataset, which may lead to incomplete


### PR DESCRIPTION
Previously, using of SELECT over DML operations caused various errors.
___________
The first block of errors is related to distributed replicated tables. There was no motion node between SELECT and DML plan nodes. This caused SELECT to work with empty result set, no matter how many rows were processed by DML beneath.
Another error was with joining such result set with any table. There were assertion errors due to incompatibility of CdbLocusType_Replicated with SELECT statements.
The fix adds additional analysis of hasModifyingCTE flag which assumes SELECT query can have DML beneath.
___________
The second block of errors is related to quals pushed down from SELECT to DML operation. It's incorrect to push down quals to DML operations, because manipulated dataset can be filtered by wrong upper quals. It also caused indistinct rewrite error.
___________
The third block of errors is related to multiple references to CTE in SELECT. It causes duplicated DML operations or mutation errors during apply_motion() of cdbparallelize().
To fix this, we restrict SELECT queries with multiple references to CTE.