### PR TITLE
Partially revert "Refactor stack unwind in GPDB"

### DIFF
--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -99,11 +99,11 @@ SERVER_PLATFORMS=rhel7_x86_64 rhel6_x86_64 rhel8_x86_64 linux_x86_64 photon3_x86
 # Compiler options
 #---------------------------------------------------------------------
 
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -g)"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
 
 ifeq (on, ${GPDBGOPT})
-CFLAGS_OPT=-O1
+CFLAGS_OPT=-O1 -fno-omit-frame-pointer
 else
 CFLAGS_OPT=-O0
 endif

--- a/src/backend/gporca/CMakeLists.txt
+++ b/src/backend/gporca/CMakeLists.txt
@@ -58,6 +58,14 @@ if (COMPILER_HAS_G3)
   SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g3")
 endif()
 
+# Do not omit frame pointer. Even with RELEASE builds, it is used for
+# backtracing.
+check_cxx_compiler_flag("-fno-omit-frame-pointer"
+                        COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
+if (COMPILER_HAS_FNO_OMIT_FRAME_POINTER)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+endif()
+
 # Turn on GPOS_DEBUG define for DEBUG builds.
 cmake_policy(SET CMP0043 NEW)
 

--- a/src/backend/gporca/gporca.mk
+++ b/src/backend/gporca/gporca.mk
@@ -2,5 +2,7 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPF
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros $(CPPFLAGS)
+# Do not omit frame pointer. Even with RELEASE builds, it is used for
+# backtracing.
+override CPPFLAGS := -Werror -Wextra -Wpedantic -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
 override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -13,7 +13,7 @@ override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPP
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 # FIXME: Would be better to include gporca.mk, but hitting a warning
-override CPPFLAGS := -Wno-variadic-macros $(CPPFLAGS)
+override CPPFLAGS := -Wno-variadic-macros -fno-omit-frame-pointer $(CPPFLAGS)
 override CPPFLAGS := -std=gnu++98 $(CPPFLAGS)
 
 OBJS        = CAutoTimer.o \


### PR DESCRIPTION
Partially revert 2e120d9d52 to get back release builds with
 `--no-omit-frame-pointers` to make it possible to use
profiling utilities. These utilities ignore stripped debug
info (e.g. perf) or ignore debug info at all (e.g. bcc-tools)
