### PR TITLE
ADBDEV-2563 Align char behavior in PowerPC with x86

### DIFF
--- a/gpAux/Makefile.global
+++ b/gpAux/Makefile.global
@@ -46,7 +46,7 @@ export NO_M64=1
 rhel6_x86_64_BLD_CFLAGS=-m64 -gdwarf-2 -gstrict-dwarf
 rhel7_x86_64_BLD_CFLAGS=-m64
 rhel8_x86_64_BLD_CFLAGS=-m64
-rhel7_ppc64le_BLD_CFLAGS=-m64 -fasynchronous-unwind-tables
+rhel7_ppc64le_BLD_CFLAGS=-m64 -fasynchronous-unwind-tables -fsigned-char
 altlinux8.2_x86_64_BLD_CFLAGS=-m64
 BLD_CFLAGS=$($(BLD_ARCH)_BLD_CFLAGS)
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -238,7 +238,7 @@ static int	InteractiveBackend(StringInfo inBuf);
 static int	interactive_getc(void);
 static int	SocketBackend(StringInfo inBuf);
 static int	ReadCommand(StringInfo inBuf);
-static void forbidden_in_wal_sender(char firstchar);
+static void forbidden_in_wal_sender(int firstchar);
 static List *pg_rewrite_query(Query *query);
 static bool check_log_statement(List *stmt_list);
 static int	errdetail_execute(List *raw_parsetree_list);
@@ -4610,7 +4610,7 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
  * received, and is used to construct the error message.
  */
 static void
-check_forbidden_in_gpdb_handlers(char firstchar)
+check_forbidden_in_gpdb_handlers(int firstchar)
 {
 	if (am_ftshandler || IsFaultHandler)
 	{
@@ -5766,7 +5766,7 @@ PostgresMain(int argc, char *argv[],
  * message was received, and is used to construct the error message.
  */
 static void
-forbidden_in_wal_sender(char firstchar)
+forbidden_in_wal_sender(int firstchar)
 {
 	if (am_walsender)
 	{


### PR DESCRIPTION
One of the recently added regression tests has revealed places in the code where the first byte (firstchar) of a proto message read from socket is used in an inaccurate way: functions `check_forbidden_in_gpdb_handlers` and `forbidden_in_wal_sender` takes firstchar argument of type char, while the calling function `PostgresMain` works with integer firstchar. In most cases it is valid, however there might be some situations when GPDB was compiled with unsigned char (e.g. the default behavior of PowerPC). This leads to misreading of EOF (-1) value - it is treated as 255. Consequently, the invalid symbol is written to the logs:

1. Run `./pg_regress --init-file=init_file fts_error`

2.  Execute a simplified version of the query from checkpoint_memleak test
```
select count(*) from gp_toolkit.__gp_log_segment_ext 
where logsegment = 'seg1'  
and logmessage like '[CheckpointMemoryLeakTest] Possible memory leak %';
```

3. An error raised
```
ERROR:  invalid byte sequence for encoding "UTF8": 0xff
CONTEXT:  External table __gp_log_segment_ext, line 57636 of file execute:cat $GP_SEG_DATADIR/pg_log/*.csv
```


