### PR TITLE
Fix INSERT INTO replicated table SELECT FROM another replicated with …

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1123,11 +1123,13 @@ broadcastPlan(Plan *plan, bool stable, bool rescannable, int numsegments)
 
 	/*
 	 * Already focused and flow is CdbLocusType_SegmentGeneral and data
-	 * is replicated on every segment of target, do nothing.
+	 * is replicated on every segment of target and no volatile functions in
+	 * target list, do nothing.
 	 */
 	if (plan->flow->flotype == FLOW_SINGLETON &&
 		plan->flow->locustype == CdbLocusType_SegmentGeneral &&
-		plan->flow->numsegments >= numsegments)
+		plan->flow->numsegments >= numsegments &&
+		!contain_volatile_functions((Node *)plan->targetlist))
 		return true;
 
 	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_BROADCAST, NIL, NIL,

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -897,6 +897,30 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Insert on t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Seq Scan on t_replicate_src
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2074)
@@ -1254,6 +1278,8 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
+drop cascades to table t_replicate_dst
+drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -895,6 +895,30 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Insert on t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Seq Scan on t_replicate_src
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2089)
@@ -1244,6 +1268,8 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
+drop cascades to table t_replicate_dst
+drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -392,6 +392,15 @@ explain (costs off) insert into t_replicate_volatile select random(), a, a from 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;


### PR DESCRIPTION
The last query from the series
"set optimizer=off;
create table t_replicate_dst(id serial, i integer) distributed replicated;
create table t_replicate_src(i integer) distributed replicated;
insert into t_replicate_src select i from generate_series(1, 5) i;
insert into t_replicate_dst (i) select i from t_replicate_src;
select distinct id from gp_dist_random('t_replicate_dst');"
returned 15 lines (not 5) on cluster with 3 segments.
The plan of the second insert was:
```
 Insert on t_replicate_dst
   ->  Seq Scan on t_replicate_src
```

The error is not reproduced on master, because when volatile functions are detected in the query at the stage of adding the Insert node, the Broadcast Motion node will be added. The plan on master is:
```
 Insert on t_replicate_dst
   ->  Broadcast Motion 1:3  (slice1; segments: 1)
         ->  Seq Scan on t_replicate_src
```

After adding a check for the absence of volatile functions to the condition for refusing to insert the Broadcast Motion node, the query plan became the same as on master.