### PR TITLE
Fixing regression test output to be compatible with PowerPC. Option #2.

### DIFF
--- a/src/test/regress/expected/subselect_gp_switch_union.out
+++ b/src/test/regress/expected/subselect_gp_switch_union.out
@@ -2471,35 +2471,35 @@ explain (costs off) select * from (
 ) run_dt,
 extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                                 QUERY PLAN
+                                                 QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop
          ->  Subquery Scan on tbl
-               Filter: (tbl.dt < '01-01-2010'::date)
+               Filter: (tbl.dt < '2010-01-01'::date)
                ->  Unique
-                     Group Key: ((SubPlan 2))
+                     Group Key: ((SubPlan 1))
                      ->  Sort
-                           Sort Key (Distinct): ((SubPlan 2))
+                           Sort Key (Distinct): ((SubPlan 1))
                            ->  Append
                                  ->  Subquery Scan on a
                                        ->  Aggregate
                                              ->  Result
-                                       SubPlan 2  (slice3; segments: 3)
+                                       SubPlan 1  (slice3; segments: 3)
                                          ->  Result
-                                               Filter: (extra_flow_dist_1.b = a.x)
+                                               Filter: (extra_flow_dist.b = a.x)
                                                ->  Materialize
                                                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+                                                           ->  Seq Scan on extra_flow_dist
                                  ->  Subquery Scan on aa
                                        ->  Aggregate
                                              ->  Result
-                                       SubPlan 1  (slice3; segments: 3)
+                                       SubPlan 2  (slice3; segments: 3)
                                          ->  Result
-                                               Filter: (extra_flow_dist.b = aa.x)
+                                               Filter: (extra_flow_dist_1.b = aa.x)
                                                ->  Materialize
                                                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                           ->  Seq Scan on extra_flow_dist
+                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1
          ->  Seq Scan on extra_flow_dist1
  Optimizer: Postgres query optimizer
 (29 rows)

--- a/src/test/regress/expected/subselect_gp_switch_union.out
+++ b/src/test/regress/expected/subselect_gp_switch_union.out
@@ -1,0 +1,2571 @@
+set optimizer_enable_master_only_queries = on;
+set optimizer_segments = 3;
+set optimizer_nestloop_factor = 1.0;
+--
+-- Base tables for CSQ tests
+--
+drop table if exists csq_t1_base;
+NOTICE:  table "csq_t1_base" does not exist, skipping
+create table csq_t1_base(x int, y int) distributed by (x);
+insert into csq_t1_base values(1,2);
+insert into csq_t1_base values(2,1);
+insert into csq_t1_base values(4,2);
+drop table if exists csq_t2_base;
+NOTICE:  table "csq_t2_base" does not exist, skipping
+create table csq_t2_base(x int, y int) distributed by (x);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,1);
+--
+-- Correlated subqueries
+--
+drop table if exists csq_t1;
+NOTICE:  table "csq_t1" does not exist, skipping
+drop table if exists csq_t2;
+NOTICE:  table "csq_t2" does not exist, skipping
+create table csq_t1(x int, y int) distributed by (x);
+create table csq_t2(x int, y int) distributed by (x);
+insert into csq_t1 select * from csq_t1_base;
+insert into csq_t2 select * from csq_t2_base;
+select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
+ x | y 
+---+---
+ 4 | 2
+(1 row)
+
+--
+-- correlations in the targetlist
+--
+select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x >= csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   7
+ 2 |   6
+ 4 |   4
+(3 rows)
+
+select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   1
+ 2 |   2
+ 4 |   4
+(3 rows)
+
+select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   1
+ 2 |   2
+ 4 |   4
+(3 rows)
+
+--
+-- CSQs with partitioned tables
+--
+drop table if exists csq_t1;
+drop table if exists csq_t2;
+create table csq_t1(x int, y int) 
+distributed by (x)
+partition by range (y) ( start (0) end (4) every (1))
+;
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_1" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_2" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_3" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_4" for table "csq_t1"
+create table csq_t2(x int, y int) 
+distributed by (x)
+partition by range (y) ( start (0) end (4) every (1))
+;
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_1" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_2" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_3" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
+insert into csq_t1 select * from csq_t1_base;
+insert into csq_t2 select * from csq_t2_base;
+explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice17; segments: 3)  (cost=810368945.20..810369375.70 rows=172200 width=8)
+   Merge Key: csq_t1_1_prt_1.x
+   ->  Sort  (cost=810368945.20..810369375.70 rows=57400 width=8)
+         Sort Key: csq_t1_1_prt_1.x
+         ->  Append  (cost=0.00..810353969.20 rows=57400 width=8)
+               ->  Seq Scan on csq_t1_1_prt_1  (cost=0.00..202588492.30 rows=14350 width=8)
+                     Filter: (SubPlan 1)
+                     SubPlan 1  (slice17; segments: 3)
+                       ->  Append  (cost=0.00..4705.00 rows=115 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_1.y = csq_t1_1_prt_1.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_1  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_2.y = csq_t1_1_prt_1.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_2  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_3.y = csq_t1_1_prt_1.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_3  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_4.y = csq_t1_1_prt_1.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_4  (cost=0.00..1176.25 rows=29 width=4)
+               ->  Seq Scan on csq_t1_1_prt_2  (cost=0.00..202588492.30 rows=14350 width=8)
+                     Filter: (SubPlan 1)
+                     SubPlan 1  (slice17; segments: 3)
+                       ->  Append  (cost=0.00..4705.00 rows=115 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_1_1.y = csq_t1_1_prt_2.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_1 csq_t2_1_prt_1_1  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_2_1.y = csq_t1_1_prt_2.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_2 csq_t2_1_prt_2_1  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_3_1.y = csq_t1_1_prt_2.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice7; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_3 csq_t2_1_prt_3_1  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_4_1.y = csq_t1_1_prt_2.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice8; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_4 csq_t2_1_prt_4_1  (cost=0.00..1176.25 rows=29 width=4)
+               ->  Seq Scan on csq_t1_1_prt_3  (cost=0.00..202588492.30 rows=14350 width=8)
+                     Filter: (SubPlan 1)
+                     SubPlan 1  (slice17; segments: 3)
+                       ->  Append  (cost=0.00..4705.00 rows=115 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_1_2.y = csq_t1_1_prt_3.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice9; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_1 csq_t2_1_prt_1_2  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_2_2.y = csq_t1_1_prt_3.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice10; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_2 csq_t2_1_prt_2_2  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_3_2.y = csq_t1_1_prt_3.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice11; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_3 csq_t2_1_prt_3_2  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_4_2.y = csq_t1_1_prt_3.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice12; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_4 csq_t2_1_prt_4_2  (cost=0.00..1176.25 rows=29 width=4)
+               ->  Seq Scan on csq_t1_1_prt_4  (cost=0.00..202588492.30 rows=14350 width=8)
+                     Filter: (SubPlan 1)
+                     SubPlan 1  (slice17; segments: 3)
+                       ->  Append  (cost=0.00..4705.00 rows=115 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_1_3.y = csq_t1_1_prt_4.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice13; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_1 csq_t2_1_prt_1_3  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_2_3.y = csq_t1_1_prt_4.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice14; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_2 csq_t2_1_prt_2_3  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_3_3.y = csq_t1_1_prt_4.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice15; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_3 csq_t2_1_prt_3_3  (cost=0.00..1176.25 rows=29 width=4)
+                             ->  Result  (cost=0.00..1176.68 rows=29 width=4)
+                                   Filter: csq_t2_1_prt_4_3.y = csq_t1_1_prt_4.y
+                                   ->  Materialize  (cost=0.00..1176.68 rows=29 width=4)
+                                         ->  Broadcast Motion 3:3  (slice16; segments: 3)  (cost=0.00..1176.25 rows=29 width=4)
+                                               ->  Seq Scan on csq_t2_1_prt_4 csq_t2_1_prt_4_3  (cost=0.00..1176.25 rows=29 width=4)
+ Optimizer: Postgres query optimizer
+(102 rows)
+
+select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
+ x | y 
+---+---
+ 4 | 2
+(1 row)
+
+drop table if exists csq_t1;
+drop table if exists csq_t2;
+drop table if exists csq_t1_base;
+drop table if exists csq_t2_base;
+--
+-- Multi-row subqueries
+--
+drop table if exists mrs_t1;
+NOTICE:  table "mrs_t1" does not exist, skipping
+create table mrs_t1(x int) distributed by (x);
+insert into mrs_t1 select generate_series(1,20);
+explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.25..6.45 rows=20 width=4)
+   ->  Result  (cost=3.25..6.45 rows=7 width=4)
+         One-Time Filter: $0
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Limit  (cost=0.00..3.27 rows=1 width=4)
+                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3.27 rows=1 width=4)
+                       ->  Limit  (cost=0.00..3.25 rows=1 width=4)
+                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=4)
+                                   Filter: (x < (-1))
+         ->  Seq Scan on mrs_t1  (cost=0.00..3.20 rows=7 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1;
+ x 
+---
+(0 rows)
+
+explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.25..6.45 rows=20 width=4)
+   ->  Result  (cost=3.25..6.45 rows=7 width=4)
+         One-Time Filter: $0
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Limit  (cost=0.00..3.27 rows=1 width=4)
+                 ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..3.27 rows=1 width=4)
+                       ->  Limit  (cost=0.00..3.25 rows=1 width=4)
+                             ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=1 width=4)
+                                   Filter: (x = 1)
+         ->  Seq Scan on mrs_t1  (cost=0.00..3.20 rows=7 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
+ x  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=3.30..6.60 rows=13 width=4)
+   ->  Seq Scan on mrs_t1  (cost=3.30..6.60 rows=5 width=4)
+         Filter: ((hashed SubPlan 1)) OR x < 5
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize  (cost=0.00..3.35 rows=7 width=4)
+                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.25 rows=7 width=4)
+                       ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..3.25 rows=7 width=4)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
+ x 
+---
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+drop table if exists mrs_t1;
+--
+-- Multi-row subquery from MSTR
+--
+drop table if exists mrs_u1;
+NOTICE:  table "mrs_u1" does not exist, skipping
+drop table if exists mrs_u2;
+NOTICE:  table "mrs_u2" does not exist, skipping
+create TABLE mrs_u1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create TABLE mrs_u2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mrs_u1 values (1,2),(11,22);
+insert into mrs_u2 values (1,2),(11,22),(33,44);
+select * from mrs_u1 join mrs_u2 on mrs_u1.a=mrs_u2.a where mrs_u1.a in (1,11) or mrs_u2.a in (select a from mrs_u1 where a=1) order by 1;
+ a  | b  | a  | b  
+----+----+----+----
+  1 |  2 |  1 |  2
+ 11 | 22 | 11 | 22
+(2 rows)
+
+drop table if exists mrs_u1;
+drop table if exists mrs_u2;
+--
+-- MPP-13758
+--
+drop table if exists csq_m1;
+NOTICE:  table "csq_m1" does not exist, skipping
+create table csq_m1();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+set allow_system_table_mods=true;
+delete from gp_distribution_policy where localoid='csq_m1'::regclass;
+reset allow_system_table_mods;
+alter table csq_m1 add column x int;
+insert into csq_m1 values(1);
+drop table if exists csq_d1;
+NOTICE:  table "csq_d1" does not exist, skipping
+create table csq_d1(x int) distributed by (x);
+insert into csq_d1 select * from csq_m1;
+explain select array(select x from csq_m1); -- no initplan
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Result  (cost=1.01..1.02 rows=1 width=0)
+   InitPlan 1 (returns $0)
+     ->  Seq Scan on csq_m1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(5 rows)
+
+select array(select x from csq_m1); -- {1}
+ array 
+-------
+ {1}
+(1 row)
+
+explain select array(select x from csq_d1); -- initplan
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Result  (cost=1.01..1.02 rows=1 width=0)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+           ->  Seq Scan on csq_d1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(6 rows)
+
+select array(select x from csq_d1); -- {1}
+ array 
+-------
+ {1}
+(1 row)
+
+--
+-- CSQs involving master-only and distributed tables
+--
+drop table if exists t3cozlib;
+NOTICE:  table "t3cozlib" does not exist, skipping
+create table t3cozlib (c1 int , c2 varchar) with (appendonly=true, compresstype=zlib, orientation=column) distributed by (c1);
+drop table if exists pg_attribute_storage;
+NOTICE:  table "pg_attribute_storage" does not exist, skipping
+create table pg_attribute_storage (attrelid int, attnum int, attoptions text[]) distributed by (attrelid);
+insert into pg_attribute_storage values ('t3cozlib'::regclass, 1, E'{\'something\'}');
+insert into pg_attribute_storage values ('t3cozlib'::regclass, 2, E'{\'something2\'}');
+SELECT a.attname
+, pg_catalog.format_type(a.atttypid, a.atttypmod)
+, ( SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+ FROM pg_catalog.pg_attrdef d
+WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef
+)
+, a.attnotnull
+, a.attnum
+, a.attstorage
+, pg_catalog.col_description(a.attrelid, a.attnum)
+, ( SELECT s.attoptions
+FROM pg_attribute_storage s
+WHERE s.attrelid = a.attrelid AND s.attnum = a.attnum
+) newcolumn
+FROM pg_catalog.pg_attribute a
+WHERE a.attrelid = 't3cozlib'::regclass AND a.attnum > 0 AND NOT a.attisdropped
+ORDER BY a.attnum
+; -- expect to see 2 rows
+ attname |    format_type    | substring | attnotnull | attnum | attstorage | col_description |   newcolumn    
+---------+-------------------+-----------+------------+--------+------------+-----------------+----------------
+ c1      | integer           |           | f          |      1 | p          |                 | {'something'}
+ c2      | character varying |           | f          |      2 | x          |                 | {'something2'}
+(2 rows)
+
+--
+-- More CSQs involving master-only and distributed relations
+--
+drop table if exists csq_m1;
+create table csq_m1();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+set allow_system_table_mods=true;
+delete from gp_distribution_policy where localoid='csq_m1'::regclass;
+reset allow_system_table_mods;
+alter table csq_m1 add column x int;
+insert into csq_m1 values(1),(2),(3);
+drop table if exists csq_d1;
+create table csq_d1(x int) distributed by (x);
+insert into csq_d1 select * from csq_m1 where x < 3;
+insert into csq_d1 values(4);
+select * from csq_m1;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+select * from csq_d1;
+ x 
+---
+ 1
+ 2
+ 4
+(3 rows)
+
+--
+-- outer plan node is master-only and CSQ has distributed relation
+--
+explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Seq Scan on csq_m1  (cost=0.00..2.58 rows=2 width=4)
+   Filter: (NOT ((subplan))) OR x < (-100)
+   SubPlan 1
+     ->  Materialize  (cost=1.02..1.04 rows=1 width=4)
+           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=2 width=4)
+                 ->  Seq Scan on csq_d1  (cost=0.00..1.02 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(8 rows)
+
+select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
+ x 
+---
+ 3
+(1 row)
+
+--
+-- outer plan node is master-only and CSQ has distributed relation
+--
+explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.07 rows=2 width=4)
+   ->  Seq Scan on csq_d1  (cost=0.00..2.07 rows=1 width=4)
+         Filter: (NOT ((subplan))) OR x < (-100)
+         SubPlan 1
+           ->  Materialize  (cost=1.03..1.06 rows=3 width=4)
+                 ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..1.03 rows=3 width=4)
+                       ->  Seq Scan on csq_m1  (cost=0.00..1.03 rows=3 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(9 rows)
+
+select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
+ x 
+---
+ 4
+(1 row)
+
+-- drop csq_m1 since we deleted its gp_distribution_policy entry
+drop table csq_m1;
+--
+-- MPP-14441 Don't lose track of initplans
+--
+drop table if exists csq_t1;
+NOTICE:  table "csq_t1" does not exist, skipping
+CREATE TABLE csq_t1 (a int, b int, c int, d int, e text) DISTRIBUTED BY (a);
+INSERT INTO csq_t1 SELECT i, i/3, i%2, 100-i, 'text'||i  FROM generate_series(1,100) i;
+select count(*) from csq_t1 t1 where a > (SELECT x.b FROM ( select avg(a)::int as b,'haha'::text from csq_t1 t2 where t2.a=t1.d) x ) ;
+ count 
+-------
+    49
+(1 row)
+
+select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 where t2.a=t1.d) ;
+ count 
+-------
+    49
+(1 row)
+
+--
+-- correlation in a func expr
+--
+CREATE OR REPLACE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL CONTAINS SQL;
+DROP TABLE IF EXISTS csq_r;
+NOTICE:  table "csq_r" does not exist, skipping
+CREATE TABLE csq_r(a int) distributed by (a);
+INSERT INTO csq_r VALUES (1);
+-- subqueries shouldn't be pulled into a join if the from clause has a function call
+-- with a correlated argument
+-- force_explain
+explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: NOT ((subplan))
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: a > ((subplan))
+         SubPlan 1
+           ->  Limit  (cost=0.00..0.01 rows=1 width=4)
+                 ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(8 rows)
+
+SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1.02 rows=1 width=4)
+         Filter: (subplan)
+         SubPlan 1
+           ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(7 rows)
+
+SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..10000000001.53 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..10000000001.53 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Nested Loop  (cost=10000000000.00..10000000001.03 rows=2 width=4)
+                 ->  Function Scan on csq_f  (cost=0.00..0.01 rows=1 width=4)
+                 ->  Result  (cost=0.00..1.01 rows=1 width=0)
+                       ->  Materialize  (cost=0.00..1.01 rows=1 width=0)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+                                   ->  Seq Scan on csq_r csq_r_1  (cost=0.00..1.01 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
+ a 
+---
+ 1
+(1 row)
+
+--
+-- Test pullup of expr CSQs to joins
+--
+--
+-- Test data
+--
+drop table if exists csq_pullup;
+NOTICE:  table "csq_pullup" does not exist, skipping
+create table csq_pullup(t text, n numeric, i int, v varchar(10)) distributed by (t);
+insert into csq_pullup values ('abc',1, 2, 'xyz');
+insert into csq_pullup values ('xyz',2, 3, 'def');  
+insert into csq_pullup values ('def',3, 1, 'abc'); 
+--
+-- Expr CSQs to joins
+--
+--
+-- text, text
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.06..2.11 rows=4 width=19)
+   ->  Hash Join  (cost=1.06..2.11 rows=2 width=19)
+         Hash Cond: t0.t = "Expr_SUBQUERY".csq_c0
+         ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.04..1.04 rows=1 width=32)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1.02..1.04 rows=1 width=32)
+                     ->  HashAggregate  (cost=1.02..1.03 rows=1 width=40)
+                           Filter: count(*) = 1
+                           Group By: t1.t
+                           ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+(3 rows)
+
+--
+-- text, varchar
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.09..2.14 rows=4 width=19)
+   ->  Hash Join  (cost=1.09..2.14 rows=2 width=19)
+         Hash Cond: t0.t = "Expr_SUBQUERY".csq_c0
+         ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.08..1.08 rows=1 width=32)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1.05..1.08 rows=1 width=32)
+                     ->  HashAggregate  (cost=1.05..1.07 rows=1 width=40)
+                           Filter: count(partial_aggregation.unnamed_attr_2) = 1
+                           Group By: "?column1?"
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.02..1.04 rows=1 width=40)
+                                 Hash Key: unnamed_attr_1
+                                 ->  HashAggregate  (cost=1.02..1.02 rows=1 width=40)
+                                       Group By: t1.v::text
+                                       ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(16 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+(3 rows)
+
+--
+-- numeric, numeric
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.09..2.16 rows=4 width=19)
+   ->  Hash Join  (cost=1.09..2.16 rows=2 width=19)
+         Hash Cond: t0.n = "Expr_SUBQUERY".csq_c0
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=19)
+               Hash Key: t0.n
+               ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.08..1.08 rows=1 width=32)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1.05..1.08 rows=1 width=32)
+                     ->  HashAggregate  (cost=1.05..1.07 rows=1 width=40)
+                           Filter: count(partial_aggregation.unnamed_attr_2) = 1
+                           Group By: t1.n
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.02..1.04 rows=1 width=40)
+                                 Hash Key: t1.n
+                                 ->  HashAggregate  (cost=1.02..1.02 rows=1 width=40)
+                                       Group By: t1.n
+                                       ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=7)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(18 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+ xyz | 2 | 3 | def
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- function(numeric), function(numeric)
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.10..2.17 rows=4 width=19)
+   ->  Hash Join  (cost=1.10..2.17 rows=2 width=19)
+         Hash Cond: (t0.n + 1::numeric) = "Expr_SUBQUERY".csq_c0
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=19)
+               Hash Key: t0.n + 1::numeric
+               ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.09..1.09 rows=1 width=32)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1.06..1.09 rows=1 width=32)
+                     ->  HashAggregate  (cost=1.06..1.08 rows=1 width=40)
+                           Filter: count(partial_aggregation.unnamed_attr_2) = 1
+                           Group By: "?column1?"
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.02..1.04 rows=1 width=40)
+                                 Hash Key: unnamed_attr_1
+                                 ->  HashAggregate  (cost=1.02..1.02 rows=1 width=40)
+                                       Group By: t1.n + 1::numeric
+                                       ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=7)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(18 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+ xyz | 2 | 3 | def
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- function(numeric), function(int)
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=1.10..2.18 rows=4 width=19)
+   ->  Hash Join  (cost=1.10..2.18 rows=2 width=19)
+         Hash Cond: (t0.n + 1::numeric) = "Expr_SUBQUERY".csq_c0
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=19)
+               Hash Key: t0.n + 1::numeric
+               ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.09..1.09 rows=1 width=32)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1.06..1.09 rows=1 width=32)
+                     ->  HashAggregate  (cost=1.06..1.08 rows=1 width=40)
+                           Filter: count(partial_aggregation.unnamed_attr_2) = 1
+                           Group By: "?column1?"
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.02..1.05 rows=1 width=40)
+                                 Hash Key: unnamed_attr_1
+                                 ->  HashAggregate  (cost=1.02..1.03 rows=1 width=40)
+                                       Group By: (t1.i + 1)::numeric
+                                       ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(18 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- Test a few cases where pulling up an aggregate subquery is not possible
+--
+-- subquery contains a LIMIT
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=17)
+   ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         SubPlan 1
+           ->  Limit  (cost=1.05..1.06 rows=1 width=8)
+                 ->  Aggregate  (cost=1.05..1.06 rows=1 width=8)
+                       ->  Result  (cost=0.00..1.04 rows=1 width=0)
+                             Filter: (t0.t = t1.t)
+                             ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                         ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+-- subquery contains a HAVING clause
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=17)
+   ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate  (cost=1.05..1.06 rows=1 width=8)
+                 Filter: (count(*) < 10)
+                 ->  Result  (cost=0.00..1.04 rows=1 width=0)
+                       Filter: (t0.t = t1.t)
+                       ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=17)
+   ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate  (cost=1.05..1.06 rows=1 width=8)
+                 ->  Result  (cost=0.00..1.04 rows=1 width=0)
+                       Filter: ((t0.n + t1.n) = (t1.i)::numeric)
+                       ->  Materialize  (cost=0.00..1.03 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=9)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
+--
+-- NOT EXISTS CSQs to joins
+--
+--
+-- text, text
+--
+explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..2.07 rows=4 width=19)
+   ->  Hash Anti Join  (cost=1.02..2.07 rows=2 width=19)
+         Hash Cond: t0.t = t1.t
+         ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.01..1.01 rows=1 width=4)
+               ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+                     Filter: t IS NOT NULL AND i = 1
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(9 rows)
+
+select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+(2 rows)
+
+--
+-- int, function(int)
+--
+explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.09..2.15 rows=4 width=19)
+   ->  Hash Anti Join  (cost=1.09..2.15 rows=2 width=19)
+         Hash Cond: t0.i = (t1.i + 1)
+         ->  Seq Scan on csq_pullup t0  (cost=0.00..1.01 rows=1 width=19)
+         ->  Hash  (cost=1.05..1.05 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=4)
+                     ->  Seq Scan on csq_pullup t1  (cost=0.00..1.01 rows=1 width=4)
+                           Filter: (i + 1) IS NOT NULL
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(10 rows)
+
+select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+(1 row)
+
+--
+-- wrong results bug MPP-16477
+--
+drop table if exists subselect_t1;
+NOTICE:  table "subselect_t1" does not exist, skipping
+drop table if exists subselect_t2;
+NOTICE:  table "subselect_t2" does not exist, skipping
+create table subselect_t1(x int) distributed by (x);
+insert into subselect_t1 values(1),(2);
+create table subselect_t2(y int) distributed by (y);
+insert into subselect_t2 values(1),(2),(2);
+analyze subselect_t1;
+analyze subselect_t2;
+explain select * from subselect_t1 where x in (select y from subselect_t2);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.07..2.13 rows=4 width=4)
+   ->  Hash Semi Join  (cost=1.07..2.13 rows=2 width=4)
+         Hash Cond: subselect_t1.x = subselect_t2.y
+         ->  Seq Scan on subselect_t1  (cost=0.00..1.02 rows=1 width=4)
+         ->  Hash  (cost=1.03..1.03 rows=1 width=4)
+               ->  Seq Scan on subselect_t2  (cost=0.00..1.03 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(8 rows)
+
+select * from subselect_t1 where x in (select y from subselect_t2);
+ x 
+---
+ 1
+ 2
+(2 rows)
+
+-- start_ignore
+-- Known_opt_diff: MPP-21351
+-- end_ignore
+explain select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=4.19..6.26 rows=4 width=4)
+   ->  Hash Semi Join  (cost=4.19..6.26 rows=2 width=4)
+         Hash Cond: subselect_t1.x = subselect_t2.y
+         ->  Seq Scan on subselect_t1  (cost=0.00..2.02 rows=1 width=4)
+         ->  Hash  (cost=4.12..4.12 rows=2 width=4)
+               ->  Append  (cost=0.00..4.06 rows=2 width=4)
+                     ->  Seq Scan on subselect_t2  (cost=0.00..2.03 rows=1 width=4)
+                     ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..2.03 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+ x 
+---
+ 1
+ 2
+(2 rows)
+
+explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Aggregate  (cost=2.21..2.22 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=2.14..2.19 rows=1 width=8)
+         ->  Aggregate  (cost=2.14..2.15 rows=1 width=8)
+               ->  Hash Semi Join  (cost=1.07..2.13 rows=2 width=0)
+                     Hash Cond: subselect_t1.x = subselect_t2.y
+                     ->  Seq Scan on subselect_t1  (cost=0.00..1.02 rows=1 width=4)
+                     ->  Hash  (cost=1.03..1.03 rows=1 width=4)
+                           ->  Seq Scan on subselect_t2  (cost=0.00..1.03 rows=1 width=4)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(10 rows)
+
+select count(*) from subselect_t1 where x in (select y from subselect_t2);
+ count 
+-------
+     2
+(1 row)
+
+-- start_ignore
+-- Known_opt_diff: MPP-21351
+-- end_ignore
+explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=6.33..6.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=6.26..6.31 rows=1 width=8)
+         ->  Aggregate  (cost=6.26..6.27 rows=1 width=8)
+               ->  Hash Semi Join  (cost=4.19..6.26 rows=2 width=0)
+                     Hash Cond: subselect_t1.x = subselect_t2.y
+                     ->  Seq Scan on subselect_t1  (cost=0.00..2.02 rows=1 width=4)
+                     ->  Hash  (cost=4.12..4.12 rows=2 width=4)
+                           ->  Append  (cost=0.00..4.06 rows=2 width=4)
+                                 ->  Seq Scan on subselect_t2  (cost=0.00..2.03 rows=1 width=4)
+                                 ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..2.03 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from 
+       ( select 1 as FIELD_1 union all select 2 as FIELD_1 ) TABLE_1 
+       where FIELD_1 in ( select 1 as FIELD_1 union all select 1 as FIELD_1 union all select 1 as FIELD_1 );
+ count 
+-------
+     1
+(1 row)
+
+       
+--
+-- Query was deadlocking because of not squelching subplans (MPP-18936)
+--
+drop table if exists t1; 
+drop table if exists t2; 
+drop table if exists t3; 
+drop table if exists t4; 
+CREATE TABLE t1 AS (SELECT generate_series(1, 5000) AS i, generate_series(5001, 10000) AS j);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2 AS (SELECT * FROM t1 WHERE gp_segment_id = 0);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t3 AS (SELECT * FROM t1 WHERE gp_segment_id = 1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t4 (i1 int, i2 int); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_interconnect_queue_depth=1;
+-- This query was deadlocking on a 2P system
+INSERT INTO t4 
+(
+SELECT t1.i, (SELECT t3.i FROM t3 WHERE t3.i + 1 = t1.i + 1)
+FROM t1, t3
+WHERE t1.i = t3.i
+)
+UNION
+(
+SELECT t1.i, (SELECT t2.i FROM t2 WHERE t2.i + 1 = t1.i + 1)
+FROM t1, t2
+WHERE t1.i = t2.i
+);
+drop table if exists t1; 
+drop table if exists t2; 
+drop table if exists t3; 
+drop table if exists t4; 
+--
+-- Initplans with no corresponding params should be removed MPP-20600
+--
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+create table t1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2(b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+ a 
+---
+(0 rows)
+
+explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+                   QUERY PLAN                   
+------------------------------------------------
+ Result  (cost=1063.00..1063.01 rows=1 width=0)
+   One-Time Filter: false
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(4 rows)
+
+explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
+union all
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
+union all
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+ a 
+---
+(0 rows)
+
+explain select * from t1,
+(select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
+where t1.a = foo.a;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Result  (cost=1063.00..1063.01 rows=1 width=0)
+   One-Time Filter: false
+ Settings:  optimizer=off; optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(4 rows)
+
+select * from t1,
+(select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
+where t1.a = foo.a;
+ a | a 
+---+---
+(0 rows)
+
+--
+-- Correlated subqueries with limit/offset clause must not be pulled up as join
+--
+insert into t1 values (1);
+insert into t2 values (1);
+explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.53 rows=1 width=0)
+   ->  Seq Scan on t1  (cost=0.00..1.53 rows=1 width=0)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Limit  (cost=0.00..1.03 rows=1 width=4)
+                 ->  Limit  (cost=0.00..1.01 rows=1 width=4)
+                       ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                             One-Time Filter: $0 = 1
+                             ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                               ->  Seq Scan on t2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(14 rows)
+
+explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.05 rows=1 width=0)
+   ->  Seq Scan on t1  (cost=0.00..2.05 rows=1 width=0)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Limit  (cost=1.03..1.03 rows=1 width=4)
+                 ->  Result  (cost=0.00..1.01 rows=1 width=4)
+                       One-Time Filter: $0 = 1
+                       ->  Result  (cost=1.01..1.02 rows=1 width=4)
+                             ->  Materialize  (cost=1.01..1.02 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+                                         ->  Seq Scan on t2  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=off; optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(13 rows)
+
+select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
+ ?column? 
+----------
+        1
+(1 row)
+
+select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
+ ?column? 
+----------
+(0 rows)
+
+drop table if exists t1;
+drop table if exists t2;
+--
+-- Test for a bug we used to have with eliminating InitPlans. The subplan,
+-- (select max(content) from y), was eliminated when it shouldn't have been.
+-- The query is supposed to return 0 rows, but returned > 0 when the bug was
+-- present.
+--
+CREATE TABLE initplan_x (i int4, t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_x values
+ (1, 'foobar1'),
+ (2, 'foobar2'),
+ (3, 'foobar3'),
+ (4, 'foobar4'),
+ (5, 'foobar5');
+CREATE TABLE initplan_y (content int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'content' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_y values (5);
+select i, t from initplan_x
+except
+select g, t from initplan_x,
+                 generate_series(0, (select max(content) from initplan_y)) g
+order by 1;
+ i | t 
+---+---
+(0 rows)
+
+drop table if exists initplan_x;
+drop table if exists initplan_y;
+--
+-- Test Initplans that return multiple params.
+--
+create table initplan_test(i int, j int, m int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_test values (1,1,1);
+select * from initplan_test where row(j, m) = (select j, m from initplan_test where i = 1);
+ i | j | m 
+---+---+---
+ 1 | 1 | 1
+(1 row)
+
+drop table initplan_test;
+--
+-- apply parallelization for subplan MPP-24563
+--
+create table t1_mpp_24563 (id int, value int) distributed by (id);
+insert into t1_mpp_24563 values (1, 3);
+create table t2_mpp_24563 (id int, value int, seq int) distributed by (id);
+insert into t2_mpp_24563 values (1, 7, 5);
+explain select row_number() over (order by seq asc) as id, foo.cnt
+from
+(select seq, (select count(*) from t1_mpp_24563 t1 where t1.id = t2.id) cnt from
+	t2_mpp_24563 t2 where value = 7) foo;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=1.02..2.12 rows=1 width=8)
+   Order By: t2.seq
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=1.02..1.05 rows=1 width=8)
+         Merge Key: t2.seq
+         ->  Sort  (cost=1.02..1.03 rows=1 width=8)
+               Sort Key: t2.seq
+               ->  Seq Scan on t2_mpp_24563 t2  (cost=0.00..1.01 rows=1 width=8)
+                     Filter: value = 7
+   SubPlan 1
+     ->  Aggregate  (cost=1.06..1.07 rows=1 width=8)
+           ->  Result  (cost=1.01..1.02 rows=1 width=0)
+                 Filter: t1.id = $0
+                 ->  Materialize  (cost=1.01..1.02 rows=1 width=0)
+                       ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+                             ->  Seq Scan on t1_mpp_24563 t1  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(17 rows)
+
+drop table t1_mpp_24563;
+drop table t2_mpp_24563;
+--
+-- MPP-20470 update the flow of node after parallelizing subplan.
+--
+CREATE TABLE t_mpp_20470 (
+    col_date timestamp without time zone,
+    col_name character varying(6),
+    col_expiry date
+) DISTRIBUTED BY (col_date) PARTITION BY RANGE(col_date)
+(
+START ('2013-05-10 00:00:00'::timestamp without time zone) END ('2013-05-11
+	00:00:00'::timestamp without time zone) WITH (tablename='t_mpp_20470_ptr1', appendonly=false ),
+START ('2013-05-24 00:00:00'::timestamp without time zone) END ('2013-05-25
+	00:00:00'::timestamp without time zone) WITH (tablename='t_mpp_20470_ptr2', appendonly=false )
+);
+NOTICE:  CREATE TABLE will create partition "t_mpp_20470_ptr1" for table "t_mpp_20470"
+NOTICE:  CREATE TABLE will create partition "t_mpp_20470_ptr2" for table "t_mpp_20470"
+COPY t_mpp_20470 from STDIN delimiter '|' null '';
+create view v1_mpp_20470 as
+SELECT
+CASE
+	WHEN  b.col_name::text = 'FUTCUR'::text
+	THEN  ( SELECT count(a.col_expiry) AS count FROM t_mpp_20470 a WHERE
+		a.col_name::text = b.col_name::text)::text
+	ELSE 'Q2'::text END  AS  cc,  1 AS nn
+FROM t_mpp_20470 b;
+explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..128099187.30 rows=93400 width=28)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1134.00 rows=93400 width=28)
+         ->  Result  (cost=0.00..1134.00 rows=31134 width=28)
+               ->  Append  (cost=0.00..1134.00 rows=31134 width=28)
+                     ->  Seq Scan on t_mpp_20470_ptr1 b  (cost=0.00..567.00 rows=15567 width=28)
+                     ->  Seq Scan on t_mpp_20470_ptr2 b_1  (cost=0.00..567.00 rows=15567 width=28)
+   SubPlan 1  (slice0)
+     ->  Aggregate  (cost=1371.47..1371.48 rows=1 width=8)
+           ->  Append  (cost=0.00..1367.50 rows=32 width=4)
+                 ->  Result  (cost=0.00..683.98 rows=16 width=4)
+                       Filter: a.col_name::text = b.col_name::text
+                       ->  Materialize  (cost=0.00..683.98 rows=16 width=4)
+                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..683.75 rows=47 width=4)
+                                   ->  Seq Scan on t_mpp_20470_ptr1 a  (cost=0.00..683.75 rows=16 width=4)
+                 ->  Result  (cost=0.00..683.98 rows=16 width=4)
+                       Filter: a_1.col_name::text = b.col_name::text
+                       ->  Materialize  (cost=0.00..683.98 rows=16 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..683.75 rows=47 width=4)
+                                   ->  Seq Scan on t_mpp_20470_ptr2 a_1  (cost=0.00..683.75 rows=16 width=4)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+drop view v1_mpp_20470;
+drop table t_mpp_20470;
+create table tbl_25484(id int, num int) distributed by (id);
+insert into tbl_25484 values(1, 1), (2, 2), (3, 3);
+select id from tbl_25484 where 3 = (select 3 where 3 = (select num));
+ id 
+----
+  3
+(1 row)
+
+drop table tbl_25484;
+reset optimizer_segments;
+reset optimizer_nestloop_factor;
+--
+-- Test case that once triggered a bug in the IN-clause pull-up code.
+--
+SELECT p.id
+    FROM (SELECT * FROM generate_series(1,10) id
+          WHERE id IN (
+              SELECT 1
+              UNION ALL
+              SELECT 0)) p;
+ id 
+----
+  1
+(1 row)
+
+--
+-- Verify another bug in the IN-clause pull-up code. This returned some
+-- rows from xsupplier twice, because of a bug in detecting whether a
+-- Redistribute node was needed.
+--
+CREATE TABLE xlineitem (l_orderkey int4, l_suppkey int4) distributed by (l_orderkey);
+insert into xlineitem select g+3, g from generate_series(10,100) g;
+insert into xlineitem select g+1, g from generate_series(10,100) g;
+insert into xlineitem select g, g from generate_series(10,100) g;
+CREATE TABLE xsupplier (s_suppkey int4, s_name text) distributed by (s_suppkey);
+insert into xsupplier select g, 'foo' || g from generate_series(1,10) g;
+select s_name from xsupplier
+where s_suppkey in (
+  select g.l_suppkey from xlineitem g
+) ;
+ s_name 
+--------
+ foo10
+(1 row)
+
+--
+-- Another case that failed at one point. (A planner bug in pulling up a
+-- subquery with constant distribution key, 1, in the outer queries.)
+--
+create table nested_in_tbl(tc1 int, tc2 int) distributed by (tc1);
+select * from nested_in_tbl t1  where tc1 in
+  (select 1 from nested_in_tbl t2 where tc1 in
+    (select 1 from nested_in_tbl t3 where t3.tc2 = t2.tc2));
+ tc1 | tc2 
+-----+-----
+(0 rows)
+
+drop table nested_in_tbl;
+--
+-- Window query with a function scan that has non-correlated subquery.
+--
+SELECT rank() over (partition by min(c) order by min(c)) AS p_rank FROM (SELECT d AS c FROM (values(1)) d1, generate_series(0,(SELECT 2)) AS d) tt GROUP BY c;
+ p_rank 
+--------
+      1
+      1
+      1
+(3 rows)
+
+--
+-- Remove unused subplans
+--
+create table foo(a int, b int) distributed by (a) partition by range(b) (start(1) end(3) every(1));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+create table bar(a int, b int) distributed by (a);
+with CT as (select a from foo except select a from bar)
+select * from foo
+where exists (select 1 from CT where CT.a = foo.a);
+ a | b 
+---+---
+(0 rows)
+
+--
+-- Multiple SUBPLAN nodes must not refer to same plan_id
+--
+CREATE TABLE bar_s (c integer, d character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO bar_s VALUES (9,9);
+SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+ c | d 
+---+---
+ 9 | 9
+(1 row)
+
+CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_one" for table "foo_s"
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_two" for table "foo_s"
+INSERT INTO foo_s VALUES (9,9);
+INSERT INTO foo_s VALUES (2,9);
+SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
+ c 
+---
+ 9
+(1 row)
+
+CREATE TABLE baz_s (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO baz_s VALUES (9);
+SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = bar_s.d::int4;
+ c 
+---
+ 9
+ 9
+(2 rows)
+
+DROP TABLE bar_s;
+DROP TABLE foo_s;
+DROP TABLE baz_s;
+--
+-- EXPLAIN tests for queries in subselect.sql to significant plan changes
+--
+-- Set up some simple test tables
+CREATE TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO SUBSELECT_TBL VALUES (1, 2, 3);
+INSERT INTO SUBSELECT_TBL VALUES (2, 3, 4);
+INSERT INTO SUBSELECT_TBL VALUES (3, 4, 5);
+INSERT INTO SUBSELECT_TBL VALUES (1, 1, 1);
+INSERT INTO SUBSELECT_TBL VALUES (2, 2, 2);
+INSERT INTO SUBSELECT_TBL VALUES (3, 3, 3);
+INSERT INTO SUBSELECT_TBL VALUES (6, 7, 8);
+INSERT INTO SUBSELECT_TBL VALUES (8, 9, NULL);
+ANALYZE SUBSELECT_TBL;
+-- Uncorrelated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.66..6.68 rows=8 width=4)
+   Merge Key: subselect_tbl.f1
+   ->  Sort  (cost=6.66..6.68 rows=3 width=4)
+         Sort Key: subselect_tbl.f1
+         ->  Hash Semi Join  (cost=3.34..6.54 rows=3 width=4)
+               Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
+               ->  Hash  (cost=3.24..3.24 rows=3 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.24 rows=3 width=4)
+                           Hash Key: subselect_tbl_1.f2
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=9.93..9.95 rows=8 width=4)
+   Merge Key: subselect_tbl.f1
+   ->  Sort  (cost=9.93..9.95 rows=3 width=4)
+         Sort Key: subselect_tbl.f1
+         ->  Hash Semi Join  (cost=6.61..9.81 rows=3 width=4)
+               Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=4)
+               ->  Hash  (cost=6.52..6.52 rows=3 width=8)
+                     ->  Hash Semi Join  (cost=3.18..6.52 rows=3 width=8)
+                           Hash Cond: subselect_tbl_1.f2 = subselect_tbl_2.f1
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.24 rows=3 width=4)
+                                 Hash Key: subselect_tbl_1.f2
+                                 ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=4)
+                           ->  Hash  (cost=3.08..3.08 rows=3 width=4)
+                                 ->  Seq Scan on subselect_tbl subselect_tbl_2  (cost=0.00..3.08 rows=3 width=4)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+EXPLAIN SELECT '' AS three, f1, f2
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) NOT IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                         WHERE f3 IS NOT NULL) ORDER BY 2,3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000009.64..10000000009.64 rows=4 width=8)
+   Merge Key: subselect_tbl.f1, subselect_tbl.f2
+   ->  Sort  (cost=10000000009.64..10000000009.64 rows=2 width=8)
+         Sort Key: subselect_tbl.f1, subselect_tbl.f2
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000009.61 rows=2 width=8)
+               Join Filter: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
+               ->  Materialize  (cost=0.00..3.47 rows=7 width=12)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.36 rows=7 width=12)
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
+                                 Filter: f3 IS NOT NULL
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+ANALYZE tenk1;
+EXPLAIN SELECT * FROM tenk1 a, tenk1 b
+WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=974.00..1636.00 rows=10000 width=488)
+   ->  Hash Join  (cost=974.00..1636.00 rows=3334 width=488)
+         Hash Cond: (c.unique2 = b.unique2)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=462.00..986.50 rows=3334 width=248)
+               Hash Key: c.unique2
+               ->  Hash Join  (cost=462.00..786.50 rows=3334 width=248)
+                     Hash Cond: (a.unique1 = c.unique1)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=244)
+                     ->  Hash  (cost=337.00..337.00 rows=3334 width=8)
+                           ->  HashAggregate  (cost=237.00..337.00 rows=3334 width=8)
+                                 Group Key: c.unique1, c.unique2
+                                 ->  Seq Scan on tenk1 c  (cost=0.00..187.00 rows=3334 width=8)
+         ->  Hash  (cost=387.00..387.00 rows=3334 width=244)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..387.00 rows=3334 width=244)
+                     Hash Key: b.unique2
+                     ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=244)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- Correlated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.10..2.11 rows=4 width=8)
+   Merge Key: upper.f1, upper.f2
+   ->  Sort  (cost=2.10..2.11 rows=2 width=8)
+         Sort Key: upper.f1, upper.f2
+         ->  Hash Semi Join  (cost=3.11..6.25 rows=2 width=8)
+               Hash Cond: upper.f1 = subselect_tbl.f1
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=8)
+               ->  Hash  (cost=1.01..1.01 rows=1 width=8)
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=8)
+                           Filter: f1 = f2
+ Settings:  optimizer=off
+ Optimizer status: Postgres query optimizer
+(12 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN
+    (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.13..2.14 rows=4 width=12)
+   Merge Key: upper.f1, upper.f3
+   ->  Sort  (cost=2.13..2.14 rows=2 width=12)
+         Sort Key: upper.f1, upper.f3
+         ->  Hash Semi Join  (cost=3.36..6.52 rows=2 width=12)
+               Hash Cond: upper.f1 = subselect_tbl.f2 AND upper.f2::double precision = subselect_tbl.f3
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=16)
+               ->  Hash  (cost=1.03..1.03 rows=1 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=12)
+                           Hash Key: subselect_tbl.f2
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+ Settings:  optimizer=off
+ Optimizer status: Postgres query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
+               WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=2.18..2.19 rows=4 width=12)
+   Merge Key: upper.f1, upper.f3
+   ->  Sort  (cost=2.18..2.19 rows=2 width=12)
+         Sort Key: upper.f1, upper.f3
+         ->  Nested Loop Semi Join  (cost=3.16..6.90 rows=2 width=12)
+               Join Filter: (upper.f1 + subselect_tbl.f2)::double precision = upper.f3
+               ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.01 rows=1 width=12)
+               ->  Materialize  (cost=1.06..1.09 rows=1 width=12)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.05 rows=1 width=12)
+                           ->  Seq Scan on subselect_tbl  (cost=0.00..1.01 rows=1 width=12)
+                                 Filter: f2 = f3::integer
+ Settings:  optimizer=off
+ Optimizer status: Postgres query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                     WHERE f3 IS NOT NULL) ORDER BY 2;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.67..6.69 rows=8 width=4)
+   Merge Key: subselect_tbl.f1
+   ->  Sort  (cost=6.67..6.69 rows=3 width=4)
+         Sort Key: subselect_tbl.f1
+         ->  Hash Semi Join  (cost=3.33..6.55 rows=3 width=4)
+               Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
+               ->  Hash  (cost=3.22..3.22 rows=3 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.22 rows=3 width=12)
+                           Hash Key: subselect_tbl_1.f2
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
+                                 Filter: f3 IS NOT NULL
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+--
+-- Test cases to catch unpleasant interactions between IN-join processing
+-- and subquery pullup.
+--
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=640.06..640.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=640.00..640.05 rows=1 width=8)
+         ->  Aggregate  (cost=640.00..640.01 rows=1 width=8)
+               ->  Hash Join  (cost=414.25..639.75 rows=34 width=0)
+                     Hash Cond: a.unique1 = b.hundred
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=4)
+                     ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                 Group Key: b.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                       Hash Key: b.hundred
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=642.06..642.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=642.00..642.05 rows=1 width=8)
+         ->  Aggregate  (cost=642.00..642.01 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.25..641.75 rows=34 width=4)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+                           ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                       Group Key: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=640.06..640.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=640.00..640.05 rows=1 width=8)
+         ->  Aggregate  (cost=640.00..640.01 rows=1 width=8)
+               ->  Hash Join  (cost=414.25..639.75 rows=34 width=0)
+                     Hash Cond: a.unique1 = b.hundred
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=4)
+                     ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                           ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                 Group Key: b.hundred
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                       Hash Key: b.hundred
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=642.06..642.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=642.00..642.05 rows=1 width=8)
+         ->  Aggregate  (cost=642.00..642.01 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=414.25..641.75 rows=34 width=4)
+                     Hash Key: a.ten
+                     ->  Hash Join  (cost=414.25..639.75 rows=34 width=4)
+                           Hash Cond: a.unique1 = b.hundred
+                           ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=8)
+                           ->  Hash  (cost=413.00..413.00 rows=34 width=4)
+                                 ->  HashAggregate  (cost=412.00..413.00 rows=34 width=4)
+                                       Group Key: b.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
+                                             Hash Key: b.hundred
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=4)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+--
+-- In case of simple exists query, planner can generate alternative
+-- subplans and choose one of them during execution based on the cost.
+-- The below test check that we are generating alternative subplans,
+-- we should see 2 subplans in the explain
+--
+EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..212.10 rows=1 width=4)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..212.10 rows=1 width=4)
+         ->  Limit  (cost=0.00..212.08 rows=1 width=4)
+               ->  Seq Scan on tenk2  (cost=0.00..2133536.35 rows=3354 width=4)
+                     SubPlan 1  (slice3; segments: 3)
+                       ->  Result  (cost=0.00..212.07 rows=1 width=0)
+                             Filter: tenk1.unique1 = tenk2.unique1
+                             ->  Materialize  (cost=0.00..212.07 rows=1 width=0)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..212.06 rows=1 width=0)
+                                         ->  Seq Scan on tenk1  (cost=0.00..212.06 rows=1 width=0)
+                     SubPlan 2  (slice3; segments: 3)
+                       ->  Materialize  (cost=0.00..237.08 rows=3335 width=4)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..187.05 rows=3335 width=4)
+                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..187.05 rows=3335 width=4)
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
+ exists 
+--------
+ t
+(1 row)
+
+--
+-- Ensure that NOT is not lost during subquery pull-up
+--
+SELECT 1 AS col1 WHERE NOT (SELECT 1 = 1);
+ col1 
+------
+(0 rows)
+
+--
+-- Test sane behavior in case of semi join semantics
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test3;
+NOTICE:  table "dedup_test3" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1)); 
+NOTICE:  CREATE TABLE will create partition "dedup_test3_1_prt_1" for table "dedup_test3"
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test2 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test3 select 1, 1, 1 from generate_series(1,10);
+ANALYZE dedup_test1;
+ANALYZE dedup_test2;
+ANALYZE dedup_test3;
+EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.24..5.37 rows=4 width=16)
+   ->  Hash Join  (cost=3.24..5.37 rows=2 width=16)
+         Hash Cond: (dedup_test1.a = dedup_test2.e)
+         ->  Hash Join  (cost=1.15..3.24 rows=2 width=12)
+               Hash Cond: (dedup_test1.a = dedup_test3_1_prt_1.a)
+               ->  Seq Scan on dedup_test1  (cost=0.00..2.04 rows=2 width=8)
+               ->  Hash  (cost=1.14..1.14 rows=1 width=4)
+                     ->  HashAggregate  (cost=1.12..1.14 rows=1 width=4)
+                           Group Key: dedup_test3_1_prt_1.a
+                           ->  Append  (cost=0.00..1.10 rows=4 width=4)
+                                 ->  Seq Scan on dedup_test3_1_prt_1  (cost=0.00..1.10 rows=4 width=4)
+         ->  Hash  (cost=2.04..2.04 rows=2 width=8)
+               ->  Seq Scan on dedup_test2  (cost=0.00..2.04 rows=2 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+ a | b | e | f 
+---+---+---+---
+ 1 | 1 | 1 | 1
+(1 row)
+
+-- Test planner to check if it optimizes the join and marks it as a dummy join
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=1.53..0.54 rows=1 width=0)
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test3;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore
+-- Test init/main plan are not both parallel
+create table init_main_plan_parallel (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- case 1: init plan is parallel, main plan is not.
+select relname from pg_class where exists(select * from init_main_plan_parallel);
+ relname 
+---------
+(0 rows)
+
+-- case2: init plan is not parallel, main plan is parallel
+select * from init_main_plan_parallel where exists (select * from pg_class);
+ c1 | c2 
+----+----
+(0 rows)
+
+-- A subplan whose targetlist might be expanded to make sure all entries of its
+-- hashExpr are in its targetlist, test the motion node above it also updated
+-- its targetlist, otherwise, a wrong answer or a crash happens.
+DROP TABLE IF EXISTS TEST_IN;
+NOTICE:  table "test_in" does not exist, skipping
+CREATE TABLE TEST_IN(
+    C01  FLOAT,
+    C02  NUMERIC(10,0)
+) DISTRIBUTED RANDOMLY;
+--insert repeatable records:
+INSERT INTO TEST_IN
+SELECT
+    ROUND(RANDOM()*1E1),ROUND(RANDOM()*1E1)
+FROM GENERATE_SERIES(1,1E4::BIGINT) I;
+ANALYZE TEST_IN;
+SELECT COUNT(*) FROM
+TEST_IN A
+WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
+ count 
+-------
+ 10000
+(1 row)
+
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                  QUERY PLAN                   
+-----------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (t1.i = t2.i)
+         ->  Seq Scan on simplify_sub t1
+         ->  Hash
+               ->  Seq Scan on simplify_sub t2
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;
+-- Regression of duplicated initplans of a partitioned table
+DROP TABLE IF EXISTS foo, lookup_table;
+NOTICE:  table "lookup_table" does not exist, skipping
+CREATE TABLE foo(a int, b text, c timestamp)
+  DISTRIBUTED BY (a)
+  PARTITION BY LIST(b) (VALUES('a'), VALUES('b'));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+INSERT INTO foo VALUES (1, 'a', '2012-12-12 13:00');
+INSERT INTO foo VALUES (2, 'b', '2012-12-13 12:00');
+CREATE TABLE lookup_table(a text, c timestamp)
+  DISTRIBUTED BY (a);
+INSERT INTO lookup_table VALUES ('a', '2012-12-12 12:00');
+INSERT INTO lookup_table VALUES ('b', '2021-12-21 21:00');
+CREATE OR REPLACE FUNCTION my_lookup(a_in text) RETURNS timestamp AS
+$$
+DECLARE
+   c_var timestamp;
+BEGIN
+   BEGIN
+      SELECT c INTO c_var FROM lookup_table WHERE a = a_in;
+   END;
+   RETURN c_var;
+END;
+$$
+LANGUAGE plpgsql NO SQL;
+SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table extra_flow_dist1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on run_dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Subquery Scan on a
+                     ->  Aggregate
+                           ->  Result
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Filter: (extra_flow_dist.b = a.x)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         ->  Seq Scan on extra_flow_dist
+         ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 21 | 21
+(3 rows)
+
+create table extra_flow_rand(a int) distributed replicated;
+insert into extra_flow_rand values (1);
+-- case 2 for subplan with segment general locus (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x  -- subplan's outer is the below segment general locus path
+	) dt
+	from (select a x from extra_flow_rand) a  -- segment general locus
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: run_dt.dt, extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: run_dt.dt, extra_flow_dist1.a, extra_flow_dist1.b
+         ->  Subquery Scan on run_dt
+               Output: run_dt.dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: (SubPlan 1)
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Output: extra_flow_dist.c
+                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                             ->  Materialize
+                                   Output: extra_flow_dist.c, extra_flow_dist.b
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: extra_flow_dist.c, extra_flow_dist.b
+                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                               Output: extra_flow_dist.c, extra_flow_dist.b
+         ->  Seq Scan on subselect_gp.extra_flow_dist1
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select a x from extra_flow_rand) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 3 for subplan with entry locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                      QUERY PLAN
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Subquery Scan on run_dt
+                     Filter: (run_dt.dt < '01-01-2010'::date)
+                     ->  Subquery Scan on a
+                           ->  Limit
+                                 ->  Seq Scan on pg_trigger
+                           SubPlan 1  (slice2)
+                             ->  Result
+                                   Filter: (extra_flow_dist.b = a.x)
+                                   ->  Materialize
+                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                               ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+-- case 4 subplan with segment general locus without param in subplan (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select x, y dt
+	from (select a x from extra_flow_rand ) a  -- segment general locus
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)  -- subplan's outer is the above segment general locus path
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Nested Loop Left Join
+               Output: extra_flow_rand.a, (max(1))
+               Join Filter: (SubPlan 1)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: extra_flow_rand.a
+               ->  Materialize
+                     Output: (max(1))
+                     ->  Aggregate
+                           Output: max(1)
+                           ->  Result
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Materialize
+                       Output: random()
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             Output: (random())
+                             ->  Seq Scan on subselect_gp.extra_flow_dist
+                                   Output: random()
+         ->  Materialize
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+               ->  Seq Scan on subselect_gp.extra_flow_dist1
+                     Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+(27 rows)
+
+-- case 5 for subplan with entry locus without param in subplan (CTE and subquery)
+explain (costs off) with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                QUERY PLAN
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Nested Loop Left Join
+                     Join Filter: (SubPlan 1)
+                     ->  Seq Scan on pg_trigger
+                     ->  Materialize
+                           ->  Aggregate
+                                 ->  Result
+                     SubPlan 1  (slice2)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- case 6 without CTE, nested subquery
+explain (costs off) select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on tbl
+               Filter: (tbl.dt < '01-01-2010'::date)
+               ->  Unique
+                     Group Key: ((SubPlan 2))
+                     ->  Sort
+                           Sort Key (Distinct): ((SubPlan 2))
+                           ->  Append
+                                 ->  Subquery Scan on a
+                                       ->  Aggregate
+                                             ->  Result
+                                       SubPlan 2  (slice3; segments: 3)
+                                         ->  Result
+                                               Filter: (extra_flow_dist_1.b = a.x)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                           ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+                                 ->  Subquery Scan on aa
+                                       ->  Aggregate
+                                             ->  Result
+                                       SubPlan 1  (slice3; segments: 3)
+                                         ->  Result
+                                               Filter: (extra_flow_dist.b = aa.x)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                           ->  Seq Scan on extra_flow_dist
+         ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(29 rows)
+
+-- case 7 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain (costs off) with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                    QUERY PLAN
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop
+         ->  Subquery Scan on run_dt
+               Filter: (run_dt.dt < '01-01-2010'::date)
+               ->  Function Scan on im x
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Filter: (extra_flow_dist.b = x.x)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+-- case 8 function scan without CTE
+explain (costs off) select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                     QUERY PLAN
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         ->  Function Scan on im x
+               Filter: ((SubPlan 2) < '01-01-2010'::date)
+               SubPlan 2  (slice3; segments: 3)
+                 ->  Result
+                       Filter: (extra_flow_dist_1.b = x.x)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+         SubPlan 1  (slice3; segments: 3)
+           ->  Result
+                 Filter: (extra_flow_dist.b = x.x)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on extra_flow_dist
+ Optimizer: Postgres query optimizer
+(19 rows)
+

--- a/src/test/regress/expected/subselect_gp_switch_union_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_switch_union_optimizer.out
@@ -1,0 +1,2716 @@
+set optimizer_enable_master_only_queries = on;
+set optimizer_segments = 3;
+set optimizer_nestloop_factor = 1.0;
+--
+-- Base tables for CSQ tests
+--
+drop table if exists csq_t1_base;
+NOTICE:  table "csq_t1_base" does not exist, skipping
+create table csq_t1_base(x int, y int) distributed by (x);
+insert into csq_t1_base values(1,2);
+insert into csq_t1_base values(2,1);
+insert into csq_t1_base values(4,2);
+drop table if exists csq_t2_base;
+NOTICE:  table "csq_t2_base" does not exist, skipping
+create table csq_t2_base(x int, y int) distributed by (x);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,2);
+insert into csq_t2_base values(3,1);
+--
+-- Correlated subqueries
+--
+drop table if exists csq_t1;
+NOTICE:  table "csq_t1" does not exist, skipping
+drop table if exists csq_t2;
+NOTICE:  table "csq_t2" does not exist, skipping
+create table csq_t1(x int, y int) distributed by (x);
+create table csq_t2(x int, y int) distributed by (x);
+insert into csq_t1 select * from csq_t1_base;
+insert into csq_t2 select * from csq_t2_base;
+select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
+ x | y 
+---+---
+ 4 | 2
+(1 row)
+
+--
+-- correlations in the targetlist
+--
+select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x >= csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   7
+ 2 |   6
+ 4 |   4
+(3 rows)
+
+select csq_t1.x, (select sum(bar.x) from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   1
+ 2 |   2
+ 4 |   4
+(3 rows)
+
+select csq_t1.x, (select bar.x from csq_t1 bar where bar.x = csq_t1.x) as sum from csq_t1 order by csq_t1.x;
+ x | sum 
+---+-----
+ 1 |   1
+ 2 |   2
+ 4 |   4
+(3 rows)
+
+--
+-- CSQs with partitioned tables
+--
+drop table if exists csq_t1;
+drop table if exists csq_t2;
+create table csq_t1(x int, y int) 
+distributed by (x)
+partition by range (y) ( start (0) end (4) every (1))
+;
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_1" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_2" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_3" for table "csq_t1"
+NOTICE:  CREATE TABLE will create partition "csq_t1_1_prt_4" for table "csq_t1"
+create table csq_t2(x int, y int) 
+distributed by (x)
+partition by range (y) ( start (0) end (4) every (1))
+;
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_1" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_2" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_3" for table "csq_t2"
+NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
+insert into csq_t1 select * from csq_t1_base;
+insert into csq_t2 select * from csq_t2_base;
+explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=8)
+   Filter: (SubPlan 1)
+   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+         Sort Key: csq_t1.x
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Partition Selector for csq_t1 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected: 4 (out of 4)
+                     ->  Dynamic Seq Scan on csq_t1 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+   SubPlan 1  (slice0)
+     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+           ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                 Filter: (CASE WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN csq_t2.x IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN csq_t1.x IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                             ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                         Filter: csq_t2.y = csq_t1.y
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                                                           ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                                 Partitions selected: 4 (out of 4)
+                                                           ->  Dynamic Seq Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(26 rows)
+
+select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
+ x | y 
+---+---
+ 4 | 2
+(1 row)
+
+drop table if exists csq_t1;
+drop table if exists csq_t2;
+drop table if exists csq_t1_base;
+drop table if exists csq_t2_base;
+--
+-- Multi-row subqueries
+--
+drop table if exists mrs_t1;
+NOTICE:  table "mrs_t1" does not exist, skipping
+create table mrs_t1(x int) distributed by (x);
+insert into mrs_t1 select generate_series(1,20);
+explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=20 width=4)
+   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=7 width=4)
+         Join Filter: true
+         ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=1)
+                     ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
+                                       Filter: x < (-1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(11 rows)
+
+select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1;
+ x 
+---
+(0 rows)
+
+explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=20 width=4)
+   ->  Nested Loop Semi Join  (cost=0.00..1293.00 rows=7 width=4)
+         Join Filter: true
+         ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=1)
+                     ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=1)
+                                 ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
+                                       Filter: x = 1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(11 rows)
+
+select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
+ x  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
+   ->  Result  (cost=0.00..1293.02 rows=7 width=4)
+         Filter: (CASE WHEN ((count("inner".ColRef_0017)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
+         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
+               Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+               ->  Result  (cost=0.00..1293.02 rows=56 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                           Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                           ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                                 Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                                 ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                             ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
+
+select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
+ x 
+---
+ 1
+ 2
+ 3
+ 4
+(4 rows)
+
+drop table if exists mrs_t1;
+--
+-- Multi-row subquery from MSTR
+--
+drop table if exists mrs_u1;
+NOTICE:  table "mrs_u1" does not exist, skipping
+drop table if exists mrs_u2;
+NOTICE:  table "mrs_u2" does not exist, skipping
+create TABLE mrs_u1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create TABLE mrs_u2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into mrs_u1 values (1,2),(11,22);
+insert into mrs_u2 values (1,2),(11,22),(33,44);
+select * from mrs_u1 join mrs_u2 on mrs_u1.a=mrs_u2.a where mrs_u1.a in (1,11) or mrs_u2.a in (select a from mrs_u1 where a=1) order by 1;
+ a  | b  | a  | b  
+----+----+----+----
+  1 |  2 |  1 |  2
+ 11 | 22 | 11 | 22
+(2 rows)
+
+drop table if exists mrs_u1;
+drop table if exists mrs_u2;
+--
+-- MPP-13758
+--
+drop table if exists csq_m1;
+NOTICE:  table "csq_m1" does not exist, skipping
+create table csq_m1();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+set allow_system_table_mods=true;
+delete from gp_distribution_policy where localoid='csq_m1'::regclass;
+reset allow_system_table_mods;
+alter table csq_m1 add column x int;
+insert into csq_m1 values(1);
+drop table if exists csq_d1;
+NOTICE:  table "csq_d1" does not exist, skipping
+create table csq_d1(x int) distributed by (x);
+insert into csq_d1 select * from csq_m1;
+explain select array(select x from csq_m1); -- no initplan
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Result  (cost=1.00..1.01 rows=1 width=0)
+   InitPlan 1 (returns $0)
+     ->  Seq Scan on csq_m1  (cost=0.00..1.00 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select array(select x from csq_m1); -- {1}
+ array 
+-------
+ {1}
+(1 row)
+
+explain select array(select x from csq_d1); -- initplan
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Result  (cost=1.01..1.02 rows=1 width=0)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
+           ->  Seq Scan on csq_d1  (cost=0.00..1.01 rows=1 width=4)
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(6 rows)
+
+select array(select x from csq_d1); -- {1}
+ array 
+-------
+ {1}
+(1 row)
+
+--
+-- CSQs involving master-only and distributed tables
+--
+drop table if exists t3cozlib;
+NOTICE:  table "t3cozlib" does not exist, skipping
+create table t3cozlib (c1 int , c2 varchar) with (appendonly=true, compresstype=zlib, orientation=column) distributed by (c1);
+drop table if exists pg_attribute_storage;
+NOTICE:  table "pg_attribute_storage" does not exist, skipping
+create table pg_attribute_storage (attrelid int, attnum int, attoptions text[]) distributed by (attrelid);
+insert into pg_attribute_storage values ('t3cozlib'::regclass, 1, E'{\'something\'}');
+insert into pg_attribute_storage values ('t3cozlib'::regclass, 2, E'{\'something2\'}');
+SELECT a.attname
+, pg_catalog.format_type(a.atttypid, a.atttypmod)
+, ( SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+ FROM pg_catalog.pg_attrdef d
+WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef
+)
+, a.attnotnull
+, a.attnum
+, a.attstorage
+, pg_catalog.col_description(a.attrelid, a.attnum)
+, ( SELECT s.attoptions
+FROM pg_attribute_storage s
+WHERE s.attrelid = a.attrelid AND s.attnum = a.attnum
+) newcolumn
+FROM pg_catalog.pg_attribute a
+WHERE a.attrelid = 't3cozlib'::regclass AND a.attnum > 0 AND NOT a.attisdropped
+ORDER BY a.attnum
+; -- expect to see 2 rows
+ attname |    format_type    | substring | attnotnull | attnum | attstorage | col_description |   newcolumn    
+---------+-------------------+-----------+------------+--------+------------+-----------------+----------------
+ c1      | integer           |           | f          |      1 | p          |                 | {'something'}
+ c2      | character varying |           | f          |      2 | x          |                 | {'something2'}
+(2 rows)
+
+--
+-- More CSQs involving master-only and distributed relations
+--
+drop table if exists csq_m1;
+create table csq_m1();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+set allow_system_table_mods=true;
+delete from gp_distribution_policy where localoid='csq_m1'::regclass;
+reset allow_system_table_mods;
+alter table csq_m1 add column x int;
+insert into csq_m1 values(1),(2),(3);
+drop table if exists csq_d1;
+create table csq_d1(x int) distributed by (x);
+insert into csq_d1 select * from csq_m1 where x < 3;
+insert into csq_d1 values(4);
+select * from csq_m1;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+select * from csq_d1;
+ x 
+---
+ 1
+ 2
+ 4
+(3 rows)
+
+--
+-- outer plan node is master-only and CSQ has distributed relation
+--
+explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
+                                                                                                                                               QUERY PLAN                                                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
+   ->  Result  (cost=0.00..1293.00 rows=1 width=4)
+         Filter: (CASE WHEN ((count((count("inner".ColRef_0016)))) > 0::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0016))))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < (-100)))
+         ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
+               Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
+                     Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
+                           Hash Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                           ->  Result  (cost=0.00..1293.00 rows=1 width=30)
+                                 ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
+                                       Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                                       ->  Result  (cost=0.00..1293.00 rows=2 width=19)
+                                             ->  Sort  (cost=0.00..1293.00 rows=2 width=19)
+                                                   Sort Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
+                                                   ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1293.00 rows=4 width=19)
+                                                         ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                                                               Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
+                                                               ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
+                                                               ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                                                                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                                                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
+(24 rows)
+
+select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
+ x 
+---
+ 3
+(1 row)
+
+--
+-- outer plan node is master-only and CSQ has distributed relation
+--
+explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
+                                                                                                                             QUERY PLAN                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Result  (cost=0.00..1293.00 rows=1 width=4)
+         Filter: (CASE WHEN ((count("inner".ColRef_0016)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0016))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < (-100)))
+         ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
+               Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+               ->  Result  (cost=0.00..1293.00 rows=2 width=19)
+                     ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                           Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                                 Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                                 ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                 ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
+                                             ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
+
+select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
+ x 
+---
+ 4
+(1 row)
+
+-- drop csq_m1 since we deleted its gp_distribution_policy entry
+drop table csq_m1;
+--
+-- MPP-14441 Don't lose track of initplans
+--
+drop table if exists csq_t1;
+NOTICE:  table "csq_t1" does not exist, skipping
+CREATE TABLE csq_t1 (a int, b int, c int, d int, e text) DISTRIBUTED BY (a);
+INSERT INTO csq_t1 SELECT i, i/3, i%2, 100-i, 'text'||i  FROM generate_series(1,100) i;
+select count(*) from csq_t1 t1 where a > (SELECT x.b FROM ( select avg(a)::int as b,'haha'::text from csq_t1 t2 where t2.a=t1.d) x ) ;
+ count 
+-------
+    49
+(1 row)
+
+select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 where t2.a=t1.d) ;
+ count 
+-------
+    49
+(1 row)
+
+--
+-- correlation in a func expr
+--
+CREATE OR REPLACE FUNCTION csq_f(a int) RETURNS int AS $$ select $1 $$ LANGUAGE SQL CONTAINS SQL;
+DROP TABLE IF EXISTS csq_r;
+NOTICE:  table "csq_r" does not exist, skipping
+CREATE TABLE csq_r(a int) distributed by (a);
+INSERT INTO csq_r VALUES (1);
+-- subqueries shouldn't be pulled into a join if the from clause has a function call
+-- with a correlated argument
+-- force_explain
+explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: a = ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(7 rows)
+
+SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: a <> ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(7 rows)
+
+SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(8 rows)
+
+SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(8 rows)
+
+SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: a > ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
+           ->  Limit  (cost=0.00..0.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+(8 rows)
+
+SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: a < ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
+(8 rows)
+
+SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
+ a 
+---
+(0 rows)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
+         Filter: a <= ((SubPlan 1))
+         SubPlan 1  (slice1; segments: 3)
+           ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
+(8 rows)
+
+SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
+ a 
+---
+ 1
+(1 row)
+
+-- force_explain
+explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1724.00 rows=1 width=4)
+   ->  Seq Scan on csq_r  (cost=0.00..1724.00 rows=1 width=4)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Nested Loop  (cost=0.00..862.00 rows=1 width=4)
+                 Join Filter: true
+                 ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                       ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                             ->  Seq Scan on csq_r csq_r_1  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(12 rows)
+
+SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
+ a 
+---
+ 1
+(1 row)
+
+--
+-- Test pullup of expr CSQs to joins
+--
+--
+-- Test data
+--
+drop table if exists csq_pullup;
+NOTICE:  table "csq_pullup" does not exist, skipping
+create table csq_pullup(t text, n numeric, i int, v varchar(10)) distributed by (t);
+insert into csq_pullup values ('abc',1, 2, 'xyz');
+insert into csq_pullup values ('xyz',2, 3, 'def');  
+insert into csq_pullup values ('def',3, 1, 'abc'); 
+--
+-- Expr CSQs to joins
+--
+--
+-- text, text
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Result  (cost=0.00..862.00 rows=1 width=17)
+         Filter: 1 = COALESCE((count()), 0::bigint)
+         ->  Result  (cost=0.00..862.00 rows=1 width=36)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+                     Hash Cond: csq_pullup.t = csq_pullup_1.t
+                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                 Group Key: csq_pullup_1.t
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: csq_pullup_1.t
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(14 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- text, varchar
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Result  (cost=0.00..862.00 rows=1 width=17)
+         Filter: (1 = COALESCE((count()), 0::bigint))
+         ->  Result  (cost=0.00..862.00 rows=1 width=36)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+                     Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
+                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                 Group Key: csq_pullup_1.v
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: csq_pullup_1.v
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Key: csq_pullup_1.v
+                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- numeric, numeric
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=1 width=17)
+   Filter: (1 = COALESCE((count()), 0::bigint))
+   ->  Result  (cost=0.00..862.00 rows=1 width=36)
+         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+               Hash Cond: (csq_pullup.n = csq_pullup_1.n)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
+                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=13)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=13)
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                                       Group Key: csq_pullup_1.n
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=5)
+                                             Sort Key: csq_pullup_1.n
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                                   Hash Key: csq_pullup_1.n
+                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(18 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+--
+-- function(numeric), function(numeric)
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: 1 = ((SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+(3 rows)
+
+--
+-- function(numeric), function(int)
+--
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: 1 = ((SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+(3 rows)
+
+--
+-- Test a few cases where pulling up an aggregate subquery is not possible
+--
+-- subquery contains a LIMIT
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1
+           ->  Limit  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             Filter: (csq_pullup.t = csq_pullup_1.t)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+-- subquery contains a HAVING clause
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Result  (cost=0.00..862.00 rows=1 width=17)
+         Filter: (1 = COALESCE((count()), '0'::bigint))
+         ->  Result  (cost=0.00..862.00 rows=1 width=36)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+                     Hash Cond: (csq_pullup.t = csq_pullup_1.t)
+                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                                 Filter: ((count()) < 10)
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
+                                       Group Key: csq_pullup_1.t
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                             Sort Key: csq_pullup_1.t
+                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
+  t  | n | i |  v  
+-----+---+---+-----
+ xyz | 2 | 3 | def
+ def | 3 | 1 | abc
+ abc | 1 | 2 | xyz
+(3 rows)
+
+-- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
+explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: ((csq_pullup.n + csq_pullup_1.n) = (csq_pullup_1.i)::numeric)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=9)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(12 rows)
+
+select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
+ t | n | i | v 
+---+---+---+---
+(0 rows)
+
+--
+-- NOT EXISTS CSQs to joins
+--
+--
+-- text, text
+--
+explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
+         Hash Cond: csq_pullup.t = csq_pullup_1.t
+         ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+                           Filter: i = 1
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(9 rows)
+
+select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
+(2 rows)
+
+--
+-- int, function(int)
+--
+explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
+   ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
+         Hash Cond: csq_pullup.i = (csq_pullup_1.i + 1)
+         ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(10 rows)
+
+select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
+  t  | n | i |  v  
+-----+---+---+-----
+ def | 3 | 1 | abc
+(1 row)
+
+--
+-- wrong results bug MPP-16477
+--
+drop table if exists subselect_t1;
+NOTICE:  table "subselect_t1" does not exist, skipping
+drop table if exists subselect_t2;
+NOTICE:  table "subselect_t2" does not exist, skipping
+create table subselect_t1(x int) distributed by (x);
+insert into subselect_t1 values(1),(2);
+create table subselect_t2(y int) distributed by (y);
+insert into subselect_t2 values(1),(2),(2);
+analyze subselect_t1;
+analyze subselect_t2;
+explain select * from subselect_t1 where x in (select y from subselect_t2);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
+         Hash Cond: subselect_t1.x = subselect_t2.y
+         ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+(7 rows)
+
+select * from subselect_t1 where x in (select y from subselect_t2);
+ x 
+---
+ 1
+ 2
+(2 rows)
+
+-- start_ignore
+-- Known_opt_diff: MPP-21351
+-- end_ignore
+explain select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
+         Hash Cond: (subselect_t1.x = subselect_t2.y)
+         ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+               ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                     Group Key: subselect_t2.y
+                     ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                           Sort Key: subselect_t2.y
+                           ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                 ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+ x 
+---
+ 1
+ 2
+(2 rows)
+
+explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(8 rows)
+
+select count(*) from subselect_t1 where x in (select y from subselect_t2);
+ count 
+-------
+     2
+(1 row)
+
+-- start_ignore
+-- Known_opt_diff: MPP-21351
+-- end_ignore
+explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                     ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                           Group Key: subselect_t2.y
+                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                                 Sort Key: subselect_t2.y
+                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                       ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
+select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from 
+       ( select 1 as FIELD_1 union all select 2 as FIELD_1 ) TABLE_1 
+       where FIELD_1 in ( select 1 as FIELD_1 union all select 1 as FIELD_1 union all select 1 as FIELD_1 );
+ count 
+-------
+     1
+(1 row)
+
+       
+--
+-- Query was deadlocking because of not squelching subplans (MPP-18936)
+--
+drop table if exists t1; 
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2; 
+NOTICE:  table "t2" does not exist, skipping
+drop table if exists t3; 
+NOTICE:  table "t3" does not exist, skipping
+drop table if exists t4; 
+NOTICE:  table "t4" does not exist, skipping
+CREATE TABLE t1 AS (SELECT generate_series(1, 5000) AS i, generate_series(5001, 10000) AS j);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+CREATE TABLE t2 AS (SELECT * FROM t1 WHERE gp_segment_id = 0);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+CREATE TABLE t3 AS (SELECT * FROM t1 WHERE gp_segment_id = 1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+CREATE TABLE t4 (i1 int, i2 int); 
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_interconnect_queue_depth=1;
+-- This query was deadlocking on a 2P system
+INSERT INTO t4 
+(
+SELECT t1.i, (SELECT t3.i FROM t3 WHERE t3.i + 1 = t1.i + 1)
+FROM t1, t3
+WHERE t1.i = t3.i
+)
+UNION
+(
+SELECT t1.i, (SELECT t2.i FROM t2 WHERE t2.i + 1 = t1.i + 1)
+FROM t1, t2
+WHERE t1.i = t2.i
+);
+drop table if exists t1; 
+drop table if exists t2; 
+drop table if exists t3; 
+drop table if exists t4; 
+--
+-- Initplans with no corresponding params should be removed MPP-20600
+--
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+create table t1(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2(b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+ a 
+---
+(0 rows)
+
+explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+                   QUERY PLAN                   
+------------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=4)
+   ->  Result  (cost=0.00..0.00 rows=0 width=4)
+         One-Time Filter: false
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
+(5 rows)
+
+explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
+union all
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=4)
+   One-Time Filter: false
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
+(4 rows)
+
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
+union all
+select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
+ a 
+---
+(0 rows)
+
+explain select * from t1,
+(select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
+where t1.a = foo.a;
+                   QUERY PLAN                   
+------------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=8)
+   ->  Result  (cost=0.00..0.00 rows=0 width=8)
+         One-Time Filter: false
+ Settings:  optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
+(5 rows)
+
+select * from t1,
+(select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
+where t1.a = foo.a;
+ a | a 
+---+---
+(0 rows)
+
+--
+-- Correlated subqueries with limit/offset clause must not be pulled up as join
+--
+insert into t1 values (1);
+insert into t2 values (1);
+explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=4)
+   ->  Result  (cost=0.00..1293.00 rows=1 width=1)
+         Filter: (SubPlan 1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+         SubPlan 1  (slice0)
+           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: t1.a = 1
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.1
+(14 rows)
+
+explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=1 width=4)
+   ->  Result  (cost=0.00..1293.00 rows=1 width=1)
+         Filter: (SubPlan 1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+         SubPlan 1  (slice0)
+           ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                       Filter: t1.a = 1
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
+(14 rows)
+
+select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
+ ?column? 
+----------
+        1
+(1 row)
+
+select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
+ ?column? 
+----------
+(0 rows)
+
+drop table if exists t1;
+drop table if exists t2;
+--
+-- Test for a bug we used to have with eliminating InitPlans. The subplan,
+-- (select max(content) from y), was eliminated when it shouldn't have been.
+-- The query is supposed to return 0 rows, but returned > 0 when the bug was
+-- present.
+--
+CREATE TABLE initplan_x (i int4, t text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_x values
+ (1, 'foobar1'),
+ (2, 'foobar2'),
+ (3, 'foobar3'),
+ (4, 'foobar4'),
+ (5, 'foobar5');
+CREATE TABLE initplan_y (content int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'content' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_y values (5);
+select i, t from initplan_x
+except
+select g, t from initplan_x,
+                 generate_series(0, (select max(content) from initplan_y)) g
+order by 1;
+ i | t 
+---+---
+(0 rows)
+
+drop table if exists initplan_x;
+drop table if exists initplan_y;
+--
+-- Test Initplans that return multiple params.
+--
+create table initplan_test(i int, j int, m int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into initplan_test values (1,1,1);
+select * from initplan_test where row(j, m) = (select j, m from initplan_test where i = 1);
+ i | j | m 
+---+---+---
+ 1 | 1 | 1
+(1 row)
+
+drop table initplan_test;
+--
+-- apply parallelization for subplan MPP-24563
+--
+create table t1_mpp_24563 (id int, value int) distributed by (id);
+insert into t1_mpp_24563 values (1, 3);
+create table t2_mpp_24563 (id int, value int, seq int) distributed by (id);
+insert into t2_mpp_24563 values (1, 7, 5);
+explain select row_number() over (order by seq asc) as id, foo.cnt
+from
+(select seq, (select count(*) from t1_mpp_24563 t1 where t1.id = t2.id) cnt from
+	t2_mpp_24563 t2 where value = 7) foo;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=1 width=16)
+   ->  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
+         Order By: t2_mpp_24563.seq
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+               Merge Key: t2_mpp_24563.seq
+               ->  Result  (cost=0.00..862.00 rows=1 width=12)
+                     ->  Result  (cost=0.00..862.00 rows=1 width=12)
+                           ->  Result  (cost=0.00..862.00 rows=1 width=12)
+                                 ->  Sort  (cost=0.00..862.00 rows=1 width=12)
+                                       Sort Key: t2_mpp_24563.seq
+                                       ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
+                                             Hash Cond: (t2_mpp_24563.id = t1_mpp_24563.id)
+                                             ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
+                                                   Filter: (value = 7)
+                                             ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                                         Group Key: t1_mpp_24563.id
+                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                                               Sort Key: t1_mpp_24563.id
+                                                               ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+drop table t1_mpp_24563;
+drop table t2_mpp_24563;
+--
+-- MPP-20470 update the flow of node after parallelizing subplan.
+--
+CREATE TABLE t_mpp_20470 (
+    col_date timestamp without time zone,
+    col_name character varying(6),
+    col_expiry date
+) DISTRIBUTED BY (col_date) PARTITION BY RANGE(col_date)
+(
+START ('2013-05-10 00:00:00'::timestamp without time zone) END ('2013-05-11
+	00:00:00'::timestamp without time zone) WITH (tablename='t_mpp_20470_ptr1', appendonly=false ),
+START ('2013-05-24 00:00:00'::timestamp without time zone) END ('2013-05-25
+	00:00:00'::timestamp without time zone) WITH (tablename='t_mpp_20470_ptr2', appendonly=false )
+);
+NOTICE:  CREATE TABLE will create partition "t_mpp_20470_ptr1" for table "t_mpp_20470"
+NOTICE:  CREATE TABLE will create partition "t_mpp_20470_ptr2" for table "t_mpp_20470"
+COPY t_mpp_20470 from STDIN delimiter '|' null '';
+create view v1_mpp_20470 as
+SELECT
+CASE
+	WHEN  b.col_name::text = 'FUTCUR'::text
+	THEN  ( SELECT count(a.col_expiry) AS count FROM t_mpp_20470 a WHERE
+		a.col_name::text = b.col_name::text)::text
+	ELSE 'Q2'::text END  AS  cc,  1 AS nn
+FROM t_mpp_20470 b;
+explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..862.00 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
+         ->  Result  (cost=0.00..862.00 rows=1 width=12)
+               ->  Result  (cost=0.00..862.00 rows=1 width=16)
+                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
+                           Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: t_mpp_20470.col_name
+                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                             Partitions selected: 2 (out of 2)
+                                       ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=16)
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                       Group Key: t_mpp_20470_1.col_name
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                             Sort Key: t_mpp_20470_1.col_name
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                                   Hash Key: t_mpp_20470_1.col_name
+                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                               Partitions selected: 2 (out of 2)
+                                                         ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(24 rows)
+
+drop view v1_mpp_20470;
+drop table t_mpp_20470;
+create table tbl_25484(id int, num int) distributed by (id);
+insert into tbl_25484 values(1, 1), (2, 2), (3, 3);
+select id from tbl_25484 where 3 = (select 3 where 3 = (select num));
+ id 
+----
+  3
+(1 row)
+
+drop table tbl_25484;
+reset optimizer_segments;
+reset optimizer_nestloop_factor;
+--
+-- Test case that once triggered a bug in the IN-clause pull-up code.
+--
+SELECT p.id
+    FROM (SELECT * FROM generate_series(1,10) id
+          WHERE id IN (
+              SELECT 1
+              UNION ALL
+              SELECT 0)) p;
+ id 
+----
+  1
+(1 row)
+
+--
+-- Verify another bug in the IN-clause pull-up code. This returned some
+-- rows from xsupplier twice, because of a bug in detecting whether a
+-- Redistribute node was needed.
+--
+CREATE TABLE xlineitem (l_orderkey int4, l_suppkey int4) distributed by (l_orderkey);
+insert into xlineitem select g+3, g from generate_series(10,100) g;
+insert into xlineitem select g+1, g from generate_series(10,100) g;
+insert into xlineitem select g, g from generate_series(10,100) g;
+CREATE TABLE xsupplier (s_suppkey int4, s_name text) distributed by (s_suppkey);
+insert into xsupplier select g, 'foo' || g from generate_series(1,10) g;
+select s_name from xsupplier
+where s_suppkey in (
+  select g.l_suppkey from xlineitem g
+) ;
+ s_name 
+--------
+ foo10
+(1 row)
+
+--
+-- Another case that failed at one point. (A planner bug in pulling up a
+-- subquery with constant distribution key, 1, in the outer queries.)
+--
+create table nested_in_tbl(tc1 int, tc2 int) distributed by (tc1);
+select * from nested_in_tbl t1  where tc1 in
+  (select 1 from nested_in_tbl t2 where tc1 in
+    (select 1 from nested_in_tbl t3 where t3.tc2 = t2.tc2));
+ tc1 | tc2 
+-----+-----
+(0 rows)
+
+drop table nested_in_tbl;
+--
+-- Window query with a function scan that has non-correlated subquery.
+--
+SELECT rank() over (partition by min(c) order by min(c)) AS p_rank FROM (SELECT d AS c FROM (values(1)) d1, generate_series(0,(SELECT 2)) AS d) tt GROUP BY c;
+ p_rank 
+--------
+      1
+      1
+      1
+(3 rows)
+
+--
+-- Remove unused subplans
+--
+create table foo(a int, b int) distributed by (a) partition by range(b) (start(1) end(3) every(1));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+create table bar(a int, b int) distributed by (a);
+with CT as (select a from foo except select a from bar)
+select * from foo
+where exists (select 1 from CT where CT.a = foo.a);
+ a | b 
+---+---
+(0 rows)
+
+--
+-- Multiple SUBPLAN nodes must not refer to same plan_id
+--
+CREATE TABLE bar_s (c integer, d character varying(10));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO bar_s VALUES (9,9);
+SELECT * FROM bar_s T1 WHERE c = (SELECT max(c) FROM bar_s T2 WHERE T2.d = T1.d GROUP BY c) AND c < 10;
+ c | d 
+---+---
+ 9 | 9
+(1 row)
+
+CREATE TABLE foo_s (a integer, b integer)  PARTITION BY RANGE(b)
+    (PARTITION sub_one START (1) END (10),
+     PARTITION sub_two START (11) END (22));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_one" for table "foo_s"
+NOTICE:  CREATE TABLE will create partition "foo_s_1_prt_sub_two" for table "foo_s"
+INSERT INTO foo_s VALUES (9,9);
+INSERT INTO foo_s VALUES (2,9);
+SELECT bar_s.c from bar_s, foo_s WHERE foo_s.a=2 AND foo_s.b = (SELECT max(b) FROM foo_s WHERE bar_s.c = 9);
+ c 
+---
+ 9
+(1 row)
+
+CREATE TABLE baz_s (i int4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO baz_s VALUES (9);
+SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz_s WHERE bar_s.c = 9) AND foo_s.b = bar_s.d::int4;
+ c 
+---
+ 9
+ 9
+(2 rows)
+
+DROP TABLE bar_s;
+DROP TABLE foo_s;
+DROP TABLE baz_s;
+--
+-- EXPLAIN tests for queries in subselect.sql to significant plan changes
+--
+-- Set up some simple test tables
+CREATE TABLE SUBSELECT_TBL (
+  f1 integer,
+  f2 integer,
+  f3 float
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO SUBSELECT_TBL VALUES (1, 2, 3);
+INSERT INTO SUBSELECT_TBL VALUES (2, 3, 4);
+INSERT INTO SUBSELECT_TBL VALUES (3, 4, 5);
+INSERT INTO SUBSELECT_TBL VALUES (1, 1, 1);
+INSERT INTO SUBSELECT_TBL VALUES (2, 2, 2);
+INSERT INTO SUBSELECT_TBL VALUES (3, 3, 3);
+INSERT INTO SUBSELECT_TBL VALUES (6, 7, 8);
+INSERT INTO SUBSELECT_TBL VALUES (8, 9, NULL);
+ANALYZE SUBSELECT_TBL;
+-- Uncorrelated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=7 width=4)
+         Merge Key: subselect_tbl.f1
+         ->  Sort  (cost=0.00..862.00 rows=3 width=4)
+               Sort Key: subselect_tbl.f1
+               ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                 Hash Key: subselect_tbl_1.f2
+                                 ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE
+    f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1293.00 rows=2 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=5 width=4)
+         Merge Key: subselect_tbl.f1
+         ->  Sort  (cost=0.00..1293.00 rows=2 width=4)
+               Sort Key: subselect_tbl.f1
+               ->  Hash Join  (cost=0.00..1293.00 rows=2 width=4)
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Hash  (cost=862.00..862.00 rows=2 width=4)
+                           ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
+                                 Group Key: subselect_tbl_1.f2
+                                 ->  Sort  (cost=0.00..862.00 rows=3 width=4)
+                                       Sort Key: subselect_tbl_1.f2
+                                       ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
+                                             Hash Cond: subselect_tbl_1.f2 = subselect_tbl_2.f1
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                   Hash Key: subselect_tbl_1.f2
+                                                   ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
+                                             ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                   ->  Seq Scan on subselect_tbl subselect_tbl_2  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(21 rows)
+
+EXPLAIN SELECT '' AS three, f1, f2
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) NOT IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                         WHERE f3 IS NOT NULL) ORDER BY 2,3;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000009.64..10000000009.64 rows=4 width=8)
+   Merge Key: subselect_tbl.f1, subselect_tbl.f2
+   ->  Sort  (cost=10000000009.64..10000000009.64 rows=2 width=8)
+         Sort Key: subselect_tbl.f1, subselect_tbl.f2
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000009.61 rows=2 width=8)
+               Join Filter: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
+               ->  Materialize  (cost=0.00..3.47 rows=7 width=12)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.36 rows=7 width=12)
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
+                                 Filter: f3 IS NOT NULL
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+ANALYZE tenk1;
+EXPLAIN SELECT * FROM tenk1 a, tenk1 b
+WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=974.00..1636.00 rows=10000 width=488)
+   ->  Hash Join  (cost=974.00..1636.00 rows=3334 width=488)
+         Hash Cond: (c.unique2 = b.unique2)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=462.00..986.50 rows=3334 width=248)
+               Hash Key: c.unique2
+               ->  Hash Join  (cost=462.00..786.50 rows=3334 width=248)
+                     Hash Cond: (a.unique1 = c.unique1)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=244)
+                     ->  Hash  (cost=337.00..337.00 rows=3334 width=8)
+                           ->  HashAggregate  (cost=237.00..337.00 rows=3334 width=8)
+                                 Group Key: c.unique1, c.unique2
+                                 ->  Seq Scan on tenk1 c  (cost=0.00..187.00 rows=3334 width=8)
+         ->  Hash  (cost=387.00..387.00 rows=3334 width=244)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..387.00 rows=3334 width=244)
+                     Hash Key: b.unique2
+                     ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=244)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- Correlated subselects
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         Merge Key: subselect_tbl.f1, subselect_tbl.f2
+         ->  Sort  (cost=0.00..862.00 rows=3 width=8)
+               Sort Key: subselect_tbl.f1, subselect_tbl.f2
+               ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f1 AND subselect_tbl.f1 = subselect_tbl_1.f2
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+(11 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN
+    (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=8 width=12)
+         Merge Key: subselect_tbl.f1, subselect_tbl.f3
+         ->  Sort  (cost=0.00..862.00 rows=3 width=12)
+               Sort Key: subselect_tbl.f1, subselect_tbl.f3
+               ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=12)
+                     Hash Cond: subselect_tbl.f2::double precision = subselect_tbl_1.f3 AND subselect_tbl.f1 = subselect_tbl_1.f2
+                     ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=16)
+                     ->  Hash  (cost=431.00..431.00 rows=3 width=12)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=12)
+                                 Hash Key: subselect_tbl_1.f2
+                                 ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f3 IN (SELECT upper.f1 + f2 FROM SUBSELECT_TBL
+               WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324033.89 rows=3 width=20)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.89 rows=8 width=12)
+         Merge Key: subselect_tbl.f1, subselect_tbl.f3
+         ->  Sort  (cost=0.00..1324033.89 rows=3 width=12)
+               Sort Key: subselect_tbl.f1, subselect_tbl.f3
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1324033.89 rows=3 width=12)
+                     Filter: (SubPlan 1)
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result  (cost=0.00..431.00 rows=4 width=4)
+                             ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                         ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=2 width=4)
+                                               Filter: f2 = f3::integer
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(14 rows)
+
+EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
+  FROM SUBSELECT_TBL
+  WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
+                     WHERE f3 IS NOT NULL) ORDER BY 2;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=6.67..6.69 rows=8 width=4)
+   Merge Key: subselect_tbl.f1
+   ->  Sort  (cost=6.67..6.69 rows=3 width=4)
+         Sort Key: subselect_tbl.f1
+         ->  Hash Semi Join  (cost=3.33..6.55 rows=3 width=4)
+               Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
+               ->  Hash  (cost=3.22..3.22 rows=3 width=12)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.22 rows=3 width=12)
+                           Hash Key: subselect_tbl_1.f2
+                           ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
+                                 Filter: f3 IS NOT NULL
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+--
+-- Test cases to catch unpleasant interactions between IN-join processing
+-- and subquery pullup.
+--
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.07 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..864.07 rows=34 width=1)
+                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                 Group Key: tenk1_1.hundred
+                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                       Sort Key: tenk1_1.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                             Hash Key: tenk1_1.hundred
+                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group Key: tenk1_1.hundred
+                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+(17 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select hundred from tenk1 b)) ss;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                         Group Key: tenk1_1.hundred
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
+
+EXPLAIN select count(*) from
+  (select 1 from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.07 rows=1 width=8)
+               ->  Hash Semi Join  (cost=0.00..864.07 rows=34 width=1)
+                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                 Group Key: tenk1_1.hundred
+                                 ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                       Sort Key: tenk1_1.hundred
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                             Hash Key: tenk1_1.hundred
+                                             ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                   Group Key: tenk1_1.hundred
+                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+(17 rows)
+
+EXPLAIN select count(distinct ss.ten) from
+  (select ten from tenk1 a
+   where unique1 IN (select distinct hundred from tenk1 b)) ss;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                         Group Key: tenk1_1.hundred
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
+
+--
+-- In case of simple exists query, planner can generate alternative
+-- subplans and choose one of them during execution based on the cost.
+-- The below test check that we are generating alternative subplans,
+-- we should see 2 subplans in the explain
+--
+EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..865.44 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
+         ->  Limit  (cost=0.00..865.44 rows=1 width=1)
+               ->  Result  (cost=0.00..865.44 rows=3334 width=1)
+                     ->  Result  (cost=0.00..865.44 rows=3334 width=8)
+                           ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
+                                 Hash Cond: (tenk2.unique1 = tenk1.unique1)
+                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
+                                 ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
+                                       ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
+                                             Group Key: tenk1.unique1
+                                             ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
+ exists 
+--------
+ t
+(1 row)
+
+--
+-- Ensure that NOT is not lost during subquery pull-up
+--
+SELECT 1 AS col1 WHERE NOT (SELECT 1 = 1);
+ col1 
+------
+(0 rows)
+
+--
+-- Test sane behavior in case of semi join semantics
+--
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+NOTICE:  table "dedup_test1" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test2;
+NOTICE:  table "dedup_test2" does not exist, skipping
+DROP TABLE IF EXISTS dedup_test3;
+NOTICE:  table "dedup_test3" does not exist, skipping
+-- end_ignore
+CREATE TABLE dedup_test1 ( a int, b int ) DISTRIBUTED BY (a);
+CREATE TABLE dedup_test2 ( e int, f int ) DISTRIBUTED BY (e);
+CREATE TABLE dedup_test3 ( a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY RANGE(c) (START(1) END(2) EVERY(1)); 
+NOTICE:  CREATE TABLE will create partition "dedup_test3_1_prt_1" for table "dedup_test3"
+INSERT INTO dedup_test1 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test2 select i, i from generate_series(1,4)i;
+INSERT INTO dedup_test3 select 1, 1, 1 from generate_series(1,10);
+ANALYZE dedup_test1;
+ANALYZE dedup_test2;
+ANALYZE dedup_test3;
+EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=16)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=16)
+         Hash Cond: dedup_test2.e = dedup_test1.a
+         ->  Seq Scan on dedup_test2  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=862.00..862.00 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+                     Hash Cond: dedup_test1.a = dedup_test3.a
+                     ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 Group Key: dedup_test3.a
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: dedup_test3.a
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             Hash Key: dedup_test3.a
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                                   Group Key: dedup_test3.a
+                                                   ->  Sort  (cost=0.00..431.00 rows=4 width=4)
+                                                         Sort Key: dedup_test3.a
+                                                         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                                                               ->  Sequence  (cost=0.00..431.00 rows=4 width=4)
+                                                                     ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                                                           Partitions selected: 1 (out of 1)
+                                                                     ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.60.0
+(25 rows)
+
+SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
+ a | b | e | f 
+---+---+---+---
+ 1 | 1 | 1 | 1
+(1 row)
+
+-- Test planner to check if it optimizes the join and marks it as a dummy join
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324463.60 rows=4 width=20)
+   ->  Hash Semi Join  (cost=0.00..1324463.60 rows=2 width=20)
+         Hash Cond: (dedup_test3.b = dedup_test1_1.b)
+         ->  Nested Loop  (cost=0.00..1324032.60 rows=2 width=20)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 0 (out of 1)
+                           ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 Filter: (c = 7)
+               ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+(19 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1324463.60 rows=4 width=20)
+   ->  Hash Semi Join  (cost=0.00..1324463.60 rows=2 width=20)
+         Hash Cond: (dedup_test3.b = dedup_test1_1.a)
+         ->  Nested Loop  (cost=0.00..1324032.60 rows=2 width=20)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 0 (out of 1)
+                           ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 Filter: (c = 7)
+               ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(16 rows)
+
+EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.82 rows=4 width=20)
+   ->  Hash Join  (cost=0.00..2648064.81 rows=2 width=20)
+         Hash Cond: (dedup_test3.b = dedup_test1_2.b)
+         ->  Nested Loop  (cost=0.00..1324032.60 rows=2 width=20)
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 0 (out of 1)
+                           ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
+                                 Filter: (c = 7)
+               ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=1324032.22..1324032.22 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324032.22 rows=4 width=4)
+                     ->  Nested Loop Semi Join  (cost=0.00..1324032.22 rows=2 width=4)
+                           Join Filter: true
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
+                                 Group Key: dedup_test1_2.b
+                                 ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                       Sort Key: dedup_test1_2.b
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                             Hash Key: dedup_test1_2.b
+                                             ->  Seq Scan on dedup_test1 dedup_test1_2  (cost=0.00..431.00 rows=2 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=1)
+                                       ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Limit  (cost=0.00..431.00 rows=1 width=1)
+                                                         ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(30 rows)
+
+-- start_ignore
+DROP TABLE IF EXISTS dedup_test1;
+DROP TABLE IF EXISTS dedup_test2;
+DROP TABLE IF EXISTS dedup_test3;
+-- end_ignore
+-- Test init/main plan are not both parallel
+create table init_main_plan_parallel (c1 int, c2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- case 1: init plan is parallel, main plan is not.
+select relname from pg_class where exists(select * from init_main_plan_parallel);
+ relname 
+---------
+(0 rows)
+
+-- case2: init plan is not parallel, main plan is parallel
+select * from init_main_plan_parallel where exists (select * from pg_class);
+ c1 | c2 
+----+----
+(0 rows)
+
+-- A subplan whose targetlist might be expanded to make sure all entries of its
+-- hashExpr are in its targetlist, test the motion node above it also updated
+-- its targetlist, otherwise, a wrong answer or a crash happens.
+DROP TABLE IF EXISTS TEST_IN;
+CREATE TABLE TEST_IN(
+    C01  FLOAT,
+    C02  NUMERIC(10,0)
+) DISTRIBUTED RANDOMLY;
+--insert repeatable records:
+INSERT INTO TEST_IN
+SELECT
+    ROUND(RANDOM()*1E1),ROUND(RANDOM()*1E1)
+FROM GENERATE_SERIES(1,1E4::BIGINT) I;
+ANALYZE TEST_IN;
+SELECT COUNT(*) FROM
+TEST_IN A
+WHERE A.C01 IN(SELECT C02 FROM TEST_IN);
+ count 
+-------
+ 10000
+(1 row)
+
+-- EXISTS sublink simplication
+drop table if exists simplify_sub;
+NOTICE:  table "simplify_sub" does not exist, skipping
+create table simplify_sub (i int) distributed by (i);
+insert into simplify_sub values (1);
+insert into simplify_sub values (2);
+-- limit n
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Result
+                 ->  Limit
+                       ->  Result
+                             Filter: (simplify_sub.i = simplify_sub_1.i)
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(14 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Semi Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Limit
+               ->  Result
+                     ->  Result
+                           One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(9 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Anti Join
+         Join Filter: true
+         ->  Seq Scan on simplify_sub
+         ->  Result
+               One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(7 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Semi Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Anti Join
+         Hash Cond: (simplify_sub.i = simplify_sub_1.i)
+         ->  Seq Scan on simplify_sub
+         ->  Hash
+               ->  Result
+                     ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(8 rows)
+
+select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
+ i 
+---
+(0 rows)
+
+-- aggregates without GROUP BY or HAVING
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on simplify_sub
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(3 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   ->  Result
+         One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(4 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+(0 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+ 2
+ 1
+(2 rows)
+
+explain (costs off)
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on simplify_sub
+   SubPlan 1  (slice0)
+     ->  Limit
+           ->  Aggregate
+                 ->  Result
+                       Filter: (simplify_sub.i = simplify_sub_1.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on simplify_sub simplify_sub_1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+(13 rows)
+
+select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
+ i 
+---
+(0 rows)
+
+drop table if exists simplify_sub;
+-- Regression of duplicated initplans of a partitioned table
+DROP TABLE IF EXISTS foo, lookup_table;
+NOTICE:  table "lookup_table" does not exist, skipping
+CREATE TABLE foo(a int, b text, c timestamp)
+  DISTRIBUTED BY (a)
+  PARTITION BY LIST(b) (VALUES('a'), VALUES('b'));
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_1" for table "foo"
+NOTICE:  CREATE TABLE will create partition "foo_1_prt_2" for table "foo"
+INSERT INTO foo VALUES (1, 'a', '2012-12-12 13:00');
+INSERT INTO foo VALUES (2, 'b', '2012-12-13 12:00');
+CREATE TABLE lookup_table(a text, c timestamp)
+  DISTRIBUTED BY (a);
+INSERT INTO lookup_table VALUES ('a', '2012-12-12 12:00');
+INSERT INTO lookup_table VALUES ('b', '2021-12-21 21:00');
+CREATE OR REPLACE FUNCTION my_lookup(a_in text) RETURNS timestamp AS
+$$
+DECLARE
+   c_var timestamp;
+BEGIN
+   BEGIN
+      SELECT c INTO c_var FROM lookup_table WHERE a = a_in;
+   END;
+   RETURN c_var;
+END;
+$$
+LANGUAGE plpgsql NO SQL;
+SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
+ a | b 
+---+---
+ 1 | a
+ 2 | b
+(2 rows)
+
+-- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
+-- for the corresponding slice instead of the containing the plan node's flow.
+-- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
+create table extra_flow_dist(a int, b int, c date);
+create table extra_flow_dist1(a int, b int);
+insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
+insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
+-- case 1 subplan with general locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Aggregate
+                                       ->  Result
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = (max(1)))
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+with run_dt as (
+	select
+	(
+	  select c from extra_flow_dist where b = x
+	) dt
+	from (select ( max(1) ) x) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
+(3 rows)
+
+create table extra_flow_rand(a int) distributed replicated;
+insert into extra_flow_rand values (1);
+-- case 2 for subplan with segment general locus (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x  -- subplan's outer is the below segment general locus path
+	) dt
+	from (select a x from extra_flow_rand) a  -- segment general locus
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: true
+         ->  Seq Scan on subselect_gp.extra_flow_dist1
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+         ->  Result
+               Output: ((SubPlan 1))
+               Filter: (((SubPlan 1)) < '01-01-2010'::date)
+               ->  Result
+                     Output: (SubPlan 1)
+                     ->  Seq Scan on subselect_gp.extra_flow_rand
+                           Output: extra_flow_rand.a
+                     SubPlan 1  (slice2; segments: 3)
+                       ->  Result
+                             Output: extra_flow_dist.c
+                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                             ->  Materialize
+                                   Output: extra_flow_dist.b, extra_flow_dist.c
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: extra_flow_dist.b, extra_flow_dist.c
+                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                               Output: extra_flow_dist.b, extra_flow_dist.c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(26 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select a x from extra_flow_rand) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 20 | 20
+ 10-01-1949 | 21 | 21
+(3 rows)
+
+-- case 3 for subplan with entry locus (CTE and subquery)
+explain (costs off) with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Limit
+                                       ->  Result
+                                             ->  Seq Scan on pg_trigger
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = "outer".x)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+                                                           Filter: (b = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+with run_dt as (
+	select
+	(
+		select c from extra_flow_dist where b = x
+	) dt
+	from (select 1 x from pg_trigger limit 1) a
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+     dt     | a  | b  
+------------+----+----
+ 10-01-1949 | 22 | 22
+ 10-01-1949 | 21 | 21
+ 10-01-1949 | 20 | 20
+(3 rows)
+
+-- case 4 subplan with segment general locus without param in subplan (CTE and subquery)
+explain (verbose, costs off) with run_dt as (
+	select x, y dt
+	from (select a x from extra_flow_rand ) a  -- segment general locus
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)  -- subplan's outer is the above segment general locus path
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+   ->  Nested Loop
+         Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Nested Loop Left Join
+               Output: extra_flow_rand.a, (max(1))
+               Join Filter: (SubPlan 1)
+               ->  Seq Scan on subselect_gp.extra_flow_rand
+                     Output: extra_flow_rand.a
+               ->  Materialize
+                     Output: (max(1))
+                     ->  Aggregate
+                           Output: max(1)
+                           ->  Result
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Materialize
+                       Output: random()
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             Output: (random())
+                             ->  Seq Scan on subselect_gp.extra_flow_dist
+                                   Output: random()
+         ->  Materialize
+               Output: extra_flow_dist1.a, extra_flow_dist1.b
+               ->  Seq Scan on subselect_gp.extra_flow_dist1
+                     Output: extra_flow_dist1.a, extra_flow_dist1.b
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=on
+(28 rows)
+
+-- case 5 for subplan with entry locus without param in subplan (CTE and subquery)
+explain (costs off) with run_dt as (
+	select x, y dt
+	from (select tgtype x from pg_trigger ) a
+	left join (select max(1) y) aaa
+	on a.x > any (select random() from extra_flow_dist)
+)
+select * from run_dt, extra_flow_dist1
+where dt < extra_flow_dist1.a;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: ((max(1)) < extra_flow_dist1.a)
+         ->  Broadcast Motion 1:3  (slice2)
+               ->  Nested Loop Left Join
+                     Join Filter: (SubPlan 1)
+                     ->  Seq Scan on pg_trigger
+                     ->  Materialize
+                           ->  Aggregate
+                                 ->  Result
+                     SubPlan 1  (slice2)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Seq Scan on extra_flow_dist
+         ->  Materialize
+               ->  Seq Scan on extra_flow_dist1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- case 6 without CTE, nested subquery
+explain (costs off) select * from (
+	select dt from (
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) a
+		union
+		select
+		(
+			select c from extra_flow_dist where b = x
+		) dt
+		from (select ( max(1) ) x) aa
+	) tbl
+) run_dt,
+extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                     ->  GroupAggregate
+                           Group Key: ((SubPlan 1))
+                           ->  Sort
+                                 Sort Key: ((SubPlan 1))
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: ((SubPlan 1))
+                                       ->  GroupAggregate
+                                             Group Key: ((SubPlan 1))
+                                             ->  Sort
+                                                   Sort Key: ((SubPlan 1))
+                                                   ->  Redistribute Motion 1:3  (slice3)
+                                                         ->  Append
+                                                               ->  Result
+                                                                     Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                                                                     ->  Result
+                                                                           ->  Aggregate
+                                                                                 ->  Result
+                                                                           SubPlan 1  (slice3)
+                                                                             ->  Result
+                                                                                   Filter: (extra_flow_dist.b = (max(1)))
+                                                                                   ->  Materialize
+                                                                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                                                               ->  Seq Scan on extra_flow_dist
+                                                               ->  Result
+                                                                     Filter: (((SubPlan 2)) < '01-01-2010'::date)
+                                                                     ->  Result
+                                                                           ->  Aggregate
+                                                                                 ->  Result
+                                                                           SubPlan 2  (slice3)
+                                                                             ->  Result
+                                                                                   Filter: (extra_flow_dist_1.b = (max(1)))
+                                                                                   ->  Materialize
+                                                                                         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                                                               ->  Seq Scan on extra_flow_dist extra_flow_dist_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(41 rows)
+
+-- case 7 function scan with general locus
+CREATE OR REPLACE FUNCTION im() RETURNS
+SETOF integer AS $$
+        BEGIN
+                RETURN QUERY
+                select 1 from generate_series(1, 10);
+        END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+explain (costs off) with run_dt as (
+   select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x
+)
+select * from run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Function Scan on im
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = im.im)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+-- case 8 function scan without CTE
+explain (costs off) select * from (select
+   (
+     select c from extra_flow_dist where b = x
+   ) dt
+   from im() x) run_dt, extra_flow_dist1
+where dt < '2010-01-01'::date;
+                                         QUERY PLAN
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Seq Scan on extra_flow_dist1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                           ->  Result
+                                 ->  Function Scan on im
+                                 SubPlan 1  (slice2)
+                                   ->  Result
+                                         Filter: (extra_flow_dist.b = im.im)
+                                         ->  Materialize
+                                               ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                     ->  Seq Scan on extra_flow_dist
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+

--- a/src/test/regress/resultmap
+++ b/src/test/regress/resultmap
@@ -15,3 +15,4 @@ int8:out:i.86-pc-mingw32=int8-exp-three-digits.out
 int8:out:x86_64-w64-mingw32=int8-exp-three-digits.out
 int8:out:i.86-w64-mingw32=int8-exp-three-digits.out
 int8:out:i.86-pc-win32vc=int8-exp-three-digits.out
+subselect_gp:out:powerpc64le=subselect_gp_switch_union.out


### PR DESCRIPTION
This fix adds additional resultmap entry which points to file specific to powerpc64le. This file (subselect_gp_switch_union.out) contains only one difference compared to original (subselect_gp.out) - the subplans of query with UNION clause were switched.
