### PR TITLE
ADBDEV-3098-2: ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -5103,6 +5103,14 @@ FillSliceTable_walker(Node *node, void *context)
 				FillSliceGangInfo(sendSlice, getgpsegmentCount());
 		}
 
+		if (stmt->planGen == PLANGEN_OPTIMIZER &&
+			recvSlice->gangType == GANGTYPE_SINGLETON_READER &&
+			motion->motionType == MOTIONTYPE_HASH)
+		{
+			recvSlice->gangType = GANGTYPE_PRIMARY_READER;
+			FillSliceGangInfo(recvSlice, getgpsegmentCount());
+		}
+
 		MemoryContextSwitchTo(oldcxt);
 
 		/* recurse into children */

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1565,6 +1565,50 @@ drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
+CREATE TABLE a (a bigint, b bigint) DISTRIBUTED BY (a);
+CREATE TABLE b (a bigint, b bigint, c bigint, d bigint) DISTRIBUTED BY (a) PARTITION BY LIST(b) (PARTITION a VALUES(0));
+CREATE TABLE c (a bigint, b bigserial, c varchar(255)) DISTRIBUTED REPLICATED;
+EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
+WITH d AS (
+    SELECT b FROM a GROUP BY b
+), e AS (
+    SELECT b.d FROM b JOIN d f ON f.b = b.c JOIN d g ON g.b = b.c
+) SELECT * FROM e JOIN c ON c.a = e.d;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (b_1_prt_a.d = c.a)
+         ->  Hash Join
+               Hash Cond: (b_1_prt_a.c = a.b)
+               ->  Append
+                     ->  Seq Scan on b_1_prt_a
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (a.b = a_1.b)
+                                 ->  HashAggregate
+                                       Group Key: a.b
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                             Hash Key: a.b
+                                             ->  HashAggregate
+                                                   Group Key: a.b
+                                                   ->  Seq Scan on a
+                                 ->  Hash
+                                       ->  HashAggregate
+                                             Group Key: a_1.b
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                   Hash Key: a_1.b
+                                                   ->  HashAggregate
+                                                         Group Key: a_1.b
+                                                         ->  Seq Scan on a a_1
+         ->  Hash
+               ->  Seq Scan on c
+GP_IGNORE:(29 rows)
+
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+DROP TABLE IF EXISTS c;
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1551,6 +1551,54 @@ drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
+CREATE TABLE a (a bigint, b bigint) DISTRIBUTED BY (a);
+CREATE TABLE b (a bigint, b bigint, c bigint, d bigint) DISTRIBUTED BY (a) PARTITION BY LIST(b) (PARTITION a VALUES(0));
+NOTICE:  CREATE TABLE will create partition "b_1_prt_a" for table "b"
+CREATE TABLE c (a bigint, b bigserial, c varchar(255)) DISTRIBUTED REPLICATED;
+EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
+WITH d AS (
+    SELECT b FROM a GROUP BY b
+), e AS (
+    SELECT b.d FROM b JOIN d f ON f.b = b.c JOIN d g ON g.b = b.c
+) SELECT * FROM e JOIN c ON c.a = e.d;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 4:0)
+               ->  Materialize
+                     ->  GroupAggregate
+                           Group Key: a.b
+                           ->  Sort
+                                 Sort Key: a.b
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: a.b
+                                       ->  Seq Scan on a
+         ->  Hash Join
+               Hash Cond: (c.a = b.d)
+               ->  Seq Scan on c
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (share0_ref3.b = b.c)
+                                 ->  Shared Scan (share slice:id 2:0)
+                                 ->  Hash
+                                       ->  Hash Join
+                                             Hash Cond: (b.c = share0_ref2.b)
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                   Hash Key: b.c
+                                                   ->  Sequence
+                                                         ->  Partition Selector for b (dynamic scan id: 1)
+                                                               Partitions selected: 1 (out of 1)
+                                                         ->  Dynamic Seq Scan on b (dynamic scan id: 1)
+                                             ->  Hash
+                                                   ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(31 rows)
+
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+DROP TABLE IF EXISTS c;
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -575,6 +575,19 @@ drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
 
+CREATE TABLE a (a bigint, b bigint) DISTRIBUTED BY (a);
+CREATE TABLE b (a bigint, b bigint, c bigint, d bigint) DISTRIBUTED BY (a) PARTITION BY LIST(b) (PARTITION a VALUES(0));
+CREATE TABLE c (a bigint, b bigserial, c varchar(255)) DISTRIBUTED REPLICATED;
+EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
+WITH d AS (
+    SELECT b FROM a GROUP BY b
+), e AS (
+    SELECT b.d FROM b JOIN d f ON f.b = b.c JOIN d g ON g.b = b.c
+) SELECT * FROM e JOIN c ON c.a = e.d;
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+DROP TABLE IF EXISTS c;
+
 -- start_ignore
 drop schema rpt cascade;
 -- end_ignore


### PR DESCRIPTION
With some conditions ORCA generates `Redistribute Motion` from all segments to one segment which can not executed because inconsistency CTE producers and consumers.
For example, create tables
```sql
CREATE TABLE a (a bigint, b bigint) DISTRIBUTED BY (a);
CREATE TABLE b (a bigint, b bigint, c bigint, d bigint) DISTRIBUTED BY (a) PARTITION BY LIST(b) (PARTITION a VALUES(0));
CREATE TABLE c (a bigint, b bigserial, c varchar(255)) DISTRIBUTED REPLICATED;
```
and run
```sql
EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
WITH d AS (
    SELECT b FROM a GROUP BY b
), e AS (
    SELECT b.d FROM b JOIN d f ON f.b = b.c JOIN d g ON g.b = b.c
) SELECT * FROM e JOIN c ON c.a = e.d;
```
that gives bogus plan
```sql
                                                QUERY PLAN                                                 

-----------------------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice4; segments: 1)
   ->  Sequence
         ->  Shared Scan (share slice:id 4:0)
               ->  Materialize
                     ->  GroupAggregate
                           Group Key: a.b
                           ->  Sort
                                 Sort Key: a.b
                                 ->  Redistribute Motion 3:1  (slice3; segments: 3)
                                       Hash Key: a.b
                                       ->  Seq Scan on a
         ->  Hash Join
               Hash Cond: (c.a = b.d)
               ->  Seq Scan on c
               ->  Hash
                     ->  Broadcast Motion 3:1  (slice2; segments: 3)
                           ->  Hash Join
                                 Hash Cond: (share0_ref3.b = b.c)
                                 ->  Shared Scan (share slice:id 2:0)
                                 ->  Hash
                                       ->  Hash Join
                                             Hash Cond: (b.c = share0_ref2.b)
                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                   Hash Key: b.c
                                                   ->  Sequence
                                                         ->  Partition Selector for b (dynamic scan id: 1)
                                                               Partitions selected: 1 (out of 1)
                                                         ->  Dynamic Seq Scan on b (dynamic scan id: 1)
                                             ->  Hash
                                                   ->  Shared Scan (share slice:id 2:0)
 Optimizer: Pivotal Optimizer (GPORCA)
(31 rows)
```
In this plan `Shared Scan (share slice:id 4:0)` is CTE producer that is executed only on one segment because `Redistribute Motion 3:1  (slice3; segments: 3)`, but CTE consumers (`Shared Scan (share slice:id 2:0)`) are executed on all 3 segments and then query hangs.

Solution is changing `Redistribute Motion` to from all segments to all segments which is done by changing gang type of parent slice from singleton reader to primary reader and refill gang info of parent slice. It is gives right plan
```sql
                                                QUERY PLAN                                                 

-----------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice4; segments: 3)
   ->  Sequence
         ->  Shared Scan (share slice:id 4:0)
               ->  Materialize
                     ->  GroupAggregate
                           Group Key: a.b
                           ->  Sort
                                 Sort Key: a.b
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                       Hash Key: a.b
                                       ->  Seq Scan on a
         ->  Hash Join
               Hash Cond: (c.a = b.d)
               ->  Seq Scan on c
               ->  Hash
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
                           ->  Hash Join
                                 Hash Cond: (share0_ref3.b = b.c)
                                 ->  Shared Scan (share slice:id 2:0)
                                 ->  Hash
                                       ->  Hash Join
                                             Hash Cond: (b.c = share0_ref2.b)
                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
                                                   Hash Key: b.c
                                                   ->  Sequence
                                                         ->  Partition Selector for b (dynamic scan id: 1)
                                                               Partitions selected: 1 (out of 1)
                                                         ->  Dynamic Seq Scan on b (dynamic scan id: 1)
                                             ->  Hash
                                                   ->  Shared Scan (share slice:id 2:0)
 Optimizer: Pivotal Optimizer (GPORCA)
(31 rows)
```
Upstream master (gpdb 7) also is affected by this problem, but with other error
```sql
FATAL:  Unexpected internal error (assert.c:44)
DETAIL:  FailedAssertion("!(pMotion->numHashSegments < motion_recv)", File: "explain.c", Line: 2513)
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```