### PR TITLE
ADBDEV-2885-5: Postgres planner produces bogus plan for query to replicated table with SIRV function

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -749,17 +749,6 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 		if (containingPlanDistributed)
 		{
 			Assert(NULL != context->currentPlanFlow);
-
-			PlannerInfo *origRoot = planner_subplan_get_root(context->root, spExpr);
-
-			if ((newPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
-				(contain_volatile_functions((Node *) newPlan->targetlist) ||
-				 contain_volatile_functions(origRoot->parse->havingQual)))
-			{
-				newPlan->flow->locustype = CdbLocusType_SingleQE;
-				newPlan->flow->flotype = FLOW_SINGLETON;
-			}
-
 			broadcastPlan(newPlan, false /* stable */ , false /* rescannable */,
 						  context->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -574,9 +574,8 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		{
 			Assert (NULL != ctx->currentPlanFlow);
 
-			if ((scanPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
-				(contain_volatile_functions((Node *) scanPlan->targetlist) ||
-				 contain_volatile_functions((Node *) scanPlan->qual)))
+			if (scanPlan->flow->locustype == CdbLocusType_SegmentGeneral &&
+				contain_volatile_functions((Node *) scanPlan->qual))
 			{
 				scanPlan->flow->locustype = CdbLocusType_SingleQE;
 				scanPlan->flow->flotype = FLOW_SINGLETON;

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -574,12 +574,9 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		{
 			Assert (NULL != ctx->currentPlanFlow);
 
-			Plan	   *origPlan = planner_subplan_get_plan((PlannerInfo *) ctx->base.node, ctx->sp);
-			PlannerInfo *origRoot = planner_subplan_get_root((PlannerInfo *) ctx->base.node, ctx->sp);
-
-			if ((origPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
-				(contain_volatile_functions((Node *) origPlan->targetlist) ||
-				contain_volatile_functions(origRoot->parse->havingQual)))
+			if ((scanPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
+				(contain_volatile_functions((Node *) scanPlan->targetlist) ||
+				contain_volatile_functions(scanPlan->qual)))
 			{
 				scanPlan->flow->locustype = CdbLocusType_SingleQE;
 				scanPlan->flow->flotype = FLOW_SINGLETON;

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -751,9 +751,11 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 		{
 			Assert(NULL != context->currentPlanFlow);
 
+			PlannerInfo *origRoot = planner_subplan_get_root(context->root, spExpr);
+
 			if ((newPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
 				(contain_volatile_functions((Node *) newPlan->targetlist) ||
-				contain_volatile_functions((Node *) newPlan->qual)))
+				 contain_volatile_functions(origRoot->parse->havingQual)))
 			{
 				newPlan->flow->locustype = CdbLocusType_SingleQE;
 				newPlan->flow->flotype = FLOW_SINGLETON;

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -573,15 +573,6 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
 			Assert (NULL != ctx->currentPlanFlow);
-
-			if ((scanPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
-				(contain_volatile_functions((Node *) scanPlan->targetlist) ||
-				contain_volatile_functions((Node *) scanPlan->qual)))
-			{
-				scanPlan->flow->locustype = CdbLocusType_SingleQE;
-				scanPlan->flow->flotype = FLOW_SINGLETON;
-			}
-
 			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
 						  ctx->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -576,7 +576,7 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 
 			if ((scanPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
 				(contain_volatile_functions((Node *) scanPlan->targetlist) ||
-				contain_volatile_functions(scanPlan->qual)))
+				contain_volatile_functions((Node *) scanPlan->qual)))
 			{
 				scanPlan->flow->locustype = CdbLocusType_SingleQE;
 				scanPlan->flow->flotype = FLOW_SINGLETON;
@@ -753,7 +753,7 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 
 			if ((newPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
 				(contain_volatile_functions((Node *) newPlan->targetlist) ||
-				contain_volatile_functions(newPlan->qual)))
+				contain_volatile_functions((Node *) newPlan->qual)))
 			{
 				newPlan->flow->locustype = CdbLocusType_SingleQE;
 				newPlan->flow->flotype = FLOW_SINGLETON;

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -573,6 +573,15 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
 			Assert (NULL != ctx->currentPlanFlow);
+
+			if ((scanPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
+				(contain_volatile_functions((Node *) scanPlan->targetlist) ||
+				 contain_volatile_functions((Node *) scanPlan->qual)))
+			{
+				scanPlan->flow->locustype = CdbLocusType_SingleQE;
+				scanPlan->flow->flotype = FLOW_SINGLETON;
+			}
+
 			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
 						  ctx->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -751,11 +751,9 @@ ParallelizeSubplan(SubPlan *spExpr, PlanProfile *context)
 		{
 			Assert(NULL != context->currentPlanFlow);
 
-			PlannerInfo *origRoot = planner_subplan_get_root(context->root, spExpr);
-
 			if ((newPlan->flow->locustype == CdbLocusType_SegmentGeneral) &&
 				(contain_volatile_functions((Node *) newPlan->targetlist) ||
-				contain_volatile_functions(origRoot->parse->havingQual)))
+				contain_volatile_functions(newPlan->qual)))
 			{
 				newPlan->flow->locustype = CdbLocusType_SingleQE;
 				newPlan->flow->flotype = FLOW_SINGLETON;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -845,7 +845,7 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	if (IsA(newnode, Motion) &&flow->req_move != MOVEMENT_NONE)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
-		plan->flow->flow_before_req_move = plan->flow;
+		flow->flow_before_req_move = plan->flow;
 		plan->flow = flow;
 		newnode = (Node *) plan;
 	}

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -845,6 +845,8 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	if (IsA(newnode, Motion) &&flow->req_move != MOVEMENT_NONE)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
+
+		/* Save previous flow and copy flow of deleting motion. */
 		flow->flow_before_req_move = plan->flow;
 		plan->flow = flow;
 		newnode = (Node *) plan;

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -845,7 +845,8 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	if (IsA(newnode, Motion) &&flow->req_move != MOVEMENT_NONE)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
-		flow = plan->flow;
+		plan->flow->flow_before_req_move = plan->flow;
+		plan->flow = flow;
 		newnode = (Node *) plan;
 	}
 

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -846,7 +846,10 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
 
-		/* Save previous flow and copy flow of deleting motion. */
+		/* We'll recreate this motion later below. But we should save motion
+		 * request to create appropriate motion above the child node.
+		 * Original flow for the child node will be restored
+		 * after motion creation. */
 		flow->flow_before_req_move = plan->flow;
 		plan->flow = flow;
 		newnode = (Node *) plan;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6691,7 +6691,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
 					if (contain_volatile_functions((Node *)subplan->targetlist) ||
-						contain_volatile_functions((Node *)subplan->qual))
+						contain_volatile_functions(root->parse->havingQual))
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6686,8 +6686,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				 * Obviously, tmp_tab in new segments can't get data if we don't
 				 * add a broadcast here. 
 				 */
-				if (optimizer_replicated_table_insert &&
-					subplan->flow->flotype == FLOW_SINGLETON &&
+				if (subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
 					if (contain_volatile_functions((Node *)subplan->targetlist) ||
@@ -6695,7 +6694,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}
-					else if (subplan->flow->numsegments >= targetPolicy->numsegments)
+					else if (optimizer_replicated_table_insert &&
+							 subplan->flow->numsegments >= targetPolicy->numsegments)
 					{
 						/*
 						 * A query to reach here:

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6691,7 +6691,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
 					if (contain_volatile_functions((Node *)subplan->targetlist) ||
-						contain_volatile_functions(root->parse->havingQual))
+						contain_volatile_functions(subplan->qual))
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6690,7 +6690,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
-					if (contain_volatile_functions((Node *)subplan->targetlist))
+					if (contain_volatile_functions((Node *)subplan->targetlist) ||
+						contain_volatile_functions(root->parse->havingQual))
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}
@@ -6720,7 +6721,8 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				if (optimizer_replicated_table_insert &&
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_General &&
-					!contain_volatile_functions((Node *)subplan->targetlist))
+					!contain_volatile_functions((Node *)subplan->targetlist) &&
+					!contain_volatile_functions(root->parse->havingQual))
 				{
 					subplan->dispatch = DISPATCH_PARALLEL;
 					if (subplan->flow->numsegments >= targetPolicy->numsegments)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6691,7 +6691,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
 					if (contain_volatile_functions((Node *)subplan->targetlist) ||
-						contain_volatile_functions(subplan->qual))
+						contain_volatile_functions((Node *)subplan->qual))
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}
@@ -6722,7 +6722,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_General &&
 					!contain_volatile_functions((Node *)subplan->targetlist) &&
-					!contain_volatile_functions(subplan->qual))
+					!contain_volatile_functions((Node *)subplan->qual))
 				{
 					subplan->dispatch = DISPATCH_PARALLEL;
 					if (subplan->flow->numsegments >= targetPolicy->numsegments)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6722,7 +6722,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_General &&
 					!contain_volatile_functions((Node *)subplan->targetlist) &&
-					!contain_volatile_functions(root->parse->havingQual))
+					!contain_volatile_functions(subplan->qual))
 				{
 					subplan->dispatch = DISPATCH_PARALLEL;
 					if (subplan->flow->numsegments >= targetPolicy->numsegments)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6688,10 +6688,13 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				 */
 				if (optimizer_replicated_table_insert &&
 					subplan->flow->flotype == FLOW_SINGLETON &&
-					subplan->flow->locustype == CdbLocusType_SegmentGeneral &&
-					!contain_volatile_functions((Node *)subplan->targetlist))
+					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
-					if (subplan->flow->numsegments >= targetPolicy->numsegments)
+					if (contain_volatile_functions((Node *)subplan->targetlist))
+					{
+						subplan->flow->locustype = CdbLocusType_SingleQE;
+					}
+					else if (subplan->flow->numsegments >= targetPolicy->numsegments)
 					{
 						/*
 						 * A query to reach here:

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6689,8 +6689,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				if (subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
-					if (contain_volatile_functions((Node *)subplan->targetlist) ||
-						contain_volatile_functions(root->parse->havingQual))
+					if (contain_volatile_functions((Node *)subplan->targetlist))
 					{
 						subplan->flow->locustype = CdbLocusType_SingleQE;
 					}

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6721,8 +6721,7 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				if (optimizer_replicated_table_insert &&
 					subplan->flow->flotype == FLOW_SINGLETON &&
 					subplan->flow->locustype == CdbLocusType_General &&
-					!contain_volatile_functions((Node *)subplan->targetlist) &&
-					!contain_volatile_functions((Node *)subplan->qual))
+					!contain_volatile_functions((Node *)subplan->targetlist))
 				{
 					subplan->dispatch = DISPATCH_PARALLEL;
 					if (subplan->flow->numsegments >= targetPolicy->numsegments)

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -638,8 +638,7 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 							&subroot,
 							config);
 
-	if ((plan->flow->locustype == CdbLocusType_SegmentGeneral ||
-		 plan->flow->locustype == CdbLocusType_General) &&
+	if ((plan->flow->locustype == CdbLocusType_General) &&
 		(contain_volatile_functions((Node *) plan->targetlist) ||
 		 contain_volatile_functions(subquery->havingQual)))
 	{

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -41,8 +41,10 @@
 #include "utils/syscache.h"
 
 #include "cdb/cdbmutate.h"
+#include "cdb/cdbsetop.h"
 #include "cdb/cdbsubselect.h"
 #include "cdb/cdbvars.h"
+
 
 typedef struct convert_testexpr_context
 {
@@ -644,6 +646,13 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 	{
 		plan->flow->locustype = CdbLocusType_SingleQE;
 		plan->flow->flotype = FLOW_SINGLETON;
+	}
+
+	if (plan->flow->locustype == CdbLocusType_SegmentGeneral &&
+		(contain_volatile_functions((Node *) plan->targetlist) ||
+		 contain_volatile_functions(subquery->havingQual)))
+	{
+		plan = (Plan *) make_motion_gather(subroot, plan, NIL, CdbLocusType_SingleQE);
 	}
 
 	/* Isolate the params needed by this specific subplan */

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -638,7 +638,7 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 							&subroot,
 							config);
 
-	if ((plan->flow->locustype == CdbLocusType_General) &&
+	if (plan->flow->locustype == CdbLocusType_General &&
 		(contain_volatile_functions((Node *) plan->targetlist) ||
 		 contain_volatile_functions(subquery->havingQual)))
 	{

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1447,6 +1447,24 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+explain (costs off, verbose) insert into t1 select max(i) from t group by random();
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert on rpt.t1
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: "*SELECT*".max
+         Hash Key: "*SELECT*".max
+         ->  Subquery Scan on "*SELECT*"
+               Output: "*SELECT*".max
+               ->  HashAggregate
+                     Output: max(t.i), (random())
+                     Group Key: random()
+                     ->  Seq Scan on rpt.t
+                           Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                      QUERY PLAN                      

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1488,6 +1488,31 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1329,6 +1329,139 @@ select c from rep_tab where c in (select distinct d from rand_tab);
  2
 (2 rows)
 
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion
+explain (costs off, verbose) SELECT (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                             Output: t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(17 rows)
+
+explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: 1
+   ->  Result
+         Output: 1
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -989,14 +989,35 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
 
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
@@ -1446,24 +1467,6 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
-
-explain (costs off, verbose) insert into t1 select max(i) from t group by random();
-                      QUERY PLAN                      
-------------------------------------------------------
- Insert on rpt.t1
-   ->  Redistribute Motion 1:3  (slice1; segments: 1)
-         Output: "*SELECT*".max
-         Hash Key: "*SELECT*".max
-         ->  Subquery Scan on "*SELECT*"
-               Output: "*SELECT*".max
-               ->  HashAggregate
-                     Output: max(t.i), (random())
-                     Group Key: random()
-                     ->  Seq Scan on rpt.t
-                           Output: t.i, random()
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(13 rows)
 
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1375,6 +1375,7 @@ explain (costs off, verbose) SELECT (select f(i) from t);
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (9 rows)
 
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1412,14 +1412,14 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
 
 -- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1  (slice1; segments: 1)
            ->  GroupAggregate
                  Output: random(), t.i
                  Group Key: t.i
@@ -1428,13 +1428,11 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
                        Filter: (t.i = t1.a)
                        ->  Materialize
                              Output: t.i, t.i
-                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                             ->  Seq Scan on rpt.t
                                    Output: t.i, t.i
-                                   ->  Seq Scan on rpt.t
-                                         Output: t.i, t.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
-(20 rows)
+(18 rows)
 
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
                      QUERY PLAN                      
@@ -1450,26 +1448,24 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
 
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1  (slice1; segments: 1)
            ->  Result
                  Output: random()
                  Filter: (t.i = t1.a)
                  ->  Materialize
                        Output: t.i
-                       ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       ->  Seq Scan on rpt.t
                              Output: t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
-(17 rows)
+(15 rows)
 
 explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -985,6 +985,29 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Insert on t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Seq Scan on t_replicate_src
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2074)
@@ -1475,6 +1498,8 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
+drop cascades to table t_replicate_dst
+drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1381,7 +1381,7 @@ create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
--- ensure we make gather motion
+-- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1475,7 +1475,7 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (15 rows)
 
--- ensure we make broadcast motion
+-- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1488,6 +1488,7 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
 explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1396,7 +1396,6 @@ explain (costs off, verbose) select (select f(i) from t);
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (9 rows)
 
--- ensure we do not make broadcast motion
 explain (costs off, verbose) select (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1432,6 +1431,7 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (13 rows)
 
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
                      QUERY PLAN                      
 -----------------------------------------------------

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1008,6 +1008,7 @@ select distinct id from gp_dist_random('t_replicate_dst') order by id;
   4
   5
 (5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2074)

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1382,7 +1382,7 @@ create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
-explain (costs off, verbose) SELECT (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from t);
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1397,7 +1397,7 @@ explain (costs off, verbose) SELECT (select f(i) from t);
 (9 rows)
 
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1414,7 +1414,7 @@ explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (12 rows)
 
-explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1432,7 +1432,6 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (13 rows)
 
--- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1456,19 +1455,6 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (18 rows)
 
-explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
- Insert on rpt.t2
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         Output: t.i, (random())
-         ->  Seq Scan on rpt.t
-               Output: t.i, random()
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(7 rows)
-
--- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1489,13 +1475,27 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (15 rows)
 
-explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+-- ensure we make broadcast motion
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: 1
+   Output: t1.a
    ->  Result
-         Output: 1
+         Output: t1.a
          One-Time Filter: (SubPlan 1)
          ->  Seq Scan on rpt.t1
                Output: t1.a

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1358,6 +1358,7 @@ select c from rep_tab where c in (select distinct d from rand_tab);
 --
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
 explain (costs off, verbose) SELECT (select f(i) from t);
@@ -1435,6 +1436,18 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (20 rows)
 
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                               QUERY PLAN                               
@@ -1485,6 +1498,7 @@ explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i
 
 drop table if exists t;
 drop table if exists t1;
+drop table if exists t2;
 drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -875,7 +875,7 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -866,7 +866,7 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1312,6 +1312,139 @@ select c from rep_tab where c in (select distinct d from rand_tab);
  2
 (2 rows)
 
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion
+explain (costs off, verbose) SELECT (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                             Output: t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(17 rows)
+
+explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: 1
+   ->  Result
+         Output: 1
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1471,6 +1471,31 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1430,6 +1430,24 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+explain (costs off, verbose) insert into t1 select max(i) from t group by random();
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert on rpt.t1
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: "*SELECT*".max
+         Hash Key: "*SELECT*".max
+         ->  Subquery Scan on "*SELECT*"
+               Output: "*SELECT*".max
+               ->  HashAggregate
+                     Output: max(t.i), (random())
+                     Group Key: random()
+                     ->  Seq Scan on rpt.t
+                           Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                      QUERY PLAN                      

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -980,14 +980,35 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
 
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
@@ -1429,24 +1450,6 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
-
-explain (costs off, verbose) insert into t1 select max(i) from t group by random();
-                      QUERY PLAN                      
-------------------------------------------------------
- Insert on rpt.t1
-   ->  Redistribute Motion 1:3  (slice1; segments: 1)
-         Output: "*SELECT*".max
-         Hash Key: "*SELECT*".max
-         ->  Subquery Scan on "*SELECT*"
-               Output: "*SELECT*".max
-               ->  HashAggregate
-                     Output: max(t.i), (random())
-                     Group Key: random()
-                     ->  Seq Scan on rpt.t
-                           Output: t.i, random()
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(13 rows)
 
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1341,6 +1341,7 @@ select c from rep_tab where c in (select distinct d from rand_tab);
 --
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
 explain (costs off, verbose) SELECT (select f(i) from t);
@@ -1418,6 +1419,18 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (20 rows)
 
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                               QUERY PLAN                               
@@ -1468,6 +1481,7 @@ explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i
 
 drop table if exists t;
 drop table if exists t1;
+drop table if exists t2;
 drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1365,7 +1365,7 @@ create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
-explain (costs off, verbose) SELECT (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from t);
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1380,7 +1380,7 @@ explain (costs off, verbose) SELECT (select f(i) from t);
 (9 rows)
 
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1397,7 +1397,7 @@ explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (12 rows)
 
-explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
                      QUERY PLAN                      
 -----------------------------------------------------
  Result
@@ -1415,7 +1415,6 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (13 rows)
 
--- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1439,19 +1438,6 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (18 rows)
 
-explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
- Insert on rpt.t2
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         Output: t.i, (random())
-         ->  Seq Scan on rpt.t
-               Output: t.i, random()
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(7 rows)
-
--- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1472,13 +1458,27 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (15 rows)
 
-explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+-- ensure we make broadcast motion
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: 1
+   Output: t1.a
    ->  Result
-         Output: 1
+         Output: t1.a
          One-Time Filter: (SubPlan 1)
          ->  Seq Scan on rpt.t1
                Output: t1.a

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1358,6 +1358,7 @@ explain (costs off, verbose) SELECT (select f(i) from t);
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (9 rows)
 
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -976,6 +976,30 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Insert on t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         ->  Seq Scan on t_replicate_src
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2089)
@@ -1458,6 +1482,8 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
+drop cascades to table t_replicate_dst
+drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1395,14 +1395,14 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
 
 -- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1  (slice1; segments: 1)
            ->  GroupAggregate
                  Output: random(), t.i
                  Group Key: t.i
@@ -1411,13 +1411,11 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
                        Filter: (t.i = t1.a)
                        ->  Materialize
                              Output: t.i, t.i
-                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                             ->  Seq Scan on rpt.t
                                    Output: t.i, t.i
-                                   ->  Seq Scan on rpt.t
-                                         Output: t.i, t.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
-(20 rows)
+(18 rows)
 
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
                      QUERY PLAN                      
@@ -1433,26 +1431,24 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
 
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1  (slice1; segments: 1)
            ->  Result
                  Output: random()
                  Filter: (t.i = t1.a)
                  ->  Materialize
                        Output: t.i
-                       ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       ->  Seq Scan on rpt.t
                              Output: t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off
-(17 rows)
+(15 rows)
 
 explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
                                QUERY PLAN                               

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1379,7 +1379,6 @@ explain (costs off, verbose) select (select f(i) from t);
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (9 rows)
 
--- ensure we do not make broadcast motion
 explain (costs off, verbose) select (select f(i) from t group by f(i));
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1415,6 +1414,7 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (13 rows)
 
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
                      QUERY PLAN                      
 -----------------------------------------------------

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1364,7 +1364,7 @@ create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
--- ensure we make gather motion
+-- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1458,7 +1458,7 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (15 rows)
 
--- ensure we make broadcast motion
+-- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1471,6 +1471,7 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
  Settings: enable_bitmapscan=off, enable_seqscan=off
 (7 rows)
 
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
 explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -424,6 +424,15 @@ explain (costs off) insert into t_replicate_volatile select random(), a, a from 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -550,6 +550,7 @@ create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
 explain (costs off, verbose) SELECT (select f(i) from t);
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
 explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
 -- ensure we make broadcast motion

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -556,6 +556,7 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
 -- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+explain (costs off, verbose) insert into t1 select max(i) from t group by random();
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
 explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -558,6 +558,7 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
 -- ensure we make broadcast motion
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
 drop table if exists t;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -429,7 +429,8 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
 
@@ -556,7 +557,6 @@ explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0)
 -- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-explain (costs off, verbose) insert into t1 select max(i) from t group by random();
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
 explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -546,6 +546,7 @@ select c from rep_tab where c in (select distinct d from rand_tab);
 --
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
 explain (costs off, verbose) SELECT (select f(i) from t);
@@ -553,11 +554,13 @@ explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
 explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
 -- ensure we make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
 explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
 drop table if exists t;
 drop table if exists t1;
+drop table if exists t2;
 drop function if exists f(i int);
 
 -- start_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -551,9 +551,9 @@ create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
 explain (costs off, verbose) select (select f(i) from t);
--- ensure we do not make broadcast motion
 explain (costs off, verbose) select (select f(i) from t group by f(i));
 explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+-- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
 -- ensure we make broadcast motion

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -532,6 +532,25 @@ select c from rep_tab where c in (select distinct a from dist_tab);
 explain select c from rep_tab where c in (select distinct d from rand_tab);
 select c from rep_tab where c in (select distinct d from rand_tab);
 
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion
+explain (costs off, verbose) SELECT (select f(i) from t);
+explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
+explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
+-- ensure we make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+drop table if exists t;
+drop table if exists t1;
+drop function if exists f(i int);
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -550,16 +550,16 @@ create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion
-explain (costs off, verbose) SELECT (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from t);
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
-explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
--- ensure we make broadcast motion
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+-- ensure we make broadcast motion
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
 -- ensure we do not break broadcast motion
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-explain (costs off, verbose) select 1 as mrs_t1 from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;


### PR DESCRIPTION
# 1. Volatile function in subplan
Query with subplan containing volatile functions on distributed replicated tables may not make gather motion. This produces wrong plan and leads to segfault.
Currently, gpdb replaces locuses for subplans subtrees to SingleQE in case of they have SegmentGeneral (i.e. replicated table scan, data is only on segments) locus and contains volatile functions. But it's incorrect because SingleQE locus assume that data is available on any segment instance including coordinator. As a result, there is no reason to add gather motion above such subtree and the resulting plan will be invalid.
Steps to reproduce this problem:
```sql
create table t (i int) distributed replicated;
create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
select (select f(i) from t); -- <-- segfault here!!!
select (select f(i) from t group by f(i)); -- <-- segfault here!!!
select (select i from t group by i having f(i) > 0); -- <-- segfault here!!!
```
This happens, because gather motion does not made, when volatile function exists in subplan.
Wrong plans:
```sql
explain (costs off, verbose) SELECT (select f(i) from t);
             QUERY PLAN              
-------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)
     ->  Seq Scan on public.t
           Output: f(i)
 Optimizer: Postgres query optimizer
(6 rows)
explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
             QUERY PLAN              
-------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)
     ->  HashAggregate
           Output: (f(i))
           Group Key: f(t.i)
           ->  Seq Scan on public.t
                 Output: i, f(i)
 Optimizer: Postgres query optimizer
(9 rows)
explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
             QUERY PLAN              
-------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)
     ->  HashAggregate
           Output: i
           Group Key: t.i
           Filter: (f(t.i) > 0)
           ->  Seq Scan on public.t
                 Output: i
 Optimizer: Postgres query optimizer
(10 rows)
```
Solution is make explicit gather motion in such case.
Right plans:
```sql
explain (costs off, verbose) SELECT (select f(i) from t);
                    QUERY PLAN                    
--------------------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)  (slice2)
     ->  Gather Motion 1:1  (slice1; segments: 1)
           Output: (f(i))
           ->  Seq Scan on public.t
                 Output: f(i)
 Optimizer: Postgres query optimizer
(8 rows)
explain (costs off, verbose) SELECT (select f(i) from t group by f(i));
                    QUERY PLAN                    
--------------------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)  (slice2)
     ->  Gather Motion 1:1  (slice1; segments: 1)
           Output: (f(i))
           ->  HashAggregate
                 Output: (f(i))
                 Group Key: f(t.i)
                 ->  Seq Scan on public.t
                       Output: i, f(i)
 Optimizer: Postgres query optimizer
(11 rows)
explain (costs off, verbose) SELECT (select i from t group by i having f(i) > 0);
                    QUERY PLAN                    
--------------------------------------------------
 Result
   Output: $0
   InitPlan 1 (returns $0)  (slice2)
     ->  Gather Motion 1:1  (slice1; segments: 1)
           Output: i
           ->  HashAggregate
                 Output: i
                 Group Key: t.i
                 Filter: (f(t.i) > 0)
                 ->  Seq Scan on public.t
                       Output: i
 Optimizer: Postgres query optimizer
(12 rows)
```
# 2. Volatile function in modify subplan targret list
Query on distributed replicated tables may not make broadcast motion. This produces wrong plan. Usually insert query uses subquery. Volatile functions in such subqueries are catched in set_subqueryscan_pathlist which adds gather motion for that. But some subqueries are simplifyed on early planning stages and subquery subtree is substituted into main plan (see is_simple_subquery). In such case we should explicit catch volatile functions before adding ModifyTable node. To ensure rows are explicitly forwarded to all segments we should replace subplan locus (with volatile functions) with SingleQE before request motion append. It is necessary because planner considers pointless to send rows from replicated tables.
Steps to reproduce this problem:
```sql
create table t_replicate_dst(id serial, i integer) distributed replicated;
create table t_replicate_src(i integer) distributed replicated;
insert into t_replicate_src select i from generate_series(1, 5) i;
insert into t_replicate_dst (i) select i from t_replicate_src;
select distinct id from gp_dist_random('t_replicate_dst');
```
Last query returns 15 lines (not 5) on cluster with 3 segments. This happens, because broadcast motion does not made, when volatile function exists.
Wrong plan:
```sql
explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Insert on public.t_replicate_dst
   ->  Seq Scan on public.t_replicate_src
         Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
 Optimizer: Postgres query optimizer
(4 rows)
```
Solution is set `CdbLocusType_SingleQE` in such cases, that later make broadcast motion.
Right plan:
```sql
explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
                                         QUERY PLAN                                          
---------------------------------------------------------------------------------------------
 Insert on public.t_replicate_dst
   ->  Broadcast Motion 1:3  (slice1; segments: 1)
         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
         ->  Seq Scan on public.t_replicate_src
               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
 Optimizer: Postgres query optimizer
(6 rows)
```
# 3. Volatile function in deleting motion flow
Query containing volatile functions on distributed replicated tables may not make broadcast motion. This produces wrong plan.
Steps to reproduce this problem:
```sql
create table t (i int) distributed replicated;
create table t2 (a int, b float) distributed replicated;
```
This happens, because `apply_motion_mutator` delete pre-existing broadcast motion flow. We'll recreate this motion later below. But we should save motion request to create appropriate motion above the child node. Original flow for the child node will be restored after motion creation.
Wrong plan:
```sql
explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
             QUERY PLAN              
-------------------------------------
 Insert on public.t2
   ->  Seq Scan on public.t
         Output: t.i, random()
 Optimizer: Postgres query optimizer
(4 rows)
```
Solution is save such flow, that later make broadcast motion.
Right plan:
```sql
explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
                    QUERY PLAN                     
---------------------------------------------------
 Insert on public.t2
   ->  Broadcast Motion 1:3  (slice1; segments: 1)
         Output: t.i, (random())
         ->  Seq Scan on public.t
               Output: t.i, random()
 Optimizer: Postgres query optimizer
(6 rows)
```
# 4. Volatile function in correlated subplan quals
Query on distributed replicated tables may not make broadcast motion. This produces wrong plan.
Steps to reproduce this problem:
```sql
create table t (i int) distributed replicated;
create table t1 (a int) distributed by (a);
create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
```
This happens, because broadcast motion does not made, when volatile function exists. Planner considers pointless to send rows from replicated tables. But if volatile function exist in quals we need broadcast motion.
Wrong plan:
```sql
explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
                       QUERY PLAN                       
--------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: t1.a
   ->  Seq Scan on public.t1
         Output: t1.a
         Filter: (SubPlan 1)
         SubPlan 1  (slice1; segments: 1)
           ->  Result
                 Output: f(t.i)
                 ->  Result
                       Output: t.i
                       Filter: (t.i = t1.a)
                       ->  Materialize
                             Output: t.i, t.i
                             ->  Seq Scan on public.t
                                   Output: t.i, t.i
                                   Filter: (f(t.i) > 0)
 Optimizer: Postgres query optimizer
(17 rows)
```
Solution is set `CdbLocusType_SingleQE` in such cases, that later make broadcast motion.
Right plan:
```sql
explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
                                 QUERY PLAN                                  
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)
   Output: t1.a
   ->  Seq Scan on public.t1
         Output: t1.a
         Filter: (SubPlan 1)
         SubPlan 1  (slice2; segments: 3)
           ->  Result
                 Output: f(t.i)
                 ->  Result
                       Output: t.i
                       Filter: (t.i = t1.a)
                       ->  Materialize
                             Output: t.i, t.i
                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
                                   Output: t.i, t.i
                                   ->  Seq Scan on public.t
                                         Output: t.i, t.i
                                         Filter: (f(t.i) > 0)
 Optimizer: Postgres query optimizer
(19 rows)
```