### PR TITLE
ADBDEV-3098-11: ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
@@ -69,7 +69,7 @@ CPhysicalMotion::FValidContext(CMemoryPool *, COptimizationContext *poc,
 //---------------------------------------------------------------------------
 CDistributionSpec *
 CPhysicalMotion::PdsRequired(CMemoryPool *mp,
-							 CExpressionHandle &,  // exprhdl
+							 CExpressionHandle &exprhdl,
 							 CDistributionSpec *pdsRequired,
 							 ULONG
 #ifdef GPOS_DEBUG
@@ -138,7 +138,8 @@ CPhysicalMotion::PdsRequired(CMemoryPool *mp,
 	}
 
 	if (CDistributionSpec::EdtReplicated == pdsRequired->Edt() &&
-		CDistributionSpec::EdtStrictReplicated == Pds()->Edt())
+		CDistributionSpec::EdtStrictReplicated == Pds()->Edt() &&
+		exprhdl.Pgexpr()->Pgroup()->FHasAnyCTEConsumer())
 	{
 		return GPOS_NEW(mp) CDistributionSpecSingleton(
 			CDistributionSpecSingleton::EstSegment);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
@@ -137,6 +137,12 @@ CPhysicalMotion::PdsRequired(CMemoryPool *mp,
 		return GPOS_NEW(mp) CDistributionSpecRandom();
 	}
 
+	if (CDistributionSpec::EdtStrictReplicated == Pds()->Edt())
+	{
+		return GPOS_NEW(mp) CDistributionSpecSingleton(
+			CDistributionSpecSingleton::EstSegment);
+	}
+
 	// any motion operator is distribution-establishing and does not require
 	// child to deliver any specific distribution
 	return GPOS_NEW(mp) CDistributionSpecAny(this->Eopid());

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalMotion.cpp
@@ -137,7 +137,8 @@ CPhysicalMotion::PdsRequired(CMemoryPool *mp,
 		return GPOS_NEW(mp) CDistributionSpecRandom();
 	}
 
-	if (CDistributionSpec::EdtStrictReplicated == Pds()->Edt())
+	if (CDistributionSpec::EdtReplicated == pdsRequired->Edt() &&
+		CDistributionSpec::EdtStrictReplicated == Pds()->Edt())
 	{
 		return GPOS_NEW(mp) CDistributionSpecSingleton(
 			CDistributionSpecSingleton::EstSegment);


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
