### PR TITLE
Backport: Correctly report instrumentation of zero-ouput node

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1112,6 +1112,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 	 */
 	CdbExplain_NodeSummary *ns;
 	CdbExplain_DepStatAcc ntuples;
+	CdbExplain_DepStatAcc nloops;
 	CdbExplain_DepStatAcc execmemused;
 	CdbExplain_DepStatAcc workmemused;
 	CdbExplain_DepStatAcc workmemwanted;
@@ -1140,6 +1141,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 
 	/* Initialize per-node accumulators. */
 	cdbexplain_depStatAcc_init0(&ntuples);
+	cdbexplain_depStatAcc_init0(&nloops);
 	cdbexplain_depStatAcc_init0(&execmemused);
 	cdbexplain_depStatAcc_init0(&workmemused);
 	cdbexplain_depStatAcc_init0(&workmemwanted);
@@ -1184,6 +1186,7 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 
 		/* Update per-node accumulators. */
 		cdbexplain_depStatAcc_upd(&ntuples, rsi->ntuples, rsh, rsi, nsi);
+		cdbexplain_depStatAcc_upd(&nloops, rsi->nloops, rsh, rsi, nsi);
 		cdbexplain_depStatAcc_upd(&execmemused, rsi->execmemused, rsh, rsi, nsi);
 		cdbexplain_depStatAcc_upd(&workmemused, rsi->workmemused, rsh, rsi, nsi);
 		cdbexplain_depStatAcc_upd(&workmemwanted, rsi->workmemwanted, rsh, rsi, nsi);
@@ -1239,6 +1242,9 @@ cdbexplain_depositStatsToNode(PlanState *planstate, CdbExplain_RecvStatCtx *ctx)
 		instr->workfileCreated = ntuples.nsimax->workfileCreated;
 		instr->firststart = ntuples.nsimax->firststart;
 	}
+	/* Save non-zero nloops even when 0 tuple is returned */
+	else if (nloops.agg.vcnt > 0)
+		instr->nloops = nloops.nsimax->nloops;
 
 	/* Save extra message text for the most interesting winning qExecs. */
 	if (ctx->extratextbuf)

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -813,23 +813,23 @@ select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
 -- explain analyze
 --
 explain analyze select * from t, pt where tid = ptid;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..443.01 rows=18 width=50) (actual time=3.690..5.812 rows=18 loops=1)
-   ->  Nested Loop  (cost=0.00..443.01 rows=6 width=50) (actual time=2.262..3.300 rows=8 loops=1)
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50) (actual time=0.750..0.755 rows=18 loops=1)
+   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50) (actual time=0.313..0.524 rows=9 loops=1)
          Join Filter: true
-         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=1.427..1.428 rows=2 loops=1)
-               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.003..0.003 rows=2 loops=1)
-         ->  Sequence  (cost=0.00..12.00 rows=3 width=31) (actual time=0.545..1.061 rows=4 loops=2)
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=0.208..0.358 rows=2 loops=1)
+               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.020..0.021 rows=2 loops=1)
+         ->  Sequence  (cost=0.00..54.00 rows=3 width=31) (actual time=0.048..0.075 rows=4 loops=2)
                ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (actual time=0.000..0.006 rows=0 loops=2)
                      Partitions selected: 6 (out of 6)
-               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..12.00 rows=3 width=31) (actual time=0.539..1.054 rows=4 loops=2)
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31) (actual time=0.046..0.073 rows=4 loops=2)
                      Index Cond: (ptid = t.tid)
                      Partitions scanned:  Avg 6.0 (out of 6) x 3 workers of 2 scans.  Max 6 parts (seg0).
  Planning time: 20.481 ms
-   (slice0)    Executor memory: 135K bytes.
-   (slice1)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
-   (slice2)    Executor memory: 144K bytes avg x 3 workers, 144K bytes max (seg0).
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
+   (slice2)    Executor memory: 155K bytes avg x 3 workers, 155K bytes max (seg0).
    (slice3)    
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -813,27 +813,28 @@ select * from t, t1, pt where t1.t2 = t.t2 and t1.tid = ptid;
 -- explain analyze
 --
 explain analyze select * from t, pt where tid = ptid;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..485.01 rows=18 width=50) (actual time=0.750..0.755 rows=18 loops=1)
-   ->  Nested Loop  (cost=0.00..485.01 rows=6 width=50) (actual time=0.313..0.524 rows=9 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..443.01 rows=18 width=50) (actual time=3.690..5.812 rows=18 loops=1)
+   ->  Nested Loop  (cost=0.00..443.01 rows=6 width=50) (actual time=2.262..3.300 rows=8 loops=1)
          Join Filter: true
-         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=0.208..0.358 rows=2 loops=1)
-               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.020..0.021 rows=2 loops=1)
-         ->  Sequence  (cost=0.00..54.00 rows=3 width=31) (actual time=0.048..0.075 rows=4 loops=2)
-               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (never executed)
+         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=19) (actual time=1.427..1.428 rows=2 loops=1)
+               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=19) (actual time=0.003..0.003 rows=2 loops=1)
+         ->  Sequence  (cost=0.00..12.00 rows=3 width=31) (actual time=0.545..1.061 rows=4 loops=2)
+               ->  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (actual time=0.000..0.006 rows=0 loops=2)
                      Partitions selected: 6 (out of 6)
-               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..54.00 rows=3 width=31) (actual time=0.046..0.073 rows=4 loops=2)
-                     Index Cond: ptid = $0
+               ->  Dynamic Index Scan on pt (dynamic scan id: 1)  (cost=0.00..12.00 rows=3 width=31) (actual time=0.539..1.054 rows=4 loops=2)
+                     Index Cond: (ptid = t.tid)
                      Partitions scanned:  Avg 6.0 (out of 6) x 3 workers of 2 scans.  Max 6 parts (seg0).
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 60K bytes avg x 3 workers, 62K bytes max (seg0).
-   (slice2)    Executor memory: 155K bytes avg x 3 workers, 155K bytes max (seg0).
+ Planning time: 20.481 ms
+   (slice0)    Executor memory: 135K bytes.
+   (slice1)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
+   (slice2)    Executor memory: 144K bytes avg x 3 workers, 144K bytes max (seg0).
    (slice3)    
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
- Total runtime: 2.810 ms
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 6.685 ms
+(19 rows)
 
 --
 -- Partitioned table on both sides of the join. This will create a result node as Append node is

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -1,0 +1,42 @@
+-- start_matchsubs
+-- m/ Gather Motion [12]:1  \(slice1; segments: [12]\)/
+-- s/ Gather Motion [12]:1  \(slice1; segments: [12]\)/ Gather Motion XXX/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- end_matchsubs
+CREATE TEMP TABLE empty_table(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- We used to incorrectly report "never executed" for a node that returns 0 rows
+-- from every segment. This was misleading because "never executed" should
+-- indicate that the node was never executed by its parent.
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+-- explain_processing_on
+-- For a node that is truly never executed, we still expect "never executed" to
+-- be reported
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Hash Join (actual rows=0 loops=1)
+         Hash Cond: (t1.a = t2.a)
+         ->  Seq Scan on empty_table t1 (actual rows=0 loops=1)
+         ->  Hash (never executed)
+               ->  Seq Scan on empty_table t2 (never executed)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- explain_processing_on

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -7,36 +7,82 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning time: .*ms/
+-- s/Planning time: .*ms/Planning time: 0 ms/
+-- m/Execution time: .*ms/
+-- s/Execution time: .*ms/Execution time: 0 ms/
 -- end_matchsubs
-CREATE TEMP TABLE empty_table(a int);
+CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- We used to incorrectly report "never executed" for a node that returns 0 rows
 -- from every segment. This was misleading because "never executed" should
 -- indicate that the node was never executed by its parent.
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on empty_table (actual rows=0 loops=1)
+ Planning time: 1.866 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
  Optimizer: Postgres query optimizer
-(3 rows)
+ Execution time: 1.643 ms
+(8 rows)
 
 -- explain_processing_on
 -- For a node that is truly never executed, we still expect "never executed" to
 -- be reported
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (t1.a = t2.a)
          ->  Seq Scan on empty_table t1 (actual rows=0 loops=1)
          ->  Hash (never executed)
                ->  Seq Scan on empty_table t2 (never executed)
+ Planning time: 0.740 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
+ Memory used:  128000kB
  Optimizer: Postgres query optimizer
-(7 rows)
+ Execution time: 1.143 ms
+(12 rows)
+
+-- Test with predicate
+INSERT INTO empty_table select generate_series(1, 1000)::int as a;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+         Filter: (b = 2)
+ Planning time: 0.380 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 0.824 ms
+(9 rows)
+
+ANALYZE a;
+ERROR:  relation "a" does not exist
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+         Filter: (b = 2)
+ Planning time: 0.212 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 0.829 ms
+(9 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -7,10 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
--- m/Planning time: .*ms/
--- s/Planning time: .*ms/Planning time: 0 ms/
--- m/Execution time: .*ms/
--- s/Execution time: .*ms/Execution time: 0 ms/
+-- m/Execution time: \d+\.\d+ ms/
+-- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
+-- m/Planning time: \d+\.\d+ ms/
+-- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -11,6 +11,12 @@
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/
 -- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
+-- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
+-- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -69,8 +75,7 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
  Execution time: 0.824 ms
 (9 rows)
 
-ANALYZE a;
-ERROR:  relation "a" does not exist
+ANALYZE empty_table;
 EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -1,0 +1,43 @@
+-- start_matchsubs
+-- m/ Gather Motion [12]:1  \(slice1; segments: [12]\)/
+-- s/ Gather Motion [12]:1  \(slice1; segments: [12]\)/ Gather Motion XXX/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- end_matchsubs
+CREATE TEMP TABLE empty_table(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- We used to incorrectly report "never executed" for a node that returns 0 rows
+-- from every segment. This was misleading because "never executed" should
+-- indicate that the node was never executed by its parent.
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+-- explain_processing_on
+-- For a node that is truly never executed, we still expect "never executed" to
+-- be reported
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Hash Join (actual rows=0 loops=1)
+         Hash Cond: (empty_table.a = empty_table_1.a)
+         ->  Seq Scan on empty_table (never executed)
+         ->  Hash (actual rows=0 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+               ->  Seq Scan on empty_table empty_table_1 (actual rows=0 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+-- explain_processing_on

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -7,37 +7,82 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning time: .*ms/
+-- s/Planning time: .*ms/Planning time: 0 ms/
+-- m/Execution time: .*ms/
+-- s/Execution time: .*ms/Execution time: 0 ms/
 -- end_matchsubs
-CREATE TEMP TABLE empty_table(a int);
+CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- We used to incorrectly report "never executed" for a node that returns 0 rows
 -- from every segment. This was misleading because "never executed" should
 -- indicate that the node was never executed by its parent.
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Seq Scan on empty_table (actual rows=0 loops=1)
+ Planning time: 36.594 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
-(3 rows)
+ Execution time: 1.216 ms
+(8 rows)
 
 -- explain_processing_on
 -- For a node that is truly never executed, we still expect "never executed" to
 -- be reported
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (empty_table.a = empty_table_1.a)
          ->  Seq Scan on empty_table (never executed)
          ->  Hash (actual rows=0 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4096kB
                ->  Seq Scan on empty_table empty_table_1 (actual rows=0 loops=1)
+ Planning time: 20.770 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 4170K bytes avg x 3 workers, 4170K bytes max (seg0).
+ Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+ Execution time: 8.442 ms
+(12 rows)
+
+-- Test with predicate
+INSERT INTO empty_table select generate_series(1, 1000)::int as a;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+         Filter: (b = 2)
+ Planning time: 28.345 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.561 ms
+(9 rows)
+
+ANALYZE a;
+ERROR:  relation "a" does not exist
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on empty_table (actual rows=0 loops=1)
+         Filter: (b = 2)
+ Planning time: 8.519 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.594 ms
+(9 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -7,10 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
--- m/Planning time: .*ms/
--- s/Planning time: .*ms/Planning time: 0 ms/
--- m/Execution time: .*ms/
--- s/Execution time: .*ms/Execution time: 0 ms/
+-- m/Execution time: \d+\.\d+ ms/
+-- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
+-- m/Planning time: \d+\.\d+ ms/
+-- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -11,6 +11,12 @@
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/
 -- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
+-- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
+-- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -69,8 +75,7 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
  Execution time: 1.561 ms
 (9 rows)
 
-ANALYZE a;
-ERROR:  relation "a" does not exist
+ANALYZE empty_table;
 EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -50,9 +50,9 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84) (actual time=5.588..5.588 rows=0 loops=1)
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84) (actual time=7.762..7.762 rows=0 loops=1)
    ->  Hash Left Join  (cost=4626.75..9520.88 rows=25967 width=84) (actual time=0.000..5.279 rows=0 loops=1)
          Hash Cond: (boxes.location_id = box_locations.id)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7233.75 rows=25967 width=48) (actual time=0.000..3.985 rows=0 loops=1)
@@ -66,14 +66,14 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                                  ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (actual time=0.000..0.001 rows=0 loops=1)
          ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (actual time=0.000..0.009 rows=0 loops=1)
                ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (actual time=0.000..0.004 rows=0 loops=1)
- Planning time: 1.903 ms
+ Planning time: 0.791 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
    (slice3)    Executor memory: 1104K bytes avg x 3 workers, 1104K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 18.901 ms
+ Execution time: 29.929 ms
 (22 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -50,30 +50,30 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84) (actual time=7.762..7.762 rows=0 loops=1)
-   ->  Hash Left Join  (cost=4626.75..9520.88 rows=25967 width=84) (never executed)
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=4626.75..9520.88 rows=77900 width=84) (actual time=5.588..5.588 rows=0 loops=1)
+   ->  Hash Left Join  (cost=4626.75..9520.88 rows=25967 width=84) (actual time=0.000..5.279 rows=0 loops=1)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7233.75 rows=25967 width=48) (never executed)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3410.75..7233.75 rows=25967 width=48) (actual time=0.000..3.985 rows=0 loops=1)
                Hash Key: boxes.location_id
-               ->  Hash Right Join  (cost=3410.75..5675.75 rows=25967 width=48) (never executed)
+               ->  Hash Right Join  (cost=3410.75..5675.75 rows=25967 width=48) (actual time=0.000..4.099 rows=0 loops=1)
                      Hash Cond: (apples.id = boxes.apple_id)
                      ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36) (never executed)
-                     ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12) (never executed)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12) (never executed)
+                     ->  Hash  (cost=2437.00..2437.00 rows=25967 width=12) (actual time=0.000..0.807 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12) (actual time=0.000..0.804 rows=0 loops=1)
                                  Hash Key: boxes.apple_id
-                                 ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (never executed)
-         ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (never executed)
-               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (never executed)
- Planning time: 0.791 ms
+                                 ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12) (actual time=0.000..0.001 rows=0 loops=1)
+         ->  Hash  (cost=596.00..596.00 rows=16534 width=36) (actual time=0.000..0.009 rows=0 loops=1)
+               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36) (actual time=0.000..0.004 rows=0 loops=1)
+ Planning time: 1.903 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
    (slice3)    Executor memory: 1104K bytes avg x 3 workers, 1104K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 29.929 ms
+ Execution time: 18.901 ms
 (22 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -50,23 +50,23 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..449.00 rows=3 width=28) (actual time=2.297..2.297 rows=0 loops=1)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=28) (never executed)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..449.00 rows=3 width=28) (actual time=2.418..2.418 rows=0 loops=1)
+   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=28) (actual time=0.000..1.899 rows=0 loops=1)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=16) (never executed)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=16) (actual time=0.000..1.895 rows=0 loops=1)
                Hash Key: boxes.location_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=16) (never executed)
+               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=16) (actual time=0.000..0.322 rows=0 loops=1)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (never executed)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.320 rows=0 loops=1)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (never executed)
+                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.002 rows=0 loops=1)
                      ->  Index Scan using apples_pkey on apples  (cost=0.00..6.00 rows=1 width=4) (never executed)
                            Index Cond: (id = boxes.apple_id)
          ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..12.00 rows=1 width=12) (never executed)
                Index Cond: (id = boxes.location_id)
- Planning time: 14.784 ms
+ Planning time: 31.709 ms
    (slice0)    Executor memory: 192K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
@@ -75,7 +75,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
    (slice5)    
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 23.433 ms
+ Execution time: 19.424 ms
 (24 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -50,9 +50,9 @@ EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT 
 --- Check Explain Analyze Text output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..449.00 rows=3 width=28) (actual time=2.418..2.418 rows=0 loops=1)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..449.00 rows=3 width=28) (actual time=2.297..2.297 rows=0 loops=1)
    ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=28) (actual time=0.000..1.899 rows=0 loops=1)
          Join Filter: true
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=16) (actual time=0.000..1.895 rows=0 loops=1)
@@ -66,7 +66,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
                            Index Cond: (id = boxes.apple_id)
          ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..12.00 rows=1 width=12) (never executed)
                Index Cond: (id = boxes.location_id)
- Planning time: 31.709 ms
+ Planning time: 14.784 ms
    (slice0)    Executor memory: 192K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
@@ -75,7 +75,7 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
    (slice5)    
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 19.424 ms
+ Execution time: 23.433 ms
 (24 rows)
 
 -- explain_processing_on

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -25,27 +25,27 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=6.019..6.019 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=5.614..6.010 rows=3 loops=1)
-         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=3.621..3.621 rows=1 loops=1)
-               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (never executed)
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=6.484..6.485 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=6.006..6.454 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=4.737..4.737 rows=1 loops=1)
+               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (actual time=0.000..4.717 rows=0 loops=1)
                      Hash Cond: (a.c2 = c.c2)
                      ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
                            Hash Cond: (a.c2 = b.c2)
                            ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                                  Hash Key: a.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
                            ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
                                  ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                                        Hash Key: b.c2
-                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
-                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (actual time=0.000..0.032 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.027 rows=0 loops=1)
                                  Hash Key: c.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
- Planning time: 3.415 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+ Planning time: 2.208 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
@@ -53,35 +53,35 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 19.418 ms
+ Execution time: 31.646 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=4.816..4.816 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=3.549..4.806 rows=3 loops=1)
-         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.772..3.772 rows=1 loops=1)
-               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (never executed)
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=7.345..7.345 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=7.259..7.324 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=6.708..6.709 rows=1 loops=1)
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (actual time=0.000..7.085 rows=0 loops=1)
                      Hash Cond: (a.c2 = b.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                            Hash Key: a.c2
-                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
-                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.001 rows=0 loops=1)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (actual time=0.000..0.038 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.034 rows=0 loops=1)
                                  Hash Key: b.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
- Planning time: 1.300 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+ Planning time: 0.621 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 8.568 ms
+ Execution time: 9.183 ms
 (20 rows)
 
 -- so in this query the gangs C, D and E should be used
@@ -89,27 +89,27 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=4.357..4.357 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=3.881..4.346 rows=3 loops=1)
-         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=2.066..2.066 rows=1 loops=1)
-               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (never executed)
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=5.231..5.231 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=5.206..5.211 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=4.406..4.408 rows=1 loops=1)
+               ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (actual time=0.000..4.397 rows=0 loops=1)
                      Hash Cond: (a.c2 = c.c2)
                      ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
                            Hash Cond: (a.c2 = b.c2)
                            ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                                  Hash Key: a.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
+                                 ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
                            ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
                                  ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                                        Hash Key: b.c2
-                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
-                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                                       ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (actual time=0.000..0.121 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.116 rows=0 loops=1)
                                  Hash Key: c.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (never executed)
- Planning time: 1.931 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+ Planning time: 1.401 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
@@ -117,35 +117,35 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 5.753 ms
+ Execution time: 7.114 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=5.047..5.047 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=4.225..5.010 rows=3 loops=1)
-         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.209..3.210 rows=1 loops=1)
-               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (never executed)
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=7.225..7.225 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=6.610..7.194 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=6.224..6.224 rows=1 loops=1)
+               ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (actual time=0.000..6.903 rows=0 loops=1)
                      Hash Cond: (a.c2 = b.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
                            Hash Key: a.c2
-                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (never executed)
-                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1 a  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.005 rows=0 loops=1)
+                     ->  Hash  (cost=2683.00..2683.00 rows=28700 width=4) (actual time=0.000..0.030 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.026 rows=0 loops=1)
                                  Hash Key: b.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (never executed)
- Planning time: 1.231 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+ Planning time: 0.651 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 6.223 ms
+ Execution time: 8.960 ms
 (20 rows)
 
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gang_reuse.out
+++ b/src/test/regress/expected/gang_reuse.out
@@ -25,11 +25,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=6.484..6.485 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=6.006..6.454 rows=3 loops=1)
-         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=4.737..4.737 rows=1 loops=1)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=6.019..6.019 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=5.614..6.010 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=3.621..3.621 rows=1 loops=1)
                ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (actual time=0.000..4.717 rows=0 loops=1)
                      Hash Cond: (a.c2 = c.c2)
                      ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
@@ -45,7 +45,7 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.027 rows=0 loops=1)
                                  Hash Key: c.c2
                                  ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
- Planning time: 2.208 ms
+ Planning time: 3.415 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
@@ -53,18 +53,18 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 31.646 ms
+ Execution time: 19.418 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=7.345..7.345 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=7.259..7.324 rows=3 loops=1)
-         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=6.708..6.709 rows=1 loops=1)
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=4.816..4.816 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=3.549..4.806 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.772..3.772 rows=1 loops=1)
                ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (actual time=0.000..7.085 rows=0 loops=1)
                      Hash Cond: (a.c2 = b.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
@@ -74,14 +74,14 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.034 rows=0 loops=1)
                                  Hash Key: b.c2
                                  ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.003 rows=0 loops=1)
- Planning time: 0.621 ms
+ Planning time: 1.300 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 9.183 ms
+ Execution time: 8.568 ms
 (20 rows)
 
 -- so in this query the gangs C, D and E should be used
@@ -89,11 +89,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=5.231..5.231 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=5.206..5.211 rows=3 loops=1)
-         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=4.406..4.408 rows=1 loops=1)
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=88792873.08..88792873.09 rows=1 width=8) (actual time=4.357..4.357 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=88792873.01..88792873.06 rows=1 width=8) (actual time=3.881..4.346 rows=3 loops=1)
+         ->  Aggregate  (cost=88792873.01..88792873.02 rows=1 width=8) (actual time=2.066..2.066 rows=1 loops=1)
                ->  Hash Join  (cost=7518.50..87197179.56 rows=212759127 width=0) (actual time=0.000..4.397 rows=0 loops=1)
                      Hash Cond: (a.c2 = c.c2)
                      ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=8) (never executed)
@@ -109,7 +109,7 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.116 rows=0 loops=1)
                                  Hash Key: c.c2
                                  ->  Seq Scan on test_gang_reuse_t1 c  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.002 rows=0 loops=1)
- Planning time: 1.401 ms
+ Planning time: 1.931 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
@@ -117,18 +117,18 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 2128K bytes avg x 3 workers, 2128K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 7.114 ms
+ Execution time: 5.753 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=7.225..7.225 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=6.610..7.194 rows=3 loops=1)
-         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=6.224..6.224 rows=1 loops=1)
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1025973.94..1025973.95 rows=1 width=8) (actual time=5.047..5.047 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=1025973.88..1025973.93 rows=1 width=8) (actual time=4.225..5.010 rows=3 loops=1)
+         ->  Aggregate  (cost=1025973.88..1025973.89 rows=1 width=8) (actual time=3.209..3.210 rows=1 loops=1)
                ->  Hash Join  (cost=3759.25..1007440.85 rows=2471070 width=0) (actual time=0.000..6.903 rows=0 loops=1)
                      Hash Cond: (a.c2 = b.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (never executed)
@@ -138,14 +138,14 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..2683.00 rows=28700 width=4) (actual time=0.000..0.026 rows=0 loops=1)
                                  Hash Key: b.c2
                                  ->  Seq Scan on test_gang_reuse_t1 b  (cost=0.00..961.00 rows=28700 width=4) (actual time=0.000..0.003 rows=0 loops=1)
- Planning time: 0.651 ms
+ Planning time: 1.231 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 8.960 ms
+ Execution time: 6.223 ms
 (20 rows)
 
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -25,63 +25,63 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.447..4.447 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.563..4.437 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.334..4.334 rows=1 loops=1)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.986..9.987 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.364..9.919 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=8.055..8.056 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (actual time=0.000..8.561 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                            Hash Key: test_gang_reuse_t1.c2
-                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (actual time=0.000..3.516 rows=0 loops=1)
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (actual time=0.000..3.510 rows=0 loops=1)
                                  Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
                                  ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                                        Hash Key: test_gang_reuse_t1_1.c2
-                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
-                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.038 rows=0 loops=1)
+                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.033 rows=0 loops=1)
                                              Hash Key: test_gang_reuse_t1_2.c2
-                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
- Planning time: 82.403 ms
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+ Planning time: 114.262 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
- Execution time: 26.149 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 38.315 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=4.706..4.706 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=4.697..4.700 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.688..3.688 rows=1 loops=1)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=10.983..10.984 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=8.741..10.949 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=8.000..8.001 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..9.612 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                            Hash Key: test_gang_reuse_t1.c2
-                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.035 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.030 rows=0 loops=1)
                                  Hash Key: test_gang_reuse_t1_1.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
- Planning time: 12.168 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.001 rows=0 loops=1)
+ Planning time: 26.781 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
- Execution time: 5.858 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 13.170 ms
 (20 rows)
 
 -- so in this query the gangs C, D and E should be used
@@ -89,63 +89,63 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.645..3.645 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=2.705..3.632 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.024..4.024 rows=1 loops=1)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (never executed)
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=10.256..10.256 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=8.163..10.207 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.514..9.515 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (actual time=0.000..9.516 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                            Hash Key: test_gang_reuse_t1.c2
-                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (never executed)
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.003 rows=0 loops=1)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4) (actual time=0.000..4.456 rows=0 loops=1)
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4) (actual time=0.000..4.449 rows=0 loops=1)
                                  Hash Cond: (test_gang_reuse_t1_1.c2 = test_gang_reuse_t1_2.c2)
                                  ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                                        Hash Key: test_gang_reuse_t1_1.c2
-                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
-                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                       ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.025 rows=0 loops=1)
+                                       ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.023 rows=0 loops=1)
                                              Hash Key: test_gang_reuse_t1_2.c2
-                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (never executed)
- Planning time: 44.030 ms
+                                             ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+ Planning time: 81.473 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
- Execution time: 6.743 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 12.490 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.480..3.480 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=3.201..3.473 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=2.975..2.976 rows=1 loops=1)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=8.860..8.860 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=8.825..8.834 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=7.850..7.851 rows=1 loops=1)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..8.591 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                            Hash Key: test_gang_reuse_t1.c2
-                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
-                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                           ->  Seq Scan on test_gang_reuse_t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.702 rows=0 loops=1)
+                           ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.696 rows=0 loops=1)
                                  Hash Key: test_gang_reuse_t1_1.c2
-                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
- Planning time: 9.705 ms
+                                 ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.006 rows=0 loops=1)
+ Planning time: 20.957 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
- Execution time: 4.820 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 11.176 ms
 (20 rows)
 
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gang_reuse_optimizer.out
+++ b/src/test/regress/expected/gang_reuse_optimizer.out
@@ -25,11 +25,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.986..9.987 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.364..9.919 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=8.055..8.056 rows=1 loops=1)
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.447..4.447 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.563..4.437 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.334..4.334 rows=1 loops=1)
                ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (actual time=0.000..8.561 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
@@ -45,7 +45,7 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                        ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.033 rows=0 loops=1)
                                              Hash Key: test_gang_reuse_t1_2.c2
                                              ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.003 rows=0 loops=1)
- Planning time: 114.262 ms
+ Planning time: 82.403 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
@@ -53,18 +53,18 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 38.315 ms
+ Execution time: 26.149 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=10.983..10.984 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=8.741..10.949 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=8.000..8.001 rows=1 loops=1)
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=4.706..4.706 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=4.697..4.700 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.688..3.688 rows=1 loops=1)
                ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..9.612 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
@@ -74,14 +74,14 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.030 rows=0 loops=1)
                                  Hash Key: test_gang_reuse_t1_1.c2
                                  ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.001 rows=0 loops=1)
- Planning time: 26.781 ms
+ Planning time: 12.168 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 13.170 ms
+ Execution time: 5.858 ms
 (20 rows)
 
 -- so in this query the gangs C, D and E should be used
@@ -89,11 +89,11 @@ explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
   join test_gang_reuse_t1 c using (c2)
 ;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=10.256..10.256 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=8.163..10.207 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=9.514..9.515 rows=1 loops=1)
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=3.645..3.645 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice4; gang0; segments: 3)  (cost=0.00..1293.00 rows=1 width=8) (actual time=2.705..3.632 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..1293.00 rows=1 width=8) (actual time=4.024..4.024 rows=1 loops=1)
                ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1) (actual time=0.000..9.516 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
@@ -109,7 +109,7 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                                        ->  Redistribute Motion 3:3  (slice3; gang9; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.023 rows=0 loops=1)
                                              Hash Key: test_gang_reuse_t1_2.c2
                                              ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.002 rows=0 loops=1)
- Planning time: 81.473 ms
+ Planning time: 44.030 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
@@ -117,18 +117,18 @@ explain analyze select count(*) from test_gang_reuse_t1 a
    (slice4)    Executor memory: 4192K bytes avg x 3 workers, 4192K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 12.490 ms
+ Execution time: 6.743 ms
 (27 rows)
 
 -- so in this query the gangs C and D should be used
 explain analyze select count(*) from test_gang_reuse_t1 a
   join test_gang_reuse_t1 b using (c2)
 ;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=8.860..8.860 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=8.825..8.834 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=7.850..7.851 rows=1 loops=1)
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=3.480..3.480 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice3; gang0; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=3.201..3.473 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=2.975..2.976 rows=1 loops=1)
                ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..8.591 rows=0 loops=1)
                      Hash Cond: (test_gang_reuse_t1.c2 = test_gang_reuse_t1_1.c2)
                      ->  Redistribute Motion 3:3  (slice1; gang3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
@@ -138,14 +138,14 @@ explain analyze select count(*) from test_gang_reuse_t1 a
                            ->  Redistribute Motion 3:3  (slice2; gang6; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.696 rows=0 loops=1)
                                  Hash Key: test_gang_reuse_t1_1.c2
                                  ->  Seq Scan on test_gang_reuse_t1 test_gang_reuse_t1_1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.006 rows=0 loops=1)
- Planning time: 20.957 ms
+ Planning time: 9.705 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 4176K bytes avg x 3 workers, 4176K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 11.176 ms
+ Execution time: 4.820 ms
 (20 rows)
 
 reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -317,31 +317,33 @@ begin;
 	union all select * from t2 c join t2 d using(c2) ;
                                                                       QUERY PLAN                                                                       
 -------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=1.01..4.21 rows=7 width=28) (actual time=3.504..3.504 rows=0 loops=1)
-   ->  Append  (cost=1.01..4.21 rows=4 width=28) (actual time=0.000..3.101 rows=0 loops=1)
-         ->  Hash Join  (cost=1.01..2.05 rows=4 width=28) (actual time=0.000..1.574 rows=0 loops=1)
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=3.25..17.52 rows=14 width=28) (actual time=1.483..1.483 rows=0 loops=2)
+   ->  Append  (cost=3.25..17.52 rows=5 width=28) (actual time=0.000..2.279 rows=0 loops=1)
+         ->  Hash Join  (cost=3.25..5.69 rows=3 width=28) (actual time=0.000..0.827 rows=0 loops=1)
                Hash Cond: (a.c2 = b.c2)
-               ->  Seq Scan on t1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.011..0.011 rows=1 loops=1)
-               ->  Hash  (cost=1.00..1.00 rows=1 width=16) (actual time=0.000..0.041 rows=0 loops=1)
-                     ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.009..0.029 rows=100 loops=1)
-         ->  Hash Join  (cost=1.03..2.09 rows=2 width=28) (actual time=0.000..3.095 rows=0 loops=1)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Seq Scan on t1 a  (cost=0.00..2.00 rows=34 width=16) (actual time=0.006..0.006 rows=0 loops=2)
+               ->  Hash  (cost=2.00..2.00 rows=34 width=16) (actual time=0.000..0.043 rows=0 loops=1)
+                     ->  Seq Scan on t1 b  (cost=0.00..2.00 rows=34 width=16) (actual time=0.004..0.015 rows=50 loops=2)
+         ->  Hash Join  (cost=6.25..11.69 rows=3 width=28) (actual time=0.000..2.221 rows=0 loops=1)
                Hash Cond: (c.c2 = d.c2)
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (never executed)
+               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
+               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (never executed)
                      Hash Key: c.c2
-                     ->  Seq Scan on t2 c  (cost=0.00..1.00 rows=1 width=16) (actual time=0.012..0.052 rows=52 loops=1)
-               ->  Hash  (cost=1.02..1.02 rows=1 width=16) (actual time=0.000..1.281 rows=0 loops=1)
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.040..0.239 rows=100 loops=1)
+                     ->  Seq Scan on t2 c  (cost=0.00..3.00 rows=34 width=16) (actual time=0.010..0.018 rows=28 loops=2)
+               ->  Hash  (cost=5.00..5.00 rows=34 width=16) (actual time=0.000..0.915 rows=0 loops=1)
+                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (actual time=0.266..0.449 rows=50 loops=2)
                            Hash Key: d.c2
-                           ->  Seq Scan on t2 d  (cost=0.00..1.00 rows=1 width=16) (actual time=0.007..0.016 rows=52 loops=1)
- Planning time: 8.572 ms
-   (slice0)    Executor memory: 263K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 2200K bytes avg x 2 workers, 2200K bytes max (seg0).
+                           ->  Seq Scan on t2 d  (cost=0.00..3.00 rows=34 width=16) (actual time=0.006..0.013 rows=28 loops=2)
+ Planning time: 1.493 ms
+   (slice0)    Executor memory: 518K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 3232K bytes avg x 2 workers, 4258K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 5.422 ms
-(24 rows)
+ Execution time: 3.839 ms
+(26 rows)
 
 abort;
 -- partitioned table should have the same numsegments for parent and children
@@ -1168,23 +1170,24 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from d1 a join t2 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.424..0.424 rows=0 loops=1)
-   Hash Cond: (b.c1 = a.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.421..0.421 rows=0 loops=1)
-         ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.005 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
- Planning time: 3.655 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.488..1.488 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.058 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.004..0.004 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.139 ms
-(14 rows)
+ Total runtime: 4.018 ms
+(16 rows)
 
 :explain select * from d1 a join t2 b using (c1, c2);
                                                             QUERY PLAN                                                             
@@ -1238,42 +1241,44 @@ select gp_debug_reset_create_table_default_numsegments();
 (11 rows)
 
 :explain select * from d1 a join r2 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.313..0.313 rows=0 loops=1)
-   Hash Cond: (b.c1 = a.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.310..0.310 rows=0 loops=1)
-         ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
- Planning time: 3.627 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.544..1.544 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.324..0.324 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.323..0.323 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.180 ms
-(14 rows)
+ Total runtime: 3.589 ms
+(16 rows)
 
 :explain select * from d1 a join r2 b using (c1, c2);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.400..0.400 rows=0 loops=1)
-   Hash Cond: ((b.c1 = a.c1) AND (b.c2 = a.c2))
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.397..0.397 rows=0 loops=1)
-         ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
- Planning time: 3.778 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=0.919..0.919 rows=0 loops=2)
+   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.175 ms
-(14 rows)
+ Total runtime: 2.643 ms
+(16 rows)
 
 :explain select * from r1 a join t2 b using (c1);
                                                               QUERY PLAN                                                              
@@ -1419,23 +1424,24 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from t2 a join d1 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.377..0.377 rows=0 loops=1)
-   Hash Cond: (a.c1 = b.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.373..0.373 rows=0 loops=1)
-         ->  Seq Scan on t2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.006 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.003 rows=0 loops=1)
- Planning time: 4.872 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.470..1.470 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.613..0.613 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.612..0.612 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.065 ms
-(14 rows)
+ Total runtime: 3.343 ms
+(16 rows)
 
 :explain select * from t2 a join d1 b using (c1, c2);
                                                             QUERY PLAN                                                             
@@ -1627,42 +1633,44 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from r2 a join d1 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.465..0.465 rows=0 loops=1)
-   Hash Cond: (a.c1 = b.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.460..0.460 rows=0 loops=1)
-         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.008 rows=0 loops=1)
- Planning time: 3.962 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.540..1.540 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.636..0.636 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.635..0.635 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.681 ms
-(14 rows)
+ Total runtime: 3.470 ms
+(16 rows)
 
 :explain select * from r2 a join d1 b using (c1, c2);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.516..0.516 rows=0 loops=1)
-   Hash Cond: ((a.c1 = b.c1) AND (a.c2 = b.c2))
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.513..0.513 rows=0 loops=1)
-         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.006 rows=0 loops=1)
- Planning time: 3.727 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.428..1.428 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.023 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.648..0.648 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.647..0.647 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4234K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.324 ms
-(14 rows)
+ Total runtime: 3.332 ms
+(16 rows)
 
 :explain select * from r2 a join r1 b using (c1);
                                                               QUERY PLAN                                                              
@@ -2704,23 +2712,24 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from t2 a left join d1 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.693..0.693 rows=0 loops=1)
-   Hash Cond: (a.c1 = b.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.686..0.686 rows=0 loops=1)
-         ->  Seq Scan on t2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.016 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.002 rows=0 loops=1)
- Planning time: 4.622 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=0.920..0.920 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.577 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 2.006 ms
-(14 rows)
+ Total runtime: 2.487 ms
+(16 rows)
 
 :explain select * from t2 a left join d1 b using (c1, c2);
                                                              QUERY PLAN                                                             
@@ -2936,42 +2945,44 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from r2 a left join d1 b using (c1);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.319..0.319 rows=0 loops=1)
-   Hash Cond: (a.c1 = b.c1)
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.317..0.317 rows=0 loops=1)
-         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.000 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.003 rows=0 loops=1)
- Planning time: 4.362 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.099..1.099 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.198..0.198 rows=0 loops=2)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.087..0.087 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.086..0.086 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.077 ms
-(14 rows)
+ Total runtime: 2.591 ms
+(16 rows)
 
 :explain select * from r2 a left join d1 b using (c1, c2);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.375..0.375 rows=0 loops=1)
-   Hash Cond: ((a.c1 = b.c1) AND (a.c2 = b.c2))
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.373..0.373 rows=0 loops=1)
-         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
-   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
-               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.002 rows=0 loops=1)
- Planning time: 5.656 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes (seg0).
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.158..1.158 rows=0 loops=2)
+   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
+   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.258..0.258 rows=0 loops=2)
+         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
+   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.138..0.138 rows=0 loops=2)
+         Buckets: 524288  Batches: 1  Memory Usage: 0kB
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.137..0.137 rows=0 loops=2)
+               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
+   (slice0)    Executor memory: 4238K bytes.
+   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 1.902 ms
-(14 rows)
+ Total runtime: 2.802 ms
+(16 rows)
 
 :explain select * from r2 a left join r1 b using (c1);
                                                                       QUERY PLAN                                                                      

--- a/src/test/regress/expected/partial_table.out
+++ b/src/test/regress/expected/partial_table.out
@@ -317,33 +317,31 @@ begin;
 	union all select * from t2 c join t2 d using(c2) ;
                                                                       QUERY PLAN                                                                       
 -------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice3; segments: 2)  (cost=3.25..17.52 rows=14 width=28) (actual time=1.483..1.483 rows=0 loops=2)
-   ->  Append  (cost=3.25..17.52 rows=5 width=28) (actual time=0.000..2.279 rows=0 loops=1)
-         ->  Hash Join  (cost=3.25..5.69 rows=3 width=28) (actual time=0.000..0.827 rows=0 loops=1)
+ Gather Motion 2:1  (slice3; segments: 2)  (cost=1.01..4.21 rows=7 width=28) (actual time=3.504..3.504 rows=0 loops=1)
+   ->  Append  (cost=1.01..4.21 rows=4 width=28) (actual time=0.000..3.101 rows=0 loops=1)
+         ->  Hash Join  (cost=1.01..2.05 rows=4 width=28) (actual time=0.000..1.574 rows=0 loops=1)
                Hash Cond: (a.c2 = b.c2)
-               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
-               ->  Seq Scan on t1 a  (cost=0.00..2.00 rows=34 width=16) (actual time=0.006..0.006 rows=0 loops=2)
-               ->  Hash  (cost=2.00..2.00 rows=34 width=16) (actual time=0.000..0.043 rows=0 loops=1)
-                     ->  Seq Scan on t1 b  (cost=0.00..2.00 rows=34 width=16) (actual time=0.004..0.015 rows=50 loops=2)
-         ->  Hash Join  (cost=6.25..11.69 rows=3 width=28) (actual time=0.000..2.221 rows=0 loops=1)
+               ->  Seq Scan on t1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.011..0.011 rows=1 loops=1)
+               ->  Hash  (cost=1.00..1.00 rows=1 width=16) (actual time=0.000..0.041 rows=0 loops=1)
+                     ->  Seq Scan on t1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.009..0.029 rows=100 loops=1)
+         ->  Hash Join  (cost=1.03..2.09 rows=2 width=28) (actual time=0.000..3.095 rows=0 loops=1)
                Hash Cond: (c.c2 = d.c2)
-               Extra Text: (seg0)   Hash chain length 0.0 avg, 0 max, using 0 of 262144 buckets.
-               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (never executed)
+               ->  Redistribute Motion 2:2  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (never executed)
                      Hash Key: c.c2
-                     ->  Seq Scan on t2 c  (cost=0.00..3.00 rows=34 width=16) (actual time=0.010..0.018 rows=28 loops=2)
-               ->  Hash  (cost=5.00..5.00 rows=34 width=16) (actual time=0.000..0.915 rows=0 loops=1)
-                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..5.00 rows=50 width=16) (actual time=0.266..0.449 rows=50 loops=2)
+                     ->  Seq Scan on t2 c  (cost=0.00..1.00 rows=1 width=16) (actual time=0.012..0.052 rows=52 loops=1)
+               ->  Hash  (cost=1.02..1.02 rows=1 width=16) (actual time=0.000..1.281 rows=0 loops=1)
+                     ->  Redistribute Motion 2:2  (slice2; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.040..0.239 rows=100 loops=1)
                            Hash Key: d.c2
-                           ->  Seq Scan on t2 d  (cost=0.00..3.00 rows=34 width=16) (actual time=0.006..0.013 rows=28 loops=2)
- Planning time: 1.493 ms
-   (slice0)    Executor memory: 518K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 2 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 3232K bytes avg x 2 workers, 4258K bytes max (seg0).
+                           ->  Seq Scan on t2 d  (cost=0.00..1.00 rows=1 width=16) (actual time=0.007..0.016 rows=52 loops=1)
+ Planning time: 8.572 ms
+   (slice0)    Executor memory: 263K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 2 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 2200K bytes avg x 2 workers, 2200K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Execution time: 3.839 ms
-(26 rows)
+ Execution time: 5.422 ms
+(24 rows)
 
 abort;
 -- partitioned table should have the same numsegments for parent and children
@@ -1170,24 +1168,23 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from d1 a join t2 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.488..1.488 rows=0 loops=2)
-   Hash Cond: b.c1 = a.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on t2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.058 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.004..0.004 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.003..0.003 rows=0 loops=2)
-               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.424..0.424 rows=0 loops=1)
+   Hash Cond: (b.c1 = a.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.421..0.421 rows=0 loops=1)
+         ->  Seq Scan on t2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.005 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
+ Planning time: 3.655 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 4.018 ms
-(16 rows)
+ Execution time: 1.139 ms
+(14 rows)
 
 :explain select * from d1 a join t2 b using (c1, c2);
                                                             QUERY PLAN                                                             
@@ -1241,44 +1238,42 @@ select gp_debug_reset_create_table_default_numsegments();
 (11 rows)
 
 :explain select * from d1 a join r2 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.544..1.544 rows=0 loops=2)
-   Hash Cond: b.c1 = a.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.324..0.324 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.323..0.323 rows=0 loops=2)
-               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.313..0.313 rows=0 loops=1)
+   Hash Cond: (b.c1 = a.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.310..0.310 rows=0 loops=1)
+         ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
+ Planning time: 3.627 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 3.589 ms
-(16 rows)
+ Execution time: 1.180 ms
+(14 rows)
 
 :explain select * from d1 a join r2 b using (c1, c2);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=0.919..0.919 rows=0 loops=2)
-   Hash Cond: b.c1 = a.c1 AND b.c2 = a.c2
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on r2 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.020 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
-               ->  Seq Scan on d1 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.400..0.400 rows=0 loops=1)
+   Hash Cond: ((b.c1 = a.c1) AND (b.c2 = a.c2))
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.397..0.397 rows=0 loops=1)
+         ->  Seq Scan on r2 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.004 rows=0 loops=1)
+ Planning time: 3.778 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 2.643 ms
-(16 rows)
+ Execution time: 1.175 ms
+(14 rows)
 
 :explain select * from r1 a join t2 b using (c1);
                                                               QUERY PLAN                                                              
@@ -1424,24 +1419,23 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from t2 a join d1 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.470..1.470 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.613..0.613 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.612..0.612 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.377..0.377 rows=0 loops=1)
+   Hash Cond: (a.c1 = b.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.373..0.373 rows=0 loops=1)
+         ->  Seq Scan on t2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.006 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+ Planning time: 4.872 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 3.343 ms
-(16 rows)
+ Execution time: 1.065 ms
+(14 rows)
 
 :explain select * from t2 a join d1 b using (c1, c2);
                                                             QUERY PLAN                                                             
@@ -1633,44 +1627,42 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from r2 a join d1 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.540..1.540 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.018 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.636..0.636 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.635..0.635 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.010 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.465..0.465 rows=0 loops=1)
+   Hash Cond: (a.c1 = b.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.460..0.460 rows=0 loops=1)
+         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.008 rows=0 loops=1)
+ Planning time: 3.962 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 3.470 ms
-(16 rows)
+ Execution time: 1.681 ms
+(14 rows)
 
 :explain select * from r2 a join d1 b using (c1, c2);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=1877.50..1268319.05 rows=5056 width=24) (actual time=1.428..1.428 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (never executed)
-         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.023 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.648..0.648 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.647..0.647 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 4234K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.516..0.516 rows=0 loops=1)
+   Hash Cond: ((a.c1 = b.c1) AND (a.c2 = b.c2))
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.513..0.513 rows=0 loops=1)
+         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.006 rows=0 loops=1)
+ Planning time: 3.727 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 3.332 ms
-(16 rows)
+ Execution time: 1.324 ms
+(14 rows)
 
 :explain select * from r2 a join r1 b using (c1);
                                                               QUERY PLAN                                                              
@@ -2712,24 +2704,23 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from t2 a left join d1 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=0.920..0.920 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
-         ->  Seq Scan on t2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.577 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.003..0.003 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.002..0.002 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 4238K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.693..0.693 rows=0 loops=1)
+   Hash Cond: (a.c1 = b.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.686..0.686 rows=0 loops=1)
+         ->  Seq Scan on t2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.016 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.002 rows=0 loops=1)
+ Planning time: 4.622 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 2.487 ms
-(16 rows)
+ Execution time: 2.006 ms
+(14 rows)
 
 :explain select * from t2 a left join d1 b using (c1, c2);
                                                              QUERY PLAN                                                             
@@ -2945,44 +2936,42 @@ select gp_debug_reset_create_table_default_numsegments();
 (14 rows)
 
 :explain select * from r2 a left join d1 b using (c1);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1699.75..686563.85 rows=5055210 width=28) (actual time=1.099..1.099 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.198..0.198 rows=0 loops=2)
-         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.014 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.087..0.087 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.086..0.086 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.009 rows=0 loops=1)
-   (slice0)    Executor memory: 4238K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1.01..2.07 rows=4 width=28) (actual time=0.319..0.319 rows=0 loops=1)
+   Hash Cond: (a.c1 = b.c1)
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.317..0.317 rows=0 loops=1)
+         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.000 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.003 rows=0 loops=1)
+ Planning time: 4.362 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 2.591 ms
-(16 rows)
+ Execution time: 1.077 ms
+(14 rows)
 
 :explain select * from r2 a left join d1 b using (c1, c2);
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Hash Left Join  (cost=1877.50..1268979.50 rows=71100 width=24) (actual time=1.158..1.158 rows=0 loops=2)
-   Hash Cond: a.c1 = b.c1 AND a.c2 = b.c2
-   Extra Text: Hash chain length 0.0 avg, 0 max, using 0 of 524288 buckets.
-   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..2233.00 rows=71100 width=16) (actual time=0.258..0.258 rows=0 loops=2)
-         ->  Seq Scan on r2 a  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.017 rows=0 loops=1)
-   ->  Hash  (cost=811.00..811.00 rows=23700 width=16) (actual time=0.138..0.138 rows=0 loops=2)
-         Buckets: 524288  Batches: 1  Memory Usage: 0kB
-         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=811.00..811.00 rows=71100 width=16) (actual time=0.137..0.137 rows=0 loops=2)
-               ->  Seq Scan on d1 b  (cost=0.00..811.00 rows=23700 width=16) (actual time=0.000..0.013 rows=0 loops=1)
-   (slice0)    Executor memory: 4238K bytes.
-   (slice1)    Executor memory: 50K bytes avg x 3 workers, 50K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes (seg0).
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Hash Left Join  (cost=1.01..2.08 rows=4 width=24) (actual time=0.375..0.375 rows=0 loops=1)
+   Hash Cond: ((a.c1 = b.c1) AND (a.c2 = b.c2))
+   ->  Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..1.02 rows=1 width=16) (actual time=0.373..0.373 rows=0 loops=1)
+         ->  Seq Scan on r2 a  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.001 rows=0 loops=1)
+   ->  Hash  (cost=1.00..1.00 rows=1 width=16) (never executed)
+         ->  Gather Motion 1:1  (slice2; segments: 1)  (cost=1.00..1.00 rows=1 width=16) (never executed)
+               ->  Seq Scan on d1 b  (cost=0.00..1.00 rows=1 width=16) (actual time=0.000..0.002 rows=0 loops=1)
+ Planning time: 5.656 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 2 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 42K bytes (seg0).
  Memory used:  128000kB
  Optimizer: Postgres query optimizer
- Total runtime: 2.802 ms
-(16 rows)
+ Execution time: 1.902 ms
+(14 rows)
 
 :explain select * from r2 a left join r1 b using (c1);
                                                                       QUERY PLAN                                                                      

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -59,7 +59,7 @@ test: gpcopy
 # parallel test running vacuum could have trouble
 test: matview_ao
 
-test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format direct_dispatch_explain_analyze
+test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format direct_dispatch_explain_analyze explain_analyze
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: guc_gp

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1028,7 +1028,7 @@ explain analyze select * from t_create_gang_time where tc1=1;
 INFO:  (Gang) is reused
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1176.25 rows=87 width=8) (actual time=0.370..0.370 rows=0 loops=1)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1176.25 rows=87 width=8) (actual time=0.329..0.329 rows=0 loops=1)
    ->  Seq Scan on t_create_gang_time  (cost=0.00..1176.25 rows=29 width=8) (actual time=0.000..0.001 rows=0 loops=1)
          Filter: (tc1 = 1)
  Planning time: 0.289 ms
@@ -1053,14 +1053,14 @@ INFO:  (Gang) is reused
 INFO:  (Gang) is reused
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000243071.10 rows=7413211 width=16) (actual time=0.372..0.372 rows=0 loops=1)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000243071.10 rows=7413211 width=16) (actual time=0.328..0.328 rows=0 loops=1)
    ->  Nested Loop  (cost=10000000000.00..10000243071.10 rows=2471071 width=16) (actual time=0.000..0.002 rows=0 loops=1)
          ->  Seq Scan on t_create_gang_time t2  (cost=0.00..961.00 rows=28700 width=8) (actual time=0.000..0.001 rows=0 loops=1)
          ->  Materialize  (cost=0.00..1180.99 rows=87 width=8) (never executed)
                ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..1179.69 rows=259 width=8) (never executed)
                      ->  Seq Scan on t_create_gang_time t1  (cost=0.00..1176.25 rows=29 width=8) (actual time=0.000..0.001 rows=0 loops=1)
                            Filter: (tc1 = 2)
- Planning time: 0.340 ms
+ Planning time: 0.485 ms
    (slice0)    Executor memory: 63K bytes.
    (slice1)    Executor memory: 42K bytes (seg0).
    (slice2)    Executor memory: 63K bytes avg x 3 workers, 63K bytes max (seg0).

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1028,8 +1028,8 @@ explain analyze select * from t_create_gang_time where tc1=1;
 INFO:  (Gang) is reused
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1176.25 rows=87 width=8) (actual time=0.329..0.329 rows=0 loops=1)
-   ->  Seq Scan on t_create_gang_time  (cost=0.00..1176.25 rows=29 width=8) (never executed)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1176.25 rows=87 width=8) (actual time=0.370..0.370 rows=0 loops=1)
+   ->  Seq Scan on t_create_gang_time  (cost=0.00..1176.25 rows=29 width=8) (actual time=0.000..0.001 rows=0 loops=1)
          Filter: (tc1 = 1)
  Planning time: 0.289 ms
    (slice0)    Executor memory: 59K bytes.
@@ -1053,14 +1053,14 @@ INFO:  (Gang) is reused
 INFO:  (Gang) is reused
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000243071.10 rows=7413211 width=16) (actual time=0.328..0.328 rows=0 loops=1)
-   ->  Nested Loop  (cost=10000000000.00..10000243071.10 rows=2471071 width=16) (never executed)
-         ->  Seq Scan on t_create_gang_time t2  (cost=0.00..961.00 rows=28700 width=8) (never executed)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000243071.10 rows=7413211 width=16) (actual time=0.372..0.372 rows=0 loops=1)
+   ->  Nested Loop  (cost=10000000000.00..10000243071.10 rows=2471071 width=16) (actual time=0.000..0.002 rows=0 loops=1)
+         ->  Seq Scan on t_create_gang_time t2  (cost=0.00..961.00 rows=28700 width=8) (actual time=0.000..0.001 rows=0 loops=1)
          ->  Materialize  (cost=0.00..1180.99 rows=87 width=8) (never executed)
                ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..1179.69 rows=259 width=8) (never executed)
-                     ->  Seq Scan on t_create_gang_time t1  (cost=0.00..1176.25 rows=29 width=8) (never executed)
+                     ->  Seq Scan on t_create_gang_time t1  (cost=0.00..1176.25 rows=29 width=8) (actual time=0.000..0.001 rows=0 loops=1)
                            Filter: (tc1 = 2)
- Planning time: 0.485 ms
+ Planning time: 0.340 ms
    (slice0)    Executor memory: 63K bytes.
    (slice1)    Executor memory: 42K bytes (seg0).
    (slice2)    Executor memory: 63K bytes avg x 3 workers, 63K bytes max (seg0).

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -1,0 +1,24 @@
+-- start_matchsubs
+-- m/ Gather Motion [12]:1  \(slice1; segments: [12]\)/
+-- s/ Gather Motion [12]:1  \(slice1; segments: [12]\)/ Gather Motion XXX/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- end_matchsubs
+
+CREATE TEMP TABLE empty_table(a int);
+-- We used to incorrectly report "never executed" for a node that returns 0 rows
+-- from every segment. This was misleading because "never executed" should
+-- indicate that the node was never executed by its parent.
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
+-- explain_processing_on
+
+-- For a node that is truly never executed, we still expect "never executed" to
+-- be reported
+-- explain_processing_off
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+-- explain_processing_on

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -7,10 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
--- m/Planning time: .*ms/
--- s/Planning time: .*ms/Planning time: 0 ms/
--- m/Execution time: .*ms/
--- s/Execution time: .*ms/Execution time: 0 ms/
+-- m/Execution time: \d+\.\d+ ms/
+-- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
+-- m/Planning time: \d+\.\d+ ms/
+-- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int, b int);

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -7,18 +7,30 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning time: .*ms/
+-- s/Planning time: .*ms/Planning time: 0 ms/
+-- m/Execution time: .*ms/
+-- s/Execution time: .*ms/Execution time: 0 ms/
 -- end_matchsubs
 
-CREATE TEMP TABLE empty_table(a int);
+CREATE TEMP TABLE empty_table(a int, b int);
 -- We used to incorrectly report "never executed" for a node that returns 0 rows
 -- from every segment. This was misleading because "never executed" should
 -- indicate that the node was never executed by its parent.
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
+
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table;
 -- explain_processing_on
 
 -- For a node that is truly never executed, we still expect "never executed" to
 -- be reported
 -- explain_processing_off
-EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
+
+-- Test with predicate
+INSERT INTO empty_table select generate_series(1, 1000)::int as a;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
+
+ANALYZE a;
+EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
 -- explain_processing_on

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -11,6 +11,12 @@
 -- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
 -- m/Planning time: \d+\.\d+ ms/
 -- s/Planning time: \d+\.\d+ ms/Planning time: ##.### ms/
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
+-- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
+-- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
+-- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int, b int);
@@ -31,6 +37,6 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT t1.a FROM empty_table t1 join em
 INSERT INTO empty_table select generate_series(1, 1000)::int as a;
 EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
 
-ANALYZE a;
+ANALYZE empty_table;
 EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT a FROM empty_table WHERE b = 2;
 -- explain_processing_on


### PR DESCRIPTION
### This patch is a backport of patch from [gdpb/7.x](https://github.com/greenplum-db/gpdb/pull/14119).


There is a no difference in the source code with original patch, but tests has been changed a bit:
- `dpe_optimizer`/`gang_reuse`/`partial_table` tests were changed: some test cases, which contained a label `(never executed)` inside output of `explain analyze` was updated. These tests won't fail without updating test cases, because `explain.pl` perl script (which is called from `atmsort.pm` which in turns called from `gpdiff.pm`) which transforms the output of `explain analyze` ignores the `costs` and `labels` at the text output of plan node
  For example:

  ```>  Partition Selector for pt (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4) (never executed)```

  Transforms into next representation:

  ```
  { ...
    'id' => 5,
    'parent' => 4,
    'short' => 'Partition Selector for pt (dynamic scan id: 1)'
    ...
  }
  ```

  Thus after `gpddiff.pl` would compare these representations without labels, it will find no difference. But seems, it's worth to update such test cases for consitency.

- `explain_analyze` test, which was introduced in the original patch was changed, because there is no option `SUMMARY OFF` for `explain analyze` at the `6.x`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
