### PR TITLE
2849 - Enable epq for orca

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -961,17 +961,6 @@ ldelete:;
 				{
 					TupleTableSlot *epqslot;
 
-					/*
-					 * TODO: DML node doesn't initialize `epqstate` parameter so
-					 * we exclude EPQ routine for this type of modification and
-					 * act as in RR and upper isolation levels.
-					 */
-					if (!epqstate)
-						ereport(ERROR,
-								(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-								 errmsg("could not serialize access due to concurrent update"),
-								 errhint("Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting")));
-
 					epqslot = EvalPlanQual(estate,
 										   epqstate,
 										   resultRelationDesc,

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -60,6 +60,7 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 {
 	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
 	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	m_used_rte_indexes = GPOS_NEW(m_mp) HMUlIndex(m_mp);
 }
 
 //---------------------------------------------------------------------------
@@ -74,6 +75,7 @@ CContextDXLToPlStmt::~CContextDXLToPlStmt()
 {
 	m_cte_consumer_info->Release();
 	m_num_partition_selectors_array->Release();
+	m_used_rte_indexes->Release();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -28,11 +28,19 @@ CContextQueryToDXL::CContextQueryToDXL(CMemoryPool *mp)
 {
 	// map that stores gpdb att to optimizer col mapping
 	m_colid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);
+	m_queryid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_QUERY_ID_START);
 	m_cte_id_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_CTE_ID_START);
 }
 
 CContextQueryToDXL::~CContextQueryToDXL()
 {
+	GPOS_DELETE(m_queryid_counter);
 	GPOS_DELETE(m_colid_counter);
 	GPOS_DELETE(m_cte_id_counter);
+}
+
+ULONG
+CContextQueryToDXL::GetNextQueryId()
+{
+	return m_queryid_counter->next_id();
 }

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4234,6 +4234,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	plan->lefttree = child_plan;
 	plan->nMotionNodes = child_plan->nMotionNodes;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	dml->epqParam = m_dxl_to_plstmt_context->GetNextParamId();
 
 	if (CMD_INSERT == m_cmd_type && 0 == plan->nMotionNodes)
 	{

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -109,9 +109,9 @@ CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
-								BOOL *is_distributed_table,	// output
-								BOOL *is_replicated_table	// output
-)
+								BOOL *is_distributed_table,	 // output
+								BOOL *is_replicated_table,	 // output
+								ULONG assigned_query_id)
 {
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
@@ -133,8 +133,8 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	CDXLTableDescr *table_descr =
-		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser);
+	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(
+		mp, mdid, table_mdname, rte->checkAsUser, assigned_query_id);
 
 	const ULONG len = rel->ColumnCount();
 

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -91,6 +91,11 @@ private:
 	// if true, it means this descriptor has partial indexes
 	BOOL m_fHasPartialIndexes;
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation
+	ULONG m_assigned_query_id;
+
 	// private copy ctor
 	CTableDescriptor(const CTableDescriptor &);
 
@@ -103,7 +108,7 @@ public:
 					 BOOL convert_hash_to_random,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
-					 ULONG ulExecuteAsUser);
+					 ULONG ulExecuteAsUser, ULONG assigned_query_id);
 
 	// dtor
 	virtual ~CTableDescriptor();
@@ -237,6 +242,12 @@ public:
 	{
 		return m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyCols ||
 			   m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyRows;
+	}
+
+	ULONG
+	GetAssignedQueryId() const
+	{
+		return m_assigned_query_id;
 	}
 
 };	// class CTableDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -37,7 +37,8 @@ FORCE_GENERATE_DBGSTR(CTableDescriptor);
 CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
-	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser)
+	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
+	ULONG assigned_query_id)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),
@@ -51,7 +52,8 @@ CTableDescriptor::CTableDescriptor(
 	  m_pdrgpbsKeys(NULL),
 	  m_num_of_partitions(0),
 	  m_execute_as_user_id(ulExecuteAsUser),
-	  m_fHasPartialIndexes(FDescriptorWithPartialIndexes())
+	  m_fHasPartialIndexes(FDescriptorWithPartialIndexes()),
+	  m_assigned_query_id(assigned_query_id)
 {
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(mdid->IsValid());

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2099,7 +2099,8 @@ CTranslatorDXLToExpr::Ptabdesc(CDXLTableDescr *table_descr)
 	mdid->AddRef();
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
-		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId());
+		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId(),
+		table_descr->GetAssignedQueryId());
 
 	const ULONG ulColumns = table_descr->Arity();
 	for (ULONG ul = 0; ul < ulColumns; ul++)
@@ -2298,8 +2299,8 @@ CTranslatorDXLToExpr::PtabdescFromCTAS(CDXLLogicalCTAS *pdxlopCTAS)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type,
-		0  // TODO:  - Mar 5, 2014; ulExecuteAsUser
-	);
+		0,	// TODO:  - Mar 5, 2014; ulExecuteAsUser
+		UNASSIGNED_QUERYID);
 
 	// populate column information from the dxl table descriptor
 	CDXLColDescrArray *dxl_col_descr_array =

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1365,7 +1365,8 @@ CTranslatorExprToDXL::PdxlnMultiExternalScan(
 			m_mp, extpart_mdid, extpart->Mdname().GetMDName(),
 			extpart->ConvertHashToRandom(), extpart->GetRelDistribution(),
 			extpart->RetrieveRelStorageType(),
-			multi_extscan->Ptabdesc()->GetExecuteAsUserId());
+			multi_extscan->Ptabdesc()->GetExecuteAsUserId(),
+			multi_extscan->Ptabdesc()->GetAssignedQueryId());
 
 		// Each scan shares the same col descriptors as the parent partitioned table
 		// FIXME: Dropped columns break the assumption above. Handle it correctly.
@@ -7569,7 +7570,8 @@ CTranslatorExprToDXL::MakeDXLTableDescr(const CTableDescriptor *ptabdesc,
 	mdid->AddRef();
 
 	CDXLTableDescr *table_descr = GPOS_NEW(m_mp)
-		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId());
+		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
+					   ptabdesc->GetAssignedQueryId());
 
 	const ULONG ulColumns = ptabdesc->ColumnCount();
 	// translate col descriptors

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -20,6 +20,9 @@
 #include "naucrates/md/CMDName.h"
 #include "naucrates/md/IMDId.h"
 
+// default value for m_assigned_query_id - no assigned query for table descriptor
+#define UNASSIGNED_QUERYID 0
+
 namespace gpdxl
 {
 using namespace gpmd;
@@ -50,6 +53,11 @@ private:
 	// id of user the table needs to be accessed with
 	ULONG m_execute_as_user_id;
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation
+	ULONG m_assigned_query_id;
+
 	// private copy ctor
 	CDXLTableDescr(const CDXLTableDescr &);
 
@@ -58,7 +66,8 @@ private:
 public:
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-				   ULONG ulExecuteAsUser);
+				   ULONG ulExecuteAsUser,
+				   ULONG assigned_query_id = UNASSIGNED_QUERYID);
 
 	virtual ~CDXLTableDescr();
 
@@ -84,6 +93,9 @@ public:
 
 	// serialize to dxl format
 	void SerializeToDXL(CXMLSerializer *xml_serializer) const;
+
+	// assigned query id
+	ULONG GetAssignedQueryId() const;
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -462,6 +462,7 @@ enum Edxltoken
 	EdxltokenIsNull,
 	EdxltokenLintValue,
 	EdxltokenDoubleValue,
+	EdxltokenAssignedQueryId,
 
 	EdxltokenRelTemporary,
 	EdxltokenRelHasOids,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1479,7 +1479,12 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 			EdxltokenTableDescr);
 	}
 
-	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id);
+	ULONG assigned_query_id = ExtractConvertAttrValueToUlong(
+		dxl_memory_manager, attrs, EdxltokenAssignedQueryId,
+		EdxltokenTableDescr, true /* is_optional */, UNASSIGNED_QUERYID);
+
+	return GPOS_NEW(mp)
+		CDXLTableDescr(mp, mdid, mdname, user_id, assigned_query_id);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -30,12 +30,13 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-							   ULONG ulExecuteAsUser)
+							   ULONG ulExecuteAsUser, ULONG assigned_query_id)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(NULL),
-	  m_execute_as_user_id(ulExecuteAsUser)
+	  m_execute_as_user_id(ulExecuteAsUser),
+	  m_assigned_query_id(assigned_query_id)
 {
 	GPOS_ASSERT(NULL != m_mdname);
 	m_dxl_column_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
@@ -205,6 +206,13 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 			m_execute_as_user_id);
 	}
 
+	if (UNASSIGNED_QUERYID != m_assigned_query_id)
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenAssignedQueryId),
+			m_assigned_query_id);
+	}
+
 	// serialize columns
 	xml_serializer->OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
@@ -225,6 +233,22 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenTableDescr));
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLTableDescr::GetAssignedQueryId
+//
+//	@doc:
+//		Return id of query, to which TableDescr belongs to
+//		(if it's a target entry)
+//
+//---------------------------------------------------------------------------
+ULONG
+CDXLTableDescr::GetAssignedQueryId() const
+{
+	return m_assigned_query_id;
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -510,6 +510,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenIsNull, GPOS_WSZ_LIT("IsNull")},
 		{EdxltokenLintValue, GPOS_WSZ_LIT("LintValue")},
 		{EdxltokenDoubleValue, GPOS_WSZ_LIT("DoubleValue")},
+		{EdxltokenAssignedQueryId, GPOS_WSZ_LIT("AssignedQueryId")},
 
 		{EdxltokenRelTemporary, GPOS_WSZ_LIT("IsTemporary")},
 		{EdxltokenRelHasOids, GPOS_WSZ_LIT("HasOids")},

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -196,7 +196,8 @@ CTestUtils::PtabdescPlainWithColNameFormat(
 		mp, mdid, nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0  // ulExecuteAsUser
+		0,	// ulExecuteAsUser
+		0	// UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < num_cols; i++)

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -314,7 +314,8 @@ CStatisticsTest::PtabdescTwoColumnSource(CMemoryPool *mp,
 		mp, GPOS_NEW(mp) CMDIdGPDB(GPOPT_TEST_REL_OID1, 1, 1), nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0  // ulExecuteAsUser
+		0,	// ulExecuteAsUser
+		0	// UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < 2; i++)

--- a/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
@@ -251,7 +251,9 @@ public:
 		m_ptabdesc = GPOS_NEW(mp) CTableDescriptor(
 			mp, mdid, CName(&strTableName), convert_hash_to_random,
 			CMDRelationGPDB::EreldistrMasterOnly,
-			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser);
+			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser,
+			0  // UNASSIGNED_QUERYID
+		);
 	}
 
 	void

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1337,6 +1337,7 @@ _copyDML(const DML *from)
 	COPY_SCALAR_FIELD(actionColIdx);
 	COPY_SCALAR_FIELD(ctidColIdx);
 	COPY_SCALAR_FIELD(tupleoidColIdx);
+	COPY_SCALAR_FIELD(epqParam);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1215,6 +1215,7 @@ _outDML(StringInfo str, const DML *node)
 	WRITE_INT_FIELD(actionColIdx);
 	WRITE_INT_FIELD(ctidColIdx);
 	WRITE_INT_FIELD(tupleoidColIdx);
+	WRITE_INT_FIELD(epqParam);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2237,6 +2237,7 @@ _readDML(void)
 	READ_INT_FIELD(actionColIdx);
 	READ_INT_FIELD(ctidColIdx);
 	READ_INT_FIELD(tupleoidColIdx);
+	READ_INT_FIELD(epqParam);
 
 	readPlanInfo((Plan *)local_node);
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -90,6 +90,11 @@ private:
 					 CleanupDelete<SCTEConsumerInfo> >
 		HMUlCTEConsumerInfo;
 
+	typedef CHashMap<ULONG, Index, gpos::HashValue<ULONG>,
+					gpos::Equals<ULONG>, CleanupDelete<ULONG>,
+					CleanupDelete<Index> >
+		HMUlIndex;
+
 	CMemoryPool *m_mp;
 
 	// counter for generating plan ids
@@ -127,6 +132,9 @@ private:
 
 	// CTAS distribution policy
 	GpPolicy *m_distribution_policy;
+
+	// hash map of the queryid (of DML query) and the target relation index
+	HMUlIndex *m_used_rte_indexes;
 
 public:
 	// ctor/dtor
@@ -215,6 +223,12 @@ public:
 	// based on decision made by DetermineDistributionHashOpclasses()
 	Oid GetDistributionHashOpclassForType(Oid typid);
 	Oid GetDistributionHashFuncForType(Oid typid);
+
+	HMUlIndex *
+	GetUsedRelationIndexesMap() const
+	{
+		return m_used_rte_indexes;
+	}
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -22,6 +22,7 @@
 
 #define GPDXL_CTE_ID_START 1
 #define GPDXL_COL_ID_START 1
+#define GPDXL_QUERY_ID_START 1
 
 namespace gpdxl
 {
@@ -53,6 +54,9 @@ private:
 	// counter for generating unique CTE ids
 	CIdGenerator *m_cte_id_counter;
 
+	// counter for upper-level query and its subqueries
+	CIdGenerator *m_queryid_counter;
+
 	// does the query have any distributed tables?
 	BOOL m_has_distributed_tables;
 
@@ -71,6 +75,8 @@ public:
 
 	// dtor
 	~CContextQueryToDXL();
+
+	ULONG GetNextQueryId();
 };
 }  // namespace gpdxl
 #endif	// GPDXL_CContextQueryToDXL_H

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -196,6 +196,11 @@ private:
 	// Set InitPlanVariable in PlannedStmt
 	void SetInitPlanVariables(PlannedStmt *);
 
+	Index ProcessTableDescr(
+		const gpdxl::CDXLTableDescr *dxl_table_descr, RangeTblEntry **rte,
+		gpdxl::CDXLTranslateContextBaseTable *base_table_context,
+		AclMode acl_mode = ACL_SELECT);
+
 	// translate DXL table scan node into a SeqScan node
 	Plan *TranslateDXLTblScan(
 		const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -138,6 +138,10 @@ private:
 	// CTE producer IDs defined at the current query level
 	UlongBoolHashMap *m_cteid_at_current_query_level_map;
 
+	// id of current query (and for nested queries), it's used for correct assigning
+	// of relation links to target relation of DML query
+	ULONG m_query_id;
+
 	//ctor
 	// private constructor, called from the public factory function QueryToDXLInstance
 	CTranslatorQueryToDXL(
@@ -427,6 +431,8 @@ private:
 
 	// true iff this query or one of its ancestors is a DML query
 	BOOL IsDMLQuery();
+
+	CDXLTableDescr *GetTableDescr(const RangeTblEntry *rte, ULONG rt_index);
 
 public:
 	// dtor

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -147,7 +147,8 @@ public:
 										 CIdGenerator *id_generator,
 										 const RangeTblEntry *rte,
 										 BOOL *is_distributed_table = NULL,
-										 BOOL *is_replicated_table = NULL);
+										 BOOL *is_replicated_table = NULL,
+										 ULONG assigned_query_id = UNASSIGNED_QUERYID);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF
 	static CDXLLogicalTVF *ConvertToCDXLLogicalTVF(CMemoryPool *mp,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2829,6 +2829,7 @@ typedef struct DMLState
 	JunkFilter *junkfilter;			/* filter that removes junk and dropped attributes */
 	TupleTableSlot *cleanedUpSlot;	/* holds 'final' tuple which matches the target relation schema */
 	AttrNumber	segid_attno;		/* attribute number of "gp_segment_id" */
+	EPQState dml_epqstate;
 } DMLState;
 
 /*

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1328,7 +1328,7 @@ typedef struct DML
 	AttrNumber	actionColIdx;	/* index of action column into the target list */
 	AttrNumber	ctidColIdx;		/* index of ctid column into the target list */
 	AttrNumber	tupleoidColIdx;	/* index of tuple oid column into the target list */
-
+	int			epqParam;		/* ID of Param for EvalPlanQual re-eval */
 } DML;
 
 /*

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -251,10 +251,7 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
--- Currently the DML node (modification variant in ORCA) doesn't support EPQ
--- routine so concurrent modification is not possible in this case. User have
--- to be informed to fallback to postgres optimizer.
--- This test makes sense just for ORCA
+-- check that orca concurrent delete transaction won't delete tuple, updated in other transaction (which doesn't match predicate anymore)
 create table test as select 0 as i distributed randomly;
 CREATE 1
 -- in session 1, turn off the optimizer so it will invoke heap_update
@@ -267,12 +264,32 @@ UPDATE 1
 -- in session 2, in case of ORCA DML invokes EPQ
 -- the following SQL will hang due to XID lock
 2&: delete from test where i = 0;  <waiting ...>
--- commit session1's transaction so the above session2 will continue and emit
--- error about serialization failure in case of ORCA
 1: end;
 END
 2<:  <... completed>
 DELETE 0
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- check that orca concurrent delete transaction will delete tuple, updated in other transaction (which still matches predicate)
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+DELETE 1
 drop table test;
 DROP
 1q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -251,10 +251,7 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
--- Currently the DML node (modification variant in ORCA) doesn't support EPQ
--- routine so concurrent modification is not possible in this case. User have
--- to be informed to fallback to postgres optimizer.
--- This test makes sense just for ORCA
+-- check that orca concurrent delete transaction won't delete tuple, updated in other transaction (which doesn't match predicate anymore)
 create table test as select 0 as i distributed randomly;
 CREATE 1
 -- in session 1, turn off the optimizer so it will invoke heap_update
@@ -267,13 +264,32 @@ UPDATE 1
 -- in session 2, in case of ORCA DML invokes EPQ
 -- the following SQL will hang due to XID lock
 2&: delete from test where i = 0;  <waiting ...>
--- commit session1's transaction so the above session2 will continue and emit
--- error about serialization failure in case of ORCA
 1: end;
 END
 2<:  <... completed>
-ERROR:  could not serialize access due to concurrent update
-HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting
+DELETE 0
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- check that orca concurrent delete transaction will delete tuple, updated in other transaction (which still matches predicate)
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+DELETE 1
 drop table test;
 DROP
 1q: ... <quitting>

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -200,7 +200,7 @@ explain (costs off) update tab1 set b = b + 1;
  Update                                                     
    ->  Result                                               
          ->  Redistribute Motion 3:3  (slice1; segments: 3) 
-               Hash Key: tab1.b                             
+               Hash Key: b                                  
                ->  Split                                    
                      ->  Result                             
                            ->  Seq Scan on tab1             

--- a/src/test/isolation2/output/uao/parallel_delete_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_delete_optimizer.source
@@ -19,15 +19,13 @@ DELETE 1
  coalesce | mode                | locktype                 | node   
 ----------+---------------------+--------------------------+--------
  ao       | AccessExclusiveLock | append-only segment file | master 
- ao       | AccessShareLock     | relation                 | master 
  ao       | ExclusiveLock       | relation                 | master 
-(3 rows)
+(2 rows)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
  coalesce | mode             | locktype | node       
 ----------+------------------+----------+------------
- ao       | AccessShareLock  | relation | n segments 
  ao       | RowExclusiveLock | relation | n segments 
-(2 rows)
+(1 row)
 -- The case here should delete a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: DELETE FROM ao WHERE a = 3;  <waiting ...>

--- a/src/test/isolation2/output/uao/parallel_update_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_update_optimizer.source
@@ -19,16 +19,14 @@ UPDATE 1
  coalesce | mode                | locktype                 | node   
 ----------+---------------------+--------------------------+--------
  ao       | AccessExclusiveLock | append-only segment file | master 
- ao       | AccessShareLock     | relation                 | master 
  ao       | ExclusiveLock       | relation                 | master 
-(3 rows)
+(2 rows)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
  coalesce | mode                | locktype                 | node       
 ----------+---------------------+--------------------------+------------
  ao       | AccessExclusiveLock | append-only segment file | 1 segment  
- ao       | AccessShareLock     | relation                 | n segments 
  ao       | RowExclusiveLock    | relation                 | n segments 
-(3 rows)
+(2 rows)
 -- The case here should update a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: UPDATE ao SET b = 42 WHERE a = 3;  <waiting ...>

--- a/src/test/regress/expected/ao_locks_optimizer.out
+++ b/src/test/regress/expected/ao_locks_optimizer.out
@@ -78,9 +78,8 @@ SELECT * FROM locktest_master where coalesce = 'ao_locks_table' or
     coalesce    |        mode         |         locktype         |  node  
 ----------------+---------------------+--------------------------+--------
  ao_locks_table | AccessExclusiveLock | append-only segment file | master
- ao_locks_table | AccessShareLock     | relation                 | master
  ao_locks_table | ExclusiveLock       | relation                 | master
-(3 rows)
+(2 rows)
 
 SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
@@ -88,9 +87,8 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
 -----------------+------------------+----------+------------
  aovisimap index | RowExclusiveLock | relation | 1 segment
  ao_locks_table  | RowExclusiveLock | relation | n segments
- ao_locks_table  | AccessShareLock  | relation | n segments
  aovisimap table | RowExclusiveLock | relation | 1 segment
-(4 rows)
+(3 rows)
 
 COMMIT;
 BEGIN;
@@ -100,19 +98,17 @@ SELECT * FROM locktest_master where coalesce = 'ao_locks_table' or
     coalesce    |        mode         |         locktype         |  node  
 ----------------+---------------------+--------------------------+--------
  ao_locks_table | AccessExclusiveLock | append-only segment file | master
- ao_locks_table | AccessShareLock     | relation                 | master
  ao_locks_table | ExclusiveLock       | relation                 | master
-(3 rows)
+(2 rows)
 
 SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |        mode         |         locktype         |    node    
 -----------------+---------------------+--------------------------+------------
- ao_locks_table  | AccessShareLock     | relation                 | n segments
  aovisimap table | RowExclusiveLock    | relation                 | 1 segment
  ao_locks_table  | AccessExclusiveLock | append-only segment file | 1 segment
  aovisimap index | RowExclusiveLock    | relation                 | 1 segment
  ao_locks_table  | RowExclusiveLock    | relation                 | n segments
-(5 rows)
+(4 rows)
 
 COMMIT;

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -671,11 +671,11 @@ explain delete from foo using (select a from foo union all select b from bar) v;
    ->  Result  (cost=0.00..1765380.23 rows=67 width=18)
          ->  Nested Loop  (cost=0.00..1765380.23 rows=67 width=14)
                Join Filter: true
-               ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=14)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=14)
                ->  Materialize  (cost=0.00..862.00 rows=20 width=1)
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=20 width=1)
                            ->  Append  (cost=0.00..862.00 rows=7 width=1)
-                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=1)
+                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=1)
                                  ->  Seq Scan on bar  (cost=0.00..431.00 rows=4 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -498,6 +498,8 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_9_i_idx | RowExclusiveLock | relation | master
 (19 rows)
 
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
 -------------------+------------------+----------+-----------

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -471,13 +471,14 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_9 | ExclusiveLock | relation | master
 (10 rows)
 
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |    node    
--------------------------+------------------+----------+------------
- partlockt               | RowExclusiveLock | relation | n segments
- partlockt_1_prt_4       | AccessShareLock  | relation | n segments
- partlockt_1_prt_4_i_idx | AccessShareLock  | relation | n segments
-(3 rows)
+     coalesce      |       mode       | locktype |    node    
+-------------------+------------------+----------+------------
+ partlockt         | RowExclusiveLock | relation | n segments
+ partlockt_1_prt_4 | AccessShareLock  | relation | n segments
+(2 rows)
 
 commit;
 -- drop index

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -369,7 +369,7 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
          ->  Sort
                Sort Key: (DMLAction)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: base_tbl.a
+                     Hash Key: a
                      ->  Split
                            ->  Result
                                  ->  Index Scan using base_tbl_pkey on base_tbl
@@ -449,7 +449,7 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
          ->  Sort
                Sort Key: (DMLAction)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: base_tbl.a
+                     Hash Key: a
                      ->  Split
                            ->  Result
                                  ->  Index Scan using base_tbl_pkey on base_tbl
@@ -2079,7 +2079,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
                ->  Result
                      ->  Nested Loop Semi Join
                            Join Filter: true
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           ->  Index Scan using base_tbl_pkey on base_tbl
                                  Index Cond: (id = 2)
                            ->  Materialize
                                  ->  Broadcast Motion 1:3  (slice2; segments: 1)
@@ -2087,7 +2087,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
                                              ->  Result
                                                    ->  Limit
                                                          ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                               ->  Index Scan using base_tbl_pkey on base_tbl
+                                                               ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                                                                      Index Cond: (id = 2)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.11.0
 (38 rows)

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -341,7 +341,7 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
  Update
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: tab3.c1, tab3.c2, tab3.c3
+               Hash Key: c1, c2, c3
                ->  Split
                      ->  Result
                            ->  Seq Scan on tab3

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -148,6 +148,8 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 


### PR DESCRIPTION
# Problem description

Currently, `ExecDML()` [passes](https://github.com/greenplum-db/gpdb/blob/2d4a9cd4d030277505bad2983ea0aff71fe0873a/src/backend/executor/nodeDML.c#L148) `NULL` value to parameter `epqstate` in `ExecDelete()` call marking it as `DestReceiver`. As a consequence, the EPQ functionality is not possible for heap tables in case when `DML` node (instead of postgres-specific `ModifyTable`) is planned.
The `DestReceiver` name [was used](https://github.com/greenplum-db/gpdb/blob/5X_STABLE/src/include/executor/execDML.h#L41) in interface of `ExecDelete()` in gpdb-5x releases therefore we might conclude that preparing gpdb 6 the EPQ feature was not appropriately ported.

For testing we might use the following case (work when global deadlock detector is enabled):
```sql
-- Create table with one row
create table test as select 1 as i distributed randomly;

-- Start update transaction
1: begin;
1: set optimizer to off;
1: update test set i = i where i = 1;

-- Second session starts deletion of target row
-- it waits for result of update
2&: delete from test where i = 1;

-- Commit the first transaction;
-- Deletion is performed on second version of row
-- As this version is checked on predicate `i = 1` using EPQ routine we end up with:
-- ```ERROR:  could not serialize access due to concurrent update
-- HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting```
-- Correct behavior have to successfully remove the row
1: commit;
```

This patch adds support of `EPQ` mechanism for the `orca` planner for `DML` operations: the `DML` and `DMLState` objects were extended with `epqParam` and `epqstate` fields respectively. Also there was added the fix to `orca` that makes target relation of `DML` operation and main scanning relation to refer to the same `RTE`. The last problem reveals in the following scenario

```sql
create table test as select 0 as i distributed randomly;

-- Start update transaction
1: begin;
1: set optimizer = off;
1: update test set i = i + 1;

-- Second session tries to delete modified row and
-- it waits for result of update
2&: delete from test where i = 0;
1: end;
-- as a result updated row was deleted - this is
-- not vaild behaviour (there must be no deletion)
DELETE 1
```

Here is a plan of `delete` query, there is a problem: `DML` and `SEQSCAN` node has different `scanrelid` (1 and 2 respectively), but they should point to the same RTE (like at pg planner).
```
{PLANNEDSTMT 
    ...
   :planTree 
      {DML 
      :scanrelid 1 
      ...
      :lefttree 
         {RESULT 
         :plan_node_id 1 
         ...
         :lefttree 
            {SEQSCAN 
            :plan_node_id 2
            ... 
            :scanrelid 2
            }
        ...
         }
      ...
      }
   :rtable (
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :rtekind 0 
      :relid 16387 
      :requiredPerms 8 
      ...
      }
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :rtekind 0 
      :relid 16387 
      :requiredPerms 2 
      ...
      }
   )
   :resultRelations (i 1)
   :relationOids (o 16387 16387 16387)
   ...
   }
```

EPQ mechanism through function call chain calls `ExecScanFetch`.
Due to incorrect `scanrelid` at `SEQSCAN` node next branch  ```if (estate->es_epqTupleSet[scanrelid - 1])``` won't be executed. Thus instead of working with slot from `es_epqTuple` cache - slot with an old row is returned from access method routine - `(*accessMtd) (node)` (which uses snapshot for delete operation). As a result `EvalPlanQual` returns not null slot with an old version of row to `ExecDelete`, but [tupleid points to the updated version and deletion is performed](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/executor/nodeModifyTable.c#L982-L986)
```c
static inline TupleTableSlot *
ExecScanFetch(ScanState *node,
			  ExecScanAccessMtd accessMtd,
			  ExecScanRecheckMtd recheckMtd)
{
	EState	   *estate = node->ps.state;
	if (estate->es_epqTuple != NULL)
	{
		//...
		Index		scanrelid = ((Scan *) node->ps.plan)->scanrelid;
		//...
		if (estate->es_epqTupleSet[scanrelid - 1])
		{
			TupleTableSlot *slot = node->ss_ScanTupleSlot;

			/* Return empty slot if we already returned a tuple */
			if (estate->es_epqScanDone[scanrelid - 1])
				return ExecClearTuple(slot);
			//...
			/* Store test tuple in the plan node's scan slot */
			ExecStoreHeapTuple(estate->es_epqTuple[scanrelid - 1],
						   slot, InvalidBuffer, false);
			//...
			return slot;
		}
	}

	/*
	 * Run the node-type-specific access method function to get the next tuple
	 */
	return (*accessMtd) (node);
}
```

At the initial Query structure (parsed and analyzed query) we have right links to `RTE`'s, so to fix the problem with `scanrelid` - we want to transfer this information to the initial algebrized plan tree of orca. So we assign the `queryid` to each query structure (for subqueruies `queryid` assigned too) and, also, we assign `queryid` to table descriptors `CDXLTableDescr` which explicitly refers to target relation of dml. After orca planning transformations this value exposes to which target relation of `DML` operation is referred the current table descriptor. And this allows to correctly assign `RTE` indexes in result plan under transformation from `DXL` representation.

## Forced changes

There are three groups of tests which was fixed after patch changes

### Tests on locks (with one relation)
- src/test/regress/expected/ao_locks_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/ao_locks_optimizer.out#L75), [2](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/ao_locks_optimizer.out#L95))
- src/test/isolation2/output/uao/parallel_delete_optimizer.source ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/isolation2/output/uao/parallel_delete_optimizer.source#L16))
- src/test/isolation2/output/uao/parallel_update_optimizer.source )([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/isolation2/output/uao/parallel_update_optimizer.source#L16))

At these tests DML operation is performed on the one table. Due to fixes of this patch, DML operations at these tests has only one (single) RTE - target relation, unlike it was before (scanrelid of DML and `*SCAN` plan nodes were different and plan contained two rtables, but there should be only one). So call [`ExecOpenScanRelation`](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/executor/execUtils.c#L890) (on target relation) now doesn't set excess `AccessShareLock`, and relations still have more privileged `Exclusive` lock.

### Tests with explain (with one relation)

- src/test/regress/expected/updatable_views_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/updatable_views_optimizer.out#L364), [2](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/updatable_views_optimizer.out#L444))
- src/test/regress/expected/update_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/update_optimizer.out#L338))
- src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out#L197))

Like at previous test group, `DML` operations at these tests performed on the one table - target relation, so now plan has correct `scanrelid` at `DML` and `*SCAN` nodes, and only one `RTE` contains at `rtable` list. Prefixes to column names at queries, that uses one table is not shown, like it is in postgres. Here is some links to code, related to showing prefix ([setting flag to show prefix](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/commands/explain_gp.c#L2356), and function get_variable, where prefix [may be appended](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/utils/adt/ruleutils.c#L6176)).

### Tests on partition locking

- src/test/regress/expected/partition_locking_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/d5c027744df9313b176570ab0b429bec649cc0c9/src/test/regress/expected/partition_locking_optimizer.out#L455))

Like at previous test group, `DML` operations at this test performed on the one table - target relation. Thus index_open [opens](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/executor/nodeIndexscan.c#L556-L565) index with `NoLock`. 
 

### Tests with explain (used more than one relation)

- src/test/regress/expected/bfv_dml_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/bfv_dml_optimizer.out#L667))
- src/test/regress/expected/updatable_views_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/66708a74bd73c74f84865c5618231a111bafe9ef/src/test/regress/expected/updatable_views_optimizer.out#L2052))

This test group was changed due to fixes of `scanrelid` too. `scanrelid` for DML and associated to it `*SCAN` node points to the same rte (and rtable list doesn't contain duplicate of dml target relation). Thus `ExplainPrintPlan` now [calculates](https://github.com/greenplum-db/gpdb/blob/6X_STABLE/src/backend/commands/explain.c#L743) list of relation names for `explain` a bit different (in comparsion to what was before) (calcultion is based on `rels_used` bitmap - now it calculates correctly - there is no unused relation in a plan), so position of table names with suffixes changed due to fixes of `scanrelid`'s. 


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
