### PR TITLE
Quote PGC_STRING GUC value at GUC value rollback

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5394,6 +5394,10 @@ DispatchSyncPGVariable(struct config_generic * gconfig)
 
 			appendStringInfo(&buffer, "%s TO ", gconfig->name);
 
+			/*
+			 * Plain string literal or identifier. Quote it.
+			 * GUC_LIST_INPUT should not be quoted or it will break list.
+			 */
 			if (!(gconfig->flags & GUC_LIST_INPUT))
 			{
 				str = quote_literal_cstr(*sguc->variable);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5389,10 +5389,15 @@ DispatchSyncPGVariable(struct config_generic * gconfig)
 		case PGC_STRING:
 		{
 			struct config_string *sguc = (struct config_string *) gconfig;
-			const char *str = *sguc->variable;
+			char *str = *sguc->variable;
 			int			i;
 
 			appendStringInfo(&buffer, "%s TO ", gconfig->name);
+
+			if (!(gconfig->flags & GUC_LIST_INPUT))
+			{
+				str = quote_literal_cstr(*sguc->variable);
+			}
 
 			/*
 			 * All whitespace characters must be escaped. See

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -336,3 +336,277 @@ INFO:  iteration:3 unsafe truncate performed
  
 (1 row)
 
+-- Test single query default_tablespace GUC rollback
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET default_tablespace TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When default_tablespace GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query gp_default_storage_options GUC rollback
+-- Function just to save gp_default_storage_options to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET gp_default_storage_options TO 'appendonly=false,blocksize=32768,compresstype=none,checksum=true,orientation=row';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save gp_default_storage_options GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger gp_default_storage_options GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When gp_default_storage_options GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query lc_numeric GUC rollback
+-- Set lc_numeric to value that has to be quoted due to dot
+SET lc_numeric TO 'en_US.utf8';
+-- Function just to save lc_numeric GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET lc_numeric TO 'en_US.utf8';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save lc_numeric GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger lc_numeric GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When lc_numeric GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query pljava_classpath GUC rollback
+-- Function just to save pljava_classpath GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_classpath TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save pljava_classpath GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger pljava_classpath GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When pljava_classpath GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query pljava_vmoptions GUC rollback
+-- Function just to save pljava_vmoptions GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_vmoptions TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save pljava_vmoptions GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger pljava_vmoptions GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When pljava_vmoptions GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;
+-- Test single query GUC TimeZone rollback
+-- Set TimeZone to value that has to be quoted due to slash
+SET TimeZone TO 'Africa/Mbabane';
+-- Function just to save TimeZone to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET TimeZone TO 'UTC';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Save TimeZone GUC to gp_guc_restore_list
+SELECT set_conf_param();
+ set_conf_param 
+----------------
+ 
+(1 row)
+
+-- Trigger TimeZone GUC restore from gp_guc_restore_list
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- When TimeZone GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+ count 
+-------
+     3
+(1 row)
+
+-- Cleanup
+DROP TABLE just_a_temp_table;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -218,3 +218,151 @@ $$
 $$ language plpythonu;
 
 select run_all_in_one();
+
+-- Test single query default_tablespace GUC rollback
+-- Function just to save default_tablespace GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET default_tablespace TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save default_tablespace GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger default_tablespace GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When default_tablespace GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query gp_default_storage_options GUC rollback
+-- Function just to save gp_default_storage_options to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET gp_default_storage_options TO 'appendonly=false,blocksize=32768,compresstype=none,checksum=true,orientation=row';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save gp_default_storage_options GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger gp_default_storage_options GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When gp_default_storage_options GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query lc_numeric GUC rollback
+-- Set lc_numeric to value that has to be quoted due to dot
+SET lc_numeric TO 'en_US.utf8';
+-- Function just to save lc_numeric GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET lc_numeric TO 'en_US.utf8';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save lc_numeric GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger lc_numeric GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When lc_numeric GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query pljava_classpath GUC rollback
+-- Function just to save pljava_classpath GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_classpath TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save pljava_classpath GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger pljava_classpath GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When pljava_classpath GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query pljava_vmoptions GUC rollback
+-- Function just to save pljava_vmoptions GUC to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET pljava_vmoptions TO '';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save pljava_vmoptions GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger pljava_vmoptions GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When pljava_vmoptions GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;
+
+-- Test single query GUC TimeZone rollback
+-- Set TimeZone to value that has to be quoted due to slash
+SET TimeZone TO 'Africa/Mbabane';
+-- Function just to save TimeZone to gp_guc_restore_list
+CREATE OR REPLACE FUNCTION set_conf_param() RETURNS VOID
+AS $$
+BEGIN
+    EXECUTE 'SELECT 1;';
+END;
+$$ LANGUAGE plpgsql
+SET TimeZone TO 'UTC';
+-- Create temp table to create temp schema
+CREATE TEMP TABLE just_a_temp_table (a int);
+-- Temp schema should be created for each segment
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Save TimeZone GUC to gp_guc_restore_list
+SELECT set_conf_param();
+-- Trigger TimeZone GUC restore from gp_guc_restore_list
+SELECT 1;
+-- When TimeZone GUC is restored from gp_guc_restore_list
+-- successfully no RemoveTempRelationsCallback is called.
+-- So check that segments still have temp schemas
+SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg_temp%';
+-- Cleanup
+DROP TABLE just_a_temp_table;


### PR DESCRIPTION
Quote `PGC_STRING` GUC value at GUC value rollback

GUC value rollback was added by commit 09e4d0ab4c35bc88657e6c6d9efc9e090c521017

But it was found that GUC values of `PGC_STRING` type should be
quoted or parsing will fail otherwise as, for example, for
gp_default_storage_options GUC:

> "ERROR","42601","syntax error at or near ""=""",,,,,,"SET gp_default_storage_options TO appendonly=false,blocksize=32768,compresstype=none,checksum=true,orientation=row",45,,"scan.l",1062,


As failed SET command leads to transaction abort that leads to
backend exit that triggers RemoveTempRelationsCallback to remove
temp relations, the new tests verify that after GUC `PGC_STRING` value
rollback no temp relation is removed.

The values with `GUC_LIST_INPUT` set in flags should not be quoted as
it will destroy list.
For example as for search_path:

> SET search_path TO '"$user",public'


should remain

> SET search_path TO "$user",public


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
