### PR TITLE
require c++11 support for builds with ORCA

### DIFF
--- a/config/python.m4
+++ b/config/python.m4
@@ -16,7 +16,7 @@
 # "python2" and "python3", in which case it's reasonable to prefer the
 # newer version.
 AC_DEFUN([PGAC_PATH_PYTHON],
-[PGAC_PATH_PROGS(PYTHON, [python python2])
+[PGAC_PATH_PROGS(PYTHON, [python python3 python2])
 if test x"$PYTHON" = x""; then
   AC_MSG_ERROR([Python not found])
 fi

--- a/configure
+++ b/configure
@@ -6435,7 +6435,7 @@ fi
 $as_echo "checking whether to build with gpcloud... $enable_gpcloud" >&6; }
 
 
-if test "$enable_gpcloud" = yes; then :
+if test "$enable_orca" = yes || test "$enable_gpcloud" = yes; then :
    # then
     ax_cxx_compile_alternatives="11 0x"    ax_cxx_compile_cxx11_required=true
   ac_ext=cpp

--- a/configure.in
+++ b/configure.in
@@ -844,7 +844,7 @@ PGAC_ARG_BOOL(enable, gpcloud, yes, [disable gpcloud support],
 AC_MSG_RESULT([checking whether to build with gpcloud... $enable_gpcloud])
 AC_SUBST(enable_gpcloud)
 
-AS_IF([test "$enable_gpcloud" = yes],
+AS_IF([test "$enable_orca" = yes || test "$enable_gpcloud" = yes],
 [ # then
   AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 ]) # fi

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -3,4 +3,3 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPP
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros $(CPPFLAGS)
-override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -14,7 +14,6 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # FIXME: Would be better to include gporca.mk, but hitting a warning
 override CPPFLAGS := -Wno-variadic-macros $(CPPFLAGS)
-override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
 
 OBJS        = CAutoTimer.o \
               CBitSet.o \


### PR DESCRIPTION
https://github.com/arenadata/gpdb/commit/ac6ce1a5c467b95c9ce2a29286ce6f1cbb48acac implemented changes that require c++11 standard support to build ORCA
(at least nullptr literal). But this problem was masked on default builds
because gpcloud has already required this standard. This patch resolve issues
for builds with `--disable-gpcloud` flag.

The second commit removes diff between configure script in repo
and autoconf result that was pushed by https://github.com/arenadata/gpdb/commit/af96694494c31657305abf2a433beb9861f45e7e. This issue was detected 
during configure regeneration.