### PR TITLE
Extend PgBackendStatus with waiting event start time.

### DIFF
--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -819,6 +819,8 @@ typedef struct PgBackendStatus
 	/* the start time of queueing on resource group */
 	TimestampTz	st_resgroup_queue_start_timestamp;
 	TimestampTz st_state_start_timestamp;
+	/* the start time of lock awaiting */
+	TimestampTz st_waiting_start_timestamp;
 
 	/* Database OID, owning user's OID, connection client address */
 	Oid			st_databaseid;


### PR DESCRIPTION
As we want to somehow monitor main waiting events (PGBE_WAITING_LOCK, PGBE_WAITING_REPLICATION) we need to add a time events initially started. 
We also need to clear it once awaiting is over (PGBE_WAITING_NONE). To handle this, we add new st_waiting_start_timestamp field and working with it when track_activities GUC is enabled.
