### PR TITLE
Fix entrydb process wrong slot resetting on moving

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/input/resgroup/resgroup_move_query.source
@@ -301,6 +301,11 @@ SELECT num_running FROM gp_toolkit.gp_resgroup_status WHERE rsgname='rg_move_que
 2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query_mem_small';
 1<:
 2: SELECT is_session_in_group(pid, 'rg_move_query') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+-- and check we can move it back right in the same transaction
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query';
+1<:
+2: SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
 1: END;
 
 DROP ROLE role_move_query;

--- a/src/test/isolation2/output/resgroup/resgroup_move_query.source
+++ b/src/test/isolation2/output/resgroup/resgroup_move_query.source
@@ -663,6 +663,23 @@ BEGIN
 ---------------------
  t                   
 (1 row)
+-- and check we can move it back right in the same transaction
+1&: SELECT * FROM gp_dist_random('gp_id'), pg_sleep(3) LIMIT 1;  <waiting ...>
+2: SELECT gp_toolkit.pg_resgroup_move_query(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND rsgname='rg_move_query';
+ pg_resgroup_move_query 
+------------------------
+ t                      
+(1 row)
+1<:  <... completed>
+ gpname    | numsegments | dbid | content | pg_sleep 
+-----------+-------------+------+---------+----------
+ Greenplum | -1          | -1   | -1      |          
+(1 row)
+2: SELECT is_session_in_group(pid, 'rg_move_query_mem_small') FROM pg_stat_activity WHERE query LIKE '%pg_sleep%' AND state = 'idle in transaction';
+ is_session_in_group 
+---------------------
+ t                   
+(1 row)
 1: END;
 END
 


### PR DESCRIPTION
Entrydb and main processes may share same resgroup slot or, in other words, they
have same session slot. When moving process to new group, we free old slot only
when last (in our case entrydb) process moved to new group. At the same time we
zeroing current session slot. The `sessionResetSlot()` called from
`UnassignResGroup()` didn't check which slot we zeroing. This caused a bug, when
we was unable to move same session twice (with the error like `ERROR: process
XXX is in IDLE state`). The reason - new session slot set in main process, was
zeroed by entrydb process. From now, we analyze current session slot before
zeroing.