### PR TITLE
On DDL operation keep the lock on partitions until end of transaction

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1485,6 +1485,8 @@ FinishPreparedTransaction(const char *gid, bool isCommit, bool raiseErrorIfNotFo
 
 	ProcArrayRemove(proc, latestXid);
 
+	SIMPLE_FAULT_INJECTOR("finish_prepared_after_pgproc_removal_before_cache_invalidation");
+
 	/*
 	 * In case we fail while running the callbacks, mark the gxact invalid so
 	 * no one else will try to commit/rollback, and so it will be recycled

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1343,19 +1343,6 @@ AcquireDeletionLock(const ObjectAddress *object, int flags)
 			LockRelationOid(object->objectId, ShareUpdateExclusiveLock);
 		else
 			LockRelationOid(object->objectId, AccessExclusiveLock);
-		/*
-		 * GPDB: If this was a partition, or some other object for which
-		 * we are careful to always lock the parent object, we don't need
-		 * to keep the lock on the sub-object. This helps to keep the lock
-		 * table size in check, if you e.g. drop a table with thousands
-		 * of partitions. It would be unpleasent if you could not drop
-		 * such a table because the lock table runs out of space.
-		 *
-		 * To provide at least some protection though, we still actuire
-		 * the lock momentarily.
-		 */
-		if (!rel_needs_long_lock(object->objectId))
-			UnlockRelationOid(object->objectId, AccessExclusiveLock);
 	}
 	else
 	{
@@ -1372,16 +1359,7 @@ static void
 ReleaseDeletionLock(const ObjectAddress *object)
 {
 	if (object->classId == RelationRelationId)
-	{
-		/*
-		 * GPDB: Since we might already have released the lock (see
-		 * AcquireDeletionLock), we mustn't try to release it again.
-		 */
-		if (!rel_needs_long_lock(object->objectId))
-			return;
-
 		UnlockRelationOid(object->objectId, AccessExclusiveLock);
-	}
 	else
 		/* assume we should lock the whole object not a sub-object */
 		UnlockDatabaseObject(object->classId, object->objectId, 0,

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2332,7 +2332,6 @@ void
 heap_drop_with_catalog(Oid relid)
 {
 	Relation	rel;
-	bool		is_part_child = false;
 	bool		is_appendonly_rel;
 	bool		is_external_rel;
 	char		relkind;
@@ -2394,15 +2393,11 @@ heap_drop_with_catalog(Oid relid)
 	}
 
 	/*
-	 * Close relcache entry, but *keep* AccessExclusiveLock (unless this is
-	 * a child partition) on the relation until transaction commit.  This
-	 * ensures no one else will try to do something with the doomed relation.
+	 * Close relcache entry, but *keep* AccessExclusiveLock on the relation
+	 * until transaction commit.  This ensures no one else will try to do
+	 * something with the doomed relation.
 	 */
-	is_part_child = !rel_needs_long_lock(RelationGetRelid(rel));
-	if (is_part_child)
-		relation_close(rel, AccessExclusiveLock);
-	else
-		relation_close(rel, NoLock);
+	relation_close(rel, NoLock);
 
 	/*
 	 * Forget any ON COMMIT action for the rel

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1241,18 +1241,8 @@ index_create(Relation heapRelation,
 	/*
 	 * Close the index; but we keep the lock that we acquired above until end
 	 * of transaction.  Closing the heap is caller's responsibility.
-	 *
-	 * GPDB: if we're dealing with a child of a partitioned table, also release
-	 * the lock. We should be holding a lock on the master, which is sufficient.
 	 */
-	if (rel_needs_long_lock(RelationGetRelid(heapRelation)))
-	{
-		index_close(indexRelation, NoLock);
-	}
-	else
-	{
-		index_close(indexRelation, AccessExclusiveLock);
-	}
+	index_close(indexRelation, NoLock);
 
 	return indexRelationId;
 }
@@ -1513,7 +1503,6 @@ index_drop(Oid indexId, bool concurrent)
 	Relation	indexRelation;
 	HeapTuple	tuple;
 	bool		hasexprs;
-	bool		need_long_lock;
 	LockRelId	heaprelid,
 				indexrelid;
 	LOCKTAG		heaplocktag;
@@ -1723,11 +1712,7 @@ index_drop(Oid indexId, bool concurrent)
 	 * try to rebuild it while we're deleting catalog entries. We keep the
 	 * lock though.
 	 */
-	need_long_lock = rel_needs_long_lock(RelationGetRelid(userIndexRelation));
-	if (need_long_lock)
-		index_close(userIndexRelation, NoLock);
-	else
-		index_close(userIndexRelation, AccessExclusiveLock);
+	index_close(userIndexRelation, NoLock);
 
 	RelationForgetRelation(indexId);
 
@@ -1786,7 +1771,7 @@ index_drop(Oid indexId, bool concurrent)
 	/*
 	 * Close owning rel, but keep lock
 	 */
-	heap_close(userHeapRelation, need_long_lock ? NoLock : AccessExclusiveLock);
+	heap_close(userHeapRelation, NoLock);
 
 
 	/*

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -552,7 +552,6 @@ RemoveConstraintById(Oid conId)
 	if (OidIsValid(con->conrelid))
 	{
 		Relation	rel;
-		bool		is_part_child = false;
 
 		/*
 		 * If the constraint is for a relation, open and exclusive-lock the
@@ -593,14 +592,8 @@ RemoveConstraintById(Oid conId)
 			heap_close(pgrel, RowExclusiveLock);
 		}
 
-		is_part_child = !rel_needs_long_lock(RelationGetRelid(rel));
-
-		if (is_part_child)
-			/* sufficiently locked, in the case of a partitioned table */
-			heap_close(rel, AccessExclusiveLock);
-		else
-			/* Keep lock on constraint's rel until end of xact */
-			heap_close(rel, NoLock);
+		/* Keep lock on constraint's rel until end of xact */
+		heap_close(rel, NoLock);
 	}
 	else if (OidIsValid(con->contypid))
 	{

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -688,7 +688,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, bool forcetemp,
 	OldHeap = heap_open(OIDOldHeap, lockmode);
 	OldHeapDesc = RelationGetDescr(OldHeap);
 
-	is_part_child = !rel_needs_long_lock(OIDOldHeap);
+	is_part_child = rel_is_part_child(OIDOldHeap);
 
 	/*
 	 * Check pg_inherits to determine if the OldHeap relation is a non-leaf

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -433,7 +433,6 @@ DefineIndex(Oid relationId,
 	LOCKTAG		heaplocktag;
 	LOCKMODE	lockmode;
 	Snapshot	snapshot;
-	bool		need_longlock = true;
 	bool		shouldDispatch;
 	int			i;
 
@@ -807,14 +806,6 @@ DefineIndex(Oid relationId,
 		 */
 	}
 
-	if (rel_needs_long_lock(RelationGetRelid(rel)))
-		need_longlock = true;
-	/* if this is a concurrent build, we must lock you long time */
-	else if (stmt->concurrent)
-		need_longlock = true;
-	else
-		need_longlock = false;
-
 	/*
 	 * A valid stmt->oldNode implies that we already have a built form of the
 	 * index.  The caller should also decline any index build.
@@ -887,10 +878,7 @@ DefineIndex(Oid relationId,
 			for (i = 0; i < numberOfAttributes; i++)
 				opfamOids[i] = get_opclass_family(classObjectId[i]);
 
-			if (need_longlock)
-				heap_close(rel, NoLock);
-			else
-				heap_close(rel, lockmode);
+			heap_close(rel, NoLock);
 
 			/*
 			 * For each partition, scan all existing indexes; if one matches
@@ -1078,10 +1066,7 @@ DefineIndex(Oid relationId,
 		 */
 		else
 		{
-			if (need_longlock)
-				heap_close(rel, NoLock);
-			else
-				heap_close(rel, lockmode);
+			heap_close(rel, NoLock);
 		}
 		/*
 		 * Indexes on partitioned tables are not themselves built, so we're
@@ -1093,10 +1078,7 @@ DefineIndex(Oid relationId,
 	if (!stmt->concurrent)
 	{
 		/* Close the heap and we're done, in the non-concurrent case */
-		if (need_longlock)
-			heap_close(rel, NoLock);
-		else
-			heap_close(rel, lockmode);
+		heap_close(rel, NoLock);
 		return indexRelationId;
 	}
 
@@ -1114,10 +1096,7 @@ DefineIndex(Oid relationId,
 	/* save lockrelid and locktag for below, then close rel */
 	heaprelid = rel->rd_lockInfo.lockRelId;
 	SET_LOCKTAG_RELATION(heaplocktag, heaprelid.dbId, heaprelid.relId);
-	if (need_longlock)
-		heap_close(rel, NoLock);
-	else
-		heap_close(rel, lockmode);
+	heap_close(rel, NoLock);
 
 	/*
 	 * For a concurrent build, it's important to make the catalog entries

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5423,7 +5423,7 @@ ATAddToastIfNeeded(List **wqueue, LOCKMODE lockmode)
 		if (tab->relkind == RELKIND_RELATION ||
 			tab->relkind == RELKIND_MATVIEW)
 		{
-			bool is_part = !rel_needs_long_lock(tab->relid);
+			bool is_part;
 
 			/*
 			 * FIXME: we've passed false as is_part_parent to make_new_heap().
@@ -5435,6 +5435,7 @@ ATAddToastIfNeeded(List **wqueue, LOCKMODE lockmode)
 			 * relation's OID, whether an auxiliary table needs valid
 			 * relfrozenxid or not?
 			 */
+			is_part = rel_is_part_child(tab->relid);
 			AlterTableCreateToastTable(tab->relid, (Datum) 0, lockmode,
 									   is_part, false);
 		}
@@ -15961,14 +15962,12 @@ rel_is_parent(Oid relid)
 }
 
 /*
- * partition children, toast tables and indexes, and indexes on partition
- * children do not need long lived locks because the lock on the partition master
- * protects us.
+ * Is the given relation a partition of a partitioned table?
  */
 bool
-rel_needs_long_lock(Oid relid)
+rel_is_part_child(Oid relid)
 {
-	bool needs_lock = true;
+	bool result = false;
 	Relation rel = relation_open(relid, NoLock);
 
 	relid = rel_get_table_oid(rel);
@@ -15976,7 +15975,7 @@ rel_needs_long_lock(Oid relid)
 	relation_close(rel, NoLock);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
-		needs_lock = !rel_is_child_partition(relid);
+		result = rel_is_child_partition(relid);
 	else
 	{
 		Relation inhrel;
@@ -15998,12 +15997,12 @@ rel_needs_long_lock(Oid relid)
 								   true, NULL, 2, scankey);
 
 		if (systable_getnext(sscan))
-			needs_lock = false;
+			result = true;
 
 		systable_endscan(sscan);
 		heap_close(inhrel, AccessShareLock);
 	}
-	return needs_lock;
+	return result;
 }
 
 

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1558,7 +1558,7 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 
 		/* Close child relations, but keep locks */
 		if (childOID != parentOID)
-			heap_close(newrelation, rel_needs_long_lock(childOID) ? NoLock: lockmode);
+			heap_close(newrelation, NoLock);
 	}
 
 	heap_close(oldrelation, NoLock);

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1412,16 +1412,18 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 	 * to the query, we must obtain an appropriate lock, because this will be
 	 * the first use of those relations in the parse/rewrite/plan pipeline.
 	 *
-	 * If the parent relation is the query's result relation, then we need
-	 * RowExclusiveLock.  Otherwise, if it's accessed FOR UPDATE/SHARE, we
-	 * need RowShareLock; otherwise AccessShareLock.  We can't just grab
-	 * AccessShareLock because then the executor would be trying to upgrade
-	 * the lock, leading to possible deadlocks.  (This code should match the
-	 * parser and rewriter.)
+	 * If the parent relation is the query's result relation, i.e. we have
+	 * UPDATE/DELETE/INSERT operation, then all relevant locks was acquired in
+	 * parse/analyze stage (inside `setTargetTable()` function) and nothing
+	 * needs to be done. Otherwise, if parent is accessed FOR UPDATE/SHARE, we
+	 * need RowShareLock; otherwise AccessShareLock. We can't just grab
+	 * AccessShareLock because then the executor would be trying to upgrade the
+	 * lock, leading to possible deadlocks. (This code should match the parser
+	 * and rewriter.)
 	 */
 	oldrc = get_plan_rowmark(root->rowMarks, rti);
 	if (rti == parse->resultRelation)
-		lockmode = RowExclusiveLock;
+		lockmode = NoLock;
 	else if (oldrc && RowMarkRequiresRowShareLock(oldrc->markType))
 		lockmode = RowShareLock;
 	else

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -101,7 +101,6 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	Relation	relation;
 	bool		hasindex;
 	List	   *indexinfos = NIL;
-	bool		needs_longlock;
 
 	/*
 	 * We need not lock the relation since it was already locked, either by
@@ -109,7 +108,6 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 	 * rangetable.
 	 */
 	relation = heap_open(relationObjectId, NoLock);
-	needs_longlock = rel_needs_long_lock(relationObjectId);
 
 	/* Temporary and unlogged relations are inaccessible during recovery. */
 	if (!RelationNeedsWAL(relation) && RecoveryInProgress())
@@ -400,7 +398,7 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 				info->tree_height = -1;
 			}
 
-			index_close(indexRelation, needs_longlock ? NoLock : lmode);
+			index_close(indexRelation, NoLock);
 
 			indexinfos = lcons(info, indexinfos);
 		}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3314,17 +3314,9 @@ transformIndexStmt(Oid relid, IndexStmt *stmt, const char *queryString)
 	free_parsestate(pstate);
 
 	/*
-	 * Close relation. Unless this is a CREATE INDEX
-	 * for a partitioned table, and we're processing a partition. In that
-	 * case, we want to release the lock on the partition early, so that
-	 * you don't run out of space in the lock manager if there are a lot
-	 * of partitions. Holding the lock on the parent table should be
-	 * enough.
+	 * Close relation but keep the lock.
 	 */
-	if (!rel_needs_long_lock(RelationGetRelid(rel)))
-		heap_close(rel, lockmode);
-	else
-		heap_close(rel, NoLock);
+	heap_close(rel, NoLock);
 
 	return stmt;
 }

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -32,6 +32,7 @@
 #include "storage/fd.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/int8.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
@@ -576,7 +577,9 @@ calculate_table_size(Relation rel)
 		Relation ao_rel;
 
 		Assert(OidIsValid(rel->rd_appendonly->segrelid));
+		SIMPLE_FAULT_INJECTOR("pg_calculate_table_size_before_pg_aoseg_estimation");
 		ao_rel = try_relation_open(rel->rd_appendonly->segrelid, AccessShareLock, false);
+		Assert(PointerIsValid(ao_rel));
 		size += calculate_total_relation_size(ao_rel);
 		relation_close(ao_rel, AccessShareLock);
 

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -114,7 +114,7 @@ extern void AtEOSubXact_on_commit_actions(bool isCommit,
 							  SubTransactionId parentSubid);
 
 extern bool rel_is_parent(Oid relid);
-extern bool rel_needs_long_lock(Oid relid);
+extern bool rel_is_part_child(Oid relid);
 extern Oid  rel_partition_get_master(Oid relid);
 
 extern Oid get_settable_tablespace_oid(char *tablespacename);

--- a/src/test/isolation2/expected/ddl_on_root_locks_all_parts.out
+++ b/src/test/isolation2/expected/ddl_on_root_locks_all_parts.out
@@ -1,0 +1,96 @@
+-- For DDL op running over partitioned tables table we should acquire
+-- AccessExclusive locks on root relation and child partitions and keep their
+-- until transaction completion. Otherwise if locks on partitions are not kept
+-- on QD, failure might occur from concurrent queries running on the leaf
+-- partitions.
+
+-- Prepare setup: create appendonly partitioned table with two partitions
+CREATE extension if NOT EXISTS gp_inject_fault;
+CREATE
+DROP TABLE IF EXISTS ptest;
+DROP
+CREATE TABLE ptest(i int) WITH(appendonly=true) PARTITION BY RANGE (i) (START (0) END (2) EXCLUSIVE EVERY (1));
+CREATE
+
+-- The first session removes partitioned table inside transaction block
+-- When locks on partitions are not set (buggy case), the second session that
+-- works with specific partition will have progress
+1: BEGIN;
+BEGIN
+1: DROP TABLE ptest;
+DROP
+
+-- The second session executes `pg_total_relation_size()` up to accessing to
+-- pg_aoseg relation for some partition on some segment node if its progress is
+-- not restricted by locks on partitions from concurrent DROP stmt.
+-- After fixing of partition locking issue the second session have to stuck on
+-- acquiring of AccessShare lock and take advance only after commit in the first
+-- session completes.
+SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2&: SELECT pg_total_relation_size('ptest_1_prt_1'::regclass);  <waiting ...>
+
+-- Wait some amount time so that the second session have achieved fault point if
+-- it has progress
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- Try to stop txn commit on some segment in the first session up to catalog
+-- cache invalidation but after the routine that removes PGPROC entry from
+-- ProcArray so that renewed snapshots instantiated in concurrent transactions
+-- have treated current transaction as completed
+SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: COMMIT;  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Issue some dummy DDL query to inspire invalidation of catalog snapshot inside
+-- catalog cache invalidation routine later in the second session
+CREATE TABLE dummy_test(i int);
+CREATE
+
+-- Resume second session
+-- Cache invalidation occurs within `LockRelationOid()` function on pg_aoseg oid
+-- inside `try_relation_open()` call that returns abnormal NULL value. Failure
+-- occurs later.
+SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- Wait some amount time so that the second session eventually have executed
+-- `try_relation_open()` function if it has progress.
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+COMMIT
+2<:  <... completed>
+ pg_total_relation_size 
+------------------------
+                        
+(1 row)
+
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/expected/ddl_on_root_locks_all_parts.out
+++ b/src/test/isolation2/expected/ddl_on_root_locks_all_parts.out
@@ -1,8 +1,7 @@
--- For DDL op running over partitioned tables table we should acquire
--- AccessExclusive locks on root relation and child partitions and keep their
--- until transaction completion. Otherwise if locks on partitions are not kept
--- on QD, failure might occur from concurrent queries running on the leaf
--- partitions.
+-- For DDL op running over partitioned table we should acquire AccessExclusive
+-- locks on root relation and child partitions and keep them until transaction
+-- completion. Otherwise if locks on partitions are not kept on QD, failure
+-- might occur from concurrent queries running on the leaf partitions.
 
 -- Prepare setup: create appendonly partitioned table with two partitions
 CREATE extension if NOT EXISTS gp_inject_fault;
@@ -33,18 +32,18 @@ SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'su
 (1 row)
 2&: SELECT pg_total_relation_size('ptest_1_prt_1'::regclass);  <waiting ...>
 
--- Wait some amount time so that the second session have achieved fault point if
--- it has progress
+-- Wait some amount of time so that second session have reached the fault point
+-- if it has progress
 SELECT pg_sleep(1);
  pg_sleep 
 ----------
           
 (1 row)
 
--- Try to stop txn commit on some segment in the first session up to catalog
--- cache invalidation but after the routine that removes PGPROC entry from
--- ProcArray so that renewed snapshots instantiated in concurrent transactions
--- have treated current transaction as completed
+-- On some segment try to stop commit process in the place after passing the
+-- removing PGPROC entry from ProcArray and not achieving catalog cache
+-- invalidation routine. All renewed snapshots instantiating in concurrent
+-- sessions already have to treat this transaction as completed
 SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/sql/ddl_on_root_locks_all_parts.sql
+++ b/src/test/isolation2/sql/ddl_on_root_locks_all_parts.sql
@@ -1,0 +1,62 @@
+-- For DDL op running over partitioned tables table we should acquire
+-- AccessExclusive locks on root relation and child partitions and keep their
+-- until transaction completion. Otherwise if locks on partitions are not kept
+-- on QD, failure might occur from concurrent queries running on the leaf
+-- partitions.
+
+-- Prepare setup: create appendonly partitioned table with two partitions
+CREATE extension if NOT EXISTS gp_inject_fault;
+DROP TABLE IF EXISTS ptest;
+CREATE TABLE ptest(i int) WITH(appendonly=true) PARTITION BY RANGE (i) (START (0) END (2) EXCLUSIVE EVERY (1));
+
+-- The first session removes partitioned table inside transaction block
+-- When locks on partitions are not set (buggy case), the second session that
+-- works with specific partition will have progress
+1: BEGIN;
+1: DROP TABLE ptest;
+
+-- The second session executes `pg_total_relation_size()` up to accessing to
+-- pg_aoseg relation for some partition on some segment node if its progress is
+-- not restricted by locks on partitions from concurrent DROP stmt.
+-- After fixing of partition locking issue the second session have to stuck on
+-- acquiring of AccessShare lock and take advance only after commit in the first
+-- session completes.
+SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+2&: SELECT pg_total_relation_size('ptest_1_prt_1'::regclass);
+
+-- Wait some amount time so that the second session have achieved fault point if
+-- it has progress
+SELECT pg_sleep(1);
+
+-- Try to stop txn commit on some segment in the first session up to catalog
+-- cache invalidation but after the routine that removes PGPROC entry from
+-- ProcArray so that renewed snapshots instantiated in concurrent transactions
+-- have treated current transaction as completed
+SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+1&: COMMIT;
+
+SELECT gp_wait_until_triggered_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+-- Issue some dummy DDL query to inspire invalidation of catalog snapshot inside
+-- catalog cache invalidation routine later in the second session
+CREATE TABLE dummy_test(i int);
+
+-- Resume second session
+-- Cache invalidation occurs within `LockRelationOid()` function on pg_aoseg oid
+-- inside `try_relation_open()` call that returns abnormal NULL value. Failure
+-- occurs later.
+SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+-- Wait some amount time so that the second session eventually have executed
+-- `try_relation_open()` function if it has progress.
+SELECT pg_sleep(1);
+SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+1<:
+2<:
+
+1q:
+2q:

--- a/src/test/isolation2/sql/ddl_on_root_locks_all_parts.sql
+++ b/src/test/isolation2/sql/ddl_on_root_locks_all_parts.sql
@@ -1,8 +1,7 @@
--- For DDL op running over partitioned tables table we should acquire
--- AccessExclusive locks on root relation and child partitions and keep their
--- until transaction completion. Otherwise if locks on partitions are not kept
--- on QD, failure might occur from concurrent queries running on the leaf
--- partitions.
+-- For DDL op running over partitioned table we should acquire AccessExclusive
+-- locks on root relation and child partitions and keep them until transaction
+-- completion. Otherwise if locks on partitions are not kept on QD, failure
+-- might occur from concurrent queries running on the leaf partitions.
 
 -- Prepare setup: create appendonly partitioned table with two partitions
 CREATE extension if NOT EXISTS gp_inject_fault;
@@ -25,14 +24,14 @@ SELECT gp_inject_fault('pg_calculate_table_size_before_pg_aoseg_estimation', 'su
 FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 2&: SELECT pg_total_relation_size('ptest_1_prt_1'::regclass);
 
--- Wait some amount time so that the second session have achieved fault point if
--- it has progress
+-- Wait some amount of time so that second session have reached the fault point
+-- if it has progress
 SELECT pg_sleep(1);
 
--- Try to stop txn commit on some segment in the first session up to catalog
--- cache invalidation but after the routine that removes PGPROC entry from
--- ProcArray so that renewed snapshots instantiated in concurrent transactions
--- have treated current transaction as completed
+-- On some segment try to stop commit process in the place after passing the
+-- removing PGPROC entry from ProcArray and not achieving catalog cache
+-- invalidation routine. All renewed snapshots instantiating in concurrent
+-- sessions already have to treat this transaction as completed
 SELECT gp_inject_fault('finish_prepared_after_pgproc_removal_before_cache_invalidation', 'suspend', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 1&: COMMIT;

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -479,33 +479,24 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 -------------------------+------------------+----------+--------
  partlockt               | ExclusiveLock    | relation | master
  partlockt_1_prt_1       | ExclusiveLock    | relation | master
- partlockt_1_prt_1       | RowExclusiveLock | relation | master
  partlockt_1_prt_1_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_2       | ExclusiveLock    | relation | master
- partlockt_1_prt_2       | RowExclusiveLock | relation | master
  partlockt_1_prt_2_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_3       | ExclusiveLock    | relation | master
- partlockt_1_prt_3       | RowExclusiveLock | relation | master
  partlockt_1_prt_3_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_4       | ExclusiveLock    | relation | master
- partlockt_1_prt_4       | RowExclusiveLock | relation | master
  partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_5       | ExclusiveLock    | relation | master
- partlockt_1_prt_5       | RowExclusiveLock | relation | master
  partlockt_1_prt_5_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_6       | ExclusiveLock    | relation | master
- partlockt_1_prt_6       | RowExclusiveLock | relation | master
  partlockt_1_prt_6_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_7       | ExclusiveLock    | relation | master
- partlockt_1_prt_7       | RowExclusiveLock | relation | master
  partlockt_1_prt_7_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_8       | ExclusiveLock    | relation | master
- partlockt_1_prt_8       | RowExclusiveLock | relation | master
  partlockt_1_prt_8_i_idx | RowExclusiveLock | relation | master
  partlockt_1_prt_9       | ExclusiveLock    | relation | master
- partlockt_1_prt_9       | RowExclusiveLock | relation | master
  partlockt_1_prt_9_i_idx | RowExclusiveLock | relation | master
-(28 rows)
+(19 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -1,5 +1,12 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
+--
+-- Previously, we used to only lock the parent table in many DDL operations.
+-- That was always a bit bogus, but we did it to avoid running out of lock space
+-- when working on large partition hierarchies. We don't play fast and loose
+-- like that anymore, but keep the tests. If a user runs out of lock space, you
+-- can work around that by simply bumping up max_locks_per_transactions.
+--
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -115,7 +122,34 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(30 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -123,7 +157,34 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(30 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -212,7 +273,25 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(24 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -223,7 +302,25 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(24 rows)
 
 commit;
 -- Indexing
@@ -252,36 +349,54 @@ NOTICE:  building index for child partition "partlockt_1_prt_7"
 NOTICE:  building index for child partition "partlockt_1_prt_8"
 NOTICE:  building index for child partition "partlockt_1_prt_9"
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |  node  
--------------------+---------------------+----------+--------
- partlockt         | ShareLock           | relation | master
- partlockt_1_prt_1 | ShareLock           | relation | master
- partlockt_1_prt_2 | ShareLock           | relation | master
- partlockt_1_prt_3 | ShareLock           | relation | master
- partlockt_1_prt_4 | ShareLock           | relation | master
- partlockt_1_prt_5 | ShareLock           | relation | master
- partlockt_1_prt_6 | ShareLock           | relation | master
- partlockt_1_prt_7 | ShareLock           | relation | master
- partlockt_1_prt_8 | ShareLock           | relation | master
- partlockt_1_prt_9 | ShareLock           | relation | master
- partlockt_idx     | AccessExclusiveLock | relation | master
-(11 rows)
+        coalesce         |        mode         | locktype |  node  
+-------------------------+---------------------+----------+--------
+ partlockt               | ShareLock           | relation | master
+ partlockt_1_prt_1       | ShareLock           | relation | master
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_2       | ShareLock           | relation | master
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_3       | ShareLock           | relation | master
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_4       | ShareLock           | relation | master
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_5       | ShareLock           | relation | master
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_6       | ShareLock           | relation | master
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_7       | ShareLock           | relation | master
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_8       | ShareLock           | relation | master
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_9       | ShareLock           | relation | master
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | master
+ partlockt_idx           | AccessExclusiveLock | relation | master
+(20 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_idx     | AccessExclusiveLock | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_6 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
-(11 rows)
+        coalesce         |        mode         | locktype |    node    
+-------------------------+---------------------+----------+------------
+ partlockt               | ShareLock           | relation | n segments
+ partlockt_1_prt_1       | ShareLock           | relation | n segments
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_2       | ShareLock           | relation | n segments
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_3       | ShareLock           | relation | n segments
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_4       | ShareLock           | relation | n segments
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_5       | ShareLock           | relation | n segments
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_6       | ShareLock           | relation | n segments
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_7       | ShareLock           | relation | n segments
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_8       | ShareLock           | relation | n segments
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_9       | ShareLock           | relation | n segments
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_idx           | AccessExclusiveLock | relation | n segments
+(20 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -303,7 +418,23 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt               | AccessShareLock | relation | master
  partlockt_1_prt_1       | AccessShareLock | relation | master
  partlockt_1_prt_1_i_idx | AccessShareLock | relation | master
-(3 rows)
+ partlockt_1_prt_2       | AccessShareLock | relation | master
+ partlockt_1_prt_2_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_3       | AccessShareLock | relation | master
+ partlockt_1_prt_3_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_4       | AccessShareLock | relation | master
+ partlockt_1_prt_4_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_5       | AccessShareLock | relation | master
+ partlockt_1_prt_5_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_6       | AccessShareLock | relation | master
+ partlockt_1_prt_6_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_7       | AccessShareLock | relation | master
+ partlockt_1_prt_7_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_8       | AccessShareLock | relation | master
+ partlockt_1_prt_8_i_idx | AccessShareLock | relation | master
+ partlockt_1_prt_9       | AccessShareLock | relation | master
+ partlockt_1_prt_9_i_idx | AccessShareLock | relation | master
+(19 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    
@@ -344,19 +475,37 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |     mode      | locktype |  node  
--------------------+---------------+----------+--------
- partlockt         | ExclusiveLock | relation | master
- partlockt_1_prt_1 | ExclusiveLock | relation | master
- partlockt_1_prt_2 | ExclusiveLock | relation | master
- partlockt_1_prt_3 | ExclusiveLock | relation | master
- partlockt_1_prt_4 | ExclusiveLock | relation | master
- partlockt_1_prt_5 | ExclusiveLock | relation | master
- partlockt_1_prt_6 | ExclusiveLock | relation | master
- partlockt_1_prt_7 | ExclusiveLock | relation | master
- partlockt_1_prt_8 | ExclusiveLock | relation | master
- partlockt_1_prt_9 | ExclusiveLock | relation | master
-(10 rows)
+        coalesce         |       mode       | locktype |  node  
+-------------------------+------------------+----------+--------
+ partlockt               | ExclusiveLock    | relation | master
+ partlockt_1_prt_1       | ExclusiveLock    | relation | master
+ partlockt_1_prt_1       | RowExclusiveLock | relation | master
+ partlockt_1_prt_1_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_2       | ExclusiveLock    | relation | master
+ partlockt_1_prt_2       | RowExclusiveLock | relation | master
+ partlockt_1_prt_2_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_3       | ExclusiveLock    | relation | master
+ partlockt_1_prt_3       | RowExclusiveLock | relation | master
+ partlockt_1_prt_3_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_4       | ExclusiveLock    | relation | master
+ partlockt_1_prt_4       | RowExclusiveLock | relation | master
+ partlockt_1_prt_4_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_5       | ExclusiveLock    | relation | master
+ partlockt_1_prt_5       | RowExclusiveLock | relation | master
+ partlockt_1_prt_5_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_6       | ExclusiveLock    | relation | master
+ partlockt_1_prt_6       | RowExclusiveLock | relation | master
+ partlockt_1_prt_6_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_7       | ExclusiveLock    | relation | master
+ partlockt_1_prt_7       | RowExclusiveLock | relation | master
+ partlockt_1_prt_7_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_8       | ExclusiveLock    | relation | master
+ partlockt_1_prt_8       | RowExclusiveLock | relation | master
+ partlockt_1_prt_8_i_idx | RowExclusiveLock | relation | master
+ partlockt_1_prt_9       | ExclusiveLock    | relation | master
+ partlockt_1_prt_9       | RowExclusiveLock | relation | master
+ partlockt_1_prt_9_i_idx | RowExclusiveLock | relation | master
+(28 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
@@ -375,7 +524,43 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(40 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -384,6 +569,42 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(40 rows)
 
 commit;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -1,5 +1,12 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
+--
+-- Previously, we used to only lock the parent table in many DDL operations.
+-- That was always a bit bogus, but we did it to avoid running out of lock space
+-- when working on large partition hierarchies. We don't play fast and loose
+-- like that anymore, but keep the tests. If a user runs out of lock space, you
+-- can work around that by simply bumping up max_locks_per_transactions.
+--
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -115,7 +122,34 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(30 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -123,7 +157,34 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(3 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(30 rows)
 
 commit;
 -- AO table (ao segments, block directory won't exist after create)
@@ -212,7 +273,25 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(24 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -223,7 +302,25 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(6 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(24 rows)
 
 commit;
 -- Indexing
@@ -252,36 +349,54 @@ NOTICE:  building index for child partition "partlockt_1_prt_7"
 NOTICE:  building index for child partition "partlockt_1_prt_8"
 NOTICE:  building index for child partition "partlockt_1_prt_9"
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |  node  
--------------------+---------------------+----------+--------
- partlockt         | ShareLock           | relation | master
- partlockt_1_prt_1 | ShareLock           | relation | master
- partlockt_1_prt_2 | ShareLock           | relation | master
- partlockt_1_prt_3 | ShareLock           | relation | master
- partlockt_1_prt_4 | ShareLock           | relation | master
- partlockt_1_prt_5 | ShareLock           | relation | master
- partlockt_1_prt_6 | ShareLock           | relation | master
- partlockt_1_prt_7 | ShareLock           | relation | master
- partlockt_1_prt_8 | ShareLock           | relation | master
- partlockt_1_prt_9 | ShareLock           | relation | master
- partlockt_idx     | AccessExclusiveLock | relation | master
-(11 rows)
+        coalesce         |        mode         | locktype |  node  
+-------------------------+---------------------+----------+--------
+ partlockt               | ShareLock           | relation | master
+ partlockt_1_prt_1       | ShareLock           | relation | master
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_2       | ShareLock           | relation | master
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_3       | ShareLock           | relation | master
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_4       | ShareLock           | relation | master
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_5       | ShareLock           | relation | master
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_6       | ShareLock           | relation | master
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_7       | ShareLock           | relation | master
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_8       | ShareLock           | relation | master
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | master
+ partlockt_1_prt_9       | ShareLock           | relation | master
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | master
+ partlockt_idx           | AccessExclusiveLock | relation | master
+(20 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-     coalesce      |        mode         | locktype |    node    
--------------------+---------------------+----------+------------
- partlockt_1_prt_6 | ShareLock           | relation | n segments
- partlockt_1_prt_5 | ShareLock           | relation | n segments
- partlockt         | ShareLock           | relation | n segments
- partlockt_1_prt_9 | ShareLock           | relation | n segments
- partlockt_1_prt_1 | ShareLock           | relation | n segments
- partlockt_1_prt_3 | ShareLock           | relation | n segments
- partlockt_1_prt_8 | ShareLock           | relation | n segments
- partlockt_1_prt_4 | ShareLock           | relation | n segments
- partlockt_1_prt_7 | ShareLock           | relation | n segments
- partlockt_1_prt_2 | ShareLock           | relation | n segments
- partlockt_idx     | AccessExclusiveLock | relation | n segments
-(11 rows)
+        coalesce         |        mode         | locktype |    node    
+-------------------------+---------------------+----------+------------
+ partlockt               | ShareLock           | relation | n segments
+ partlockt_1_prt_1       | ShareLock           | relation | n segments
+ partlockt_1_prt_1_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_2       | ShareLock           | relation | n segments
+ partlockt_1_prt_2_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_3       | ShareLock           | relation | n segments
+ partlockt_1_prt_3_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_4       | ShareLock           | relation | n segments
+ partlockt_1_prt_4_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_5       | ShareLock           | relation | n segments
+ partlockt_1_prt_5_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_6       | ShareLock           | relation | n segments
+ partlockt_1_prt_6_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_7       | ShareLock           | relation | n segments
+ partlockt_1_prt_7_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_8       | ShareLock           | relation | n segments
+ partlockt_1_prt_8_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_1_prt_9       | ShareLock           | relation | n segments
+ partlockt_1_prt_9_i_idx | AccessExclusiveLock | relation | n segments
+ partlockt_idx           | AccessExclusiveLock | relation | n segments
+(20 rows)
 
 commit;
 -- Force use of the index in the select and delete below. We're not interested
@@ -375,7 +490,43 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
  dropped table | AccessExclusiveLock | relation | master
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+ dropped table | AccessExclusiveLock | relation | master
+(40 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
    coalesce    |        mode         | locktype |    node    
@@ -384,6 +535,42 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
  dropped table | AccessExclusiveLock | relation | n segments
-(4 rows)
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+ dropped table | AccessExclusiveLock | relation | n segments
+(40 rows)
 
 commit;

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -1,6 +1,12 @@
 -- Test locking behaviour. When creating, dropping, querying or adding indexes
 -- partitioned tables, we want to lock only the master, not the children.
-
+--
+-- Previously, we used to only lock the parent table in many DDL operations.
+-- That was always a bit bogus, but we did it to avoid running out of lock space
+-- when working on large partition hierarchies. We don't play fast and loose
+-- like that anymore, but keep the tests. If a user runs out of lock space, you
+-- can work around that by simply bumping up max_locks_per_transactions.
+--
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,


### PR DESCRIPTION
Commit fa287d0 have introduced early lock releasing on partitions within operations with partitioned parent table. This was done to save memory in lock manager I suppose. But such behavior incurs some issues, e.g., possible segfault when we perform drop of partitioned table and concurrent `pg_total_relation_size()` call on some AO partition.

Obviously, we have to restore full locking of inheritance hierarchy as it's done in vanilla PostgreSQL. To eliminate running out of lock memory we need to increase max_locks_per_transactions setting. Memory is cheap, and if we're working with tens of thousands of partitions, we can afford reserving some memory for the lock manager.

Partially for DML operations the problem of partitions locking was resolved in commit 99fbc8e. Therefore in current work the support for DDL operations have been added. And it's in fact backport of corresponding commit to master 86ded36. Also there have been added test scenario to reproduce noted above segfault case and related assert check inside `calculate_table_size()` function.

Backport of PR https://github.com/greenplum-db/gpdb/pull/10468 .
Fixes https://github.com/greenplum-db/gpdb/issues/12962 . All details about faulty case you might find there.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
