### PR TITLE
Fix failure when DynamicSeqScan has a subPlan

### DIFF
--- a/src/backend/executor/nodeDynamicBitmapHeapscan.c
+++ b/src/backend/executor/nodeDynamicBitmapHeapscan.c
@@ -55,14 +55,17 @@ ExecInitDynamicBitmapHeapScan(DynamicBitmapHeapScan *node, EState *estate, int e
 
 	state->scan_state = SCAN_INIT;
 
+	state->ss.ps.qual = (List *) ExecInitExpr((Expr *) node->bitmapheapscan.scan.plan.qual,
+											   (PlanState *) state);
+	state->ss.ps.targetlist = (List *) ExecInitExpr((Expr *) node->bitmapheapscan.scan.plan.targetlist,
+													 (PlanState *) state);
+
 	/* Initialize result tuple type. */
 	ExecInitResultTupleSlot(estate, &state->ss.ps);
 	ExecAssignResultTypeFromTL(&state->ss.ps);
 
 	reloid = getrelid(node->bitmapheapscan.scan.scanrelid, estate->es_range_table);
 	Assert(OidIsValid(reloid));
-
-	state->firstPartition = true;
 
 	/* lastRelOid is used to remap varattno for heterogeneous partitions */
 	state->lastRelOid = reloid;
@@ -171,26 +174,6 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 		 */
 		node->lastRelOid = currentPartitionOid;
 		pfree(attMap);
-	}
-
-	/*
-	 * For the very first partition, the targetlist of planstate is set to null.
-	 * So, we must initialize quals and targetlist.
-	 */
-	if (node->firstPartition)
-	{
-		node->firstPartition = false;
-
-		MemoryContextReset(node->partitionMemoryContext);
-		MemoryContext oldCxt = MemoryContextSwitchTo(node->partitionMemoryContext);
-
-		/* Initialize child expressions */
-		scanState->ps.qual = (List *) ExecInitExpr((Expr *) scanState->ps.plan->qual,
-												   (PlanState *) scanState);
-		scanState->ps.targetlist = (List *) ExecInitExpr((Expr *) scanState->ps.plan->targetlist,
-														 (PlanState *) scanState);
-
-		MemoryContextSwitchTo(oldCxt);
 	}
 
 	DynamicScan_SetTableOid(&node->ss, currentPartitionOid);

--- a/src/backend/executor/nodeDynamicBitmapHeapscan.c
+++ b/src/backend/executor/nodeDynamicBitmapHeapscan.c
@@ -170,16 +170,17 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 		 * the new varnos correspond to
 		 */
 		node->lastRelOid = currentPartitionOid;
+		pfree(attMap);
 	}
 
 	/*
-	 * For the very first partition, the targetlist of planstate is set to null. So, we must
-	 * initialize quals and targetlist, regardless of remapping requirements. For later
-	 * partitions, we only initialize quals and targetlist if a column re-mapping is necessary.
+	 * For the very first partition, the targetlist of planstate is set to null.
+	 * So, we must initialize quals and targetlist.
 	 */
-	if (attMap || node->firstPartition)
+	if (node->firstPartition)
 	{
 		node->firstPartition = false;
+
 		MemoryContextReset(node->partitionMemoryContext);
 		MemoryContext oldCxt = MemoryContextSwitchTo(node->partitionMemoryContext);
 
@@ -191,9 +192,6 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 
 		MemoryContextSwitchTo(oldCxt);
 	}
-
-	if (attMap)
-		pfree(attMap);
 
 	DynamicScan_SetTableOid(&node->ss, currentPartitionOid);
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2242,11 +2242,6 @@ typedef struct DynamicSeqScanState
 	bool		shouldCallHashSeqTerm;
 
 	/*
-	 * The first partition requires initialization of expression states,
-	 * such as qual and targetlist, regardless of whether we need to re-map varattno
-	 */
-	bool		firstPartition;
-	/*
 	 * lastRelOid is the last relation that corresponds to the
 	 * varattno mapping of qual and target list. Each time we open a new partition, we will
 	 * compare the last relation with current relation by using varattnos_map()

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1966,11 +1966,6 @@ typedef struct DynamicBitmapHeapScanState
 	bool		shouldCallHashSeqTerm;
 
 	/*
-	 * The first partition requires initialization of expression states,
-	 * such as qual and targetlist, regardless of whether we need to re-map varattno
-	 */
-	bool		firstPartition;
-	/*
 	 * lastRelOid is the last relation that corresponds to the
 	 * varattno mapping of qual and target list. Each time we open a new partition, we will
 	 * compare the last relation with current relation by using varattnos_map()

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11565,7 +11565,7 @@ SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f =
 ---+---+---+---+---
 (0 rows)
 
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000004.33..10000000039.13 rows=7 width=20)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11686,7 +11686,7 @@ SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f =
 ---+---+---+---+---
 (0 rows)
 
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324481.28 rows=1000 width=20)

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16186,6 +16186,80 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 ----------+------+--------+--------
 (0 rows)
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_deflt" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_2" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_3" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_4" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_5" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_6" for table "ds_main"
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET optimizer_enforce_subplans TO ON;
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: ds_main_1_prt_deflt.a
+   ->  Sort
+         Sort Key: ds_main_1_prt_deflt.a
+         ->  Nested Loop Semi Join
+               ->  Hash Join
+                     Hash Cond: (ds_main_1_prt_deflt.c = non_part2.e)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: ds_main_1_prt_deflt.c
+                           ->  Append
+                                 ->  Seq Scan on ds_main_1_prt_deflt
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_3
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_4
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_5
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_6
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_2
+                                       Filter: (a = a)
+                     ->  Hash
+                           ->  Seq Scan on non_part2
+                                 Filter: (f < 10)
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on non_part1
+ Optimizer: Postgres query optimizer
+(29 rows)
+
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c | e | f 
+---+---+---+---+---
+ 1 | 2 | 3 | 3 | 4
+ 2 | 3 | 4 | 4 | 5
+ 3 | 4 | 5 | 5 | 6
+ 4 | 5 | 6 | 6 | 7
+ 5 | 6 | 7 | 7 | 8
+ 6 | 7 | 8 | 8 | 9
+(6 rows)
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16219,13 +16219,13 @@ SET optimizer_enforce_subplans TO ON;
 -- drop columns to get attribute remapping
 ALTER TABLE ds_part1 drop column a1;
 ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
-INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
-INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
 INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
 analyze ds_main;
 analyze non_part1;
 analyze non_part2;
-EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
@@ -16252,23 +16252,24 @@ EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2
                                        Filter: (a = a)
                      ->  Hash
                            ->  Seq Scan on non_part2
-                                 Filter: (f < 10)
                ->  Materialize
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            ->  Seq Scan on non_part1
  Optimizer: Postgres query optimizer
-(29 rows)
+(28 rows)
 
-SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
- a | b | c | e | f 
----+---+---+---+---
- 1 | 2 | 3 | 3 | 4
- 2 | 3 | 4 | 4 | 5
- 3 | 4 | 5 | 5 | 6
- 4 | 5 | 6 | 6 | 7
- 5 | 6 | 7 | 7 | 8
- 6 | 7 | 8 | 8 | 9
-(6 rows)
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c  | e  | f  
+---+---+----+----+----
+ 1 | 2 |  3 |  3 |  4
+ 2 | 3 |  4 |  4 |  5
+ 3 | 4 |  5 |  5 |  6
+ 4 | 5 |  6 |  6 |  7
+ 5 | 6 |  7 |  7 |  8
+ 6 | 7 |  8 |  8 |  9
+ 7 | 8 |  9 |  9 | 10
+ 8 | 9 | 10 | 10 | 11
+(8 rows)
 
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16187,6 +16187,16 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 (0 rows)
 
 -- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+NOTICE:  table "ds_main" does not exist, skipping
+DROP TABLE if exists ds_part1;
+NOTICE:  table "ds_part1" does not exist, skipping
+DROP TABLE if exists non_part1;
+NOTICE:  table "non_part1" does not exist, skipping
+DROP TABLE if exists non_part2;
+NOTICE:  table "non_part2" does not exist, skipping
+-- end_ignore
 CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16141,13 +16141,13 @@ SET optimizer_enforce_subplans TO ON;
 -- drop columns to get attribute remapping
 ALTER TABLE ds_part1 drop column a1;
 ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
-INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
-INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
 INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
 analyze ds_main;
 analyze non_part1;
 analyze non_part2;
-EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
@@ -16163,26 +16163,26 @@ EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2
                              ->  Broadcast Motion 1:3  (slice2)
                                    ->  Limit
                                          ->  Gather Motion 3:1  (slice1; segments: 3)
-                                               ->  Limit
-                                                     ->  Seq Scan on non_part1
+                                               ->  Seq Scan on non_part1
                ->  Hash
                      ->  Partition Selector for ds_main (dynamic scan id: 1)
                            ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                  ->  Seq Scan on non_part2
-                                       Filter: (f < 10)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(19 rows)
 
-SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
- a | b | c | e | f 
----+---+---+---+---
- 1 | 2 | 3 | 3 | 4
- 2 | 3 | 4 | 4 | 5
- 3 | 4 | 5 | 5 | 6
- 4 | 5 | 6 | 6 | 7
- 5 | 6 | 7 | 7 | 8
- 6 | 7 | 8 | 8 | 9
-(6 rows)
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c  | e  | f  
+---+---+----+----+----
+ 1 | 2 |  3 |  3 |  4
+ 2 | 3 |  4 |  4 |  5
+ 3 | 4 |  5 |  5 |  6
+ 4 | 5 |  6 |  6 |  7
+ 5 | 6 |  7 |  7 |  8
+ 6 | 7 |  8 |  8 |  9
+ 7 | 8 |  9 |  9 | 10
+ 8 | 9 | 10 | 10 | 11
+(8 rows)
 
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16109,6 +16109,16 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 (0 rows)
 
 -- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+NOTICE:  table "ds_main" does not exist, skipping
+DROP TABLE if exists ds_part1;
+NOTICE:  table "ds_part1" does not exist, skipping
+DROP TABLE if exists non_part1;
+NOTICE:  table "non_part1" does not exist, skipping
+DROP TABLE if exists non_part2;
+NOTICE:  table "non_part2" does not exist, skipping
+-- end_ignore
 CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16108,6 +16108,72 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 ----------+------+--------+--------
 (0 rows)
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_deflt" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_2" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_3" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_4" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_5" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_6" for table "ds_main"
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET optimizer_enforce_subplans TO ON;
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Merge Key: ds_main.a
+   ->  Sort
+         Sort Key: ds_main.a
+         ->  Hash Join
+               Hash Cond: (ds_main.c = non_part2.e)
+               ->  Dynamic Seq Scan on ds_main (dynamic scan id: 1)
+                     Filter: ((a = a) AND (SubPlan 1))
+                     SubPlan 1  (slice4; segments: 3)
+                       ->  Materialize
+                             ->  Broadcast Motion 1:3  (slice2)
+                                   ->  Limit
+                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                               ->  Limit
+                                                     ->  Seq Scan on non_part1
+               ->  Hash
+                     ->  Partition Selector for ds_main (dynamic scan id: 1)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on non_part2
+                                       Filter: (f < 10)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c | e | f 
+---+---+---+---+---
+ 1 | 2 | 3 | 3 | 4
+ 2 | 3 | 4 | 4 | 5
+ 3 | 4 | 5 | 5 | 6
+ 4 | 5 | 6 | 6 | 7
+ 5 | 6 | 7 | 7 | 8
+ 6 | 7 | 8 | 8 | 9
+(6 rows)
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2259,7 +2259,7 @@ analyze ds_part;
 analyze non_part1;
 analyze non_part2;
 SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
 
 SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
 CREATE INDEX ds_idx ON ds_part(a);

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8643,16 +8643,16 @@ SET optimizer_enforce_subplans TO ON;
 ALTER TABLE ds_part1 drop column a1;
 ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
 
-INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
-INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
 INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
 
 analyze ds_main;
 analyze non_part1;
 analyze non_part2;
 
-EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
-SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
 
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8625,6 +8625,13 @@ explain select * from multi_part_mid_bitmap where date = '2017-02-05' and region
 select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
 
 -- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+DROP TABLE if exists ds_part1;
+DROP TABLE if exists non_part1;
+DROP TABLE if exists non_part2;
+-- end_ignore
+
 CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
 CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
 CREATE TABLE non_part1 (c INT);

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8624,6 +8624,29 @@ explain select * from multi_part_mid_bitmap where date = '2017-02-05' and region
 -- end_ignore
 select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+CREATE TABLE non_part1 (c INT);
+CREATE TABLE non_part2 (e INT, f INT);
+
+SET optimizer_enforce_subplans TO ON;
+
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 100)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT a FROM non_part1) order by a;
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.


### PR DESCRIPTION
SubPlan is added to List at ExecInitExpr.
At commit 81a671f6c560f8424d3589c1ccca23805090a266 call of ExecInitExpr is added
to ExecInitDynamicSeqScan, but not removed from initNextTableToScan.
Because of this while inittialize first subPlan is added by ExecInitDynamicSeqScan->ExecInitExpr,
second subPlan is added by initNextTableToScan->initNextTableToScan.
QE has two subPlans, but QD has only one.
On explain analyze At receiving statistics from QE to QD we got internal error.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
