### PR TITLE
ADBDEV-3098-8: ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -527,6 +527,12 @@ CPhysicalHashJoin::PdsRequiredReplicate(
 	// otherwise, require second child to deliver non-singleton distribution
 	GPOS_ASSERT(CDistributionSpec::EdtStrictReplicated == pdsInner->Edt() ||
 				CDistributionSpec::EdtTaintedReplicated == pdsInner->Edt());
+
+	if (CDistributionSpec::EdtAny == pdsInput->Edt())
+	{
+		return GPOS_NEW(mp) CDistributionSpecSingleton();
+	}
+
 	return GPOS_NEW(mp) CDistributionSpecNonSingleton();
 }
 


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
