### PR TITLE
ADBDEV-3365-8: test some patches

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1829,12 +1829,10 @@ aorow_compression_ratio_internal(Relation parentrel)
 
 			if (NULL == attr1 || NULL == attr2)
 			{
-				SPI_finish();
-				return 1;
+				compress_ratio = 1;
 			}
-
-			if (scanint8(attr1, true, &eof) &&
-				scanint8(attr2, true, &eof_uncomp))
+			else if (scanint8(attr1, true, &eof) &&
+					 scanint8(attr2, true, &eof_uncomp))
 			{
 				/* guard against division by zero */
 				if (eof > 0)
@@ -1845,6 +1843,12 @@ aorow_compression_ratio_internal(Relation parentrel)
 					/* format to 2 digit decimal precision */
 					compress_ratio = round(compress_ratio * 100.0) / 100.0;
 				}
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("unable to parse aorow compress_ratio string to int8.")));
 			}
 		}
 

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1226,7 +1226,9 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 		{"autovacuum_analyze_scale_factor", RELOPT_TYPE_REAL,
 		offsetof(StdRdOptions, autovacuum) +offsetof(AutoVacOpts, analyze_scale_factor)},
 		{"user_catalog_table", RELOPT_TYPE_BOOL,
-		offsetof(StdRdOptions, user_catalog_table)}
+		offsetof(StdRdOptions, user_catalog_table)},
+		{SOPT_ANALYZEHLL, RELOPT_TYPE_BOOL,
+		offsetof(StdRdOptions, analyze_hll_non_part_table)}
 	};
 
 	options = parseRelOptions(reloptions, validate, kind, &numoptions);

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -61,6 +61,15 @@ static relopt_bool boolRelOpts_gp[] =
 		},
 		AO_DEFAULT_CHECKSUM
 	},
+	{
+		{
+			SOPT_ANALYZEHLL,
+			"Enable HLL stats collection during analyze",
+			RELOPT_KIND_HEAP,
+			ShareUpdateExclusiveLock
+		},
+		ANALYZE_DEFAULT_HLL
+	},
 	/* list terminator */
 	{{NULL}}
 };
@@ -603,7 +612,8 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 				foundComptype = false,
 				foundComplevel = false,
 				foundChecksum = false,
-				foundOrientation = false;
+				foundOrientation = false,
+				foundAnalyzeHLL = false;
 
 	/*
 	 * withOpts must be parsed to see if an option was spcified in WITH()
@@ -723,6 +733,17 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 				astate = accumArrayResult(astate, d, false, TEXTOID,
 										  CurrentMemoryContext);
 			}
+			soptLen = strlen(SOPT_ANALYZEHLL);
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, SOPT_ANALYZEHLL, soptLen) == 0)
+			{
+				foundAnalyzeHLL = true;
+				d = CStringGetTextDatum(psprintf("%s=%s",
+												 SOPT_ANALYZEHLL,
+												 (opts->analyze_hll_non_part_table ? "true" : "false")));
+				astate = accumArrayResult(astate, d, false, TEXTOID,
+										  CurrentMemoryContext);
+			}
 		}
 	}
 
@@ -792,6 +813,14 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 		astate = accumArrayResult(astate, d, false, TEXTOID,
 								  CurrentMemoryContext);
 	}
+	if ((opts->analyze_hll_non_part_table != ANALYZE_DEFAULT_HLL) && !foundAnalyzeHLL)
+	{
+		d = CStringGetTextDatum(psprintf("%s=%s",
+										 SOPT_ANALYZEHLL,
+										 (opts->analyze_hll_non_part_table ? "true" : "false")));
+		astate = accumArrayResult(astate, d, false, TEXTOID,
+								  CurrentMemoryContext);
+	}
 	return astate ?
 		makeArrayResult(astate, CurrentMemoryContext) :
 		PointerGetDatum(NULL);
@@ -810,6 +839,7 @@ validate_and_adjust_options(StdRdOptions *result,
 	relopt_value *complevel_opt;
 	relopt_value *checksum_opt;
 	relopt_value *orientation_opt;
+	relopt_value *analyze_hll_non_part_table_opt;
 
 	/* fillfactor */
 	fillfactor_opt = get_option_set(options, num_options, SOPT_FILLFACTOR);
@@ -1066,6 +1096,16 @@ validate_and_adjust_options(StdRdOptions *result,
 								result->compresstype)));
 		}
 	}
+	/* analyze_hll_non_part_table */
+	analyze_hll_non_part_table_opt = get_option_set(options, num_options, SOPT_ANALYZEHLL);
+	if (analyze_hll_non_part_table_opt != NULL)
+	{
+		if (!KIND_IS_RELATION(kind))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("usage of parameter \"analyze_hll_non_part_table\" in a non relation object is not supported")));
+		result->analyze_hll_non_part_table = analyze_hll_non_part_table_opt->values.bool_val;
+	}
 
 	if (result->appendonly && result->compresstype[0])
 		if (result->compresslevel == AO_DEFAULT_COMPRESSLEVEL)
@@ -1100,6 +1140,8 @@ validate_and_refill_options(StdRdOptions *result, relopt_value *options,
 
 		if (!(get_option_set(options, numrelopts, SOPT_ORIENTATION)))
 			result->columnstore = ao_storage_opts.columnstore;
+		if (!(get_option_set(options, numrelopts, SOPT_ANALYZEHLL)))
+			result->analyze_hll_non_part_table = ao_storage_opts.analyze_hll_non_part_table;
 	}
 
 	validate_and_adjust_options(result, options, numrelopts, kind, validate);

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -409,7 +409,42 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 	return;
 }
 
+/*
+ * cdbsubselect_drop_distinct
+ */
+void
+cdbsubselect_drop_distinct(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete DISTINCT. */
+		if (!subselect->hasDistinctOn ||
+			list_length(subselect->distinctClause) == list_length(subselect->targetList))
+			subselect->distinctClause = NIL;
 
+		/* Delete GROUP BY if subquery has no aggregates and no HAVING. */
+		if (!subselect->hasAggs &&
+			subselect->havingQual == NULL)
+			subselect->groupClause = NIL;
+	}
+}	/* cdbsubselect_drop_distinct */
+
+/*
+ * cdbsubselect_drop_orderby
+ */
+void
+cdbsubselect_drop_orderby(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete ORDER BY. */
+		if (!subselect->hasDistinctOn ||
+			list_length(subselect->distinctClause) == list_length(subselect->targetList))
+			subselect->sortClause = NIL;
+	}
+}	/* cdbsubselect_drop_orderby */
 
 /**
  * Safe to convert expr sublink to a join
@@ -1351,7 +1386,18 @@ is_exprs_nullable_internal(Node *exprs, List *nonnullable_vars, List *rtable)
 
 	if (IsA(exprs, Var))
 	{
+		Var *tmpvar = (Var *)exprs;
+
+		/* params treat as nullable exprs */
+		if (tmpvar->varlevelsup != 0)
+			return true;
+
 		Var		   *var = cdb_map_to_base_var((Var *) exprs, rtable);
+
+		/* once not found RTE of var, return as nullable expr */
+		if (var == NULL)
+			return true;
+
 		return !list_member(nonnullable_vars, var);
 	}
 	else if (IsA(exprs, List))
@@ -1424,6 +1470,20 @@ convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink,
 	{
 		Assert(list_length(parse->jointree->fromlist) == 1);
 
+		/* Delete ORDER BY and DISTINCT.
+		 *
+		 * There is no need to do the group-by or order-by inside the
+		 * subquery, if we have decided to pull up the sublink. For the
+		 * group-by case, after the sublink pull-up, there will be a semi-join
+		 * plan node generated in top level, which will weed out duplicate
+		 * tuples naturally. For the order-by case, after the sublink pull-up,
+		 * the subquery will become a jointree, inside which the tuples' order
+		 * doesn't matter. In a summary, it's safe to elimate the group-by or
+		 * order-by causes here.
+		 */
+		cdbsubselect_drop_orderby(subselect);
+		cdbsubselect_drop_distinct(subselect);
+
 		int			subq_indx      = add_notin_subquery_rte(parse, subselect);
 		List       *inner_exprs    = NIL;
 		List       *outer_exprs    = NIL;
@@ -1493,7 +1553,10 @@ cdb_find_all_vars_walker(Node *node, FindAllVarsContext *context)
 
 	if (IsA(node, Var))
 	{
-		Var     *var;
+		Var *var = (Var *)node;
+
+		if (var->varlevelsup != 0)
+			return false;
 
 		/*
 		 * The vars fetched from targetList/testexpr.. can be from virtual range table (RTE_JOIN),
@@ -1501,7 +1564,10 @@ cdb_find_all_vars_walker(Node *node, FindAllVarsContext *context)
 		 * them to base vars is needed before check nullable.
 		 */
 		var = cdb_map_to_base_var((Var *) node, context->rtable);
-		context->vars = list_append_unique(context->vars, var);
+
+		if (var != NULL)
+			context->vars = list_append_unique(context->vars, var);
+
 		return false;
 	}
 
@@ -1513,11 +1579,15 @@ cdb_map_to_base_var(Var *var, List *rtable)
 {
 	RangeTblEntry *rte    = rt_fetch(var->varno, rtable);
 
-	while(rte->rtekind == RTE_JOIN && rte->joinaliasvars)
+	while(rte != NULL && rte->rtekind == RTE_JOIN && rte->joinaliasvars)
 	{
 		var = (Var *) list_nth(rte->joinaliasvars, var->varattno-1);
 		rte = rt_fetch(var->varno, rtable);
 	}
+
+	/* not found RTE in current level rtable */
+	if (rte == NULL)
+		return NULL;
 
 	return var;
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1361,7 +1361,11 @@ serializeParamListInfo(ParamListInfo paramLI, int *len_p)
 	 * If there were any record types, include the transient record type cache.
 	 */
 	if (found_records)
-		sparams = lcons(build_tuple_node_list(0), sparams);
+	{
+		List *transientTypeList = build_tuple_node_list(0);
+		if (transientTypeList != NULL)
+			sparams = lcons(transientTypeList, sparams);
+	}
 
 	return nodeToBinaryStringFast(sparams, len_p);
 }

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -802,9 +802,17 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 										 totalrows);
 				/*
 				 * Store HLL/HLL fullscan information for leaf partitions in
-				 * the stats object
+				 * the stats object. If table was created with "analyze_hll_non_part_table" option, also collect
+				 * HLL stats for non-leaf tables
 				 */
-				if (rel_part_status(stats->attr->attrelid) == PART_STATUS_LEAF)
+				bool analyze_hll_non_part_table = false;
+				if (onerel->rd_options != NULL &&
+							((StdRdOptions *) onerel->rd_options)->analyze_hll_non_part_table)
+				{
+					analyze_hll_non_part_table = true;
+				}
+				if (rel_part_status(stats->attr->attrelid) == PART_STATUS_LEAF || 
+						(onerel->rd_rel->relkind == RELKIND_RELATION && analyze_hll_non_part_table))
 				{
 					MemoryContext old_context;
 					Datum *hll_values;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -406,7 +406,7 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	 *
 	 * See Github Issue for details: https://github.com/greenplum-db/gpdb/issues/11956
 	 */
-	List       *saved_dispatch_oids = GetAssignedOidsForDispatch();
+	List       *saved_dispatch_oids = SaveOidAssignments();
 
 	/* Lock and rewrite, using a copy to preserve the original query. */
 	copied_query = copyObject(query);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -53,6 +53,7 @@
 
 #include "access/fileam.h"
 #include "access/transam.h"
+#include "catalog/aocatalog.h"
 #include "catalog/pg_statistic.h"
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbappendonlyam.h"
@@ -1852,7 +1853,8 @@ ExecModifyTable(ModifyTableState *node)
 				bool		isNull;
 
 				relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
-				if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
+				if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW ||
+					IsAppendonlyMetadataRelkind(relkind))
 				{
 					datum = ExecGetJunkAttribute(slot,
 												 junkfilter->jf_junkAttNo,
@@ -2347,7 +2349,8 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 
 					relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
 					if (relkind == RELKIND_RELATION ||
-						relkind == RELKIND_MATVIEW)
+						relkind == RELKIND_MATVIEW ||
+						IsAppendonlyMetadataRelkind(relkind))
 					{
 						j->jf_junkAttNo = ExecFindJunkAttribute(j, "ctid");
 						if (!AttributeNumberIsValid(j->jf_junkAttNo))

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-GpSegmentId-MultiCol-Conjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-GpSegmentId-MultiCol-Conjunction.mdp
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective:  Allow direct dispatch when filtering gp_segment_id on conjunction constraints
+    Setup:
+          create table bar (a int, b int);
+          explain select * from bar where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+                                                        QUERY PLAN
+          --------------------------------------------------------------------------------------------
+           Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+             ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+                   Filter: ((b >= 1) AND (b <= 5) AND (gp_segment_id = 2) AND (a >= 1) AND (a <= 10))
+           Optimizer: Pivotal Optimizer (GPORCA)
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.32561.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.32561.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32561.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32561.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32561.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32561.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000157" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000127" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+            </dxl:And>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.32561.1.0" TableName="bar" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo IsRaw="true">
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-GpSegmentId-SingleCol-Conjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-GpSegmentId-SingleCol-Conjunction.mdp
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective:  Allow direct dispatch when filtering gp_segment_id on conjunction constraints
+    Setup:
+           create table foo (a int);
+           explain select * from foo where gp_segment_id=2 and a between 1 and 10;
+                                                 QUERY PLAN
+           ------------------------------------------------------------------------------
+           Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: ((gp_segment_id = 2) AND (a >= 1) AND (a <= 10))
+           Optimizer: Pivotal Optimizer (GPORCA)
+  ]]></dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.523.1.0" Name="&lt;=" ComparisonType="LEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.149.1.0"/>
+        <dxl:Commutator Mdid="0.525.1.0"/>
+        <dxl:InverseOp Mdid="0.521.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.32558.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.32558.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.32558.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.32558.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32558.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000104" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000089" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.523.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+            </dxl:And>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.32558.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo IsRaw="true">
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -206,6 +206,12 @@ public:
 		return false;
 	}
 
+	virtual CConstraint *
+	GetConstraintOnSegmentId() const
+	{
+		return NULL;
+	}
+
 	// return a copy of the constraint with remapped columns
 	virtual CConstraint *PcnstrCopyWithRemappedColumns(
 		CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist) = 0;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintConjunction.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintConjunction.h
@@ -86,6 +86,9 @@ public:
 	virtual CConstraint *PcnstrRemapForColumn(CMemoryPool *mp,
 											  CColRef *colref) const;
 
+	// Returns the constraint for system column gp_segment_id
+	CConstraint *GetConstraintOnSegmentId() const;
+
 	// print
 	virtual IOstream &
 	OsPrint(IOstream &os) const

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -175,6 +175,8 @@ public:
 				   CDXLTokens::GetDXLTokenStr(EdxltokenGpSegmentIdColName));
 	}
 
+	CConstraint *GetConstraintOnSegmentId() const;
+
 	// return a copy of the constraint with remapped columns
 	virtual CConstraint *PcnstrCopyWithRemappedColumns(
 		CMemoryPool *mp, UlongToColRefMap *colref_mapping, BOOL must_exist);

--- a/src/backend/gporca/libgpopt/src/base/CConstraintConjunction.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraintConjunction.cpp
@@ -240,4 +240,26 @@ CConstraintConjunction::PexprScalar(CMemoryPool *mp)
 	return m_pexprScalar;
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CConstraintConjunction::GetConstraintOnSegmentId
+//
+//	@doc:
+//		Returns the constraint for system column gp_segment_id
+//
+//---------------------------------------------------------------------------
+CConstraint *
+CConstraintConjunction::GetConstraintOnSegmentId() const
+{
+	for (ULONG ul = 0; ul < m_pdrgpcnstr->Size(); ul++)
+	{
+		CConstraint *pcnstr = (*m_pdrgpcnstr)[ul];
+		if (pcnstr->FConstraintOnSegmentId())
+		{
+			return pcnstr;
+		}
+	}
+	return NULL;
+}
+
 // EOF

--- a/src/backend/gporca/libgpopt/src/base/CConstraintInterval.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraintInterval.cpp
@@ -113,6 +113,25 @@ CConstraintInterval::PcnstrCopyWithRemappedColumns(
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CConstraintInterval::GetConstraintOnSegmentId
+//
+//	@doc:
+//		Returns the constraint for system column gp_segment_id
+//
+//---------------------------------------------------------------------------
+
+CConstraint *
+CConstraintInterval::GetConstraintOnSegmentId() const
+{
+	if (FConstraintOnSegmentId())
+	{
+		return (CConstraint *) this;
+	}
+
+	return NULL;
+}
+//---------------------------------------------------------------------------
+//	@function:
 //		CConstraintInterval::PciIntervalFromScalarExpr
 //
 //	@doc:

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
@@ -30,6 +30,8 @@ ULONG CDirectDispatchTest::m_ulDirectDispatchCounter =
 const CHAR *rgszDirectDispatchFileNames[] = {
 	"../data/dxl/minidump/DirectDispatch-SingleCol.mdp",
 	"../data/dxl/minidump/DirectDispatch-GpSegmentId.mdp",
+	"../data/dxl/minidump/DirectDispatch-GpSegmentId-SingleCol-Conjunction.mdp",
+	"../data/dxl/minidump/DirectDispatch-GpSegmentId-MultiCol-Conjunction.mdp",
 	"../data/dxl/minidump/DirectDispatch-SingleCol-Disjunction.mdp",
 	"../data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-IsNull.mdp",
 	"../data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-Negative.mdp",

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1413,6 +1413,20 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	Assert(sublink->subLinkType == ANY_SUBLINK);
 	Assert(IsA(subselect, Query));
 
+	/* Delete ORDER BY and DISTINCT.
+	 *
+	 * There is no need to do the group-by or order-by inside the
+	 * subquery, if we have decided to pull up the sublink. For the
+	 * group-by case, after the sublink pull-up, there will be a semi-join
+	 * plan node generated in top level, which will weed out duplicate
+	 * tuples naturally. For the order-by case, after the sublink pull-up,
+	 * the subquery will become a jointree, inside which the tuples' order
+	 * doesn't matter. In a summary, it's safe to elimate the group-by or
+	 * order-by causes here.
+	*/
+	cdbsubselect_drop_orderby(subselect);
+	cdbsubselect_drop_distinct(subselect);
+
 	/*
 	 * If deeply correlated, then don't pull it up
 	 */

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -22,6 +22,7 @@
 #include "postgres.h"
 
 #include "access/htup_details.h"
+#include "catalog/oid_dispatch.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_operator.h"
@@ -2666,7 +2667,9 @@ transform_array_Const_to_ArrayExpr(Const *c)
 Node *
 eval_const_expressions(PlannerInfo *root, Node *node)
 {
-	eval_const_expressions_context context;
+	eval_const_expressions_context	 context;
+	Node							*result;
+	List							*saved_oid_assignments;
 
 	if (root)
 		context.boundParams = root->glob->boundParams;	/* bound Params */
@@ -2681,7 +2684,11 @@ eval_const_expressions(PlannerInfo *root, Node *node)
 	context.max_size = 0;
 	context.eval_stable_functions = should_eval_stable_functions(root);
 
-	return eval_const_expressions_mutator(node, &context);
+	saved_oid_assignments = SaveOidAssignments();
+	result = eval_const_expressions_mutator(node, &context);
+	RestoreOidAssignments(saved_oid_assignments);
+
+	return result;
 }
 
 /*--------------------

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -12425,6 +12425,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_ROLLUP;
 					n->groupsets = $3;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | CUBE '(' expr_list ')'
@@ -12432,6 +12433,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_CUBE;
 					n->groupsets = $3;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | GROUPING SETS '(' group_elem_list ')'
@@ -12439,6 +12441,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_GROUPING_SETS;
 					n->groupsets = $4;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | '(' ')'

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -32,8 +32,8 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
+#include "catalog/aocatalog.h"
 #include "catalog/pg_exttable.h"
-
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1379,7 +1379,8 @@ rewriteTargetListUD(Query *parsetree, RangeTblEntry *target_rte,
 	Var 		*varSegid = NULL;
 
 	if (target_relation->rd_rel->relkind == RELKIND_RELATION ||
-		target_relation->rd_rel->relkind == RELKIND_MATVIEW)
+		target_relation->rd_rel->relkind == RELKIND_MATVIEW ||
+		IsAppendonlyMetadataRelkind(target_relation->rd_rel->relkind))
 	{
 		/*
 		 * Emit CTID so that executor can find the row to update or delete.
@@ -1840,8 +1841,12 @@ fireRIRrules(Query *parsetree, List *activeRIRs, bool forUpdatePushedDown)
 		 * expanded as if they were regular views, if they are not scannable.
 		 * In that case this test would need to be postponed till after we've
 		 * opened the rel, so that we could check its state.
+		 *
+		 * In the minirepro utility in GPDB, we use the expandMatViews flag
+		 * to treat materialized views as regular views when dumping the
+		 * DDL in order to dump dependent objects
 		 */
-		if (rte->relkind == RELKIND_MATVIEW)
+		if (rte->relkind == RELKIND_MATVIEW && !parsetree->expandMatViews)
 			continue;
 
 		/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -241,7 +241,6 @@ static int	interactive_getc(void);
 static int	SocketBackend(StringInfo inBuf);
 static int	ReadCommand(StringInfo inBuf);
 static void forbidden_in_wal_sender(int firstchar);
-static List *pg_rewrite_query(Query *query);
 static bool check_log_statement(List *stmt_list);
 static int	errdetail_execute(List *raw_parsetree_list);
 static int	errdetail_params(ParamListInfo params);
@@ -901,7 +900,7 @@ pg_analyze_and_rewrite_params(Node *parsetree,
  * Note: query must just have come from the parser, because we do not do
  * AcquireRewriteLocks() on it.
  */
-static List *
+List *
 pg_rewrite_query(Query *query)
 {
 	List	   *querytree_list;

--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -16,6 +16,7 @@
 #include "catalog/pg_proc.h"
 #include "tcop/tcopprot.h"
 #include "optimizer/planmain.h"
+#include "parser/analyze.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/syscache.h"
@@ -118,10 +119,10 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 		Node	   *parsetree = (Node *) lfirst(lc);
 		List	   *queryTree_sublist;
 
-		queryTree_sublist = pg_analyze_and_rewrite(parsetree,
-												   sqlText,
-												   NULL,
-												   0);
+		Query	*query = parse_analyze(parsetree, sqlText, NULL, 0);
+		query->expandMatViews = true;
+		queryTree_sublist = pg_rewrite_query(query);
+
 		flat_query_list = list_concat(flat_query_list,
 									  list_copy(queryTree_sublist));
 	}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13910,7 +13910,20 @@ dumpExternal(Archive *fout, TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer delq)
 				appendPQExpBuffer(q, "%s ", fmtId(tbinfo->attnames[j]));
 
 				/* Attribute type */
-				appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				if (tbinfo->attisdropped[j])
+				{
+					/*
+					 * ALTER TABLE DROP COLUMN clears
+					 * pg_attribute.atttypid, so we will not have gotten a
+					 * valid type name; insert INTEGER as a stopgap. We'll
+					 * clean things up later.
+					 */
+					appendPQExpBufferStr(q, " INTEGER /* dummy */");
+				}
+				else
+				{
+					appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				}
 
 				actual_atts++;
 			}

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -41,6 +41,7 @@
 #endif
 #define AO_DEFAULT_CHECKSUM       true
 #define AO_DEFAULT_COLUMNSTORE    false
+#define ANALYZE_DEFAULT_HLL       false
 
 /* types supported by reloptions */
 typedef enum relopt_type

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -32,6 +32,7 @@ extern Oid GetPreassignedOidForDatabase(const char *datname);
 
 /* Functions used in master and QE nodes */
 extern void RestoreOidAssignments(List *oid_assignments);
+extern List *SaveOidAssignments(void);
 
 /* Functions used in binary upgrade */
 extern bool IsOidAcceptable(Oid oid);

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -24,4 +24,7 @@ extern bool is_simple_subquery(PlannerInfo *root, Query *subquery, RangeTblEntry
 				   JoinExpr *lowest_outer_join);
 extern JoinExpr *convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink, Relids available_rels);
 
+extern void cdbsubselect_drop_orderby(Query *subselect);
+extern void cdbsubselect_drop_distinct(Query *subselect);
+
 #endif   /* CDBSUBSELECT_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -214,6 +214,7 @@ typedef struct Query
 	 * would always be dispatched in parallel.
 	 */
 	ParentStmtType	parentStmtType;
+	bool		expandMatViews; /* force expansion of materialized views during rewrite to treat as views */
 } Query;
 
 /****************************************************************************
@@ -1026,6 +1027,7 @@ typedef struct GroupingClause
 	NodeTag      type;
 	GroupingType groupType;
 	List         *groupsets;
+	int			 location;
 } GroupingClause;
 
 /*

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -48,6 +48,7 @@ typedef enum
 extern PGDLLIMPORT int log_statement;
 
 extern List *pg_parse_query(const char *query_string);
+extern List *pg_rewrite_query(Query *query);
 extern List *pg_analyze_and_rewrite(Node *parsetree, const char *query_string,
 					   Oid *paramTypes, int numParams);
 extern List *pg_analyze_and_rewrite_params(Node *parsetree,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -613,6 +613,7 @@ extern IndexCheckType gp_indexcheck_vacuum;
 #define SOPT_ALIAS_APPENDOPTIMIZED "appendoptimized"
 /* Max number of chars needed to hold value of a storage option. */
 #define MAX_SOPT_VALUE_LEN 15
+#define SOPT_ANALYZEHLL    "analyze_hll_non_part_table"
 
 /*
  * Functions exported by guc.c

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -228,6 +228,7 @@ typedef struct StdRdOptions
 	int			fillfactor;		/* page fill factor in percent (0..100) */
 	AutoVacOpts autovacuum;		/* autovacuum-related options */
 
+	bool		analyze_hll_non_part_table; 		/* force hll statistics collection on relation */
 	bool		appendonly;		/* is this an appendonly relation? */
 	int			blocksize;		/* max varblock size (AO rels only) */
 	int			compresslevel;  /* compression level (AO rels only) */

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -401,20 +401,149 @@ ABORT
 1q: ... <quitting>
 2q: ... <quitting>
 
-11: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+CREATE
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+INSERT 10
+1: set optimizer = off;
+SET
+
+-- 2.8.1 with GDD enabled, expect blocking as is.
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1: show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+-- close session to avoid renew session failure after restart
+1q: ... <quitting>
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+-- 2.8.2 with GDD disabled, expect blocking
+-- reset gdd
+2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
 ALTER
+-- close session to avoid renew session failure after restart
+2q: ... <quitting>
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
  pg_ctl 
 --------
  OK     
 (1 row)
 
+1: set optimizer = off;
+SET
 1: show gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 
 ------------------------------------
  off                                
 (1 row)
 
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+
 1: drop table lockmodes_datadir;
 DROP
 1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/input/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/input/uao/create_index_allows_readonly.source
@@ -1,0 +1,53 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+create table ao_@orientation@_create_index_with_select_tbl(a int, b int) with (appendonly = true, orientation = @orientation@);
+insert into ao_@orientation@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+
+2: begin;
+-- expect no hang
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+-- expect no hang
+3: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+
+1: end;
+2: end;
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index ao_@orientation@_create_index_with_select_idx;
+
+1: begin;
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+
+2: begin;
+-- expect blocking
+2&: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+
+1: commit;
+
+2<:
+2: commit;
+
+drop index ao_@orientation@_create_index_with_select_idx;
+
+2: begin;
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+
+1: begin;
+-- expect blocking
+1&: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+
+2: commit;
+
+1<:
+1: commit;
+
+drop table ao_@orientation@_create_index_with_select_tbl;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -159,6 +159,7 @@ test: uao/vacuum_cleanup_row
 test: uao/vacuum_index_stats_row
 test: uao/insert_should_not_use_awaiting_drop_row
 test: uao/bitmapindex_rescan_row
+test: uao/create_index_allows_readonly_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_xlog_switch
@@ -213,6 +214,7 @@ test: uao/vacuum_cleanup_column
 test: uao/vacuum_index_stats_column
 test: uao/insert_should_not_use_awaiting_drop_column
 test: uao/bitmapindex_rescan_column
+test: uao/create_index_allows_readonly_column
 test: add_column_after_vacuum_skip_drop_column
 test: vacuum_after_vacuum_skip_drop_column
 

--- a/src/test/isolation2/output/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/output/uao/create_index_allows_readonly.source
@@ -1,0 +1,89 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+create table ao_@orientation@_create_index_with_select_tbl(a int, b int) with (appendonly = true, orientation = @orientation@);
+CREATE
+insert into ao_@orientation@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+INSERT 10
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+BEGIN
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect no hang
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+CREATE
+-- expect no hang
+3: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+1: end;
+END
+2: end;
+END
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index ao_@orientation@_create_index_with_select_idx;
+DROP
+
+1: begin;
+BEGIN
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect blocking
+2&: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: commit;
+COMMIT
+
+drop index ao_@orientation@_create_index_with_select_idx;
+DROP
+
+2: begin;
+BEGIN
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+CREATE
+
+1: begin;
+BEGIN
+-- expect blocking
+1&: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;  <waiting ...>
+
+2: commit;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: commit;
+COMMIT
+
+drop table ao_@orientation@_create_index_with_select_tbl;
+DROP

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -201,10 +201,90 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1q:
 2q:
 
-11: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+1: set optimizer = off;
+
+-- 2.8.1 with GDD enabled, expect blocking as is.
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1: show gp_enable_global_deadlock_detector;
+
+1: BEGIN;
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: set optimizer = off;
+
+2: BEGIN;
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: COMMIT;
+
+2<:
+2: COMMIT;
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+2: BEGIN;
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: BEGIN;
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: COMMIT;
+
+1<:
+1: COMMIT;
+-- close session to avoid renew session failure after restart
+1q:
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+-- 2.8.2 with GDD disabled, expect blocking
+-- reset gdd
+2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- close session to avoid renew session failure after restart
+2q:
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
 
+1: set optimizer = off;
 1: show gp_enable_global_deadlock_detector;
+
+1: BEGIN;
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: set optimizer = off;
+
+2: BEGIN;
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: COMMIT;
+
+2<:
+2: COMMIT;
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+2: BEGIN;
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: BEGIN;
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: COMMIT;
+
+1<:
+1: COMMIT;
 
 1: drop table lockmodes_datadir;
 1q:
+2q:

--- a/src/test/regress/expected/AORO_Compression.out
+++ b/src/test/regress/expected/AORO_Compression.out
@@ -25,3 +25,17 @@ CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=tr
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  rle_type cannot be used with Append Only relations row orientation
+-- Test get_ao_compression_ratio
+CREATE TABLE test_table (date date)
+PARTITION BY RANGE(date)
+(
+PARTITION test_cmp_02 START ('2022-02-01'::date) END ('2022-03-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_cmp_202202', appendonly='true', orientation='row', compresstype=zlib),
+START ('2022-03-01'::date) END ('2022-04-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_123', appendonly='false')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'date' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_table_1_prt_cmp_202202" for table "test_table"
+NOTICE:  CREATE TABLE will create partition "test_table_1_prt_123" for table "test_table"
+select get_ao_compression_ratio(partitionschemaname||'.'||partitiontablename) from pg_partitions WHERE tablename IN('test_table');
+ERROR:  'test_table_1_prt_123' is not an append-only relation
+drop table test_table;

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -796,6 +796,152 @@ INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via gp_segment_id qual with conjunction
+create table t_test_dd_via_segid_conj(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_test_dd_via_segid_conj select i,i from generate_series(1, 10)i;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((a >= 1) AND (a <= 10) AND (gp_segment_id = 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 2 | 2
+             0 | 3 | 3
+             0 | 4 | 4
+             0 | 7 | 7
+             0 | 8 | 8
+(5 rows)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((b >= 1) AND (b <= 5) AND (a >= 1) AND (a <= 10) AND (gp_segment_id = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             2 | 5 | 5
+(1 row)
+
+--test direct dispatch via gp_segment_id with disjunction
+explain (costs off) select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((gp_segment_id = 1) OR ((a = 3) AND (gp_segment_id = 2)))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+--test direct dispatch with constant distribution column and constant/variable gp_segment_id condition
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((b >= 1) AND (b <= 10) AND (gp_segment_id = ANY ('{0,1}'::integer[])) AND (a = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((b >= 1) AND (b <= 10) AND (gp_segment_id <> 1) AND (a = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((b >= 1) AND (b <= 100) AND (a = 3) AND (gp_segment_id = 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((a = ANY ('{1,3}'::integer[])) AND (gp_segment_id <> 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
+ gp_segment_id | a | b 
+---------------+---+---
+             1 | 1 | 1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((a = ANY ('{1,3}'::integer[])) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+             1 | 1 | 1
+(2 rows)
+
 -- test direct dispatch via gp_segment_id qual on distributed randomly table
 alter table t_test_dd_via_segid set distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -818,6 +818,158 @@ INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
              2 |     2
 (3 rows)
 
+-- test direct dispatch via gp_segment_id qual with conjunction
+create table t_test_dd_via_segid_conj(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_test_dd_via_segid_conj select i,i from generate_series(1, 10)i;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((gp_segment_id = 0) AND (a >= 1) AND (a <= 10))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 2 | 2
+             0 | 3 | 3
+             0 | 4 | 4
+             0 | 7 | 7
+             0 | 8 | 8
+(5 rows)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((b >= 1) AND (b <= 5) AND (gp_segment_id = 2) AND (a >= 1) AND (a <= 10))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             2 | 5 | 5
+(1 row)
+
+--test direct dispatch via gp_segment_id with disjunction
+explain (costs off) select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t_test_dd_via_segid_conj
+         Filter: ((gp_segment_id = 1) OR ((a = 3) AND (gp_segment_id = 2)))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+--test direct dispatch with constant distribution column and constant/variable gp_segment_id condition
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((a = 3) AND (b >= 1) AND (b <= 10) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((a = 3) AND (b >= 1) AND (b <= 10) AND (gp_segment_id <> 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((a = 3) AND (b >= 1) AND (b <= 100) AND (gp_segment_id = 0))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((a = ANY ('{1,3}'::integer[])) AND (gp_segment_id <> 0))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | a | b 
+---------------+---+---
+             1 | 1 | 1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         ->  Seq Scan on t_test_dd_via_segid_conj
+               Filter: ((a = ANY ('{1,3}'::integer[])) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | a | b 
+---------------+---+---
+             0 | 3 | 3
+             1 | 1 | 1
+(2 rows)
+
 -- test direct dispatch via gp_segment_id qual on distributed randomly table
 alter table t_test_dd_via_segid set distributed randomly;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -1,17 +1,28 @@
 -- gp_dump_query_oids() doesn't list built-in functions, so we need a UDF to test with.
 CREATE FUNCTION dumptestfunc(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
 CREATE FUNCTION dumptestfunc2(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
+create table base(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view base_mv as select a from base;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
   dumptestfunc_oid oid;
   dumptestfunc2_oid oid;
+  base_oid oid;
+  base_mv_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
+    base_oid = 'base'::regclass::oid;
+    base_mv_oid = 'base_mv'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
+    t := replace(t, base_oid::text, '<base_table>');
+    t := replace(t, base_mv_oid::text, '<base_mv>');
 
     RETURN t;
 end;
@@ -149,6 +160,12 @@ SELECT count(*) from (SELECT pg_catalog.gp_dump_query_oids('select * from unknow
  count 
 -------
      1
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
 (1 row)
 
 DROP TABLE foo;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2037,3 +2037,179 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(755246, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+-- test behavior of "analyze_hll_non_part_table" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+ reloptions 
+------------
+ 
+(1 row)
+
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+    reloptions     
+-------------------
+ {appendonly=true}
+(1 row)
+
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_off';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
+select reloptions from pg_class where relname='hll_off';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+select reloptions from pg_class where relname='hll_part_def';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1441,15 +1441,11 @@ where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
                ->  Seq Scan on t1_dedupsemi_indexonly
                      Filter: (a < 3)
          ->  Hash
-               ->  HashAggregate
-                     Group Key: t2_dedupsemi_indexonly.b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: t2_dedupsemi_indexonly.b
-                           ->  HashAggregate
-                                 Group Key: t2_dedupsemi_indexonly.b
-                                 ->  Seq Scan on t2_dedupsemi_indexonly
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2_dedupsemi_indexonly.b
+                     ->  Seq Scan on t2_dedupsemi_indexonly
  Optimizer: Postgres query optimizer
-(16 rows)
+(12 rows)
 
 select * from
 (

--- a/src/test/regress/expected/misc_jiras.out
+++ b/src/test/regress/expected/misc_jiras.out
@@ -58,3 +58,49 @@ select gp_inject_fault('winagg_after_spool_tuples', 'reset', dbid)
 reset statement_mem;
 drop table misc_jiras.t1;
 drop schema misc_jiras;
+-- test for issue https://github.com/greenplum-db/gpdb/issues/14539
+-- the \c command to renew the session to make sure the global var
+-- NextRecordTypmod is 0. For details please refer to the issue.
+create table t_record_type_param_dispatch (a int, b int) distributed by (a);
+explain (costs off)
+with cte as (
+  select * from t_record_type_param_dispatch order by random() limit
+  ( select count(*) /2 from t_record_type_param_dispatch )
+)
+select *, case when t in (select t from cte t) then 'a' else 'b' end
+from t_record_type_param_dispatch t;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Seq Scan on t_record_type_param_dispatch t
+         SubPlan 2  (slice4; segments: 3)
+           ->  Materialize
+                 ->  Broadcast Motion 1:3  (slice3; segments: 1)
+                       ->  Subquery Scan on t_1
+                             ->  Limit
+                                   InitPlan 1 (returns $0)  (slice5)
+                                     ->  Aggregate
+                                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                 ->  Aggregate
+                                                       ->  Seq Scan on t_record_type_param_dispatch
+                                   ->  Gather Motion 3:1  (slice1; segments: 3)
+                                         Merge Key: (random())
+                                         ->  Limit
+                                               ->  Sort
+                                                     Sort Key: (random())
+                                                     ->  Seq Scan on t_record_type_param_dispatch t_record_type_param_dispatch_1
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+\c
+with cte as (
+  select * from t_record_type_param_dispatch order by random() limit
+  ( select count(*) /2 from t_record_type_param_dispatch )
+)
+select *, case when t in (select t from cte t) then 'a' else 'b' end
+from t_record_type_param_dispatch t;
+ a | b | case 
+---+---+------
+(0 rows)
+
+drop table t_record_type_param_dispatch;

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -393,38 +393,28 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                         QUERY PLAN
+                                                         QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000008.02..10000000008.03 rows=4 width=8)
    Merge Key: l1.x, l1.y
    ->  Sort  (cost=10000000008.02..10000000008.03 rows=2 width=8)
          Sort Key: l1.x, l1.y
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000003.25..10000000007.99 rows=2 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.35..3.56 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.35..3.51 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.35..3.39 rows=1 width=12)
-                                 ->  Unique  (cost=3.35..3.36 rows=1 width=16)
-                                       Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                       ->  Sort  (cost=3.35..3.36 rows=1 width=16)
-                                             Sort Key (Distinct): l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.30..3.34 rows=1 width=16)
-                                                   Hash Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                   ->  Unique  (cost=3.30..3.32 rows=1 width=16)
-                                                         Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                         ->  Sort  (cost=3.30..3.31 rows=1 width=16)
-                                                               Sort Key (Distinct): l1_1.y
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group Key: l1_1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: l1_1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group Key: l1_1.y
-                                                                                 ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: (y < 4)
+               ->  Materialize  (cost=3.25..3.47 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group Key: l1_1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: l1_1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group Key: l1_1.y
+                                                   ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(29 rows)
+(19 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
@@ -1633,6 +1623,81 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
         1
 (1 row)
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2p(b int, a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Update on t1p
+   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+         Hash Key: ((SubPlan 1))
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: (t1p_1.c = t1p.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1p_1.c
+                           ->  Seq Scan on t1p t1p_1
+                     ->  Hash
+                           ->  Seq Scan on t1p
+                     SubPlan 1  (slice3; segments: 1)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: ((diff.diff = t2p.a) AND (t1p_1.b = t2p.b))
+                             ->  Function Scan on generate_series diff
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     ->  Seq Scan on t2p
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+drop table t1p;
+drop table t2p;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 24 other objects

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -398,38 +398,28 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                         QUERY PLAN
+                                                         QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000008.02..10000000008.03 rows=4 width=8)
    Merge Key: l1.x, l1.y
    ->  Sort  (cost=10000000008.02..10000000008.03 rows=2 width=8)
          Sort Key: l1.x, l1.y
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000003.25..10000000007.99 rows=2 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.35..3.56 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.35..3.51 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.35..3.39 rows=1 width=12)
-                                 ->  Unique  (cost=3.35..3.36 rows=1 width=16)
-                                       Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                       ->  Sort  (cost=3.35..3.36 rows=1 width=16)
-                                             Sort Key (Distinct): l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.30..3.34 rows=1 width=16)
-                                                   Hash Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                   ->  Unique  (cost=3.30..3.32 rows=1 width=16)
-                                                         Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                         ->  Sort  (cost=3.30..3.31 rows=1 width=16)
-                                                               Sort Key (Distinct): l1_1.y
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group Key: l1_1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: l1_1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group Key: l1_1.y
-                                                                                 ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: (y < 4)
+               ->  Materialize  (cost=3.25..3.47 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group Key: l1_1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: l1_1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group Key: l1_1.y
+                                                   ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(29 rows)
+(19 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
@@ -1711,6 +1701,81 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
         1
 (1 row)
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2p(b int, a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Update on t1p
+   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+         Hash Key: ((SubPlan 1))
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: (t1p_1.c = t1p.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1p_1.c
+                           ->  Seq Scan on t1p t1p_1
+                     ->  Hash
+                           ->  Seq Scan on t1p
+                     SubPlan 1  (slice3; segments: 1)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: ((diff.diff = t2p.a) AND (t1p_1.b = t2p.b))
+                             ->  Function Scan on generate_series diff
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     ->  Seq Scan on t2p
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+drop table t1p;
+drop table t2p;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 24 other objects

--- a/src/test/regress/expected/oid_consistency.out
+++ b/src/test/regress/expected/oid_consistency.out
@@ -810,3 +810,17 @@ select verify('trigger_oid');
       1
 (1 row)
 
+-- Case for Issue: https://github.com/greenplum-db/gpdb/issues/14465
+create function func_fail_14465(int) returns int
+  immutable language plpgsql as $$
+  begin
+    perform unwanted_grant();
+    raise warning 'owned';
+    return 1;
+  exception when others then
+			  return 2;
+			  end$$;
+create materialized view mv_14465 as select 1 as c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index on mv_14465 (c) where func_fail_14465(1) > 0;

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6253,3 +6253,15 @@ order by 1, 2;
 (20 rows)
 
 drop table foo_gset;
+-- test CUBE cannot have more than 12 elements
+create table t_cube_12_limit(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int,
+                             c8 int, c9 int, c10 int, c11 int, c12 int, c13 int, c14 int,
+			     c15 int, c16 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, sum(c16) from t_cube_12_limit
+group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13), c14, c15;
+ERROR:  CUBE is limited to 12 elements
+LINE 2: group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, ...
+                 ^
+drop table t_cube_12_limit;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -2730,6 +2730,25 @@ alter table k split default partition start(10) end(20);
 ERROR:  cannot SPLIT DEFAULT PARTITION with LIST
 HINT:  Use SPLIT with the AT clause instead.
 drop table k;
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+NOTICE:  table "issue_14186" does not exist, skipping
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_1" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_2" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_3" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_4" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_5" for table "issue_14186"
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_prt_20210301" for table "issue_14186"
+ERROR:  relation "issue_14186" does not have a default partition
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -2734,6 +2734,25 @@ alter table k split default partition start(10) end(20);
 ERROR:  cannot SPLIT DEFAULT PARTITION with LIST
 HINT:  Use SPLIT with the AT clause instead.
 drop table k;
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+NOTICE:  table "issue_14186" does not exist, skipping
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_1" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_2" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_3" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_4" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_5" for table "issue_14186"
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_prt_20210301" for table "issue_14186"
+ERROR:  relation "issue_14186" does not have a default partition
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -1,4 +1,6 @@
--- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- 1) Ensure that pg_dump --binary-upgrade correctly outputs
+-- ALTER TABLE DROP COLUMN DDL for external tables.
+-- 2) Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
 -- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
 -- dropped column reference on the root partition exists whereas the
 -- same dropped column reference does not exist on all of its child
@@ -8,7 +10,15 @@
 -- pg_upgrade's check_gp.c for more details on homogeneous and
 -- heterogeneous partitions.
 CREATE SCHEMA dump_this_schema;
--- Scenario 1: Create homogeneous partition table where the root
+-- 1) External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+    a int,
+    b int,
+    c int
+) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
+-- 2) Scenario 1: Create homogeneous partition table where the root
 -- partition and ALL of its child partitions have the dropped column
 -- reference.
 CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
@@ -41,7 +51,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partiti
  dropped_column_homogeneous_partition_table          | ........pg.dropped.3........
 (3 rows)
 
--- Scenario 2: Create homogeneous partition table where only the root
+-- 2) Scenario 2: Create homogeneous partition table where only the root
 -- partition has the dropped column reference (as defined by
 -- pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
@@ -75,7 +85,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
  dropped_column_special_homogeneous_partition_table | ........pg.dropped.3........
 (1 row)
 
--- Scenario 3: Create homogeneous partition table where only the root
+-- 2) Scenario 3: Create homogeneous partition table where only the root
 -- and subroot partition has the dropped column reference (as defined
 -- by pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (
@@ -121,7 +131,8 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
 \! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
 ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN "........pg.dropped.3........";
 DROP SCHEMA dump_this_schema CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to external table dump_this_schema.external_table_with_dropped_columns
+drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1199,12 +1199,12 @@ set enable_nestloop=on;
 explain select b from dist_tab where b in (select distinct c from rep_tab);
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000601.46 rows=4 width=4)
-   ->  Nested Loop  (cost=10000000001.16..10000000601.46 rows=2 width=4)
-         ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000601.42 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000001.16..10000000601.42 rows=2 width=4)
+         ->  Unique  (cost=10000000001.03..10000000001.04 rows=1 width=4)
                Group Key: rep_tab.c
-               ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                     Sort Key: rep_tab.c
+               ->  Sort  (cost=10000000001.03..10000000001.03 rows=1 width=4)
+                     Sort Key (Distinct): rep_tab.c
                      ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
          ->  Index Only Scan using idx on dist_tab  (cost=0.13..300.17 rows=1 width=4)
                Index Cond: (b = rep_tab.c)
@@ -1232,20 +1232,16 @@ analyze rand_tab;
 --
 -- join derives EdtHashed
 explain select c from rep_tab where c in (select distinct c from rep_tab);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000001.11..20000000002.17 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000002.17 rows=4 width=4)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000001.05..20000000002.11 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000002.11 rows=4 width=4)
          Hash Cond: (rep_tab.c = rep_tab_1.c)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab_1.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab_1.c
-                           ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select c from rep_tab where c in (select distinct c from rep_tab);
  c 
@@ -1260,20 +1256,16 @@ select c from rep_tab where c in (select distinct c from rep_tab);
 --
 -- join derives EdtHashed
 explain select a from dist_tab where a in (select distinct c from rep_tab);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.20 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000003.20 rows=2 width=4)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.05..20000000003.14 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000003.14 rows=2 width=4)
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select a from dist_tab where a in (select distinct c from rep_tab);
  a 
@@ -1290,20 +1282,16 @@ select a from dist_tab where a in (select distinct c from rep_tab);
 --
 -- join derives EdtRandom
 explain select d from rand_tab where d in (select distinct c from rep_tab);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.17 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000003.17 rows=2 width=4)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.05..20000000002.11 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000002.11 rows=2 width=4)
          Hash Cond: (rand_tab.d = rep_tab.c)
-         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select d from rand_tab where d in (select distinct c from rep_tab);
  d 
@@ -1320,17 +1308,15 @@ select d from rand_tab where d in (select distinct c from rep_tab);
 explain select c from rep_tab where c in (select distinct a from dist_tab);
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
- Hash Semi Join  (cost=20000000003.18..20000000003.22 rows=4 width=4)
+ Hash Semi Join  (cost=20000000003.19..20000000003.23 rows=4 width=4)
    Hash Cond: (rep_tab.c = dist_tab.a)
    ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-   ->  Hash  (cost=10000000002.13..10000000002.13 rows=1 width=4)
-         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000002.05..10000000002.13 rows=2 width=4)
-               ->  HashAggregate  (cost=10000000002.05..10000000002.07 rows=1 width=4)
-                     Group Key: dist_tab.a
-                     ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
+   ->  Hash  (cost=10000000002.12..10000000002.12 rows=2 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000000002.12 rows=4 width=4)
+               ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 select c from rep_tab where c in (select distinct a from dist_tab);
  c 
@@ -1345,27 +1331,17 @@ select c from rep_tab where c in (select distinct a from dist_tab);
 --
 -- join derives EdtHashed
 explain select c from rep_tab where c in (select distinct d from rand_tab);
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join  (cost=20000000003.27..20000000003.31 rows=4 width=4)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Hash Semi Join  (cost=20000000003.11..20000000003.15 rows=4 width=4)
    Hash Cond: (rep_tab.c = rand_tab.d)
    ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-   ->  Hash  (cost=10000000002.22..10000000002.22 rows=1 width=4)
-         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000002.11..10000000002.22 rows=2 width=4)
-               ->  GroupAggregate  (cost=10000000002.11..10000000002.16 rows=1 width=4)
-                     Group Key: rand_tab.d
-                     ->  Sort  (cost=10000000002.11..10000000002.11 rows=1 width=4)
-                           Sort Key: rand_tab.d
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000002.03..10000000002.10 rows=1 width=4)
-                                 Hash Key: rand_tab.d
-                                 ->  GroupAggregate  (cost=10000000002.03..10000000002.06 rows=1 width=4)
-                                       Group Key: rand_tab.d
-                                       ->  Sort  (cost=10000000002.03..10000000002.03 rows=1 width=4)
-                                             Sort Key: rand_tab.d
-                                             ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
+   ->  Hash  (cost=10000000002.06..10000000002.06 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000000002.06 rows=2 width=4)
+               ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(18 rows)
+(8 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -820,7 +820,7 @@ explain (verbose, costs off)
 select * from int4_tbl where
   (case when f1 in (select unique1 from tenk1 a) then f1 else null end) in
   (select ten from tenk1 b);
-                                                  QUERY PLAN
+                                                  QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    Output: int4_tbl.f1
@@ -880,13 +880,12 @@ select * from int4_tbl o where (f1, f1) in
                ->  Subquery Scan on "ANY_subquery"
                      Output: "ANY_subquery".f1, "ANY_subquery".g
                      Filter: ("ANY_subquery".f1 = "ANY_subquery".g)
-                     ->  HashAggregate
+                     ->  Result
                            Output: i.f1, (generate_series(1, 2) / 10)
-                           Group Key: i.f1
                            ->  Seq Scan on public.int4_tbl i
                                  Output: i.f1
  Optimizer: Postgres query optimizer
-(18 rows)
+(17 rows)
 
 select * from int4_tbl o where (f1, f1) in
   (select f1, generate_series(1,2) / 10 g from int4_tbl i group by f1);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1672,6 +1672,81 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..6.30 rows=8 width=8)
+   ->  Hash Semi Join  (cost=3.11..6.30 rows=3 width=8)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..3.08 rows=3 width=8)
+         ->  Hash  (cost=3.10..3.10 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..28.15 rows=4 width=8)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..28.15 rows=2 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Limit  (cost=3.11..3.15 rows=1 width=4)
+                 ->  Limit  (cost=3.11..3.13 rows=1 width=4)
+                       ->  GroupAggregate  (cost=3.11..3.13 rows=1 width=4)
+                             Group Key: subselect_tbl.f2
+                             ->  Sort  (cost=3.11..3.11 rows=1 width=4)
+                                   Sort Key: subselect_tbl.f2
+                                   ->  Result  (cost=0.00..3.11 rows=1 width=4)
+                                         Filter: (subselect_tbl.f1 = upper.f1)
+                                         ->  Materialize  (cost=0.00..3.11 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.10 rows=1 width=4)
+                                                     ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..6.30 rows=8 width=8)
+   ->  Hash Semi Join  (cost=3.11..6.30 rows=3 width=8)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..3.08 rows=3 width=8)
+         ->  Hash  (cost=3.10..3.10 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..28.14 rows=4 width=8)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..28.14 rows=2 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Limit  (cost=3.11..3.15 rows=1 width=4)
+                 ->  Limit  (cost=3.11..3.11 rows=1 width=4)
+                       ->  Sort  (cost=3.11..3.11 rows=1 width=4)
+                             Sort Key: subselect_tbl.f2
+                             ->  Result  (cost=0.00..3.11 rows=1 width=4)
+                                   Filter: (subselect_tbl.f1 = upper.f1)
+                                   ->  Materialize  (cost=0.00..3.11 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.10 rows=1 width=4)
+                                               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.
@@ -1723,10 +1798,10 @@ EXPLAIN select count(*) from
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=437.18..437.19 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=437.11..437.16 rows=1 width=8)
-         ->  Aggregate  (cost=437.11..437.12 rows=1 width=8)
-               ->  Hash Semi Join  (cost=220.50..436.86 rows=34 width=0)
+ Aggregate  (cost=644.06..644.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=644.00..644.05 rows=1 width=8)
+         ->  Aggregate  (cost=644.00..644.01 rows=1 width=8)
+               ->  Hash Join  (cost=416.25..643.75 rows=34 width=0)
                      Hash Cond: (a.unique1 = b.hundred)
                      ->  Seq Scan on tenk1 a  (cost=0.00..189.00 rows=3334 width=4)
                      ->  Hash  (cost=219.25..219.25 rows=34 width=4)
@@ -1734,9 +1809,7 @@ EXPLAIN select count(*) from
                                  Group Key: b.hundred
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
                                        Hash Key: b.hundred
-                                       ->  HashAggregate  (cost=70.67..71.67 rows=100 width=4)
-                                             Group Key: b.hundred
-                                             ->  Seq Scan on tenk1 b  (cost=0.00..62.33 rows=3333 width=4)
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
  Optimizer: Postgres query optimizer
 (15 rows)
 
@@ -1750,7 +1823,7 @@ EXPLAIN select count(distinct ss.ten) from
          ->  Aggregate  (cost=439.11..439.12 rows=1 width=8)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=220.50..438.86 rows=34 width=4)
                      Hash Key: a.ten
-                     ->  Hash Semi Join  (cost=220.50..436.86 rows=34 width=4)
+                     ->  Hash Join  (cost=416.25..643.75 rows=34 width=4)
                            Hash Cond: (a.unique1 = b.hundred)
                            ->  Seq Scan on tenk1 a  (cost=0.00..189.00 rows=3334 width=8)
                            ->  Hash  (cost=219.25..219.25 rows=34 width=4)
@@ -1758,9 +1831,7 @@ EXPLAIN select count(distinct ss.ten) from
                                        Group Key: b.hundred
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=214.00..216.00 rows=34 width=4)
                                              Hash Key: b.hundred
-                                             ->  HashAggregate  (cost=214.00..214.00 rows=34 width=4)
-                                                   Group Key: b.hundred
-                                                   ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
  Optimizer: Postgres query optimizer
 (15 rows)
 
@@ -2668,6 +2739,34 @@ select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issu
  i |   j   
 ---+-------
  1 | 10002
+(1 row)
+
+-- case 3, check correlated DISTINCT ON
+explain select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+   ->  Seq Scan on issue_12656 a  (cost=0.00..3.11 rows=1 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Unique  (cost=1.03..1.04 rows=1 width=8)
+                 Group Key: b.i
+                 ->  Sort  (cost=1.03..1.04 rows=1 width=8)
+                       Sort Key (Distinct): b.j
+                       ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                             Filter: (a.i = b.i)
+                             ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                         ->  Seq Scan on issue_12656 b  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
 (1 row)
 
 -- A guard test case for gpexpand's populate SQL

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1654,6 +1654,81 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.55 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.55 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.55 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  GroupAggregate  (cost=0.00..431.01 rows=1 width=4)
+                             Group Key: subselect_tbl_1.f2
+                             ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                                   Sort Key: subselect_tbl_1.f2
+                                   ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                         Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                         ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.57 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.57 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.57 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                             Sort Key: subselect_tbl_1.f2
+                             ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                   Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                   ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.
@@ -2817,6 +2892,34 @@ select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issu
  i |   j   
 ---+-------
  1 | 10002
+(1 row)
+
+-- case 3, check correlated DISTINCT ON
+explain select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+   ->  Seq Scan on issue_12656 a  (cost=0.00..3.11 rows=1 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Unique  (cost=1.03..1.04 rows=1 width=8)
+                 Group Key: b.i
+                 ->  Sort  (cost=1.03..1.04 rows=1 width=8)
+                       Sort Key (Distinct): b.j
+                       ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                             Filter: (a.i = b.i)
+                             ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                         ->  Seq Scan on issue_12656 b  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
 (1 row)
 
 -- A guard test case for gpexpand's populate SQL

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -928,9 +928,8 @@ select * from int4_tbl o where (f1, f1) in
                ->  Subquery Scan on "ANY_subquery"
                      Output: "ANY_subquery".f1, "ANY_subquery".g
                      Filter: ("ANY_subquery".f1 = "ANY_subquery".g)
-                     ->  HashAggregate
+                     ->  Result
                            Output: i.f1, (generate_series(1, 2) / 10)
-                           Group Key: i.f1
                            ->  Seq Scan on public.int4_tbl i
                                  Output: i.f1
  Optimizer: Postgres query optimizer

--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -336,3 +340,131 @@ select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_a
  (2,0,1)
 (6 rows)
 
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_ao_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uao_catalog_delete_from (a int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoseg_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT select_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ select_dummy_ao_aux_entry 
+---------------------------
+                         0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION select_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -88,3 +92,131 @@ select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count
  (2,0,1)
 (6 rows)
 
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_aoco_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uaocs_catalog_delete_from (a int) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aocsseg_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT select_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ select_dummy_aoco_aux_entry 
+-----------------------------
+                           0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION select_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;

--- a/src/test/regress/sql/AORO_Compression.sql
+++ b/src/test/regress/sql/AORO_Compression.sql
@@ -11,3 +11,15 @@ SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
 
 -- Test basic create table for AO/RO table fails for rle compression. rle is only supported for columnar tables.
 CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, COMPRESSLEVEL=1, ORIENTATION=row);
+
+-- Test get_ao_compression_ratio
+CREATE TABLE test_table (date date)
+PARTITION BY RANGE(date)
+(
+PARTITION test_cmp_02 START ('2022-02-01'::date) END ('2022-03-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_cmp_202202', appendonly='true', orientation='row', compresstype=zlib),
+START ('2022-03-01'::date) END ('2022-04-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_123', appendonly='false')
+);
+
+select get_ao_compression_ratio(partitionschemaname||'.'||partitiontablename) from pg_partitions WHERE tablename IN('test_table');
+
+drop table test_table;

--- a/src/test/regress/sql/direct_dispatch.sql
+++ b/src/test/regress/sql/direct_dispatch.sql
@@ -314,6 +314,37 @@ select t1.gp_segment_id, t2.gp_segment_id, * from t_test_dd_via_segid t1, t_test
 explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
 
+-- test direct dispatch via gp_segment_id qual with conjunction
+create table t_test_dd_via_segid_conj(a int, b int);
+insert into t_test_dd_via_segid_conj select i,i from generate_series(1, 10)i;
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+select gp_segment_id, * from t_test_dd_via_segid_conj where gp_segment_id=0 and a between 1 and 10;
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+select gp_segment_id, * from t_test_dd_via_segid_conj where b between 1 and 5 and gp_segment_id=2 and a between 1 and 10;
+
+--test direct dispatch via gp_segment_id with disjunction
+
+explain (costs off) select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+select * from t_test_dd_via_segid_conj where gp_segment_id=1 or (a=3 and gp_segment_id=2);
+
+--test direct dispatch with constant distribution column and constant/variable gp_segment_id condition
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id in (0,1);
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 10 and gp_segment_id <>1;
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+select gp_segment_id, * from t_test_dd_via_segid_conj where a =3 and b between 1 and 100 and gp_segment_id =0;
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id <> 0;
+
+explain (costs off) select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+select gp_segment_id, * from t_test_dd_via_segid_conj where a in (1,3) and gp_segment_id in (0,1);
+
 -- test direct dispatch via gp_segment_id qual on distributed randomly table
 alter table t_test_dd_via_segid set distributed randomly;
 

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -845,3 +845,84 @@ truncate foo_1_prt_20210201;
 insert into foo select a, '20210101'::date+a from (select generate_series(31,40) a) t1;
 analyze verbose foo_1_prt_20210201;
 rollback;
+
+-- test behavior of "analyze_hll_non_part_table" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+
+create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_off';
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
+select reloptions from pg_class where relname='hll_off';
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -532,5 +532,54 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
 update t2_13212 set b = 2;
 select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+create table t2p(b int, a int);
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+
+drop table t1p;
+drop table t2p;
+
 reset search_path;
 drop schema notin cascade;

--- a/src/test/regress/sql/oid_consistency.sql
+++ b/src/test/regress/sql/oid_consistency.sql
@@ -429,3 +429,16 @@ $$ language plpgsql no sql;
 create trigger troid_trigger after insert on trigger_oid for each row execute procedure trig_func();
 
 select verify('trigger_oid');
+
+-- Case for Issue: https://github.com/greenplum-db/gpdb/issues/14465
+create function func_fail_14465(int) returns int
+  immutable language plpgsql as $$
+  begin
+    perform unwanted_grant();
+    raise warning 'owned';
+    return 1;
+  exception when others then
+			  return 2;
+			  end$$;
+create materialized view mv_14465 as select 1 as c;
+create index on mv_14465 (c) where func_fail_14465(1) > 0;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -705,3 +705,11 @@ group by c2, rollup((c1))
 order by 1, 2;
 
 drop table foo_gset;
+
+-- test CUBE cannot have more than 12 elements
+create table t_cube_12_limit(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int,
+                             c8 int, c9 int, c10 int, c11 int, c12 int, c13 int, c14 int,
+			     c15 int, c16 int);
+select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, sum(c16) from t_cube_12_limit
+group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13), c14, c15;
+drop table t_cube_12_limit;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1397,6 +1397,18 @@ default partition mydef);
 alter table k split default partition start(10) end(20);
 drop table k;
 
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -125,3 +130,84 @@ update uao_table_check_hidden_tup_count_after_update set j = 'test21';
 select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
 vacuum full uao_table_check_hidden_tup_count_after_update;
 select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
+
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_ao_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uao_catalog_delete_from (a int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+SELECT select_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION select_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -38,3 +43,84 @@ update uaocs_table_check_hidden_tup_count_after_update set j = 'test_update';
 select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
 vacuum full uaocs_table_check_hidden_tup_count_after_update;
 select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
+
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_aoco_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uaocs_catalog_delete_from (a int) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+SELECT select_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION select_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;


### PR DESCRIPTION
Add reloption to force table to collect HLL stats.patch Add valid Default Partition check in ATPExecPartSplit.patch Allow direct dispatch when filtering on gp_segment_id.patch Backport GPDB_12_MERGE_FIXME create index on AO-CO allows read-only transactions.patch Bring back cdbsubselect_drop_distinct.patch
CUBE is limited to at most have 12 elements.patch
Fix crash of not-in pullup sublink with Params.patch fix crash on get_ao_compression_ratio of heap table.patch Fix dependency bug with minirepro and materialized views.patch Fix errors when trying to DELETE FROM AO-CO auxiliary tables.patch Fix reference null pointer issue in deserializeParamListInfo.patch fix upgrading external tables with dropped cols.patch ORCA: Fix data corruption error for domain.patch
Refactor SaveOidAssignments and RestoreOidAssignments logic.patch

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
