### PR TITLE
Fix gpinitsystem fails with custom locale

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -641,7 +641,7 @@ CHK_LOCALE_KNOWN () {
 
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ $# -eq 0 ];then
-		if [ `$LOCALE -a |$GREP -ic $LOCALE_SETTING` -eq 0 ];then
+		if [ `$LOCALE -a |$GREP -ic $(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)` -eq 0 ];then
 			LOG_MSG "[INFO]:-Coordinator host available locale values"
 			$LOCALE -a >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on this host" 1

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -653,7 +653,7 @@ CHK_LOCALE_KNOWN () {
 		fi
 	else
 		# Hostname has been passed so check remote locale value
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$LOCALE_SETTING'" ) -eq 0 ];then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)'" ) -eq 0 ];then
 			LOG_MSG "[INFO]:-Host $1 available locale values"
 			`$TRUSTED_SHELL $1 "$LOCALE -a"` >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on $1" 1

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -641,7 +641,8 @@ CHK_LOCALE_KNOWN () {
 
 	LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 	if [ $# -eq 0 ];then
-		if [ `$LOCALE -a |$GREP -ic $(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)` -eq 0 ];then
+		if [ `$LOCALE -a |$GREP -ic $(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)` -eq 0 ] \
+			&& [`$LOCALE -a |$GREP -ic $LOCALE_SETTING` -eq 0];then
 			LOG_MSG "[INFO]:-Coordinator host available locale values"
 			$LOCALE -a >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on this host" 1
@@ -653,7 +654,8 @@ CHK_LOCALE_KNOWN () {
 		fi
 	else
 		# Hostname has been passed so check remote locale value
-		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)'" ) -eq 0 ];then
+		if [ $( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$(NORMALIZE_CODESET_IN_LOCALE $LOCALE_SETTING)'" ) -eq 0 ] \
+			&& [$( REMOTE_EXECUTE_AND_GET_OUTPUT $1 "$LOCALE -a|$GREP -ic '$LOCALE_SETTING'" ) -eq 0] ;then
 			LOG_MSG "[INFO]:-Host $1 available locale values"
 			`$TRUSTED_SHELL $1 "$LOCALE -a"` >> $LOG_FILE
 			LOG_MSG "[FATAL]:-Unable to locate locale value $LOCALE_SETTING on $1" 1

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -178,7 +178,7 @@ WARN_MARK="<<<<<"
 NORMALIZE_CODESET_IN_LOCALE () {
 	local language_and_territory=$(echo $1 | perl -ne 'print for /(^.+?(?=\.|@|$))/s')
 	local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
-	local modifier=$(echo $1 | perl -ne 'print for /((?<=@).+(?=$))/s' )
+	local modifier=$(echo -n $1 | perl -ne 'print for /((?<=@).+)/s' )
 
 	local digit_pattern='^[0-9]+$'
 	if [[ $codeset =~ $digit_pattern ]] ;

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -176,18 +176,39 @@ WARN_MARK="<<<<<"
 # https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=HEAD
 #
 
-NORMALIZE_CODESET (){
-	if [[ "$1" =~ .*".".* ]]
+NORMALIZE_CODESET_IN_LOCALE () {
+	IFS=".|@" read -a arr_locale <<< $1
+	local len=${#arr_locale[@]}
+
+	if [[ $len == 1 ]];
 	then
-		local normalize_locale=$(echo $1 | perl -pe "s/(\.[\w-]+@?)/\L\1/g; s/[^\w.@]//g; ")
-		echo $normalize_locale
-	else
 		echo $1
+	else
+		local normalized_locale=${arr_locale[0]}
+		local codeset=${arr_locale[1]}
+		local desc=${arr_locale[2]}
+
+		local digit_pattern='^[0-9]+$'
+		if [[ $codeset =~ $digit_pattern ]] ;
+		then
+			codeset="iso"
+		else
+			codeset=$(echo $codeset | perl -pe "s/([[:alnum:]-]+)/\L\1/; s/[^[:alnum:]]//g")
+		fi
+
+		normalized_locale=$(echo "$normalized_locale.$codeset")
+
+		if [ ! -z "$desc" ];
+		then
+			normalized_locale=$(echo "$normalized_locale@$desc")
+		fi
+
+		echo $normalized_locale
 	fi
 }
 
 IN_ARRAY () {
-	local locale = $(NORMALIZE_CODESET $1)
+	local locale=$(NORMALIZE_CODESET_IN_LOCALE $1)
 
 	for v in $2; do
 		if [ x"$locale" == x"$v" ]; then

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -177,36 +177,26 @@ WARN_MARK="<<<<<"
 #
 
 NORMALIZE_CODESET_IN_LOCALE () {
-	IFS=".@" read -a arr_locale <<< $1
+	IFS=".|@" read -a arr_locale <<< $1
 	local len=${#arr_locale[@]}
 
 	if [[ $len == 1 ]];
 	then
 		echo $1
 	else
-		local normalized_locale=${arr_locale[0]}
+		local language_and_territory=${arr_locale[0]}
 		local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
 		local modifier=$(echo $1 | perl -ne 'print for /((?<=@).+(?=$))/s' )
 
-	local digit_pattern='^[0-9]+$'
-	if [[ $codeset =~ $digit_pattern ]] ;
-	then
-		codeset="iso$codeset"
-	else
-		codeset=$(echo $codeset | perl -pe "s/([[:alnum:]-]+)/\L\1/; s/[^[:alnum:]]//g")
-	fi
+		local digit_pattern='^[0-9]+$'
+		if [[ $codeset =~ $digit_pattern ]] ;
+		then
+			codeset="iso$codeset"
+		else
+			codeset=$(echo $codeset | perl -pe 's/([[:alpha:]])/\L\1/g; s/[^[:alnum:]]//g')
+		fi
 
-	if [ ! -z $codeset ];
-	then
-		normalized_locale=$(echo "$normalized_locale.$codeset")
-	fi
-
-	if [ ! -z "$modifier" ];
-	then
-		normalized_locale=$(echo "$normalized_locale@$modifier")
-	fi
-
-		echo $normalized_locale
+		echo "$language_and_territory$([ ! -z $codeset ] && echo ".$codeset")$([ ! -z $modifier ] && echo "@$modifier")"
 	fi
 }
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -171,17 +171,30 @@ WARN_MARK="<<<<<"
 # Functions
 #******************************************************************************
 
-IN_ARRAY () {
-	local reg=".(cs)?[Uu][Tt][Ff](-|\s)?8"
-	local glibc_codeset=".utf8"
-	local locale=$(sed -E "s/${reg}/${glibc_codeset}/" <<< "$1")
+#
+# Simplified version of _nl_normalize_codeset from glibc
+# https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=HEAD
+#
 
-    for v in $2; do
-        if [ x"$locale" == x"$v" ]; then
-            return 1
-        fi
-    done
-    return 0
+NORMALIZE_CODESET (){
+	if [[ "$1" =~ .*".".* ]]
+	then
+		local normalize_locale=$(echo $1 | perl -pe "s/(\.[\w-]+@?)/\L\1/g; s/[^\w.@]//g; ")
+		echo $normalize_locale
+	else
+		echo $1
+	fi
+}
+
+IN_ARRAY () {
+	local locale = $(NORMALIZE_CODESET $1)
+
+	for v in $2; do
+		if [ x"$locale" == x"$v" ]; then
+			return 1
+		fi
+	done
+	return 0
 }
 
 #

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -172,8 +172,12 @@ WARN_MARK="<<<<<"
 #******************************************************************************
 
 IN_ARRAY () {
+	local reg=".(cs)?[Uu][Tt][Ff](-|\s)?8"
+	local glibc_codeset=".utf8"
+	local locale=$(sed -E "s/${reg}/${glibc_codeset}/" <<< "$1")
+
     for v in $2; do
-        if [ x"$1" == x"$v" ]; then
+        if [ x"$locale" == x"$v" ]; then
             return 1
         fi
     done

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -173,9 +173,8 @@ WARN_MARK="<<<<<"
 
 #
 # Simplified version of _nl_normalize_codeset from glibc
-# https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=HEAD
-#
-
+# https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=1305edd42c44fee6f8660734d2dfa4911ec755d6#l294
+# Input parameter - string with locale define as [language[_territory][.codeset][@modifier]]
 NORMALIZE_CODESET_IN_LOCALE () {
 	IFS=".|@" read -a arr_locale <<< $1
 	local len=${#arr_locale[@]}

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -176,27 +176,19 @@ WARN_MARK="<<<<<"
 # https://sourceware.org/git/?p=glibc.git;a=blob;f=intl/l10nflist.c;h=078a450dfec21faf2d26dc5d0cb02158c1f23229;hb=1305edd42c44fee6f8660734d2dfa4911ec755d6#l294
 # Input parameter - string with locale define as [language[_territory][.codeset][@modifier]]
 NORMALIZE_CODESET_IN_LOCALE () {
-	IFS=".|@" read -a arr_locale <<< $1
-	local len=${#arr_locale[@]}
+	local language_and_territory=$(echo $1 | perl -ne 'print for /(^.+?(?=\.|@|$))/s')
+	local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
+	local modifier=$(echo $1 | perl -ne 'print for /((?<=@).+(?=$))/s' )
 
-	if [[ $len == 1 ]];
+	local digit_pattern='^[0-9]+$'
+	if [[ $codeset =~ $digit_pattern ]] ;
 	then
-		echo $1
+		codeset="iso$codeset"
 	else
-		local language_and_territory=${arr_locale[0]}
-		local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
-		local modifier=$(echo $1 | perl -ne 'print for /((?<=@).+(?=$))/s' )
-
-		local digit_pattern='^[0-9]+$'
-		if [[ $codeset =~ $digit_pattern ]] ;
-		then
-			codeset="iso$codeset"
-		else
-			codeset=$(echo $codeset | perl -pe 's/([[:alpha:]])/\L\1/g; s/[^[:alnum:]]//g')
-		fi
-
-		echo "$language_and_territory$([ ! -z $codeset ] && echo ".$codeset")$([ ! -z $modifier ] && echo "@$modifier")"
+		codeset=$(echo $codeset | perl -pe 's/([[:alpha:]])/\L\1/g; s/[^[:alnum:]]//g')
 	fi
+
+	echo "$language_and_territory$([ ! -z $codeset ] && echo ".$codeset")$([ ! -z $modifier ] && echo "@$modifier")"
 }
 
 IN_ARRAY () {

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -195,7 +195,7 @@ IN_ARRAY () {
 	local locale=$(NORMALIZE_CODESET_IN_LOCALE $1)
 
 	for v in $2; do
-		if [ x"$locale" == x"$v" ]; then
+		if [ x"$locale" == x"$v" ] || [ x"$1" == x"$v" ]; then
 			return 1
 		fi
 	done

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -177,7 +177,7 @@ WARN_MARK="<<<<<"
 #
 
 NORMALIZE_CODESET_IN_LOCALE () {
-	IFS=".|@" read -a arr_locale <<< $1
+	IFS=".@" read -a arr_locale <<< $1
 	local len=${#arr_locale[@]}
 
 	if [[ $len == 1 ]];
@@ -185,23 +185,26 @@ NORMALIZE_CODESET_IN_LOCALE () {
 		echo $1
 	else
 		local normalized_locale=${arr_locale[0]}
-		local codeset=${arr_locale[1]}
-		local desc=${arr_locale[2]}
+		local codeset=$(echo $1 | perl -ne 'print for /((?<=\.).+?(?=@|$))/s')
+		local modifier=$(echo $1 | perl -ne 'print for /((?<=@).+(?=$))/s' )
 
-		local digit_pattern='^[0-9]+$'
-		if [[ $codeset =~ $digit_pattern ]] ;
-		then
-			codeset="iso"
-		else
-			codeset=$(echo $codeset | perl -pe "s/([[:alnum:]-]+)/\L\1/; s/[^[:alnum:]]//g")
-		fi
+	local digit_pattern='^[0-9]+$'
+	if [[ $codeset =~ $digit_pattern ]] ;
+	then
+		codeset="iso$codeset"
+	else
+		codeset=$(echo $codeset | perl -pe "s/([[:alnum:]-]+)/\L\1/; s/[^[:alnum:]]//g")
+	fi
 
+	if [ ! -z $codeset ];
+	then
 		normalized_locale=$(echo "$normalized_locale.$codeset")
+	fi
 
-		if [ ! -z "$desc" ];
-		then
-			normalized_locale=$(echo "$normalized_locale@$desc")
-		fi
+	if [ ! -z "$modifier" ];
+	then
+		normalized_locale=$(echo "$normalized_locale@$modifier")
+	fi
 
 		echo $normalized_locale
 	fi

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -1,288 +1,288 @@
 @gpinitsystem
 Feature: gpinitsystem tests
 
-    Scenario: gpinitsystem creates a cluster with data_checksums on
-        Given the database is initialized with checksum "on"
-        When the user runs "gpconfig -s data_checksums"
-        Then gpconfig should return a return code of 0
-        And gpconfig should print "Values on all segments are consistent" to stdout
-        And gpconfig should print "Coordinator value: on" to stdout
-        And gpconfig should print "Segment     value: on" to stdout
+	Scenario: gpinitsystem creates a cluster with data_checksums on
+		Given the database is initialized with checksum "on"
+		When the user runs "gpconfig -s data_checksums"
+		Then gpconfig should return a return code of 0
+		And gpconfig should print "Values on all segments are consistent" to stdout
+		And gpconfig should print "Coordinator value: on" to stdout
+		And gpconfig should print "Segment     value: on" to stdout
 
-    Scenario: gpinitsystem creates a cluster with data_checksums off
-        Given the database is initialized with checksum "off"
-        When the user runs "gpconfig -s data_checksums"
-        Then gpconfig should return a return code of 0
-        And gpconfig should print "Values on all segments are consistent" to stdout
-        And gpconfig should print "Coordinator value: off" to stdout
-        And gpconfig should print "Segment     value: off" to stdout
+	Scenario: gpinitsystem creates a cluster with data_checksums off
+		Given the database is initialized with checksum "off"
+		When the user runs "gpconfig -s data_checksums"
+		Then gpconfig should return a return code of 0
+		And gpconfig should print "Values on all segments are consistent" to stdout
+		And gpconfig should print "Coordinator value: off" to stdout
+		And gpconfig should print "Segment     value: off" to stdout
 
 	Scenario: gpinitsystem exits with status 0 when the user set locale variables
 		Given create demo cluster config
 		When the user runs command "export LC_MONETARY=en_US.UTF-8"
 		And the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
 		Then gpinitsystem should return a return code of 0
-	
-	Scenario: gpinitsystem exits with status 0 when the user set locale parameters 
+
+	Scenario: gpinitsystem exits with status 0 when the user set locale parameters
 		Given create demo cluster config
 		When the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
 		Then gpinitsystem should return a return code of 0
 
 	Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
-        Given create demo cluster config
-         When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
-         Then gpinitsystem should return a return code of 1
-        Given the user runs "gpstate"
-         Then gpstate should return a return code of 2
+		Given create demo cluster config
+		When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+		Then gpinitsystem should return a return code of 1
+		Given the user runs "gpstate"
+		Then gpstate should return a return code of 2
 
-    Scenario: gpinitsystem exits with status 1 when the user enters no for the confirmation
-        Given create demo cluster config
-         When the user runs command "echo no | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
-         Then gpinitsystem should return a return code of 1
-        Given the user runs "gpstate"
-         Then gpstate should return a return code of 2
+	Scenario: gpinitsystem exits with status 1 when the user enters no for the confirmation
+		Given create demo cluster config
+		When the user runs command "echo no | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+		Then gpinitsystem should return a return code of 1
+		Given the user runs "gpstate"
+		Then gpstate should return a return code of 2
 
-    Scenario: gpinitsystem creates a cluster when the user confirms the dialog
-        Given create demo cluster config
-         When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
-         Then gpinitsystem should return a return code of 0
-        Given the user runs "gpstate"
-         Then gpstate should return a return code of 0
+	Scenario: gpinitsystem creates a cluster when the user confirms the dialog
+		Given create demo cluster config
+		When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
+		Given the user runs "gpstate"
+		Then gpstate should return a return code of 0
 
-    Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
-        Given create demo cluster config
-        And all files in gpAdminLogs directory are deleted
-        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-        And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
-        And the user waits until saved async process is completed
-        And the user waits until gpcreateseg process is completed
-        Then gpintsystem logs should contain lines about running backout script
-        And the user runs the gpinitsystem backout script
-        And all files in gpAdminLogs directory are deleted
-        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        And gpinitsystem should return a return code of 0
-        And gpintsystem logs should not contain lines about running backout script
+	Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
+		Given create demo cluster config
+		And all files in gpAdminLogs directory are deleted
+		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+		And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
+		And the user waits until saved async process is completed
+		And the user waits until gpcreateseg process is completed
+		Then gpintsystem logs should contain lines about running backout script
+		And the user runs the gpinitsystem backout script
+		And all files in gpAdminLogs directory are deleted
+		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		And gpinitsystem should return a return code of 0
+		And gpintsystem logs should not contain lines about running backout script
 
-    Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
-        Given create demo cluster config
-        And all files in gpAdminLogs directory are deleted
-        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-        And the user asynchronously sets up to end gpcreateseg process when it starts
-        And the user waits until saved async process is completed
-        Then gpintsystem logs should contain lines about running backout script
-        And the user runs the gpinitsystem backout script
-        And all files in gpAdminLogs directory are deleted
-        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        And gpinitsystem should return a return code of 0
-        And gpintsystem logs should not contain lines about running backout script
+	Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
+		Given create demo cluster config
+		And all files in gpAdminLogs directory are deleted
+		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+		And the user asynchronously sets up to end gpcreateseg process when it starts
+		And the user waits until saved async process is completed
+		Then gpintsystem logs should contain lines about running backout script
+		And the user runs the gpinitsystem backout script
+		And all files in gpAdminLogs directory are deleted
+		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		And gpinitsystem should return a return code of 0
+		And gpintsystem logs should not contain lines about running backout script
 
-    Scenario: gpinitsystem does not create or need backout file when user terminated very early
-        Given create demo cluster config
-        And all files in gpAdminLogs directory are deleted
-        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-        And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
-        And the user waits until saved async process is completed
-        Then gpintsystem logs should not contain lines about running backout script
-        And all files in gpAdminLogs directory are deleted
-        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        Then gpinitsystem should return a return code of 0
+	Scenario: gpinitsystem does not create or need backout file when user terminated very early
+		Given create demo cluster config
+		And all files in gpAdminLogs directory are deleted
+		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+		And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
+		And the user waits until saved async process is completed
+		Then gpintsystem logs should not contain lines about running backout script
+		And all files in gpAdminLogs directory are deleted
+		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
 
-    Scenario: gpinitsystem fails with exit code 1 when the functions file is not found
-       Given create demo cluster config
-           # force a load error when trying to source gp_bash_functions.sh
-        When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link" eok
-        Then gpinitsystem should return a return code of 1
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        Then gpinitsystem should return a return code of 0
+	Scenario: gpinitsystem fails with exit code 1 when the functions file is not found
+		Given create demo cluster config
+		# force a load error when trying to source gp_bash_functions.sh
+		When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link" eok
+		Then gpinitsystem should return a return code of 1
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
 
-    Scenario: gpinitsystem continues running when gpinitstandby fails
-       Given create demo cluster config
-           # force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile"
-        Then gpinitsystem should return a return code of 0
+	Scenario: gpinitsystem continues running when gpinitstandby fails
+		Given create demo cluster config
+		# force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile"
+		Then gpinitsystem should return a return code of 0
 
-    Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0
-       Given create demo cluster config
-           # force a failure by passing no args
-        When the user runs "gpinitsystem"
-        Then gpinitsystem should return a return code of 1
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        Then gpinitsystem should return a return code of 0
+	Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0
+		Given create demo cluster config
+		# force a failure by passing no args
+		When the user runs "gpinitsystem"
+		Then gpinitsystem should return a return code of 1
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
 
-    Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
-      Given create demo cluster config
-          # log a warning
-        And the user runs command "sed -i.bak 's/^ENCODING.*//g' ../gpAux/gpdemo/clusterConfigFile"
-       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-       Then gpinitsystem should return a return code of 0
-      Given create demo cluster config
-       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-       Then gpinitsystem should return a return code of 0
+	Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
+		Given create demo cluster config
+		# log a warning
+		And the user runs command "sed -i.bak 's/^ENCODING.*//g' ../gpAux/gpdemo/clusterConfigFile"
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
+		Given create demo cluster config
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
 
-    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And the standby is not initialized
-        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
-        # stop db and make sure cluster config exists so that we can manually initialize standby
-        And the cluster config is generated with data_checksums "1"
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
-        Then gpinitsystem should return a return code of 0
-        And gpinitsystem should not print "To activate the Standby Coordinator Segment in the event of Coordinator" to stdout
-        And gpinitsystem should print "Cluster setup finished, but Standby Coordinator failed to initialize. Review contents of log files for errors." to stdout
-        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+	Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+		Given the database is running
+		And all the segments are running
+		And the segments are synchronized
+		And the standby is not initialized
+		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+		# stop db and make sure cluster config exists so that we can manually initialize standby
+		And the cluster config is generated with data_checksums "1"
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
+		Then gpinitsystem should return a return code of 0
+		And gpinitsystem should not print "To activate the Standby Coordinator Segment in the event of Coordinator" to stdout
+		And gpinitsystem should print "Cluster setup finished, but Standby Coordinator failed to initialize. Review contents of log files for errors." to stdout
+		And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums on
-        Given the cluster config is generated with data_checksums "on"
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
-        And gpinitsystem should return a return code of 0
-        Then verify that file "output_config_file" exists under "/tmp"
-        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=on"
-        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
-        Then gpinitsystem should return a return code of 0
-        When the user runs "gpconfig -s data_checksums"
-        Then gpconfig should return a return code of 0
-        And gpconfig should print "Values on all segments are consistent" to stdout
-        And gpconfig should print "Coordinator value: on" to stdout
-        And gpconfig should print "Segment     value: on" to stdout
+	Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums on
+		Given the cluster config is generated with data_checksums "on"
+		When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+		And gpinitsystem should return a return code of 0
+		Then verify that file "output_config_file" exists under "/tmp"
+		And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=on"
+		And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+		Then gpinitsystem should return a return code of 0
+		When the user runs "gpconfig -s data_checksums"
+		Then gpconfig should return a return code of 0
+		And gpconfig should print "Values on all segments are consistent" to stdout
+		And gpconfig should print "Coordinator value: on" to stdout
+		And gpconfig should print "Segment     value: on" to stdout
 
-    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums off
-        Given the cluster config is generated with data_checksums "off"
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
-        And gpinitsystem should return a return code of 0
-        Then verify that file "output_config_file" exists under "/tmp"
-        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=off"
-        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
-        Then gpinitsystem should return a return code of 0
-        When the user runs "gpconfig -s data_checksums"
-        Then gpconfig should return a return code of 0
-        And gpconfig should print "Values on all segments are consistent" to stdout
-        And gpconfig should print "Coordinator value: off" to stdout
-        And gpconfig should print "Segment     value: off" to stdout
+	Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums off
+		Given the cluster config is generated with data_checksums "off"
+		When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+		And gpinitsystem should return a return code of 0
+		Then verify that file "output_config_file" exists under "/tmp"
+		And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=off"
+		And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+		Then gpinitsystem should return a return code of 0
+		When the user runs "gpconfig -s data_checksums"
+		Then gpconfig should return a return code of 0
+		And gpconfig should print "Values on all segments are consistent" to stdout
+		And gpconfig should print "Coordinator value: off" to stdout
+		And gpconfig should print "Segment     value: off" to stdout
 
-    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And the standby is not initialized
-        And the user runs command "rm -rf $COORDINATOR_DATA_DIRECTORY/newstandby"
-        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
-        And the cluster config is generated with data_checksums "1"
-        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S $COORDINATOR_DATA_DIRECTORY/newstandby -h ../gpAux/gpdemo/hostfile"
-        Then gpinitsystem should return a return code of 0
-        And gpinitsystem should print "Log file scan check passed" to stdout
-        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+	Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+		Given the database is running
+		And all the segments are running
+		And the segments are synchronized
+		And the standby is not initialized
+		And the user runs command "rm -rf $COORDINATOR_DATA_DIRECTORY/newstandby"
+		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+		And the cluster config is generated with data_checksums "1"
+		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S $COORDINATOR_DATA_DIRECTORY/newstandby -h ../gpAux/gpdemo/hostfile"
+		Then gpinitsystem should return a return code of 0
+		And gpinitsystem should print "Log file scan check passed" to stdout
+		And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-    Scenario: gpinitsystem creates a cluster in default timezone
-        Given the database is not running
-        And "TZ" environment variable is not set
-        And the system timezone is saved
-        When a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
-        Then the database timezone is saved
-        And the database timezone matches the system timezone
-        And the startup timezone is saved
-        And the startup timezone matches the system timezone
+	Scenario: gpinitsystem creates a cluster in default timezone
+		Given the database is not running
+		And "TZ" environment variable is not set
+		And the system timezone is saved
+		When a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
+		Then the database timezone is saved
+		And the database timezone matches the system timezone
+		And the startup timezone is saved
+		And the startup timezone matches the system timezone
 
-    Scenario: gpinitsystem creates a cluster using TZ
-        Given the database is not running
-        And the environment variable "TZ" is set to "US/Hawaii"
-        When a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
-        Then the database timezone is saved
-        And the database timezone matches "HST"
-        And the startup timezone is saved
-        And the startup timezone matches "HST"
+	Scenario: gpinitsystem creates a cluster using TZ
+		Given the database is not running
+		And the environment variable "TZ" is set to "US/Hawaii"
+		When a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
+		Then the database timezone is saved
+		And the database timezone matches "HST"
+		And the startup timezone is saved
+		And the startup timezone matches "HST"
 
-    Scenario: gpinitsystem should print FQDN in pg_hba.conf when HBA_HOSTNAMES=1
-        Given the cluster config is generated with HBA_HOSTNAMES "1"
-        When generate cluster config file "/tmp/output_config_file"
-        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
-        When initialize a cluster using "/tmp/output_config_file"
-        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
-        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
+	Scenario: gpinitsystem should print FQDN in pg_hba.conf when HBA_HOSTNAMES=1
+		Given the cluster config is generated with HBA_HOSTNAMES "1"
+		When generate cluster config file "/tmp/output_config_file"
+		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
+		When initialize a cluster using "/tmp/output_config_file"
+		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
+		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
 
-    Scenario: gpinitsystem should print CIDR in pg_hba.conf when HBA_HOSTNAMES=0
-        Given the cluster config is generated with HBA_HOSTNAMES "0"
-        When generate cluster config file "/tmp/output_config_file"
-        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=0"
-        When initialize a cluster using "/tmp/output_config_file"
-        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains CIDR only for trusted host
-        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains CIDR only for trusted host
+	Scenario: gpinitsystem should print CIDR in pg_hba.conf when HBA_HOSTNAMES=0
+		Given the cluster config is generated with HBA_HOSTNAMES "0"
+		When generate cluster config file "/tmp/output_config_file"
+		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=0"
+		When initialize a cluster using "/tmp/output_config_file"
+		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains CIDR only for trusted host
+		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains CIDR only for trusted host
 
-    Scenario: gpinitsystem should print FQDN in pg_hba.conf for standby when HBA_HOSTNAMES=1
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And the standby is not initialized
-        And ensure the standby directory does not exist
-        And the cluster config is generated with HBA_HOSTNAMES "1"
-        When generate cluster config file "/tmp/output_config_file"
-        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
-        When initialize a cluster with standby using "/tmp/output_config_file"
-        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
-        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
-        And verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/newstandby/pg_hba.conf" contains FQDN only for trusted host
+	Scenario: gpinitsystem should print FQDN in pg_hba.conf for standby when HBA_HOSTNAMES=1
+		Given the database is running
+		And all the segments are running
+		And the segments are synchronized
+		And the standby is not initialized
+		And ensure the standby directory does not exist
+		And the cluster config is generated with HBA_HOSTNAMES "1"
+		When generate cluster config file "/tmp/output_config_file"
+		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
+		When initialize a cluster with standby using "/tmp/output_config_file"
+		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
+		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
+		And verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/newstandby/pg_hba.conf" contains FQDN only for trusted host
 
-    Scenario: gpinitsystem on a DCA system is able to set the DCA specific GUCs
-	Given create demo cluster config
-        And the user runs command "rm -r ~/gpAdminLogs/gpinitsystem*"
-        And a working directory of the test as '/tmp/gpinitsystem'
-        # create a dummy dca version file so that DCA specific parameters are set
-        And the user runs command "touch /tmp/gpinitsystem/gpdb-appliance-version"
-        When the user runs command "source $GPHOME/greenplum_path.sh; __DCA_VERSION_FILE__=/tmp/gpinitsystem/gpdb-appliance-version $GPHOME/bin/gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-        Then gpinitsystem should return a return code of 0
-        # the log file must have the entry indicating that DCA specific configuration has been set
-        And the user runs command "egrep 'Setting DCA specific configuration values' ~/gpAdminLogs/gpinitsystem*log"
+	Scenario: gpinitsystem on a DCA system is able to set the DCA specific GUCs
+		Given create demo cluster config
+		And the user runs command "rm -r ~/gpAdminLogs/gpinitsystem*"
+		And a working directory of the test as '/tmp/gpinitsystem'
+		# create a dummy dca version file so that DCA specific parameters are set
+		And the user runs command "touch /tmp/gpinitsystem/gpdb-appliance-version"
+		When the user runs command "source $GPHOME/greenplum_path.sh; __DCA_VERSION_FILE__=/tmp/gpinitsystem/gpdb-appliance-version $GPHOME/bin/gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
+		# the log file must have the entry indicating that DCA specific configuration has been set
+		And the user runs command "egrep 'Setting DCA specific configuration values' ~/gpAdminLogs/gpinitsystem*log"
 
-    Scenario: gpinitsystem uses the system locale if no locale is specified
-        Given the database is not running
-        And "LC_COLLATE" environment variable is not set
-        And "LC_CTYPE" environment variable is not set
-        And the system locale is saved
-        When a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
-        Then the database locales are saved
-        And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
+	Scenario: gpinitsystem uses the system locale if no locale is specified
+		Given the database is not running
+		And "LC_COLLATE" environment variable is not set
+		And "LC_CTYPE" environment variable is not set
+		And the system locale is saved
+		When a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
+		Then the database locales are saved
+		And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
 
-    Scenario: gpinitsystem uses a single locale if one is specified
-        Given the database is not running
-        And the system locale is saved
-        When a demo cluster is created using gpinitsystem args "--locale=C"
-        And gpinitsystem should return a return code of 0
-        Then the database locales are saved
-        And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the locale "C"
+	Scenario: gpinitsystem uses a single locale if one is specified
+		Given the database is not running
+		And the system locale is saved
+		When a demo cluster is created using gpinitsystem args "--locale=C"
+		And gpinitsystem should return a return code of 0
+		Then the database locales are saved
+		And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the locale "C"
 
-    Scenario: gpinitsystem uses multiple locales if multiple are specified
-        Given the database is not running
-        And the environment variable "LC_COLLATE" is set to "C"
-        And the environment variable "LC_CTYPE" is set to "C"
-        And the system locale is saved
-        When a demo cluster is created using the installed UTF locale
-        And gpinitsystem should return a return code of 0
-        Then the database locales are saved
-        And the database locales "lc_collate" match the locale "C"
-        And the database locales "lc_ctype" match the installed UTF locale
-        And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
+	Scenario: gpinitsystem uses multiple locales if multiple are specified
+		Given the database is not running
+		And the environment variable "LC_COLLATE" is set to "C"
+		And the environment variable "LC_CTYPE" is set to "C"
+		And the system locale is saved
+		When a demo cluster is created using the installed UTF locale
+		And gpinitsystem should return a return code of 0
+		Then the database locales are saved
+		And the database locales "lc_collate" match the locale "C"
+		And the database locales "lc_ctype" match the installed UTF locale
+		And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
 
-    @backup_restore_bashrc
-    Scenario: gpinitsystem succeeds if there is banner on host
-        Given the database is not running
-        When the user sets banner on host
-        And a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
+	@backup_restore_bashrc
+	Scenario: gpinitsystem succeeds if there is banner on host
+		Given the database is not running
+		When the user sets banner on host
+		And a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
 
-    @backup_restore_bashrc
-    Scenario: gpinitsystem succeeds if there is multi-line banner on host
-        Given the database is not running
-        When the user sets multi-line banner on host
-        And a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
+	@backup_restore_bashrc
+	Scenario: gpinitsystem succeeds if there is multi-line banner on host
+		Given the database is not running
+		When the user sets multi-line banner on host
+		And a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
 
-    Scenario: gpinitsystem should create consistent port entry on segments postgresql.conf file
-        Given the database is not running
-        When a demo cluster is created using gpinitsystem args " "
-        And gpinitsystem should return a return code of 0
-        Then gpstate should return a return code of 0
-        And check segment conf: postgresql.conf
+	Scenario: gpinitsystem should create consistent port entry on segments postgresql.conf file
+		Given the database is not running
+		When a demo cluster is created using gpinitsystem args " "
+		And gpinitsystem should return a return code of 0
+		Then gpstate should return a return code of 0
+		And check segment conf: postgresql.conf

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,33 +17,32 @@ Feature: gpinitsystem tests
         And gpconfig should print "Coordinator value: off" to stdout
         And gpconfig should print "Segment     value: off" to stdout
 
-
     Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
         Given create demo cluster config
-        When the user runs command "export LC_ALL=en_US.UTF-8"
-        And the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And the user runs command "export LC_ALL=en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
     Scenario: gpinitsystem creates a cluster when the user set -n flag
         Given create demo cluster config
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8" 
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8 --ignore-warnings"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
     Scenario: gpinitsystem exits with status 0 when the user set locale parameters
         Given create demo cluster config
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8 --ignore-warnings"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
     Scenario: gpinitsystem exits with status 0 when the user set locale variables
         Given create demo cluster config
-        When the user runs command "export LC_MONETARY=en_US.UTF-8"
-        And the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And the user runs command "export LC_MONETARY=en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -19,15 +19,23 @@ Feature: gpinitsystem tests
 
     Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
         Given create demo cluster config
-        And the user runs command "export LC_ALL=en_US.UTF-8"
+        And the environment variable "LC_ALL" is set to "en_US.UTF-8"
         When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
-    Scenario: gpinitsystem creates a cluster when the user set -n flag
+    Scenario: gpinitsystem creates a cluster when the user set -n or --locale parameter
         Given create demo cluster config
         When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+	Scenario: gpinitsystem exits with status 0 when the user set locale variables
+        Given create demo cluster config
+        And the environment variable "LC_MONETARY" is set to "en_US.UTF-8"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
@@ -35,14 +43,6 @@ Feature: gpinitsystem tests
     Scenario: gpinitsystem exits with status 0 when the user set locale parameters
         Given create demo cluster config
         When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
-        Then gpinitsystem should return a return code of 0
-        Given the user runs "gpstate"
-        Then gpstate should return a return code of 0
-
-    Scenario: gpinitsystem exits with status 0 when the user set locale variables
-        Given create demo cluster config
-        And the user runs command "export LC_MONETARY=en_US.UTF-8"
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,18 +17,38 @@ Feature: gpinitsystem tests
         And gpconfig should print "Coordinator value: off" to stdout
         And gpconfig should print "Segment     value: off" to stdout
 
-	Scenario: gpinitsystem exits with status 0 when the user set locale variables
-		Given create demo cluster config
-		When the user runs command "export LC_MONETARY=en_US.UTF-8"
-		And the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
-	
-	Scenario: gpinitsystem exits with status 0 when the user set locale parameters 
-		Given create demo cluster config
-		When the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
-		Then gpinitsystem should return a return code of 0
 
-	Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
+    Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
+        Given create demo cluster config
+        When the user runs command "export LC_ALL=en_US.UTF-8"
+        And the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem creates a cluster when the user set -n flag
+        Given create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8" 
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 0 when the user set locale parameters
+        Given create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 0 when the user set locale variables
+        Given create demo cluster config
+        When the user runs command "export LC_MONETARY=en_US.UTF-8"
+        And the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+        Then gpstate should return a return code of 0
+
+    Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
         Given create demo cluster config
          When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
          Then gpinitsystem should return a return code of 1

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -1,288 +1,288 @@
 @gpinitsystem
 Feature: gpinitsystem tests
 
-	Scenario: gpinitsystem creates a cluster with data_checksums on
-		Given the database is initialized with checksum "on"
-		When the user runs "gpconfig -s data_checksums"
-		Then gpconfig should return a return code of 0
-		And gpconfig should print "Values on all segments are consistent" to stdout
-		And gpconfig should print "Coordinator value: on" to stdout
-		And gpconfig should print "Segment     value: on" to stdout
+    Scenario: gpinitsystem creates a cluster with data_checksums on
+        Given the database is initialized with checksum "on"
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Coordinator value: on" to stdout
+        And gpconfig should print "Segment     value: on" to stdout
 
-	Scenario: gpinitsystem creates a cluster with data_checksums off
-		Given the database is initialized with checksum "off"
-		When the user runs "gpconfig -s data_checksums"
-		Then gpconfig should return a return code of 0
-		And gpconfig should print "Values on all segments are consistent" to stdout
-		And gpconfig should print "Coordinator value: off" to stdout
-		And gpconfig should print "Segment     value: off" to stdout
+    Scenario: gpinitsystem creates a cluster with data_checksums off
+        Given the database is initialized with checksum "off"
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Coordinator value: off" to stdout
+        And gpconfig should print "Segment     value: off" to stdout
 
 	Scenario: gpinitsystem exits with status 0 when the user set locale variables
 		Given create demo cluster config
 		When the user runs command "export LC_MONETARY=en_US.UTF-8"
 		And the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
 		Then gpinitsystem should return a return code of 0
-
-	Scenario: gpinitsystem exits with status 0 when the user set locale parameters
+	
+	Scenario: gpinitsystem exits with status 0 when the user set locale parameters 
 		Given create demo cluster config
 		When the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
 		Then gpinitsystem should return a return code of 0
 
 	Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
-		Given create demo cluster config
-		When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
-		Then gpinitsystem should return a return code of 1
-		Given the user runs "gpstate"
-		Then gpstate should return a return code of 2
+        Given create demo cluster config
+         When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+         Then gpinitsystem should return a return code of 1
+        Given the user runs "gpstate"
+         Then gpstate should return a return code of 2
 
-	Scenario: gpinitsystem exits with status 1 when the user enters no for the confirmation
-		Given create demo cluster config
-		When the user runs command "echo no | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
-		Then gpinitsystem should return a return code of 1
-		Given the user runs "gpstate"
-		Then gpstate should return a return code of 2
+    Scenario: gpinitsystem exits with status 1 when the user enters no for the confirmation
+        Given create demo cluster config
+         When the user runs command "echo no | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
+         Then gpinitsystem should return a return code of 1
+        Given the user runs "gpstate"
+         Then gpstate should return a return code of 2
 
-	Scenario: gpinitsystem creates a cluster when the user confirms the dialog
-		Given create demo cluster config
-		When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
-		Given the user runs "gpstate"
-		Then gpstate should return a return code of 0
+    Scenario: gpinitsystem creates a cluster when the user confirms the dialog
+        Given create demo cluster config
+         When the user runs command "echo y | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
+         Then gpinitsystem should return a return code of 0
+        Given the user runs "gpstate"
+         Then gpstate should return a return code of 0
 
-	Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
-		Given create demo cluster config
-		And all files in gpAdminLogs directory are deleted
-		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-		And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
-		And the user waits until saved async process is completed
-		And the user waits until gpcreateseg process is completed
-		Then gpintsystem logs should contain lines about running backout script
-		And the user runs the gpinitsystem backout script
-		And all files in gpAdminLogs directory are deleted
-		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		And gpinitsystem should return a return code of 0
-		And gpintsystem logs should not contain lines about running backout script
+    Scenario: gpinitsystem creates a backout file when gpinitsystem process terminated
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end gpinitsystem process when "Waiting for parallel processes" is printed in the logs
+        And the user waits until saved async process is completed
+        And the user waits until gpcreateseg process is completed
+        Then gpintsystem logs should contain lines about running backout script
+        And the user runs the gpinitsystem backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And gpinitsystem should return a return code of 0
+        And gpintsystem logs should not contain lines about running backout script
 
-	Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
-		Given create demo cluster config
-		And all files in gpAdminLogs directory are deleted
-		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-		And the user asynchronously sets up to end gpcreateseg process when it starts
-		And the user waits until saved async process is completed
-		Then gpintsystem logs should contain lines about running backout script
-		And the user runs the gpinitsystem backout script
-		And all files in gpAdminLogs directory are deleted
-		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		And gpinitsystem should return a return code of 0
-		And gpintsystem logs should not contain lines about running backout script
+    Scenario: gpinitsystem creates a backout file when gpcreateseg process terminated
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end gpcreateseg process when it starts
+        And the user waits until saved async process is completed
+        Then gpintsystem logs should contain lines about running backout script
+        And the user runs the gpinitsystem backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        And gpinitsystem should return a return code of 0
+        And gpintsystem logs should not contain lines about running backout script
 
-	Scenario: gpinitsystem does not create or need backout file when user terminated very early
-		Given create demo cluster config
-		And all files in gpAdminLogs directory are deleted
-		When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
-		And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
-		And the user waits until saved async process is completed
-		Then gpintsystem logs should not contain lines about running backout script
-		And all files in gpAdminLogs directory are deleted
-		And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
+    Scenario: gpinitsystem does not create or need backout file when user terminated very early
+        Given create demo cluster config
+        And all files in gpAdminLogs directory are deleted
+        When the user asynchronously runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile" and the process is saved
+        And the user asynchronously sets up to end bin/gpinitsystem process in 0 seconds
+        And the user waits until saved async process is completed
+        Then gpintsystem logs should not contain lines about running backout script
+        And all files in gpAdminLogs directory are deleted
+        And the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
 
-	Scenario: gpinitsystem fails with exit code 1 when the functions file is not found
-		Given create demo cluster config
-		# force a load error when trying to source gp_bash_functions.sh
-		When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link" eok
-		Then gpinitsystem should return a return code of 1
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
+    Scenario: gpinitsystem fails with exit code 1 when the functions file is not found
+       Given create demo cluster config
+           # force a load error when trying to source gp_bash_functions.sh
+        When the user runs command "ln -s -f `which gpinitsystem` /tmp/gpinitsystem-link; . /tmp/gpinitsystem-link" eok
+        Then gpinitsystem should return a return code of 1
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
 
-	Scenario: gpinitsystem continues running when gpinitstandby fails
-		Given create demo cluster config
-		# force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile"
-		Then gpinitsystem should return a return code of 0
+    Scenario: gpinitsystem continues running when gpinitstandby fails
+       Given create demo cluster config
+           # force gpinitstandby to fail by specifying a directory that does not exist (gpinitsystem continues successfully)
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -S not-a-real-directory -P 21100 -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
 
-	Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0
-		Given create demo cluster config
-		# force a failure by passing no args
-		When the user runs "gpinitsystem"
-		Then gpinitsystem should return a return code of 1
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
+    Scenario: after a failed run of gpinitsystem, a re-run should return exit status 0
+       Given create demo cluster config
+           # force a failure by passing no args
+        When the user runs "gpinitsystem"
+        Then gpinitsystem should return a return code of 1
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
 
-	Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
-		Given create demo cluster config
-		# log a warning
-		And the user runs command "sed -i.bak 's/^ENCODING.*//g' ../gpAux/gpdemo/clusterConfigFile"
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
-		Given create demo cluster config
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
+    Scenario: after gpinitsystem logs a warning, a re-run should return exit status 0
+      Given create demo cluster config
+          # log a warning
+        And the user runs command "sed -i.bak 's/^ENCODING.*//g' ../gpAux/gpdemo/clusterConfigFile"
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+       Then gpinitsystem should return a return code of 0
+      Given create demo cluster config
+       When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+       Then gpinitsystem should return a return code of 0
 
-	Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
-		Given the database is running
-		And all the segments are running
-		And the segments are synchronized
-		And the standby is not initialized
-		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
-		# stop db and make sure cluster config exists so that we can manually initialize standby
-		And the cluster config is generated with data_checksums "1"
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
-		Then gpinitsystem should return a return code of 0
-		And gpinitsystem should not print "To activate the Standby Coordinator Segment in the event of Coordinator" to stdout
-		And gpinitsystem should print "Cluster setup finished, but Standby Coordinator failed to initialize. Review contents of log files for errors." to stdout
-		And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+        # stop db and make sure cluster config exists so that we can manually initialize standby
+        And the cluster config is generated with data_checksums "1"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -s localhost -P 21100 -S /wrong/path -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
+        And gpinitsystem should not print "To activate the Standby Coordinator Segment in the event of Coordinator" to stdout
+        And gpinitsystem should print "Cluster setup finished, but Standby Coordinator failed to initialize. Review contents of log files for errors." to stdout
+        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-	Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums on
-		Given the cluster config is generated with data_checksums "on"
-		When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
-		And gpinitsystem should return a return code of 0
-		Then verify that file "output_config_file" exists under "/tmp"
-		And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=on"
-		And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
-		Then gpinitsystem should return a return code of 0
-		When the user runs "gpconfig -s data_checksums"
-		Then gpconfig should return a return code of 0
-		And gpconfig should print "Values on all segments are consistent" to stdout
-		And gpconfig should print "Coordinator value: on" to stdout
-		And gpconfig should print "Segment     value: on" to stdout
+    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums on
+        Given the cluster config is generated with data_checksums "on"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+        And gpinitsystem should return a return code of 0
+        Then verify that file "output_config_file" exists under "/tmp"
+        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=on"
+        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+        Then gpinitsystem should return a return code of 0
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Coordinator value: on" to stdout
+        And gpconfig should print "Segment     value: on" to stdout
 
-	Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums off
-		Given the cluster config is generated with data_checksums "off"
-		When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
-		And gpinitsystem should return a return code of 0
-		Then verify that file "output_config_file" exists under "/tmp"
-		And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=off"
-		And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
-		Then gpinitsystem should return a return code of 0
-		When the user runs "gpconfig -s data_checksums"
-		Then gpconfig should return a return code of 0
-		And gpconfig should print "Values on all segments are consistent" to stdout
-		And gpconfig should print "Coordinator value: off" to stdout
-		And gpconfig should print "Segment     value: off" to stdout
+    Scenario: gpinitsystem generates an output configuration file and then starts cluster with data_checksums off
+        Given the cluster config is generated with data_checksums "off"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -O /tmp/output_config_file"
+        And gpinitsystem should return a return code of 0
+        Then verify that file "output_config_file" exists under "/tmp"
+        And verify that the file "/tmp/output_config_file" contains "HEAP_CHECKSUM=off"
+        And the user runs "gpinitsystem -a -I /tmp/output_config_file -l /tmp/"
+        Then gpinitsystem should return a return code of 0
+        When the user runs "gpconfig -s data_checksums"
+        Then gpconfig should return a return code of 0
+        And gpconfig should print "Values on all segments are consistent" to stdout
+        And gpconfig should print "Coordinator value: off" to stdout
+        And gpconfig should print "Segment     value: off" to stdout
 
-	Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
-		Given the database is running
-		And all the segments are running
-		And the segments are synchronized
-		And the standby is not initialized
-		And the user runs command "rm -rf $COORDINATOR_DATA_DIRECTORY/newstandby"
-		And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
-		And the cluster config is generated with data_checksums "1"
-		When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S $COORDINATOR_DATA_DIRECTORY/newstandby -h ../gpAux/gpdemo/hostfile"
-		Then gpinitsystem should return a return code of 0
-		And gpinitsystem should print "Log file scan check passed" to stdout
-		And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
+    Scenario: gpinitsystem should warn but not fail when standby cannot be instantiated
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And the user runs command "rm -rf $COORDINATOR_DATA_DIRECTORY/newstandby"
+        And the user runs command "rm -rf /tmp/gpinitsystemtest && mkdir /tmp/gpinitsystemtest"
+        And the cluster config is generated with data_checksums "1"
+        When the user runs "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -l /tmp/gpinitsystemtest -s localhost -P 21100 -S $COORDINATOR_DATA_DIRECTORY/newstandby -h ../gpAux/gpdemo/hostfile"
+        Then gpinitsystem should return a return code of 0
+        And gpinitsystem should print "Log file scan check passed" to stdout
+        And sql "select * from gp_toolkit.__gp_user_namespaces" is executed in "postgres" db
 
-	Scenario: gpinitsystem creates a cluster in default timezone
-		Given the database is not running
-		And "TZ" environment variable is not set
-		And the system timezone is saved
-		When a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
-		Then the database timezone is saved
-		And the database timezone matches the system timezone
-		And the startup timezone is saved
-		And the startup timezone matches the system timezone
+    Scenario: gpinitsystem creates a cluster in default timezone
+        Given the database is not running
+        And "TZ" environment variable is not set
+        And the system timezone is saved
+        When a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
+        Then the database timezone is saved
+        And the database timezone matches the system timezone
+        And the startup timezone is saved
+        And the startup timezone matches the system timezone
 
-	Scenario: gpinitsystem creates a cluster using TZ
-		Given the database is not running
-		And the environment variable "TZ" is set to "US/Hawaii"
-		When a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
-		Then the database timezone is saved
-		And the database timezone matches "HST"
-		And the startup timezone is saved
-		And the startup timezone matches "HST"
+    Scenario: gpinitsystem creates a cluster using TZ
+        Given the database is not running
+        And the environment variable "TZ" is set to "US/Hawaii"
+        When a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
+        Then the database timezone is saved
+        And the database timezone matches "HST"
+        And the startup timezone is saved
+        And the startup timezone matches "HST"
 
-	Scenario: gpinitsystem should print FQDN in pg_hba.conf when HBA_HOSTNAMES=1
-		Given the cluster config is generated with HBA_HOSTNAMES "1"
-		When generate cluster config file "/tmp/output_config_file"
-		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
-		When initialize a cluster using "/tmp/output_config_file"
-		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
-		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
+    Scenario: gpinitsystem should print FQDN in pg_hba.conf when HBA_HOSTNAMES=1
+        Given the cluster config is generated with HBA_HOSTNAMES "1"
+        When generate cluster config file "/tmp/output_config_file"
+        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
+        When initialize a cluster using "/tmp/output_config_file"
+        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
+        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
 
-	Scenario: gpinitsystem should print CIDR in pg_hba.conf when HBA_HOSTNAMES=0
-		Given the cluster config is generated with HBA_HOSTNAMES "0"
-		When generate cluster config file "/tmp/output_config_file"
-		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=0"
-		When initialize a cluster using "/tmp/output_config_file"
-		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains CIDR only for trusted host
-		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains CIDR only for trusted host
+    Scenario: gpinitsystem should print CIDR in pg_hba.conf when HBA_HOSTNAMES=0
+        Given the cluster config is generated with HBA_HOSTNAMES "0"
+        When generate cluster config file "/tmp/output_config_file"
+        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=0"
+        When initialize a cluster using "/tmp/output_config_file"
+        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains CIDR only for trusted host
+        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains CIDR only for trusted host
 
-	Scenario: gpinitsystem should print FQDN in pg_hba.conf for standby when HBA_HOSTNAMES=1
-		Given the database is running
-		And all the segments are running
-		And the segments are synchronized
-		And the standby is not initialized
-		And ensure the standby directory does not exist
-		And the cluster config is generated with HBA_HOSTNAMES "1"
-		When generate cluster config file "/tmp/output_config_file"
-		Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
-		When initialize a cluster with standby using "/tmp/output_config_file"
-		Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
-		And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
-		And verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/newstandby/pg_hba.conf" contains FQDN only for trusted host
+    Scenario: gpinitsystem should print FQDN in pg_hba.conf for standby when HBA_HOSTNAMES=1
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And the standby is not initialized
+        And ensure the standby directory does not exist
+        And the cluster config is generated with HBA_HOSTNAMES "1"
+        When generate cluster config file "/tmp/output_config_file"
+        Then verify that the file "/tmp/output_config_file" contains "HBA_HOSTNAMES=1"
+        When initialize a cluster with standby using "/tmp/output_config_file"
+        Then verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/pg_hba.conf" contains FQDN only for trusted host
+        And verify that the file "../gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_hba.conf" contains FQDN only for trusted host
+        And verify that the file "../gpAux/gpdemo/datadirs/qddir/demoDataDir-1/newstandby/pg_hba.conf" contains FQDN only for trusted host
 
-	Scenario: gpinitsystem on a DCA system is able to set the DCA specific GUCs
-		Given create demo cluster config
-		And the user runs command "rm -r ~/gpAdminLogs/gpinitsystem*"
-		And a working directory of the test as '/tmp/gpinitsystem'
-		# create a dummy dca version file so that DCA specific parameters are set
-		And the user runs command "touch /tmp/gpinitsystem/gpdb-appliance-version"
-		When the user runs command "source $GPHOME/greenplum_path.sh; __DCA_VERSION_FILE__=/tmp/gpinitsystem/gpdb-appliance-version $GPHOME/bin/gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
-		Then gpinitsystem should return a return code of 0
-		# the log file must have the entry indicating that DCA specific configuration has been set
-		And the user runs command "egrep 'Setting DCA specific configuration values' ~/gpAdminLogs/gpinitsystem*log"
+    Scenario: gpinitsystem on a DCA system is able to set the DCA specific GUCs
+	Given create demo cluster config
+        And the user runs command "rm -r ~/gpAdminLogs/gpinitsystem*"
+        And a working directory of the test as '/tmp/gpinitsystem'
+        # create a dummy dca version file so that DCA specific parameters are set
+        And the user runs command "touch /tmp/gpinitsystem/gpdb-appliance-version"
+        When the user runs command "source $GPHOME/greenplum_path.sh; __DCA_VERSION_FILE__=/tmp/gpinitsystem/gpdb-appliance-version $GPHOME/bin/gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        # the log file must have the entry indicating that DCA specific configuration has been set
+        And the user runs command "egrep 'Setting DCA specific configuration values' ~/gpAdminLogs/gpinitsystem*log"
 
-	Scenario: gpinitsystem uses the system locale if no locale is specified
-		Given the database is not running
-		And "LC_COLLATE" environment variable is not set
-		And "LC_CTYPE" environment variable is not set
-		And the system locale is saved
-		When a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
-		Then the database locales are saved
-		And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
+    Scenario: gpinitsystem uses the system locale if no locale is specified
+        Given the database is not running
+        And "LC_COLLATE" environment variable is not set
+        And "LC_CTYPE" environment variable is not set
+        And the system locale is saved
+        When a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
+        Then the database locales are saved
+        And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
 
-	Scenario: gpinitsystem uses a single locale if one is specified
-		Given the database is not running
-		And the system locale is saved
-		When a demo cluster is created using gpinitsystem args "--locale=C"
-		And gpinitsystem should return a return code of 0
-		Then the database locales are saved
-		And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the locale "C"
+    Scenario: gpinitsystem uses a single locale if one is specified
+        Given the database is not running
+        And the system locale is saved
+        When a demo cluster is created using gpinitsystem args "--locale=C"
+        And gpinitsystem should return a return code of 0
+        Then the database locales are saved
+        And the database locales "lc_collate,lc_ctype,lc_messages,lc_monetary,lc_numeric,lc_time" match the locale "C"
 
-	Scenario: gpinitsystem uses multiple locales if multiple are specified
-		Given the database is not running
-		And the environment variable "LC_COLLATE" is set to "C"
-		And the environment variable "LC_CTYPE" is set to "C"
-		And the system locale is saved
-		When a demo cluster is created using the installed UTF locale
-		And gpinitsystem should return a return code of 0
-		Then the database locales are saved
-		And the database locales "lc_collate" match the locale "C"
-		And the database locales "lc_ctype" match the installed UTF locale
-		And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
+    Scenario: gpinitsystem uses multiple locales if multiple are specified
+        Given the database is not running
+        And the environment variable "LC_COLLATE" is set to "C"
+        And the environment variable "LC_CTYPE" is set to "C"
+        And the system locale is saved
+        When a demo cluster is created using the installed UTF locale
+        And gpinitsystem should return a return code of 0
+        Then the database locales are saved
+        And the database locales "lc_collate" match the locale "C"
+        And the database locales "lc_ctype" match the installed UTF locale
+        And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
 
-	@backup_restore_bashrc
-	Scenario: gpinitsystem succeeds if there is banner on host
-		Given the database is not running
-		When the user sets banner on host
-		And a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
+    @backup_restore_bashrc
+    Scenario: gpinitsystem succeeds if there is banner on host
+        Given the database is not running
+        When the user sets banner on host
+        And a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
 
-	@backup_restore_bashrc
-	Scenario: gpinitsystem succeeds if there is multi-line banner on host
-		Given the database is not running
-		When the user sets multi-line banner on host
-		And a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
+    @backup_restore_bashrc
+    Scenario: gpinitsystem succeeds if there is multi-line banner on host
+        Given the database is not running
+        When the user sets multi-line banner on host
+        And a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
 
-	Scenario: gpinitsystem should create consistent port entry on segments postgresql.conf file
-		Given the database is not running
-		When a demo cluster is created using gpinitsystem args " "
-		And gpinitsystem should return a return code of 0
-		Then gpstate should return a return code of 0
-		And check segment conf: postgresql.conf
+    Scenario: gpinitsystem should create consistent port entry on segments postgresql.conf file
+        Given the database is not running
+        When a demo cluster is created using gpinitsystem args " "
+        And gpinitsystem should return a return code of 0
+        Then gpstate should return a return code of 0
+        And check segment conf: postgresql.conf

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,7 +17,18 @@ Feature: gpinitsystem tests
         And gpconfig should print "Coordinator value: off" to stdout
         And gpconfig should print "Segment     value: off" to stdout
 
-    Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
+	Scenario: gpinitsystem exits with status 0 when the user set locale variables
+		Given create demo cluster config
+		When the user runs command "export LC_MONETARY=en_US.UTF-8"
+		And the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile"
+		Then gpinitsystem should return a return code of 0
+	
+	Scenario: gpinitsystem exits with status 0 when the user set locale parameters 
+		Given create demo cluster config
+		When the user runs command "gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
+		Then gpinitsystem should return a return code of 0
+
+	Scenario: gpinitsystem exits with status 1 when the user enters nothing for the confirmation
         Given create demo cluster config
          When the user runs command "echo '' | gpinitsystem -c ../gpAux/gpdemo/clusterConfigFile" eok
          Then gpinitsystem should return a return code of 1

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -20,21 +20,21 @@ Feature: gpinitsystem tests
     Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
         Given create demo cluster config
         And the user runs command "export LC_ALL=en_US.UTF-8"
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
     Scenario: gpinitsystem creates a cluster when the user set -n flag
         Given create demo cluster config
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8 --ignore-warnings"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -n en_US.UTF-8"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
 
     Scenario: gpinitsystem exits with status 0 when the user set locale parameters
         Given create demo cluster config
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8 --ignore-warnings"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --lc-monetary=en_US.UTF-8"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
@@ -42,7 +42,7 @@ Feature: gpinitsystem tests
     Scenario: gpinitsystem exits with status 0 when the user set locale variables
         Given create demo cluster config
         And the user runs command "export LC_MONETARY=en_US.UTF-8"
-        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile --ignore-warnings"
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0


### PR DESCRIPTION
gpinitsystem would fail if you set a locale on startup that is not in the locale -a output, even if the locale is present on the system.
The whole problem lies in the method of storing locales - they are stored in a normalized form, i.e. the codeset for these locales is in the glibc variant, i.e. it looks something like "*.utf8".
This patch fixes this issue by adding a function to normalize the codeset. But, because in the output of locale -a sometimes there are unnormalized locales like "C.UTF-8" there is also a check for compliance with the unchanged locale