### PR TITLE
CI-1179 Run adb tests on ppc platform

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -22,8 +22,9 @@ RUN yum makecache && \
     yum -y install apache-ivy libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     yum -y install perl-IPC-Run perl-Test-Base libxslt-devel && \
     # The last python 2.7 pip
-    pip install -U pip==20.3.4 && \
+    pip install --ignore-installed "pip<21.0" && \
     pip install psi pytest==3.10.1 && \
+    pip install allure-behave==2.4.0 && \
     yum clean all
 
 # setup ssh configuration

--- a/arenadata/scripts/behave_gpdb.bash
+++ b/arenadata/scripts/behave_gpdb.bash
@@ -43,8 +43,6 @@ function _main() {
 		time install_gpdb
 		time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 
-		pip install --ignore-installed "pip<21.0"
-		pip install allure-behave==2.4.0
 
 		local hosts="sdw1 sdw2 sdw3 mdw"
 		for host in $hosts


### PR DESCRIPTION
Behave tests used to fail because of pip installation. While installing allure-behave==2.4.0 the following error occurred: Failed to establish a new connection: [Errno -2] Name or service not known. Adding this package to Dockerfile solved this problem.