### PR TITLE
Disallow EPQ routine for AO/AOCS relations and DML node

### DIFF
--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-partition.html.md
@@ -495,13 +495,13 @@ WITH TABLE jan12;
 
 **Note:** This example refers to the single-level definition of the table `sales`, before partitions were added and altered in the previous examples.
 
-**Warning:** If you specify the `WITHOUT VALIDATION` clause, you must ensure that the data in table that you are exchanging for an existing partition is valid against the constraints on the partition. Otherwise, queries against the partitioned table might return incorrect results.
+**Warning:** If you specify the `WITHOUT VALIDATION` clause, you must ensure that the data in table that you are exchanging for an existing partition is valid against the constraints on the partition. Otherwise, queries against the partitioned table might return incorrect results or even end up to data corruption after UPDATE/DELETE operation.
 
 The Greenplum Database server configuration parameter `gp_enable_exchange_default_partition` controls availability of the `EXCHANGE DEFAULT PARTITION` clause. The default value for the parameter is `off`, the clause is not available and Greenplum Database returns an error if the clause is specified in an `ALTER TABLE` command.
 
 For information about the parameter, see "Server Configuration Parameters" in the *Greenplum Database Reference Guide*.
 
-**Warning:** Before you exchange the default partition, you must ensure the data in the table to be exchanged, the new default partition, is valid for the default partition. For example, the data in the new default partition must not contain data that would be valid in other leaf child partitions of the partitioned table. Otherwise, queries against the partitioned table with the exchanged default partition that are run by GPORCA might return incorrect results.
+**Warning:** Before you exchange the default partition, you must ensure the data in the table to be exchanged, the new default partition, is valid for the default partition. For example, the data in the new default partition must not contain data that would be valid in other leaf child partitions of the partitioned table. Otherwise, queries against the partitioned table with the exchanged default partition that are run by GPORCA might return incorrect results or even end up to data corruption after UPDATE/DELETE operation.
 
 ### <a id="topic84"></a>Splitting a Partition 
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -791,7 +791,7 @@ ldelete:;
 
 			AOTupleId *aoTupleId = (AOTupleId *) tupleid;
 			result = appendonly_delete(resultRelInfo->ri_deleteDesc, aoTupleId);
-		} 
+		}
 		else if (isAOColsTable)
 		{
 			if (IsolationUsesXactSnapshot())
@@ -894,6 +894,27 @@ ldelete:;
 				break;
 
 			case HeapTupleUpdated:
+
+				/*
+				 * AO/AOCS relations don't support the chain of tuple versions
+				 * as it's done for heap relations and update/delete on these
+				 * types of relation is protected by Exclusive lock therefore
+				 * the scenario when transaction have to seek a live newer
+				 * version to update/delete is not possible.
+				 * TODO: If it occurs then most likely we work with wrong
+				 * partition. How it's possible is described in
+				 * https://github.com/greenplum-db/gpdb/pull/13860
+				 */
+				if (isAORowsTable || isAOColsTable)
+					ereport(ERROR,
+							(errcode(ERRCODE_DATA_CORRUPTED),
+							 errmsg("tuple to be %s was already removed",
+									isUpdate ? "updated": "deleted"),
+							 errdetail("for AO/AOCS table this scenario is impossible"),
+							 errhint("perhaps, modification is occuring on wrong partition")));
+
+				Assert(isHeapTable);
+
 				if (IsolationUsesXactSnapshot())
 					ereport(ERROR,
 							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
@@ -922,9 +943,24 @@ ldelete:;
 							 errmsg("concurrent updates distribution keys on the same row is not allowed")));
 				}
 
+				/*
+				 * Check whether we have the newer version for target row after
+				 * concurrent update in heap table
+				 */
 				if (!ItemPointerEquals(tupleid, &hufd.ctid))
 				{
 					TupleTableSlot *epqslot;
+
+					/*
+					 * TODO: DML node doesn't initialize `epqstate` parameter so
+					 * we exclude EPQ routine for this type of modification and
+					 * act as in RR and upper isolation levels.
+					 */
+					if (!epqstate)
+						ereport(ERROR,
+								(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+								 errmsg("could not serialize access due to concurrent update"),
+								 errhint("Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting")));
 
 					epqslot = EvalPlanQual(estate,
 										   epqstate,

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -248,6 +248,35 @@ DROP
 0: drop table tab_update_epq2;
 DROP
 0q: ... <quitting>
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Currently the DML node (modification variant in ORCA) doesn't support EPQ
+-- routine so concurrent modification is not possible in this case. User have
+-- to be informed to fallback to postgres optimizer.
+-- This test makes sense just for ORCA
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i + 1;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+-- commit session1's transaction so the above session2 will continue and emit
+-- error about serialization failure in case of ORCA
+1: end;
+END
+2<:  <... completed>
+DELETE 0
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
 
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -248,6 +248,36 @@ DROP
 0: drop table tab_update_epq2;
 DROP
 0q: ... <quitting>
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Currently the DML node (modification variant in ORCA) doesn't support EPQ
+-- routine so concurrent modification is not possible in this case. User have
+-- to be informed to fallback to postgres optimizer.
+-- This test makes sense just for ORCA
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i + 1;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+-- commit session1's transaction so the above session2 will continue and emit
+-- error about serialization failure in case of ORCA
+1: end;
+END
+2<:  <... completed>
+ERROR:  could not serialize access due to concurrent update
+HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
 
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -132,6 +132,28 @@ DROP TABLE t_concurrent_update;
 0: drop table tab_update_epq1;
 0: drop table tab_update_epq2;
 0q:
+1q:
+2q:
+
+-- Currently the DML node (modification variant in ORCA) doesn't support EPQ
+-- routine so concurrent modification is not possible in this case. User have
+-- to be informed to fallback to postgres optimizer.
+-- This test makes sense just for ORCA
+create table test as select 0 as i distributed randomly;
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+1: begin;
+1: update test set i = i + 1;
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;
+-- commit session1's transaction so the above session2 will continue and emit
+-- error about serialization failure in case of ORCA
+1: end;
+2<:
+drop table test;
+1q:
+2q:
 
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a

--- a/src/test/regress/expected/bfv_partition_dml.out
+++ b/src/test/regress/expected/bfv_partition_dml.out
@@ -1,0 +1,54 @@
+-- The failure case with AOCS partition
+-- Create partitioned table with one range and default partitions
+create table p_ao(a int) with (appendonly=true)
+PARTITION BY range(a) (start(1) end(2) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "p_ao_1_prt_extra" for table "p_ao"
+NOTICE:  CREATE TABLE will create partition "p_ao_1_prt_2" for table "p_ao"
+insert into p_ao_1_prt_2 values(1);
+analyze p_ao;
+-- create table for exchange with one value suitable to range partition with one row
+create table t_ao_exchanged(a int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_ao_exchanged values (1);
+analyze t_ao_exchanged;
+-- exchange default partition with `t_exchanged` table
+set gp_enable_exchange_default_partition to on;
+alter table p_ao exchange default partition with table t_ao_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "p_ao" with relation "t_ao_exchanged"
+select tableoid::regclass, ctid, a from p_ao;
+     tableoid     |     ctid     | a 
+------------------+--------------+---
+ p_ao_1_prt_2     | (33554432,2) | 1
+ p_ao_1_prt_extra | (33554432,2) | 1
+(2 rows)
+
+-- remove row from range partition - mark it as deleted
+delete from p_ao_1_prt_2;
+-- check whether partitioned table has a single row in default partition
+-- whose partitioning key value corresponds to neighbor range partition
+-- and tupleid is the same as previously deleted row had
+select tableoid::regclass, ctid, a from p_ao;
+     tableoid     |     ctid     | a 
+------------------+--------------+---
+ p_ao_1_prt_extra | (33554432,2) | 1
+(1 row)
+
+-- perform deletion from default partition
+-- before fix in case of ORCA it generated SIGSEGV
+explain (costs off, verbose)
+delete from p_ao_1_prt_extra where a = 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Delete on public.p_ao_1_prt_extra
+   ->  Seq Scan on public.p_ao_1_prt_extra
+         Output: ctid, gp_segment_id
+         Filter: (p_ao_1_prt_extra.a = 1)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(6 rows)
+
+delete from p_ao_1_prt_extra where a = 1;

--- a/src/test/regress/expected/bfv_partition_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_dml_optimizer.out
@@ -1,0 +1,60 @@
+-- The failure case with AOCS partition
+-- Create partitioned table with one range and default partitions
+create table p_ao(a int) with (appendonly=true)
+PARTITION BY range(a) (start(1) end(2) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "p_ao_1_prt_extra" for table "p_ao"
+NOTICE:  CREATE TABLE will create partition "p_ao_1_prt_2" for table "p_ao"
+insert into p_ao_1_prt_2 values(1);
+analyze p_ao;
+-- create table for exchange with one value suitable to range partition with one row
+create table t_ao_exchanged(a int) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_ao_exchanged values (1);
+analyze t_ao_exchanged;
+-- exchange default partition with `t_exchanged` table
+set gp_enable_exchange_default_partition to on;
+alter table p_ao exchange default partition with table t_ao_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "p_ao" with relation "t_ao_exchanged"
+select tableoid::regclass, ctid, a from p_ao;
+     tableoid     |     ctid     | a 
+------------------+--------------+---
+ p_ao_1_prt_2     | (33554432,2) | 1
+ p_ao_1_prt_extra | (33554432,2) | 1
+(2 rows)
+
+-- remove row from range partition - mark it as deleted
+delete from p_ao_1_prt_2;
+-- check whether partitioned table has a single row in default partition
+-- whose partitioning key value corresponds to neighbor range partition
+-- and tupleid is the same as previously deleted row had
+select tableoid::regclass, ctid, a from p_ao;
+     tableoid     |     ctid     | a 
+------------------+--------------+---
+ p_ao_1_prt_extra | (33554432,2) | 1
+(1 row)
+
+-- perform deletion from default partition
+-- before fix in case of ORCA it generated SIGSEGV
+explain (costs off, verbose)
+delete from p_ao_1_prt_extra where a = 1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Delete
+   Output: p_ao_1_prt_extra.a, "outer".ColRef_0004, p_ao_1_prt_extra.ctid
+   ->  Result
+         Output: p_ao_1_prt_extra.a, p_ao_1_prt_extra.ctid, p_ao_1_prt_extra.gp_segment_id, 0
+         ->  Seq Scan on public.p_ao_1_prt_extra
+               Output: p_ao_1_prt_extra.a, p_ao_1_prt_extra.ctid, p_ao_1_prt_extra.gp_segment_id
+               Filter: (p_ao_1_prt_extra.a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(9 rows)
+
+delete from p_ao_1_prt_extra where a = 1;
+ERROR:  tuple to be deleted was already removed  (seg1 127.0.1.1:6033 pid=281892)
+DETAIL:  for AO/AOCS table this scenario is impossible
+HINT:  perhaps, modification is occuring on wrong partition

--- a/src/test/regress/sql/bfv_partition_dml.sql
+++ b/src/test/regress/sql/bfv_partition_dml.sql
@@ -1,0 +1,29 @@
+-- The failure case with AOCS partition
+-- Create partitioned table with one range and default partitions
+create table p_ao(a int) with (appendonly=true)
+PARTITION BY range(a) (start(1) end(2) every(1), default partition extra);
+insert into p_ao_1_prt_2 values(1);
+analyze p_ao;
+
+-- create table for exchange with one value suitable to range partition with one row
+create table t_ao_exchanged(a int) with (appendonly=true);
+insert into t_ao_exchanged values (1);
+analyze t_ao_exchanged;
+-- exchange default partition with `t_exchanged` table
+set gp_enable_exchange_default_partition to on;
+alter table p_ao exchange default partition with table t_ao_exchanged without validation;
+select tableoid::regclass, ctid, a from p_ao;
+
+-- remove row from range partition - mark it as deleted
+delete from p_ao_1_prt_2;
+
+-- check whether partitioned table has a single row in default partition
+-- whose partitioning key value corresponds to neighbor range partition
+-- and tupleid is the same as previously deleted row had
+select tableoid::regclass, ctid, a from p_ao;
+
+-- perform deletion from default partition
+-- before fix in case of ORCA it generated SIGSEGV
+explain (costs off, verbose)
+delete from p_ao_1_prt_extra where a = 1;
+delete from p_ao_1_prt_extra where a = 1;


### PR DESCRIPTION
## Problem description

The following scenario produces segfault:
```sql
-- Create partitioned table with one range and default partitions 
create table p_ao(a int) with (appendonly=true)
PARTITION BY range(a) (start(1) end(2) every(1), default partition extra);
insert into p_ao_1_prt_2 values(1);

-- create table for exchange with one value suitable to range partition with one row
create table def(a int) with (appendonly=true);
insert into def values (1);

-- exchange default partition with `def` table
set gp_enable_exchange_default_partition to on;
alter table p_ao exchange default partition with table def without validation;

-- remove row from range partition - mark it as deleted
select tableoid::regclass, ctid, a from p_ao;
     tableoid     |     ctid     | a 
------------------+--------------+---
 p_ao_1_prt_2     | (33554432,2) | 1
 p_ao_1_prt_extra | (33554432,2) | 1
delete from p_ao_1_prt_2;

-- check whether partitioned table has a single row in default partition
-- whose partitioning key value corresponds to neighbor range partition
-- and tupleid is the same as previously deleted row had
select tableoid::regclass, ctid, a from p_ao;
     tableoid     |     ctid     | a 
------------------+--------------+---
 p_ao_1_prt_extra | (33554432,2) | 1
 
-- perform deletion from default partition
-- optimizer has to be ORCA
 explain (costs off, verbose) delete from p_ao_1_prt_extra where a = 1;
                                           QUERY PLAN                                            

-------------------------------------------------------------------------------------------------
 Delete
   Output: p_ao_1_prt_extra.a, "outer".ColRef_0004, p_ao_1_prt_extra.ctid
   ->  Result
         Output: p_ao_1_prt_extra.a, p_ao_1_prt_extra.ctid, p_ao_1_prt_extra.gp_segment_id, 0
         ->  Seq Scan on public.p_ao_1_prt_extra
               Output: p_ao_1_prt_extra.a, p_ao_1_prt_extra.ctid, p_ao_1_prt_extra.gp_segment_id
               Filter: (p_ao_1_prt_extra.a = 1)
 Optimizer: Pivotal Optimizer (GPORCA)

 delete from p_ao_1_prt_extra where a = 1;
ERROR:  Error on receive from seg0 127.0.1.1:6012 pid=110384: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

The reason of failure is that the `Delete` executor node (as one representation of DML node) [performs](https://github.com/greenplum-db/gpdb/blob/6.20.4/src/backend/executor/nodeModifyTable.c#L662-L664) internal hidden partition pruning routine trying to define target relation for row deletion based on incoming partitioning key value. It also gets tupleid value (stored inside `ctid` column) from lower nodes - after scanning of _default partition_.
As target tuple by partitioning key corresponds to range partition and at the same time it has tupleid value from default partition, `Delete` node tries to remove row from range partition using tupleid from default one. In our case we previously have removed the tuple from the slot to delete in range partition therefore after issuing delete routine `aocs_delete()` we [fall into](https://github.com/greenplum-db/gpdb/blob/6.20.4/src/backend/executor/nodeModifyTable.c#L925-L940) `EvalPlanQual()` logic. As `ExecDML()` function [passes]([https://github.com/greenplum-db/gpdb/blob/6.20.4/src/backend/executor/nodeDML.c#L148]) NULL value to `epqstate` variable we fails on [first access](https://github.com/greenplum-db/gpdb/blob/6.20.4/src/backend/executor/execMain.c#L3613) to the field of this structure.

The real problem here is that we have mismatch between target relation and tupleid to delete. This is because `Delete` node performs partition pruning to define target relation instead of getting this info from lower node (alongside with tupleid) and target tuple is located in wrong partition (the query `ALTER TABLE EXCHANGE PARTITION WITHOUT VALIDATION` allows to achieve this state). This situation is definitely horrible: instead of segfault we might end up to data corruption removing some live irrelevant row from range partition. Therefore, full fix would require to pass tableoid value along with tupleid from lower nodes and use this value to define target relation. The similar work was [done](https://github.com/postgres/postgres/blob/6ffff0fd225432fe2ae4bd5abb7ff6113e255418/src/backend/executor/nodeModifyTable.c#L3533-L3572) in postgres core in the context of [rewriting](https://github.com/postgres/postgres/commit/86dc90056dfdbd9d1b891718d2e5614e3e432f35) inheritance planner routine. I want to propose this work in future.

## Patch details

Generally, `EvalPlanQual()` routine (EPQ, for short) is not suitable for AO/CS relation types - the chain of row versions is not supported for these storage types. Also this routine have not to be issued because all update/delete operations for AO/CS are protected by Exclusive lock and cannot interleave with each other. Therefore, we exclude executing of EPQ logic for AO/CS storage types and signal to user that most probably deletion is issuing on wrong partition - the single case (as we believe) when EPQ scenario is possible.
Also failure might occur for heap tables as `ExecDML()` function passes NULL value for `epqstate` parameter. I suppose this fragment was erroneously migrated from gpdb-5x - the comment (`DestReceiver`) for `epqstate` parameter tells us that it corresponded to another old removed [parameter](https://github.com/greenplum-db/gpdb/blob/b0e84dd75289e89a9a61dcba62851391c0a1297d/src/backend/executor/execMain.c#L3418) of `ExecDelete()` function. Support of EPQ for DML node we might add in future but for this moment it's enough to temporally disable this functionality.

## Affected version

adb-6x.
In master branch the DML node on partitioned tables and command `ALTER TABLE EXCHANGE PARTITION` without validation option are disabled [[1](https://github.com/greenplum-db/gpdb/blob/fbcb59aaf8bae29759d6856144465b5c0d9401f6/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp#L1175-L1180), [2](https://github.com/greenplum-db/gpdb/blob/fbcb59aaf8bae29759d6856144465b5c0d9401f6/src/backend/parser/gram.y#L3661-L3668)]. Therefore, reproduction the failure case doesn't seem possible.