### PR TITLE
Replace usages of InterruptPending to the flag of query cancellation

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -526,7 +526,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 
 		while (PQisBusy(q->conn) && PQstatus(q->conn) == CONNECTION_OK)
 		{
-			if ((Gp_role == GP_ROLE_DISPATCH) && InterruptPending)
+			if ((Gp_role == GP_ROLE_DISPATCH) && CancelRequested())
 			{
 				PQrequestCancel(q->conn);
 			}

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1160,7 +1160,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		{
 			if (ds->primaryResults->errcode)
 				break;
-			if (InterruptPending)
+			if (CancelRequested())
 				break;
 		}
 		SIMPLE_FAULT_INJECTOR("before_one_slice_dispatched");

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2440,7 +2440,7 @@ waitOnOutbound(ChunkTransportStateEntry *pEntry)
 		if (conn_count == 0)
 			return;
 
-		if (InterruptPending || QueryFinishPending)
+		if (CancelRequested() || QueryFinishPending)
 		{
 #ifdef AMS_VERBOSE_LOGGING
 			elog(DEBUG3, "waitOnOutbound(): interrupt pending fast-track");
@@ -2462,7 +2462,7 @@ waitOnOutbound(ChunkTransportStateEntry *pEntry)
 		{
 			saved_err = errno;
 
-			if (InterruptPending || QueryFinishPending)
+			if (CancelRequested() || QueryFinishPending)
 				return;
 
 			/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5953,3 +5953,11 @@ log_disconnections(int code, Datum arg __attribute__((unused)))
 					port->user_name, port->database_name, port->remote_host,
 				  port->remote_port[0] ? " port=" : "", port->remote_port)));
 }
+
+/*
+ * Whether request on cancel or termination have arrived?
+ */
+inline bool
+CancelRequested() {
+	return InterruptPending && (ProcDiePending || QueryCancelPending);
+}

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -100,6 +100,7 @@ extern PGDLLIMPORT volatile int32 CritSectionCount;
 
 /* in tcop/postgres.c */
 extern void ProcessInterrupts(const char* filename, int lineno);
+extern bool CancelRequested();
 
 /* Hook get notified when QueryCancelPending or ProcDiePending is raised */
 typedef void (*cancel_pending_hook_type) (void);


### PR DESCRIPTION
This PR fixes https://github.com/greenplum-db/gpdb/issues/13048.

Currently some communication routines between master and segments performing polling of messages from segments rely on `InterruptPending` flag in detection of cancel or termination events [[1](https://github.com/greenplum-db/gpdb/blob/d4534e08c27ede9b572ecfcf0f167518bf562ff4/src/backend/cdb/dispatcher/cdbdisp_async.c#L414-L420),[2](https://github.com/greenplum-db/gpdb/blob/d4534e08c27ede9b572ecfcf0f167518bf562ff4/src/backend/cdb/dispatcher/cdbdisp_query.c#L1163-L1164),[3](https://github.com/greenplum-db/gpdb/blob/d4534e08c27ede9b572ecfcf0f167518bf562ff4/src/backend/cdb/cdbcopy.c#L529-L532),[4](https://github.com/greenplum-db/gpdb/blob/d4534e08c27ede9b572ecfcf0f167518bf562ff4/src/backend/cdb/motion/ic_tcp.c#L2443-L2449),[5](https://github.com/greenplum-db/gpdb/blob/d4534e08c27ede9b572ecfcf0f167518bf562ff4/src/backend/cdb/motion/ic_tcp.c#L2465-L2466)]. This flag is used to define some interruption in CHECK_FOR_INTERRUPTS() routine. Up to some time this flag was closely assigned with some exceptional case, more
often with cancel or termination request. But as GPDB merges with newest versions of PostgreSQL, there are more and more cases where interruption begins to denote some not certainly causing error thing, e.g., periodic check of connectivity with client. For this reason it becomes necessary to redefine the usages of `InterruptPending` flag to no longer erroneously evaluate the set `InterruptPending` flag as cancel request.

Current patch fixes four places of `InterruptPending` usage in waiting loops of master-segments communication:

- `checkDispatchResult()` (in blocking mode) blocks QD flow [until](https://github.com/greenplum-db/gpdb/blob/6.19.2/src/backend/cdb/dispatcher/cdbdisp_async.c#L422-L469) all QEs report some response or an error. The blocking might last a long time especially when all execution is performed on QEs' side, e.g. for `INSERT INTO ... SELECT ...` QD spends all its time in `checkDispatchResult()` function within `mppExecutorFinishup()` call. Therefore, it’s helpful to integrate CFI call in waiting loop and define cancel event based on it.
- `cdbdisp_dispatchX()` allows to cancel dispatching of plan slices somewhere [in the middle](https://github.com/greenplum-db/gpdb/blob/6.19.2/src/backend/cdb/dispatcher/cdbdisp_query.c#L1156-L1165). All dispatching happens in non-blocking mode so it’s enough to react only on cancel/termination requests. All other signals will be handled further without delay in the dispatching loop.
- `waitOnOutbound()` is called by `TeardownTCPInterconnect()` function to [receive](https://github.com/greenplum-db/gpdb/blob/6.19.2/src/backend/cdb/motion/ic_tcp.c#L2484-L2490) STOP message from segments [before](https://github.com/greenplum-db/gpdb/blob/6.19.2/src/backend/cdb/motion/ic_tcp.c#L2082-L2108) closing connections. We might hang on waiting loop for a significant period of time when `select()` completes by timeout on each iteration of waiting loop, i.e. when connectivity is kept but segments delay the sending of STOP message or when master as tcp client cannot detect disconnection of network (`tcp_keepalive` has to repair it). All of these are rare enough so regular check on cancel/termination is enough.
- `cdbCopyInternal()` is called in COPY TO/FROM operations issued on master after data transferring. Exit from [waiting loop](https://github.com/greenplum-db/gpdb/blob/6.19.2/src/backend/cdb/cdbcopy.c#L527-L538) occurs after receiving of responses from segments or when connection has failed (`PQstatus() != CONNECTION_OK`). Hanging is possible in all cases as in `waitOnOutbound()` function. Simple cancel/termination check is enough.