### PR TITLE
Fix gpperfmon fails

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -408,7 +408,7 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 BackoffSweeperStartRule},
 
 	{"perfmon process",
-	 BGWORKER_SHMEM_ACCESS,
+	 0,
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if perfmon process exits with non-zero code */
 	 PerfmonMain, {0}, {0}, 0, 0,


### PR DESCRIPTION
If we terminate the session from gpmmon using the pg_terminate_backend
function, gpprefmon background process exits with failure exit code.
As a result, the postmaster instance goes into recovery mode. It turned out
that the problem was caused the process being marked as shared memory user.
I made sure that the process is not using shared memory and disabled
the BGWORKER_SHMEM_ACCESS flag to avoid unnecessary cluster recovery.