### PR TITLE
ADBDEV-2845: ALTER TABLE erase pg_appendonly values

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14821,39 +14821,24 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 			rel->rd_rel->relhasindex)
 			cs->buildAoBlkdir = true;
 
-		if (RelationIsAoCols(rel))
+		cs->options = opts;
+
+		if (RelationIsAoRows(rel))
 		{
-			ListCell *lc;
-
-			foreach(lc, opts)
-			{
-				DefElem *de = lfirst(lc);
-				cs->options = lappend(cs->options, de);
-			}
-
-			if (useExistingColumnAttributes)
-			{
-				col_encs = RelationGetUntransformedAttributeOptions(rel);
-			}
+			/*
+			* In order to avoid being affected by the GUC of gp_default_storage_options,
+			* we should re-build storage options from original table.
+			*
+			* The reason is that when we use the default parameters to create a table,
+			* the configuration will not be written to pg_class.reloptions, and then if
+			* gp_default_storage_options is modified, the newly created table will be
+			* inconsistent with the original table.
+			*/
+			cs->options = build_ao_rel_storage_opts(cs->options, rel);
 		}
-		else
-		{
-			cs->options = opts;
 
-			if (RelationIsAoRows(rel))
-			{
-				/*
-				 * In order to avoid being affected by the GUC of gp_default_storage_options,
-				 * we should re-build storage options from original table.
-				 *
-				 * The reason is that when we use the default parameters to create a table,
-				 * the configuration will not be written to pg_class.reloptions, and then if
-				 * gp_default_storage_options is modified, the newly created table will be
-				 * inconsistent with the original table.
-				 */
-				cs->options = build_ao_rel_storage_opts(cs->options, rel);
-			}
-		}
+		if (RelationIsAoCols(rel) && useExistingColumnAttributes)
+			col_encs = RelationGetUntransformedAttributeOptions(rel);
 
 		for (attno = 0; attno < tupdesc->natts; attno++)
 		{

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14823,26 +14823,17 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 
 		if (RelationIsAoCols(rel))
 		{
+			ListCell *lc;
+
+			foreach(lc, opts)
+			{
+				DefElem *de = lfirst(lc);
+				cs->options = lappend(cs->options, de);
+			}
+
 			if (useExistingColumnAttributes)
 			{
-				ListCell *lc;
-
-				foreach(lc, opts)
-				{
-					DefElem *de = lfirst(lc);
-					cs->options = lappend(cs->options, de);
-				}
 				col_encs = RelationGetUntransformedAttributeOptions(rel);
-			}
-			else
-			{
-				ListCell *lc;
-
-				foreach(lc, opts)
-				{
-					DefElem *de = lfirst(lc);
-					cs->options = lappend(cs->options, de);
-				}
 			}
 		}
 		else

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14825,23 +14825,12 @@ prebuild_temp_table(Relation rel, RangeVar *tmpname, DistributedBy *distro, List
 		{
 			if (useExistingColumnAttributes)
 			{
-				/*
-				 * Need to remove table level compression settings for the
-				 * AOCO case since they're set at the column level.
-				 */
 				ListCell *lc;
 
 				foreach(lc, opts)
 				{
 					DefElem *de = lfirst(lc);
-
-					if (de->defname &&
-						(strcmp("compresstype", de->defname) == 0 ||
-						 strcmp("compresslevel", de->defname) == 0 ||
-						 strcmp("blocksize", de->defname) == 0))
-						continue;
-					else
-						cs->options = lappend(cs->options, de);
+					cs->options = lappend(cs->options, de);
 				}
 				col_encs = RelationGetUntransformedAttributeOptions(rel);
 			}

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -827,6 +827,30 @@ Distributed by: (a)
 Options: appendonly=true, orientation=column
 
 DROP TABLE aocs_alter_add_col_no_compress;
+-- test case: ensure reorganize keep default compresstype, compresslevel and blocksize table options
+CREATE TABLE aocs_alter_add_col_reorganize(a int) WITH (appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536);
+ALTER TABLE aocs_alter_add_col_reorganize SET WITH (reorganize=true);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2';
+-- use statement encoding
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN b int ENCODING(compresstype=zlib, compresslevel=3, blocksize=16384);
+-- use table setting
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use table setting
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN d int;
+\d+ aocs_alter_add_col_reorganize
+                            Append-Only Columnar Table "public.aocs_alter_add_col_reorganize"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ b      | integer |           | plain   |              | zlib             | 3                 | 16384      | 
+ c      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+ d      | integer |           | plain   |              | rle_type         | 4                 | 65536      | 
+Checksum: t
+Distributed by: (a)
+Options: appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536
+
+DROP TABLE aocs_alter_add_col_reorganize;
 RESET gp_add_column_inherits_table_setting;
 --
 -- Test case: validate pg_aocsseg consistency after alter table

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -473,6 +473,20 @@ ALTER TABLE aocs_alter_add_col_no_compress ADD COLUMN d int;
 \d+ aocs_alter_add_col_no_compress 
 DROP TABLE aocs_alter_add_col_no_compress;
 
+-- test case: ensure reorganize keep default compresstype, compresslevel and blocksize table options
+CREATE TABLE aocs_alter_add_col_reorganize(a int) WITH (appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4, blocksize=65536);
+ALTER TABLE aocs_alter_add_col_reorganize SET WITH (reorganize=true);
+SET gp_default_storage_options ='appendonly=true, orientation=column, compresstype=zlib, compresslevel=2';
+-- use statement encoding
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN b int ENCODING(compresstype=zlib, compresslevel=3, blocksize=16384);
+-- use table setting
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN c int;
+RESET gp_default_storage_options;
+-- use table setting
+ALTER TABLE aocs_alter_add_col_reorganize ADD COLUMN d int;
+\d+ aocs_alter_add_col_reorganize
+DROP TABLE aocs_alter_add_col_reorganize;
+
 RESET gp_add_column_inherits_table_setting;
 
 --


### PR DESCRIPTION
ADBDEV-2845: ALTER TABLE erase pg_appendonly values

Ensure reorganize keep default compresstype, compresslevel and blocksize table options.

This is need for use for append-optimized column-oriented tables
with compresstype, compresslevel and blocksize options
when gp_add_column_inherits_table_setting = on.