### PR TITLE
 ADBDEV-3098-6: ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalSequence.cpp
@@ -282,7 +282,8 @@ CPhysicalSequence::PdsRequired(CMemoryPool *mp,
 	}
 
 	// first child is non-singleton, request a non-singleton distribution on second child
-	return GPOS_NEW(mp) CDistributionSpecNonSingleton();
+	return GPOS_NEW(mp) CDistributionSpecNonSingleton(
+		true /* fAllowReplicated */, false /* fAllowEnforced */);
 }
 
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -8249,13 +8249,13 @@ CTranslatorExprToDXL::GetInputSegIdsArray(CExpression *pexprMotion)
 		// previously made CTEProducerConsumerLocality check.
 		// Related to: https://github.com/greenplum-db/gpdb/issues/13039
 
-		if (CUtils::hasUnpairedCTEConsumer(m_mp, pexprMotion))
+		/*if (CUtils::hasUnpairedCTEConsumer(m_mp, pexprMotion))
 		{
 			GPOS_RAISE(
 				gpdxl::ExmaDXL, gpdxl::ExmiExpr2DXLUnsupportedFeature,
 				GPOS_WSZ_LIT(
 					"CTE Consumer without the appropriate CTE Producer under a duplicate-hazard motion or a tainted replicated node"));
-		}
+		}*/
 
 		IntPtrArray *pdrgpi = GPOS_NEW(m_mp) IntPtrArray(m_mp);
 		INT iSegmentId = *((*m_pdrgpiSegments)[0]);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
