### PR TITLE
Fix high memory consumption for queries with SQL subqueries

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1397,6 +1397,7 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 			&& queryDesc->gpmon_pkt)
 	{			
 		gpmon_qlog_query_end(queryDesc->gpmon_pkt);
+		pfree(queryDesc->gpmon_pkt);
 		queryDesc->gpmon_pkt = NULL;
 	}
 

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -944,7 +944,11 @@ postquel_start(execution_state *es, SQLFunctionCachePtr fcache)
 		else
 		{
 			/* Otherwise, we do not record information about internal queries. */
-			es->qd->gpmon_pkt = NULL;
+			if (es->qd->gpmon_pkt != NULL)
+			{
+				pfree(es->qd->gpmon_pkt);
+				es->qd->gpmon_pkt = NULL;
+			}
 		}
 	}
 	else

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2315,7 +2315,11 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 				else
 				{
 					/* Otherwise, we do not record information about internal queries */
-					qdesc->gpmon_pkt = NULL;
+					if (qdesc->gpmon_pkt != NULL)
+					{
+						pfree(qdesc->gpmon_pkt);
+						qdesc->gpmon_pkt = NULL;
+					}
 				}
 
 				res = _SPI_pquery(qdesc, fire_triggers,


### PR DESCRIPTION
Steps to reproduce:
1. Create function written in sql language that optimizers can’t inline, e. g.:
```
create function f(a int) returns int
immutable
security definer
language sql as $$
  select case when $1 > 500 then 0 end;
$$;
```
2. Execute a query which executes this function multiple times
```
explain analyze verbose
select f(i) from generate_series(1, 1000000) i;
```
3. The query uses much more memory when gp_enable_gpperfmon=true than in the opposite case.

The reason of high memory consumption is memory allocation for two structures in CreateQueryDesc() and release of memory for only one of these structures in FreeQueryDesc(). This pair of functions is run every time when subquery is executed. The more times the subquery is executed, the more memory leaks.

The patch adds deallocation of the second structure after data in it is no longer needed. There is no leak in _SPI_execute_plan(), but deallocation is added here to be sure that the leak would not appear in the future.