### PR TITLE
Fix mirror checkpointer error on the alter database query

### DIFF
--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -2226,6 +2226,8 @@ dbase_redo(XLogRecPtr beginLoc  __attribute__((unused)), XLogRecPtr lsn  __attri
 		}
 		pfree(parentdir);
 
+		ForgetDatabaseFsyncRequests(xlrec->db_id);
+
 		/*
 		 * Force dirty buffers out to disk, to ensure source database is
 		 * up-to-date for the copy.


### PR DESCRIPTION
Steps to reproduce:
1. Set the fsync GUC to on. 
2. Make changes to a database and move it to another tablespace, for example:
```
psql -c "create tablespace ts1 location '/tmp/ts'" postgres
psql -c "create database test" postgres
psql -c "create table t (i int)  DISTRIBUTED randomly" test
psql -c "alter database test SET TABLESPACE ts1" postgres
```

If a mirror checkpointer doesn't create checkpoint between "create table" and "alter database", then attempt to create checkpoint the next time will result in the file synchronization error, because the file doesn't exist. At the moment of checkpoint creating the database file has already been moved to a new tablespace, but fsync request to checkpointer was not changed.

In the end of copydir() function the database is fsynced, so it is necessary to cancel all fsync requests to checkpointer related to this database and don't add new ones in FlushDatabaseBuffers() before copydir() calling.