### PR TITLE
Extend fstream_write() incomplete data error message

### DIFF
--- a/src/backend/utils/misc/fstream/fstream.c
+++ b/src/backend/utils/misc/fstream/fstream.c
@@ -1011,7 +1011,7 @@ int fstream_write(fstream_t *fs,
 
 		if (last_delim == 0)
 		{
-			fs->ferror = "no complete data row found for writing";
+			fs->ferror = "no complete data row found for writing or line is too long";
 			return -1;
 		}
 				

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -665,7 +665,7 @@ INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
 -- Check error correctness, if trying to insert too long row
 INSERT INTO wet_pos1(a)
 SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
-ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing
+ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing or line is too long
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger


### PR DESCRIPTION
Additionally to #470 we want to make error message more clear on gpfdist side. This patch extending existing error message, so now we see something similar to what we may see on gpdb side (`gpfdist error - line too long in file ...`).
