### PR TITLE
Replace wrong target name with valid one

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ make create-demo-cluster
 source gpAux/gpdemo/gpdemo-env.sh
 ```
 
-The directory and the TCP ports for the demo cluster can be changed on the fly.
+The directory, the TCP ports, the number of segments, and the existence of
+standbys for segments and coordinator for the demo cluster can be changed
+on the fly.
 Instead of `make create-demo-cluster`, consider:
 
 ```
-DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 make create-demo-cluster
+DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 NUM_PRIMARY_MIRROR_PAIRS=1 WITH_MIRRORS=false make create-demo-cluster
 ```
 
 The TCP port for the regression test can be changed on the fly:

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ source gpAux/gpdemo/gpdemo-env.sh
 ```
 
 The directory and the TCP ports for the demo cluster can be changed on the fly.
-Instead of `make cluster`, consider:
+Instead of `make create-demo-cluster`, consider:
 
 ```
-DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 make cluster
+DATADIRS=/tmp/gpdb-cluster PORT_BASE=5555 make create-demo-cluster
 ```
 
 The TCP port for the regression test can be changed on the fly:


### PR DESCRIPTION
'make cluster' with enviroment variables was added after 'make cluster' in
fd2e045f1a5b916125c645cbd352a4fcac7711fa, but was not changed to
'make create-demo-cluster' in either c3d74c6016c8effee851c213c12c1c2346ca19db or
bb022db333507f272373548e0b29a22e17b0a300