### PR TITLE
fix unpredictable behavior during AO index vacuum

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -125,7 +125,7 @@ static void vac_truncate_clog(TransactionId frozenXID,
 							  MultiXactId lastSaneMinMulti);
 static bool vacuum_rel(Relation onerel, Oid relid, VacuumStmt *vacstmt, LOCKMODE lmode,
 		   bool for_wraparound);
-static void scan_index(Relation indrel, bool check_stats, int elevel);
+static void scan_index(Relation indrel, double num_tuples, bool check_stats, int elevel);
 static bool appendonly_tid_reaped(ItemPointer itemptr, void *state);
 static void dispatchVacuum(VacuumStmt *vacstmt, VacuumStatsContext *ctx);
 static void vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
@@ -2645,7 +2645,10 @@ vacuum_appendonly_indexes(Relation aoRelation, VacuumStmt *vacstmt, Bitmapset *d
 		{
 			for (i = 0; i < nindexes; i++)
 			{
-				scan_index(Irel[i], true, elevel);
+				scan_index(Irel[i],
+						   aoRelation->rd_rel->reltuples,
+						   true,
+						   elevel);
 			}
 		}
 		else
@@ -2653,7 +2656,7 @@ vacuum_appendonly_indexes(Relation aoRelation, VacuumStmt *vacstmt, Bitmapset *d
 			for (i = 0; i < nindexes; i++)
 			{
 				vacuum_appendonly_index(Irel[i],
-										Irel[i]->rd_rel->reltuples,
+										aoRelation->rd_rel->reltuples,
 										dead_segs,
 										elevel);
 			}
@@ -2692,13 +2695,13 @@ vac_is_partial_index(Relation indrel)
  * We use this when we have no deletions to do.
  * 
  * We used to pass an argument num_tuples with value of table->reltuples to
- * ivinfo.num_heap_tuples, now with the new VACUUM strategy, we removed it
- * since we cannot get table->reltuples in the calling context.
- * Therefore, ivinfo.num_heap_tuples is not an accurate value, so we need
- * to set estimated_count to true.
+ * ivinfo.num_heap_tuples, now with the new VACUUM strategy,  we cannot get
+ * exact table->reltuples in the calling context. We able to use existing
+ * value from pg_class for table. Therefore, ivinfo.num_heap_tuples is not an
+ * accurate value, so we need to set estimated_count to true.
  */
 static void
-scan_index(Relation indrel, bool check_stats, int elevel)
+scan_index(Relation indrel, double num_tuples, bool check_stats, int elevel)
 {
 	IndexBulkDeleteResult *stats;
 	IndexVacuumInfo ivinfo;
@@ -2710,7 +2713,7 @@ scan_index(Relation indrel, bool check_stats, int elevel)
 	ivinfo.analyze_only = false;
 	ivinfo.estimated_count = true;
 	ivinfo.message_level = elevel;
-	ivinfo.num_heap_tuples = indrel->rd_rel->reltuples; /* inaccurate */
+	ivinfo.num_heap_tuples = num_tuples;
 	ivinfo.strategy = vac_strategy;
 
 	stats = index_vacuum_cleanup(&ivinfo, NULL);
@@ -2771,6 +2774,12 @@ scan_index(Relation indrel, bool check_stats, int elevel)
  * This is called after an append-only segment file compaction to move
  * all tuples from the compacted segment files.
  * The segmentFileList is an
+ *
+ * We used to pass an argument rel_tuple_count with value of table->reltuples to
+ * ivinfo.num_heap_tuples, now with the new VACUUM strategy,  we cannot get
+ * exact table->reltuples in the calling context. We able to use existing
+ * value from pg_class for table. Therefore, ivinfo.num_heap_tuples is not an
+ * accurate value, so we need to set estimated_count to true.
  */
 static void
 vacuum_appendonly_index(Relation indexRelation,
@@ -2779,7 +2788,7 @@ vacuum_appendonly_index(Relation indexRelation,
 						int elevel)
 {
 	IndexBulkDeleteResult *stats;
-	IndexVacuumInfo ivinfo;
+	IndexVacuumInfo ivinfo = {0};
 	PGRUsage	ru0;
 
 	Assert(RelationIsValid(indexRelation));
@@ -2787,6 +2796,8 @@ vacuum_appendonly_index(Relation indexRelation,
 	pg_rusage_init(&ru0);
 
 	ivinfo.index = indexRelation;
+	ivinfo.analyze_only = false;
+	ivinfo.estimated_count = true;
 	ivinfo.message_level = elevel;
 	ivinfo.num_heap_tuples = rel_tuple_count;
 	ivinfo.strategy = vac_strategy;


### PR DESCRIPTION
Before this patch, IndexVacuumInfo structure didn't have initial value in the vacuum_appendonly_index and as result its unfilled members contained memory garbage. E.g. estimated_count and analyzed_only. This problem could affect index_vacuum_cleanup (e.g. btvacuumcleanup for btree indexes). This function refuses to do something (including index fsm cleanup) in case of analyzed_only contained non-zero value.

The problem manifested itself after c7d99d911fd2f813ca1661155aa973a3366ac165, that rework vacuum for AO indexes. As a part of this patch, it was decided to not recalculate alive tuple counts during each vacuum compaction-drop iteration to improve performance. (The final recalculation to update pg_class statistic entries is proceeded during the vacuum cleanup phase after removing dead segments). As a result, it was suggested as a workaround to use an old index reltuples value as num_heap_tuples. It was quite strange decision, because this value is used as is as an index tuple count for several kinds of indexes (bitmap, gin). So, these indexes always will have initial reltuples count. So, I suggest changing this estimation to *relation* tuples count extracted from pg_class before vacuum (really?). This value is updated by ANALYZE unlike reltuples pg_class value for indexes.

Moreover, the new AO index vacuum strategy uses similar approach with an old index/relation tuples count not only for scan_index but for vacuum_appendonly_index too. gpdb allows notifying index access method functions about provided table tuple count is not exact by an estimated_count flag in the IndexVacuumInfo structure. Index access methods won't try to limit index tuple count calculated during index scan by using such table value (see *indexcleanup functions for btree, spgist).