### PR TITLE
Revert changes from #314

### DIFF
--- a/config/python.m4
+++ b/config/python.m4
@@ -16,7 +16,7 @@
 # "python2" and "python3", in which case it's reasonable to prefer the
 # newer version.
 AC_DEFUN([PGAC_PATH_PYTHON],
-[PGAC_PATH_PROGS(PYTHON, [python python3 python2])
+[PGAC_PATH_PROGS(PYTHON, [python python2])
 if test x"$PYTHON" = x""; then
   AC_MSG_ERROR([Python not found])
 fi

--- a/configure
+++ b/configure
@@ -6438,7 +6438,7 @@ fi
 $as_echo "checking whether to build with gpcloud... $enable_gpcloud" >&6; }
 
 
-if test "$enable_orca" = yes || test "$enable_gpcloud" = yes; then :
+if test "$enable_gpcloud" = yes; then :
    # then
     ax_cxx_compile_alternatives="11 0x"    ax_cxx_compile_cxx11_required=true
   ac_ext=cpp

--- a/configure.in
+++ b/configure.in
@@ -846,7 +846,7 @@ PGAC_ARG_BOOL(enable, gpcloud, yes, [disable gpcloud support],
 AC_MSG_RESULT([checking whether to build with gpcloud... $enable_gpcloud])
 AC_SUBST(enable_gpcloud)
 
-AS_IF([test "$enable_orca" = yes || test "$enable_gpcloud" = yes],
+AS_IF([test "$enable_gpcloud" = yes],
 [ # then
   AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 ]) # fi

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -3,3 +3,4 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPP
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros $(CPPFLAGS)
+override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -14,6 +14,7 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # FIXME: Would be better to include gporca.mk, but hitting a warning
 override CPPFLAGS := -Wno-variadic-macros $(CPPFLAGS)
+override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
 
 OBJS        = CAutoTimer.o \
               CBitSet.o \


### PR DESCRIPTION
We've decided to update C++ standard to build ORCA in the #314.
But modern compilers (e.g. [gcc 9+](https://gcc.gnu.org/gcc-9/changes.html)) throw deprecation warnings
for ORCA source code that interpreted as build error by default:

```
../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedColumn.h: In member function 'gpos::CDouble gpmd::CDXLStatsDerivedColumn::Width() const':
../../../../../src/backend/gporca/libnaucrates/include/naucrates/md/CDXLStatsDerivedColumn.h:82:10: error: implicitly-declared 'constexpr gpos::CDouble::CDouble(const gpos::CDouble&)' is deprecated [-Werror=deprecated-copy]
   82 |   return m_width;
      |          ^~~~~~~
In file included from ../../../../../src/backend/gporca/libgpdbcost/include/gpdbcost/CCostModelGPDB.h:15,
                 from CCostModelGPDB.cpp:12:
../../../../../src/backend/gporca/libgpos/include/gpos/common/CDouble.h:108:2: note: because 'gpos::CDouble' has user-provided 'gpos::CDouble& gpos::CDouble::operator=(const gpos::CDouble&)'
  108 |  operator=(const CDouble &right)
      |  ^~~~~~~~
```

> -Wdeprecated-copy (C++ and Objective-C++ only)
Warn that the implicit declaration of a copy constructor or copy assignment operator is deprecated if the class has a user-provided copy constructor or copy assignment operator, in C++11 and up. This warning is enabled by -Wextra. With -Wdeprecated-copy-dtor, also deprecate if the class has a user-provided destructor.

There are no such error during build with gnu++98 standard.
Original problem was solved by community with reverting c++11 syntax changes (see #314 comments).

PS. The assignment operator overloading was removed in https://github.com/greenplum-db/gpdb/commit/649ee57dda3af5f1a1c0ab91295bbbb9922fb0cc for master branch only to build with C++14 standard.
