### PR TITLE
Fix memory leaks in auto_explain

### DIFF
--- a/contrib/auto_explain/Makefile
+++ b/contrib/auto_explain/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = auto_explain
 OBJS = auto_explain.o
 
-REGRESS = auto_explain bfv_preload_auto_explain
+REGRESS = auto_explain bfv_preload_auto_explain memory_leaks
 REGRESS_OPTS = --init-file=init_file
 
 ifdef USE_PGXS

--- a/contrib/auto_explain/expected/memory_leaks.out
+++ b/contrib/auto_explain/expected/memory_leaks.out
@@ -1,0 +1,54 @@
+CREATE SCHEMA auto_explain_mem_leak_test;
+SET search_path=auto_explain_mem_leak_test;
+LOAD 'auto_explain';
+-- Enable auto_explain. Log all plans
+SET auto_explain.log_min_duration = 0;
+-- Log statements executed inside a function
+SET auto_explain.log_nested_statements=true;
+-- Collect data for EXPLAIN ANALYZE output. The data will be collected for every
+-- query executed inside a function
+SET auto_explain.log_analyze = true;
+CREATE OR REPLACE FUNCTION not_inlinable_sql_func(i int) returns int8
+immutable
+security definer
+language sql as $$
+-- The query contains table and its alias to perform more memory allocations
+-- at explaining than in the case of the simplest query
+    SELECT count(c.*) FROM pg_class c WHERE c.oid > i;
+$$;
+CREATE OR REPLACE FUNCTION get_executor_mem(calls_num int) returns int 
+language plpgsql
+as $$
+declare
+    line text;
+    mem int[];
+    total int = 0;
+begin
+    for line in execute(
+       'EXPLAIN ANALYZE
+        SELECT not_inlinable_sql_func(i)
+        FROM generate_series(1, $1) i')
+    using calls_num
+    loop
+        mem = regexp_matches(line, 'Executor memory: (\d+)K');
+        continue when mem is null;
+        total = total + mem[1];
+    end loop;
+
+    return total;
+end
+$$;
+-- Memory usage should not depend much on how many times a function written in
+-- sql language, that optimizers cannot inline, is called during query execution.
+-- The amount of memory used for 50,000 calls and 1000 calls should not differ
+-- by more than 10 MB.
+SELECT abs(get_executor_mem(50000) - get_executor_mem(1000)) < 10000;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- clean
+DROP FUNCTION get_executor_mem(calls_num int);
+DROP FUNCTION not_inlinable_sql_func(i int);
+DROP SCHEMA auto_explain_mem_leak_test;

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -568,8 +568,6 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
         queryDesc->showstatctx = cdbexplain_showExecStatsBegin(queryDesc,
 															   starttime);
     }
-	else
-		queryDesc->showstatctx = NULL;
 
 	/* Select execution options */
 	if (es->analyze)
@@ -735,11 +733,13 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
                                      es->showstatctx);
 	}
 
+	MemoryContext oldcxt = MemoryContextSwitchTo(queryDesc->estate->es_query_cxt);
 	ExplainPreScanNode(queryDesc->planstate, &rels_used);
 	es->rtable_names = select_rtable_names_for_explain(es->rtable, rels_used);
 	es->deparse_cxt = deparse_context_for_plan_rtable(es->rtable,
 													  es->rtable_names);
 	ExplainNode(queryDesc->planstate, NIL, NULL, NULL, es);
+	MemoryContextSwitchTo(oldcxt);
 }
 
 /*

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -28,6 +28,7 @@
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
 
+#include "cdb/cdbexplain.h"
 #include "cdb/ml_ipc.h"
 #include "commands/createas.h"
 #include "commands/queue.h"
@@ -110,6 +111,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 
 	qd->extended_query = false; /* default value */
 	qd->portal_name = NULL;
+	qd->showstatctx = NULL;
 
 	qd->ddesc = NULL;
 	qd->gpmon_pkt = NULL;
@@ -157,6 +159,7 @@ CreateUtilityQueryDesc(Node *utilitystmt,
 
 	qd->extended_query = false; /* default value */
 	qd->portal_name = NULL;
+	qd->showstatctx = NULL;
 
 	return qd;
 }
@@ -173,6 +176,9 @@ FreeQueryDesc(QueryDesc *qdesc)
 	/* forget our snapshots */
 	UnregisterSnapshot(qdesc->snapshot);
 	UnregisterSnapshot(qdesc->crosscheck_snapshot);
+
+	if (qdesc->showstatctx)
+		cdbexplain_showStatCtxFree(qdesc->showstatctx);
 
 	/* Only the QueryDesc itself need be freed */
 	pfree(qdesc);

--- a/src/include/cdb/cdbexplain.h
+++ b/src/include/cdb/cdbexplain.h
@@ -124,6 +124,14 @@ struct CdbExplain_ShowStatCtx *
 cdbexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
                               instr_time        querystarttime);
 
+/*
+ * cdbexplain_showStatCtxFree
+ *    Release memory allocated for CdbExplain_ShowStatCtx structure and its
+ *    internals.
+ */
+void
+cdbexplain_showStatCtxFree(struct CdbExplain_ShowStatCtx *ctx);
+
 
 
 #endif   /* CDBEXPLAIN_H */


### PR DESCRIPTION
Statistic context wasn't destroyed with query descriptor, so queries with multiple call of sql functions consumed a lot of memory.

Steps to reproduce:
LOAD 'auto_explain';
SET auto_explain.log_nested_statements=true;
SET auto_explain.log_min_duration = 0;
SET auto_explain.log_analyze = true;
explain analyze select information_schema._pg_truetypid(a, t) from (
    select a as a, t as t from pg_type t
    join pg_attribute a on a.atttypid = t.oid
    where typtype = 'd' limit 1
) at join generate_series(1, 9000000) gc on true;

Changes:
1. Add cdbexplain_showStatCtxFree() function to release memory allocated for statistic context. The function is called from FreeQueryDesc() when the statistic context exists. To check whether the context exists the assigning NULL value to the showstatctx field of query descriptor is moved from ExplainOnePlan() to CreateQueryDesc() and CreateUtilityQueryDesc().
2. Statistic context in auto_explain isn't created if the context already exists. It may be created in ExplainOnePlan().
