### PR TITLE
Fixing regression test output to be compatible with PowerPC.

### DIFF
--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -2454,7 +2454,7 @@ where dt < extra_flow_dist1.a;
 (17 rows)
 
 -- case 6 without CTE, nested subquery
-explain (costs off) select * from (
+explain select * from (
 	select dt from (
 		select
 		(
@@ -2471,36 +2471,36 @@ explain (costs off) select * from (
 ) run_dt,
 extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
-   ->  Nested Loop
-         ->  Subquery Scan on tbl
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000006.34..10000000009.44 rows=4 width=12)
+   ->  Nested Loop  (cost=10000000006.34..10000000009.44 rows=2 width=12)
+         ->  Subquery Scan on tbl  (cost=6.34..6.38 rows=1 width=4)
                Filter: (tbl.dt < '01-01-2010'::date)
-               ->  Unique
+               ->  Unique  (cost=6.34..6.35 rows=1 width=4)
                      Group Key: ((SubPlan 2))
-                     ->  Sort
+                     ->  Sort  (cost=6.34..6.35 rows=1 width=4)
                            Sort Key (Distinct): ((SubPlan 2))
-                           ->  Append
-                                 ->  Subquery Scan on a
-                                       ->  Aggregate
-                                             ->  Result
+                           ->  Append  (cost=0.01..6.33 rows=1 width=4)
+                                 ->  Subquery Scan on a  (cost=0.01..3.16 rows=1 width=4)
+                                       ->  Aggregate  (cost=0.01..0.02 rows=1 width=4)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
                                        SubPlan 2  (slice3; segments: 3)
-                                         ->  Result
+                                         ->  Result  (cost=0.00..3.13 rows=1 width=4)
                                                Filter: (extra_flow_dist_1.b = a.x)
-                                               ->  Materialize
-                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1
-                                 ->  Subquery Scan on aa
-                                       ->  Aggregate
-                                             ->  Result
+                                               ->  Materialize  (cost=0.00..3.13 rows=1 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1  (cost=0.00..3.12 rows=1 width=4)
+                                 ->  Subquery Scan on aa  (cost=0.01..3.16 rows=1 width=4)
+                                       ->  Aggregate  (cost=0.01..0.02 rows=1 width=4)
+                                             ->  Result  (cost=0.00..0.01 rows=1 width=0)
                                        SubPlan 1  (slice3; segments: 3)
-                                         ->  Result
+                                         ->  Result  (cost=0.00..3.13 rows=1 width=4)
                                                Filter: (extra_flow_dist.b = aa.x)
-                                               ->  Materialize
-                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                           ->  Seq Scan on extra_flow_dist
-         ->  Seq Scan on extra_flow_dist1
+                                               ->  Materialize  (cost=0.00..3.13 rows=1 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..3.12 rows=1 width=4)
+                                                           ->  Seq Scan on extra_flow_dist  (cost=0.00..3.12 rows=1 width=4)
+         ->  Seq Scan on extra_flow_dist1  (cost=0.00..3.03 rows=1 width=8)
  Optimizer: Postgres query optimizer
 (29 rows)
 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2585,7 +2585,7 @@ where dt < extra_flow_dist1.a;
 (17 rows)
 
 -- case 6 without CTE, nested subquery
-explain (costs off) select * from (
+explain select * from (
 	select dt from (
 		select
 		(

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2602,48 +2602,48 @@ explain (costs off) select * from (
 ) run_dt,
 extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
---------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)
-   ->  Nested Loop
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..1808675167.14 rows=6 width=12)
+   ->  Nested Loop  (cost=0.00..1808675167.14 rows=2 width=12)
          Join Filter: true
-         ->  Seq Scan on extra_flow_dist1
-         ->  Materialize
-               ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                     ->  GroupAggregate
+         ->  Seq Scan on extra_flow_dist1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Materialize  (cost=0.00..1765422.34 rows=2 width=4)
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1765422.34 rows=2 width=4)
+                     ->  GroupAggregate  (cost=0.00..1765422.34 rows=1 width=4)
                            Group Key: ((SubPlan 1))
-                           ->  Sort
+                           ->  Sort  (cost=0.00..1765422.34 rows=1 width=4)
                                  Sort Key: ((SubPlan 1))
-                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..1765422.34 rows=1 width=4)
                                        Hash Key: ((SubPlan 1))
-                                       ->  GroupAggregate
+                                       ->  GroupAggregate  (cost=0.00..1765422.34 rows=1 width=4)
                                              Group Key: ((SubPlan 1))
-                                             ->  Sort
+                                             ->  Sort  (cost=0.00..1765422.34 rows=1 width=4)
                                                    Sort Key: ((SubPlan 1))
-                                                   ->  Redistribute Motion 1:3  (slice3)
-                                                         ->  Append
-                                                               ->  Result
-                                                                     Filter: (((SubPlan 1)) < '01-01-2010'::date)
-                                                                     ->  Result
-                                                                           ->  Aggregate
-                                                                                 ->  Result
+                                                   ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..1765422.34 rows=2 width=4)
+                                                         ->  Append  (cost=0.00..1765422.34 rows=1 width=4)
+                                                               ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                     Filter: (((SubPlan 1)) < '2010-01-01'::date)
+                                                                     ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                           ->  Aggregate  (cost=0.00..0.00 rows=1 width=4)
+                                                                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
                                                                            SubPlan 1  (slice3)
-                                                                             ->  Result
+                                                                             ->  Result  (cost=0.00..431.00 rows=4 width=4)
                                                                                    Filter: (extra_flow_dist.b = (max(1)))
-                                                                                   ->  Materialize
-                                                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                                                               ->  Seq Scan on extra_flow_dist
-                                                               ->  Result
-                                                                     Filter: (((SubPlan 2)) < '01-01-2010'::date)
-                                                                     ->  Result
-                                                                           ->  Aggregate
-                                                                                 ->  Result
+                                                                                   ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                                                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                                                               ->  Seq Scan on extra_flow_dist  (cost=0.00..431.00 rows=4 width=8)
+                                                               ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                     Filter: (((SubPlan 2)) < '2010-01-01'::date)
+                                                                     ->  Result  (cost=0.00..882711.17 rows=1 width=4)
+                                                                           ->  Aggregate  (cost=0.00..0.00 rows=1 width=4)
+                                                                                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
                                                                            SubPlan 2  (slice3)
-                                                                             ->  Result
+                                                                             ->  Result  (cost=0.00..431.00 rows=4 width=4)
                                                                                    Filter: (extra_flow_dist_1.b = (max(1)))
-                                                                                   ->  Materialize
-                                                                                         ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                                               ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+                                                                                   ->  Materialize  (cost=0.00..431.00 rows=4 width=8)
+                                                                                         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=10 width=8)
+                                                                                               ->  Seq Scan on extra_flow_dist extra_flow_dist_1  (cost=0.00..431.00 rows=4 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
 (41 rows)
 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1016,7 +1016,7 @@ select * from run_dt, extra_flow_dist1
 where dt < extra_flow_dist1.a;
 
 -- case 6 without CTE, nested subquery
-explain (costs off) select * from (
+explain select * from (
 	select dt from (
 		select
 		(


### PR DESCRIPTION
One of regression tests, which use union, has different explain outputs on x86_64 and PowerPC. The reason is evaluation order of recurse_union_children() functions inside generate_union_plan() function. On x86_64 second call processed first. On PowerPC first call processed first. This cause plan difference. In current fix we removing '(costs off)' from explain, so output compared using advanced preprocessing without additional attributes.
