### PR TITLE
Fix statistic counters for parent memory contexts when some child one attaches/detaches

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -1107,8 +1107,6 @@ AllocSetDelete(MemoryContext context)
 	while (block != NULL)
 	{
 		AllocBlock	next = block->next;
-		size_t freesz = UserPtr_GetUserPtrSize(block);
-        MemoryContextNoteFree(&set->header, freesz);
 
 #ifdef CLOBBER_FREED_MEMORY
 		wipe_mem(block, block->freeptr - ((char *) block));
@@ -1117,6 +1115,7 @@ AllocSetDelete(MemoryContext context)
 		block = next;
 	}
 
+	MemoryContextNoteFree(&set->header, context->allBytesAlloc - context->allBytesFreed);
 	set->sharedHeaderList = NULL;
 	set->nullAccountHeader = NULL;
 }

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -332,6 +332,8 @@ MemoryContextSetParent(MemoryContext context, MemoryContext new_parent)
 				}
 			}
 		}
+
+		MemoryContextNoteFree(context->parent, context->allBytesAlloc - context->allBytesFreed);
 	}
 
 	/* And relink */
@@ -341,6 +343,7 @@ MemoryContextSetParent(MemoryContext context, MemoryContext new_parent)
 		context->parent = new_parent;
 		context->nextchild = new_parent->firstchild;
 		new_parent->firstchild = context;
+		MemoryContextNoteAlloc(new_parent, context->allBytesAlloc - context->allBytesFreed);
 	}
 	else
 	{


### PR DESCRIPTION
Counters of memory contexts became incorrect when we deleted child memory context from it. At first pointer to parent memory context was reset, at second all allocated memory was freed and counters were updated. Because of reseted pointer to parent memory context, counters of parent memory context and their parents are not updated.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
