### PR TITLE
fix behave tests flakiness

### DIFF
--- a/arenadata/docker-compose.yaml
+++ b/arenadata/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      tail -f /home/gpadmin/gpdb_src/README.md
+      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
   sdw1:
     image: "${IMAGE}"
     privileged: true
@@ -27,7 +27,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      tail -f /home/gpadmin/gpdb_src/README.md
+      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
   sdw2:
     image: "${IMAGE}"
     privileged: true
@@ -38,7 +38,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      tail -f /home/gpadmin/gpdb_src/README.md
+      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
   sdw3:
     image: "${IMAGE}"
     privileged: true
@@ -49,4 +49,4 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      tail -f /home/gpadmin/gpdb_src/README.md
+      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"

--- a/arenadata/docker-compose.yaml
+++ b/arenadata/docker-compose.yaml
@@ -16,9 +16,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
-      echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
-      tail -f /home/gpadmin/gpdb_src/README.md"
+      tail -f /home/gpadmin/gpdb_src/README.md
   sdw1:
     image: "${IMAGE}"
     privileged: true
@@ -29,11 +27,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
-      source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
-      ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash &&
-      echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
-      tail -f /home/gpadmin/gpdb_src/README.md"
+      tail -f /home/gpadmin/gpdb_src/README.md
   sdw2:
     image: "${IMAGE}"
     privileged: true
@@ -44,11 +38,7 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
-      source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
-      ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash &&
-      echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
-      tail -f /home/gpadmin/gpdb_src/README.md"
+      tail -f /home/gpadmin/gpdb_src/README.md
   sdw3:
     image: "${IMAGE}"
     privileged: true
@@ -59,8 +49,4 @@ services:
     sysctls:
       kernel.sem: 500 1024000 200 4096
     entrypoint: >
-      bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
-      source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
-      ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash &&
-      echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers &&
-      tail -f /home/gpadmin/gpdb_src/README.md"
+      tail -f /home/gpadmin/gpdb_src/README.md

--- a/arenadata/scripts/behave_gpdb.bash
+++ b/arenadata/scripts/behave_gpdb.bash
@@ -40,18 +40,6 @@ function _main() {
 				exit 1
 		fi
 
-		time install_gpdb
-		time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
-
-
-		local hosts="sdw1 sdw2 sdw3 mdw"
-		for host in $hosts
-		do
-			ssh -oStrictHostKeyChecking=no -i /home/gpadmin/.ssh/id_rsa gpadmin@$host /bin/bash -c \
-				"getent hosts ${hosts/$host/} | sudo tee -a /etc/hosts &&
-				ssh-keyscan ${hosts/$host/} >> /home/gpadmin/.ssh/known_hosts"
-		done
-
 		# Run inside a subshell so it does not pollute the environment after
 		# sourcing greenplum_path
 		time (make_cluster)

--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -45,12 +45,14 @@ run_feature() {
   echo "Started $feature behave tests on cluster $cluster and project $project"
   docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d
   # Prepare ALL containers first
-  for service in $(docker-compose -p $project -f arenadata/docker-compose.yaml config --services)
+  local services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
+  for service in $services
   do
     docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
       $service bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
         source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
-       ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
+       ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash &&
+       ssh-keyscan ${services/$service/} >> /home/gpadmin/.ssh/known_hosts" &
   done
   wait
   docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \

--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -44,6 +44,15 @@ run_feature() {
   fi
   echo "Started $feature behave tests on cluster $cluster and project $project"
   docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d
+  # Prepare ALL containers first
+  for service in $(docker-compose -p $project -f arenadata/docker-compose.yaml config --services)
+  do
+    docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
+      $service bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
+        source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
+       ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
+  done
+  wait
   docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
     -e FEATURE="$feature" -e BEHAVE_FLAGS="--tags $feature --tags=$cluster \
       -f behave_utils.arenadata.formatter:CustomFormatter \
@@ -69,7 +78,7 @@ do
      pids+="$! "
      if [[ $(jobs -r -p | wc -l) -ge $processes ]]; then
         wait -n
-        exits+="$?"
+        ((exits += $?))
      fi
   done
 done


### PR DESCRIPTION
Remove race condition between segments and coordinator containers
start. Execute prepare steps in parallel in all containers first:

1. create temporary directories
2. untar gpdb binaries
3. create gpadmin user
4. register ssh hostkeys other cluster containers

then initialize cluster from master container and run tests. 
granting sudo access rights and filling /etc/hosts seems
to be useless for existing test subset.
