### PR TITLE
Add new %d parameter to archive and restore commands

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -73,6 +73,7 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	TimeLineID	restartTli;
 
 	char        contentid[12];  /* sign, 10 digits and '\0' */
+	char		dbid[11];	/* 10 digits and '\0' */
 
 	/* In standby mode, restore_command might not be supplied */
 	if (recoveryRestoreCommand == NULL)
@@ -189,6 +190,14 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 					sp++;
 					pg_ltoa(GpIdentity.segindex, contentid);
 					StrNCpy(dp, contentid, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'd':
+					/* GPDB: %d: dbid of segment */
+					Assert(GpIdentity.dbid != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.dbid, dbid);
+					StrNCpy(dp, dbid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -72,9 +72,6 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
 
-	char		buf[12];	/* sign, 10 digits and '\0' */
-	int32		val;
-
 	/* In standby mode, restore_command might not be supplied */
 	if (recoveryRestoreCommand == NULL)
 		goto not_available;
@@ -186,13 +183,16 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 					break;
 				case 'c': /* GPDB: %c: contentId of segment */
 				case 'd': /* GPDB: %d: dbid of segment */
-					val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
+				{
+					char	buf[12];  /* sign, 10 digits and '\0' */
+					int32	val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
 					Assert(val != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					pg_ltoa(val, buf);
 					strlcpy(dp, buf, endp - dp);
 					dp += strlen(dp);
 					break;
+				}
 				case '%':
 					/* convert %% to a single % */
 					sp++;

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -72,6 +72,9 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
 
+	char		buf[12];	/* sign, 10 digits and '\0' */
+	int32		val;
+
 	/* In standby mode, restore_command might not be supplied */
 	if (recoveryRestoreCommand == NULL)
 		goto not_available;
@@ -183,8 +186,7 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 					break;
 				case 'c': /* GPDB: %c: contentId of segment */
 				case 'd': /* GPDB: %d: dbid of segment */
-					char    buf[12];  /* sign, 10 digits and '\0' */
-					int32   val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
+					val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
 					Assert(val != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					pg_ltoa(val, buf);

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -539,6 +539,9 @@ pgarch_archiveXlog(char *xlog)
 	const char *sp;
 	int			rc;
 
+	char		buf[12];	/* sign, 10 digits and '\0' */
+	int32		val;
+
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
 	/*
@@ -569,8 +572,7 @@ pgarch_archiveXlog(char *xlog)
 					break;
 				case 'c': /* GPDB: %c: contentId of segment */
 				case 'd': /* GPDB: %d: dbid of segment */
-					char    buf[12];  /* sign, 10 digits and '\0' */
-					int32   val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
+					val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
 					Assert(val != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					pg_ltoa(val, buf);

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -539,9 +539,6 @@ pgarch_archiveXlog(char *xlog)
 	const char *sp;
 	int			rc;
 
-	char		buf[12];	/* sign, 10 digits and '\0' */
-	int32		val;
-
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
 	/*
@@ -572,13 +569,16 @@ pgarch_archiveXlog(char *xlog)
 					break;
 				case 'c': /* GPDB: %c: contentId of segment */
 				case 'd': /* GPDB: %d: dbid of segment */
-					val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
+				{
+					char	buf[12];  /* sign, 10 digits and '\0' */
+					int32	val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
 					Assert(val != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
 					pg_ltoa(val, buf);
 					strlcpy(dp, buf, endp - dp);
 					dp += strlen(dp);
 					break;
+				}
 				case '%':
 					/* convert %% to a single % */
 					sp++;

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -540,6 +540,7 @@ pgarch_archiveXlog(char *xlog)
 	int			rc;
 
 	char		contentid[12];	/* sign, 10 digits and '\0' */
+	char		dbid[11];	/* 10 digits and '\0' */
 
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
@@ -575,6 +576,14 @@ pgarch_archiveXlog(char *xlog)
 					sp++;
 					pg_ltoa(GpIdentity.segindex, contentid);
 					strlcpy(dp, contentid, endp - dp);
+					dp += strlen(dp);
+					break;
+				case 'd':
+					/* GPDB: %d: dbid of segment */
+					Assert(GpIdentity.dbid != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.dbid, dbid);
+					strlcpy(dp, dbid, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -539,9 +539,6 @@ pgarch_archiveXlog(char *xlog)
 	const char *sp;
 	int			rc;
 
-	char		contentid[12];	/* sign, 10 digits and '\0' */
-	char		dbid[11];	/* 10 digits and '\0' */
-
 	snprintf(pathname, MAXPGPATH, XLOGDIR "/%s", xlog);
 
 	/*
@@ -570,20 +567,14 @@ pgarch_archiveXlog(char *xlog)
 					strlcpy(dp, xlog, endp - dp);
 					dp += strlen(dp);
 					break;
-				case 'c':
-					/* GPDB: %c: contentId of segment */
-					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+				case 'c': /* GPDB: %c: contentId of segment */
+				case 'd': /* GPDB: %d: dbid of segment */
+					char    buf[12];  /* sign, 10 digits and '\0' */
+					int32   val = (sp[1] == 'c') ? GpIdentity.segindex : GpIdentity.dbid;
+					Assert(val != UNINITIALIZED_GP_IDENTITY_VALUE);
 					sp++;
-					pg_ltoa(GpIdentity.segindex, contentid);
-					strlcpy(dp, contentid, endp - dp);
-					dp += strlen(dp);
-					break;
-				case 'd':
-					/* GPDB: %d: dbid of segment */
-					Assert(GpIdentity.dbid != UNINITIALIZED_GP_IDENTITY_VALUE);
-					sp++;
-					pg_ltoa(GpIdentity.dbid, dbid);
-					strlcpy(dp, dbid, endp - dp);
+					pg_ltoa(val, buf);
+					strlcpy(dp, buf, endp - dp);
 					dp += strlen(dp);
 					break;
 				case '%':

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -76,9 +76,9 @@ for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
   DATADIR_VAR=$segment_role
   echo "wal_level = hot_standby
 archive_mode = on
-archive_command = 'cp %p ${ARCHIVE_PREFIX}%c/%f'" >> ${!DATADIR_VAR}/postgresql.conf
+archive_command = 'cp %p ${ARCHIVE_PREFIX}%c/%d/%f'" >> ${!DATADIR_VAR}/postgresql.conf
 done
-mkdir -p ${ARCHIVE_PREFIX}{-1,0,1,2}
+mkdir -p ${ARCHIVE_PREFIX}{-1/1,0/2,1/3,2/4}
 gpstop -ar -q
 
 # Create the basebackups which will be our replicas for Point-In-Time
@@ -90,6 +90,14 @@ for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
   REPLICA_DBID_VAR=REPLICA_${segment_role}_DBID
   pg_basebackup -h localhost -p ${!PORT_VAR} -D ${!REPLICA_VAR} --target-gp-dbid ${!REPLICA_DBID_VAR}
 done
+
+# New instances will have new dbid's (--target-gp-dbid parameter upper and
+# gp_segment_configuration manipulations below). Let's create symliks with new
+# dbid's to older archieves.
+ln -s ${ARCHIVE_PREFIX}-1/1 ${ARCHIVE_PREFIX}-1/${REPLICA_MASTER_DBID}
+ln -s ${ARCHIVE_PREFIX}0/2 ${ARCHIVE_PREFIX}0/${REPLICA_PRIMARY1_DBID}
+ln -s ${ARCHIVE_PREFIX}1/3 ${ARCHIVE_PREFIX}1/${REPLICA_PRIMARY2_DBID}
+ln -s ${ARCHIVE_PREFIX}2/4 ${ARCHIVE_PREFIX}2/${REPLICA_PRIMARY3_DBID}
 
 # Create our test database.
 createdb gpdb_pitr_database
@@ -115,7 +123,7 @@ echo "Creating recovery.conf files in the replicas and starting them up..."
 for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
   REPLICA_VAR=REPLICA_$segment_role
   echo "standby_mode = 'on'
-restore_command = 'cp ${ARCHIVE_PREFIX}%c/%f %p'
+restore_command = 'cp ${ARCHIVE_PREFIX}%c/%d/%f %p'
 recovery_target_name = 'test_restore_point'
 recovery_end_command = 'touch ${!REPLICA_VAR}/recovery_finished'
 primary_conninfo = ''" > ${!REPLICA_VAR}/recovery.conf


### PR DESCRIPTION
This patch allows to use new %d parameter in archive/restore commands.
Additionally to %c which represents contentId, this new parameter represents
dbid. Existed test case was modified to show both, %c and %d works.