### PR TITLE
Fix query with mode() crash when QueryFinishPending is true

### DIFF
--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1168,7 +1168,7 @@ mode_final(PG_FUNCTION_ARGS)
 		CHECK_FOR_INTERRUPTS();
 	}
 
-	if (shouldfree && !last_val_is_mode && last_val)
+	if (shouldfree && !last_val_is_mode && PointerIsValid(DatumGetPointer(last_val)))
 		pfree(DatumGetPointer(last_val));
 
 	/*

--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1122,7 +1122,7 @@ mode_final(PG_FUNCTION_ARGS)
 	/* Finish the sort */
 	tuplesort_performsort(osastate->sortstate);
 
-	SIMPLE_FAULT_INJECTOR("set_query_finish_pending");
+	SIMPLE_FAULT_INJECTOR("before_tuplesort_getdatum_in_mode_final");
 
 	/* Scan tuples and count frequencies */
 	while (tuplesort_getdatum(osastate->sortstate, true, &val, &isnull))

--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -28,6 +28,7 @@
 #include "utils/lsyscache.h"
 #include "utils/timestamp.h"
 #include "utils/tuplesort.h"
+#include "utils/faultinjector.h"
 
 
 /*
@@ -1121,6 +1122,8 @@ mode_final(PG_FUNCTION_ARGS)
 	/* Finish the sort */
 	tuplesort_performsort(osastate->sortstate);
 
+	SIMPLE_FAULT_INJECTOR("set_query_finish_pending");
+
 	/* Scan tuples and count frequencies */
 	while (tuplesort_getdatum(osastate->sortstate, true, &val, &isnull))
 	{
@@ -1165,7 +1168,7 @@ mode_final(PG_FUNCTION_ARGS)
 		CHECK_FOR_INTERRUPTS();
 	}
 
-	if (shouldfree && !last_val_is_mode)
+	if (shouldfree && !last_val_is_mode && last_val)
 		pfree(DatumGetPointer(last_val));
 
 	/*

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -180,3 +180,19 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+-- test if a query with mode() does not crash when QueryFinishPending set to true
+create table _tmp_table3(a char, b int);
+insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
+select gp_inject_fault('set_query_finish_pending', 'finish_pending', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select gp_inject_fault('set_query_finish_pending', 'reset', 2);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+drop table _tmp_table3;

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -183,7 +183,7 @@ drop table _tmp_table2;
 -- test if a query with mode() does not crash when QueryFinishPending set to true
 create table _tmp_table3(a char, b int);
 insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
-select gp_inject_fault('set_query_finish_pending', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
  gp_inject_fault 
 -----------------
  Success:
@@ -200,7 +200,7 @@ select b, mode() within group(order by a) from _tmp_table3 group by b order by b
  2 | 
 (2 rows)
 
-select gp_inject_fault('set_query_finish_pending', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
  gp_inject_fault 
 -----------------
  Success:

--- a/src/test/regress/expected/query_finish_pending.out
+++ b/src/test/regress/expected/query_finish_pending.out
@@ -183,16 +183,29 @@ drop table _tmp_table2;
 -- test if a query with mode() does not crash when QueryFinishPending set to true
 create table _tmp_table3(a char, b int);
 insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
-select gp_inject_fault('set_query_finish_pending', 'finish_pending', 2);
+select gp_inject_fault('set_query_finish_pending', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
  gp_inject_fault 
 -----------------
  Success:
-(1 row)
+ Success:
+ Success:
+(3 rows)
 
-select gp_inject_fault('set_query_finish_pending', 'reset', 2);
+-- Make sure that no fault is triggered like
+-- DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
+select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
+ b | mode 
+---+------
+ 1 | 
+ 2 | 
+(2 rows)
+
+select gp_inject_fault('set_query_finish_pending', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
  gp_inject_fault 
 -----------------
  Success:
-(1 row)
+ Success:
+ Success:
+(3 rows)
 
 drop table _tmp_table3;

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -92,10 +92,10 @@ drop table _tmp_table2;
 -- test if a query with mode() does not crash when QueryFinishPending set to true
 create table _tmp_table3(a char, b int);
 insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
-select gp_inject_fault('set_query_finish_pending', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
 -- Make sure that no fault is triggered like
 -- DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
 select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
-select gp_inject_fault('set_query_finish_pending', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+select gp_inject_fault('before_tuplesort_getdatum_in_mode_final', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
 
 drop table _tmp_table3;

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -92,10 +92,10 @@ drop table _tmp_table2;
 -- test if a query with mode() does not crash when QueryFinishPending set to true
 create table _tmp_table3(a char, b int);
 insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
-select gp_inject_fault('set_query_finish_pending', 'finish_pending', 2);
--- start_ignore
+select gp_inject_fault('set_query_finish_pending', 'finish_pending', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
+-- Make sure that no fault is triggered like
+-- DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
 select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
--- end_ignore
-select gp_inject_fault('set_query_finish_pending', 'reset', 2);
+select gp_inject_fault('set_query_finish_pending', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content <> -1;
 
 drop table _tmp_table3;

--- a/src/test/regress/sql/query_finish_pending.sql
+++ b/src/test/regress/sql/query_finish_pending.sql
@@ -88,3 +88,14 @@ select gp_inject_fault('fts_probe', 'reset', 1);
 
 drop table _tmp_table1;
 drop table _tmp_table2;
+
+-- test if a query with mode() does not crash when QueryFinishPending set to true
+create table _tmp_table3(a char, b int);
+insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
+select gp_inject_fault('set_query_finish_pending', 'finish_pending', 2);
+-- start_ignore
+select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
+-- end_ignore
+select gp_inject_fault('set_query_finish_pending', 'reset', 2);
+
+drop table _tmp_table3;


### PR DESCRIPTION
**Issue description**

There is an issue that query with mode() aggregate crashes when QueryFinishPending is set to true.

_Steps to reproduce_:

1) Create test table
```
-- test if a query with mode() does not crash when QueryFinishPending set to true
create table _tmp_table3(a char, b int);
insert into _tmp_table3 values ('a', 1), ('a', 1), ('a', 2), ('b', 1), ('b', 1), ('b', 1), ('c', 3), ('c', 3);
```
2) Connect with gdb to any segment and set breakpoint at function mode_final
```
(gdb) br mode_final
Breakpoint 1 at 0xbcd410: file orderedsetaggs.c, line 1089.
(gdb)
```

3) Execute the following query
```
select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
```

4) Switch go gdb window with breakpoint at `mode_final`, check `QueryFinishPending` flag, set to to 1 and continue:
```
Breakpoint 1, mode_final (fcinfo=0x7ffd1782b7c0) at orderedsetaggs.c:1089
1089	{
(gdb) n
1101		Assert(AggCheckCallContext(fcinfo, NULL) == AGG_CONTEXT_AGGREGATE);
(gdb) p QueryFinishPending
$1 = 0 '\000'
(gdb) set QueryFinishPending = 1
(gdb) p QueryFinishPending
$2 = 1 '\001'
(gdb) c
Continuing.
```

5) Switch to SQL window to see that query with mode() crashed:
```
adb=# select b, mode() within group(order by a) from _tmp_table3 group by b order by b;
ERROR:  Unexpected internal error (mcxt.c:1291)  (seg0 slice2 10.92.6.153:6002 pid=18720) (mcxt.c:1291)
DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)
HINT:  Process 18720 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.
adb=# 

```

**Analisys**

If look closer at [mode_final](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1084-L1182) function we can spot that zero pointer comes from [last_val](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1095) variable:

```
(gdb) frame
#4  0x0000000000b26643 in mode_final (fcinfo=0x7ffe3b8faec0) at orderedsetaggs.c:1169
1169			pfree(DatumGetPointer([last_val](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1095)));
(gdb) list
1164	
1165			CHECK_FOR_INTERRUPTS();
1166		}
1167	
1168		if (shouldfree && !last_val_is_mode)
1169			pfree(DatumGetPointer(last_val));
1170	
1171		/*
1172		 * Note: we *cannot* clean up the tuplesort object here, because the value
1173		 * to be returned is allocated inside its sortcontext.  We could use
(gdb) 
```
`last_val` variable [init value is 0](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1095):
```
	Datum		last_val = (Datum) 0;
```
The only place for where its value can change is [inside scan tuples loop](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1124-L1166).

[last_val_is_mode](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1097) is set to false (that is OK for `!last_val_is_mode` to be true) from the beginning and can be changed [inside the same scan tuples loop](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1124-L1166). 

[shouldfree is set from osastate->qstate->typByVal](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1119)

```
(gdb) p shouldfree
$520 = 1 '\001'
(gdb)
```

So it looks like [last_val](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1095) variable has not been changed.

If look closer at [scan tuples loop](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/adt/orderedsetaggs.c#L1124-L1166) condition
```
	/* Scan tuples and count frequencies */
	while (tuplesort_getdatum(osastate->sortstate, true, &val, &isnull))
	{
```
 and check when `tuplesort_getdatum` function returns false it becomes clear that `tuplesort_getdatum` function [leads to](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/include/utils/tuplesort.h#L655) [switcheroo_tuplesort_getdatum](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/include/utils/tuplesort.h#L450-L457) function that leads to [tuplesort_getdatum_mk](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/sort/tuplesort_mk.c#L1744-L1772) function because
```
(gdb) p *osastate->sortstate
$2 = {is_mk_tuplesortstate = 1 '\001'}
(gdb)
```
[tuplesort_getdatum_mk](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/sort/tuplesort_mk.c#L1744-L1772) function [returns false if](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/sort/tuplesort_mk.c#L1759) [tuplesort_gettuple_common_pos](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/sort/tuplesort_mk.c#L1473-L1662) [returns false that really happens here](https://github.com/arenadata/gpdb/blob/6.16.2_arenadata21/src/backend/utils/sort/tuplesort_mk.c#L1488-L1495):
```
	/*
	 * No output if we are told to finish execution.
	 */
	if (QueryFinishPending)
	{
		*should_free = false;
		return false;
	}
```


Fix [checks](https://github.com/arenadata/gpdb/blob/0e6be512430b8470dcf172c645ac0c941ef22bca/src/backend/utils/adt/orderedsetaggs.c#L1171) `last_val` for 0 before `pfree`.

New test verify the fix.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
