### PR TITLE
Fix url_curl.c headers handling

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -287,14 +287,19 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 	Assert(size == 1);
 
 	/*
-	 * parse the http response line (code and message) from
+	 * Parse the http response line (code and message) from
 	 * the http header that we get. Basically it's the whole
 	 * first line (e.g: "HTTP/1.0 400 time out"). We do this
 	 * in order to capture any error message that comes from
 	 * gpfdist, and later use it to report the error string in
 	 * check_response() to the database user.
+	 * As we can get multiple header blocks for multiple HTTP
+	 * messages, we need to parse all headers and get the last
+	 * one. First header may contain only successfull status and
+	 * no info about the error.
 	 */
-	if (url->http_response == 0)
+
+	if (len > 5 && *ptr == 'H' && 0 == strncmp("HTTP/", ptr, 5))
 	{
 		int 	n = nmemb;
 		char* 	p;
@@ -309,6 +314,9 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 
 			if (n > 0 && (p[n-1] == '\r' || p[n-1] == '\n'))
 				p[--n] = 0;
+
+			if (url->http_response)
+				pfree(url->http_response);
 
 			url->http_response = p;
 		}

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -26,11 +26,6 @@ CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152
 
 -- end_ignore
 
--- start_matchsubs
--- m/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/
--- s/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/ERROR:  http response code 500 from gpfdist\. HTTP1\.0 500/
--- end_matchsubs
-
 
 -- --------------------------------------
 -- 'gpfdist' protocol

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -26,6 +26,11 @@ CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152
 
 -- end_ignore
 
+-- start_matchsubs
+-- m/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/
+-- s/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/ERROR:  http response code 500 from gpfdist\. HTTP1\.0 500/
+-- end_matchsubs
+
 
 -- --------------------------------------
 -- 'gpfdist' protocol
@@ -483,7 +488,9 @@ COPY wet_region FROM STDIN DELIMITER '|';
 3|EUROPE|ly final courts cajole furiously final excuse
 \.
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
-
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -6,10 +6,6 @@ set optimizer_print_missing_stats = off;
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 -- start_ignore
 -- end_ignore
--- start_matchsubs
--- m/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/
--- s/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/ERROR:  http response code 500 from gpfdist\. HTTP1\.0 500/
--- end_matchsubs
 -- --------------------------------------
 -- 'gpfdist' protocol
 -- --------------------------------------
@@ -669,7 +665,7 @@ INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
 -- Check error correctness, if trying to insert too long row
 INSERT INTO wet_pos1(a)
 SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
-ERROR:  http response code 500 from gpfdist. HTTP1.0 500
+ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -6,6 +6,10 @@ set optimizer_print_missing_stats = off;
 CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
 -- start_ignore
 -- end_ignore
+-- start_matchsubs
+-- m/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/
+-- s/^ERROR:  http response code 500 from gpfdist .* HTTP\/1.0 500.*$/ERROR:  http response code 500 from gpfdist\. HTTP1\.0 500/
+-- end_matchsubs
 -- --------------------------------------
 -- 'gpfdist' protocol
 -- --------------------------------------
@@ -662,6 +666,10 @@ COPY reg_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region SELECT * from reg_region;
 COPY wet_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
+ERROR:  http response code 500 from gpfdist. HTTP1.0 500
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger


### PR DESCRIPTION
Previously, header_callback(), used to get and parse HTTP headers, took only first status header from all header blocks to show it to user. The problem is that we can have multiple messages with multiple header blocks. In case of error, only first (successful) status is shown to user, which is not informative. This patch fixes header_callback(), which now process all status headers.
___________________
Here is an example of case we faced during the testing of insertion to gpfdist.
We used a long row (more that 32K) to check how gpfdist handles it.
```
gpfdist -d /opt/gpfdist -p 8081 -l /opt/gpfdist/log8081.log

create writable external table table_ext_wr(s varchar)
location ('gpfdist://localhost:8081/out_00.csv')
format 'CSV';

insert into table_ext_wr
select string_agg(md5(random()::text), '') from generate_series(1,1100);
ERROR:  http response code 500 from gpfdist (gpfdist://localhost:8081/out_00.csv): HTTP/1.0 200 ok  (seg1 127.0.1.1:6003 pid=365416)
```
The problem is users see "some" error, but, unfortunately, have no way to debug it. The only message they see is "ok" (with HTTP/1.0 200 status).
Here are all header blocks we got on gpdb side:
```
"HTTP/1.0 200 ok\r\n"
"Content-type: text/plain\r\n"
"Expires: 0\r\n"
"X-GPFDIST-VERSION: 6.22.1_arenadata41 build dev\r\n"
"X-GP-PROTO: 0\r\n"
"Cache-Control: no-cache\r\n"
"Connection: close\r\n"
"\r\n"

"HTTP/1.1 100 Continue\r\n"
"\r\n"

"HTTP/1.0 500 no complete data row found for writing\r\n"
"Content-length: 0\r\n"
"Expires: 0\r\n"
"X-GPFDIST-VERSION: 6.22.1_arenadata41 build dev\r\n"
"Cache-Control: no-cache\r\n"
"Connection: close\r\n"
"\r\n"
```
From this patch, gpdb starting to respect latest header messages.