### PR TITLE
auto_explain: fix failure when executor hooks are run in QEs

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,2 +1,3 @@
 regression.diffs
 regression.out
+results/

--- a/contrib/auto_explain/Makefile
+++ b/contrib/auto_explain/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = auto_explain
 OBJS = auto_explain.o
 
-REGRESS = auto_explain
+REGRESS = auto_explain bfv_preload_auto_explain
 REGRESS_OPTS = --init-file=init_file
 
 ifdef USE_PGXS

--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -52,7 +52,8 @@ static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
 
 #define auto_explain_enabled() \
 	(auto_explain_log_min_duration >= 0 && \
-	 (nesting_level == 0 || auto_explain_log_nested_statements))
+	 (nesting_level == 0 || auto_explain_log_nested_statements) && \
+	 (Gp_role == GP_ROLE_DISPATCH))
 
 void		_PG_init(void);
 void		_PG_fini(void);
@@ -72,7 +73,7 @@ void
 _PG_init(void)
 {
 	/* Only run auto_explain on the Query Dispatcher node */
-	if (Gp_role != GP_ROLE_DISPATCH)
+	if (!IS_QUERY_DISPATCHER())
 		return;
 
 	/* Define custom GUC variables. */

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain.out
@@ -1,0 +1,74 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220719:16:51:22:051096 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET auto_explain.log_min_duration = 0;
+SET CLIENT_MIN_MESSAGES = LOG;
+-- auto_axplain must work only at coordinator with Gp_role is GP_ROLE_DISPATCH
+-- check that auto_explain doesn't work on segments which are executors.
+-- Query 'CREATE TABLE t1 as select generate_series(1, 1)' and query 'CREATE TABLE t1 as select generate_series(1, 10*1000*1000)'
+-- are equally got segfault because it has intermediate executor's slice:
+--   Result
+--     Output: (generate_series(1, 1))
+--       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+CREATE TABLE t1 as select generate_series(1, 1);
+LOG:  statement: CREATE TABLE t1 as select generate_series(1, 1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'generate_series' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+LOG:  duration: 0.002 ms  plan:
+Query Text: CREATE TABLE t1 as select generate_series(1, 1);
+Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..5.01 rows=1000 width=0)
+  Hash Key: (generate_series(1, 1))
+  ->  Result  (cost=0.00..5.01 rows=334 width=0)
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  duration: 2.986 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Aggregate  (cost=1436.96..1436.97 rows=1 width=8)
+  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1436.90..1436.95 rows=1 width=8)
+        ->  Aggregate  (cost=1436.90..1436.91 rows=1 width=8)
+              ->  Hash Join  (cost=0.74..1434.49 rows=321 width=0)
+                    Hash Cond: (t2.i = t1.i)
+                    ->  Seq Scan on t2  (cost=0.00..1063.00 rows=32100 width=4)
+                    ->  Hash  (cost=0.61..0.61 rows=4 width=4)
+                          ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..0.61 rows=10 width=4)
+                                Hash Key: t1.i
+                                ->  Limit  (cost=0.00..0.31 rows=10 width=4)
+                                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.31 rows=10 width=4)
+                                            ->  Limit  (cost=0.00..0.11 rows=4 width=4)
+                                                  ->  Seq Scan on t1  (cost=0.00..1063.00 rows=32100 width=4)
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220719:16:51:27:051682 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -1,0 +1,76 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220719:16:46:40:026759 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET auto_explain.log_min_duration = 0;
+SET CLIENT_MIN_MESSAGES = LOG;
+-- auto_axplain must work only at coordinator with Gp_role is GP_ROLE_DISPATCH
+-- check that auto_explain doesn't work on segments which are executors.
+-- Query 'CREATE TABLE t1 as select generate_series(1, 1)' and query 'CREATE TABLE t1 as select generate_series(1, 10*1000*1000)'
+-- are equally got segfault because it has intermediate executor's slice:
+--   Result
+--     Output: (generate_series(1, 1))
+--       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+CREATE TABLE t1 as select generate_series(1, 1);
+LOG:  statement: CREATE TABLE t1 as select generate_series(1, 1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+LOG:  duration: 0.005 ms  plan:
+Query Text: CREATE TABLE t1 as select generate_series(1, 1);
+Result  (cost=0.00..0.00 rows=0 width=0)
+  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..0.01 rows=1 width=4)
+        ->  Result  (cost=0.00..0.00 rows=1 width=8)
+              ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                    One-Time Filter: (gp_execution_segment() = 0)
+                    ->  Result  (cost=0.00..0.00 rows=1 width=4)
+                          ->  Result  (cost=0.00..0.00 rows=1 width=1)
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.1.1:6000 pid=27339)
+LOG:  duration: 2.660 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Aggregate  (cost=0.00..862.00 rows=1 width=8)
+  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+        ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
+              Hash Cond: (t1.i = t2.i)
+              ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
+                    Hash Key: t1.i
+                    ->  Limit  (cost=0.00..431.00 rows=1 width=4)
+                          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+              ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220719:16:46:44:027342 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/init_file
+++ b/contrib/auto_explain/init_file
@@ -14,4 +14,10 @@ s/Rows Removed by Filter: .*/Rows Removed by Filter: /
 m/Memory used:\s+[0-9]+kB.*/
 s/Memory used:\s+[0-9]+kB.*/Memory used:/
 
+m/One-Time Filter: \(gp_execution_segment\(\) = \d+/
+s/One-Time Filter: \(gp_execution_segment\(\) = \d+/One-Time Filter: \(gp_execution_segment\(\) = ###/
+
+m/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/
+s/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db)/
+
 -- end_matchsubs

--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,0 +1,41 @@
+
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+\! gpstop -raiq;
+\c
+-- end_ignore
+
+SET auto_explain.log_min_duration = 0;
+SET CLIENT_MIN_MESSAGES = LOG;
+
+-- auto_axplain must work only at coordinator with Gp_role is GP_ROLE_DISPATCH
+-- check that auto_explain doesn't work on segments which are executors.
+-- Query 'CREATE TABLE t1 as select generate_series(1, 1)' and query 'CREATE TABLE t1 as select generate_series(1, 10*1000*1000)'
+-- are equally got segfault because it has intermediate executor's slice:
+--   Result
+--     Output: (generate_series(1, 1))
+--       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+
+CREATE TABLE t1 as select generate_series(1, 1);
+DROP TABLE t1;
+
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+
+CREATE TABLE t1(i int);
+CREATE TABLE t2(i int);
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+\! gpstop -raiq;
+-- end_ignore


### PR DESCRIPTION
The reason of failure is that auto_explain hooks are fully executed on QEs.
The global variable Gp_role is initialized after auto_explain is loaded as shared preload library.
The QE has valid planstate objects just for nodes in query plan corresponded to the slice of current QE.
As result, for "intermediate" slices we have NULL pointer to subtree state for "child" (within slice borders)
Motion nodes (subtree itself is valid and points to real node but state for this subtree is not).
ExplainNode() routine called within ExplainPrintPlan() function fails trying to dereference that pointer.

To fix the failure I've changed the guard check Gp_role != GP_ROLE_DISPATCH in _PG_init() of auto_explain
to macro IS_QUERY_DISPATCHER() that relies on GpIdentity.segindex value to define the kind of node on which
code is executed. As a consequence, hooks of auto_explain are activated just on coordinator node.
To exclude execution of hooks on coordinator on entrydb kind of worker (having gp_role=executor)
I've added additional check Gp_role != GP_ROLE_DISPATCH into macro auto_explain_enabled().
This check disables auto_explain when some work (as executor) is doing at master.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
