### PR TITLE
ADBDEV-3536 Fix extension creation when extension scripts drop anything

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -169,6 +169,7 @@ installcheck-world:
 	$(MAKE) -C src/test/heap_checksum install && $(MAKE) -C src/test/heap_checksum installcheck
 	$(MAKE) -C src/test/isolation installcheck
 	$(MAKE) -C src/test/isolation2 installcheck
+	$(MAKE) -C src/test/modules installcheck
 	$(MAKE) -C src/pl installcheck
 	#$(MAKE) -C src/interfaces/ecpg installcheck
 	#$(MAKE) -C contrib installcheck

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -653,6 +653,10 @@ recursiveDeletion(const ObjectAddress *object,
 									 otherObjDesc)));
 				}
 
+				if (otherObject.classId == ExtensionRelationId &&
+					otherObject.objectId == CurrentExtensionObject)
+					break;
+
 				/*
 				 * 2. When recursing from the other end of this dependency,
 				 * it's okay to continue with the deletion. This holds when

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3993,6 +3993,7 @@ _copyAlterExtensionStmt(AlterExtensionStmt *from)
 
 	COPY_STRING_FIELD(extname);
 	COPY_NODE_FIELD(options);
+	COPY_SCALAR_FIELD(update_ext_state);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1001,6 +1001,7 @@ _equalAlterExtensionStmt(AlterExtensionStmt *a, AlterExtensionStmt *b)
 {
 	COMPARE_STRING_FIELD(extname);
 	COMPARE_NODE_FIELD(options);
+	COMPARE_SCALAR_FIELD(update_ext_state);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4291,6 +4291,7 @@ _outAlterExtensionStmt(StringInfo str, AlterExtensionStmt *node)
 
 	WRITE_STRING_FIELD(extname);
 	WRITE_NODE_FIELD(options);
+	WRITE_ENUM_FIELD(update_ext_state, UpdateExtensionState);
 }
 
 static void

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2621,7 +2621,7 @@ _readAlterExtensionStmt(void)
 	READ_LOCALS(AlterExtensionStmt);
 	READ_STRING_FIELD(extname);
 	READ_NODE_FIELD(options);
-
+	READ_ENUM_FIELD(update_ext_state, UpdateExtensionState);
 	READ_DONE();
 }
 

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -48,4 +48,6 @@ extern void AlterExtensionNamespace(List *names, const char *newschema);
 
 extern void AlterExtensionOwner_oid(Oid extensionOid, Oid newOwnerId);
 
+extern void ResetExtensionCreatingGlobalVarsOnQE(void);
+
 #endif   /* EXTENSION_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1133,6 +1133,13 @@ typedef enum CreateExtensionState
 	CREATE_EXTENSION_END		/* finish to create extension */
 } CreateExtensionState;
 
+typedef enum UpdateExtensionState
+{
+	UPDATE_EXTENSION_INIT,		/* not start to update extension */
+	UPDATE_EXTENSION_BEGIN,     /* start to update extension */
+	UPDATE_EXTENSION_END		/* finish to update extension */
+} UpdateExtensionState;
+
 typedef struct CreateExtensionStmt
 {
 	NodeTag		type;
@@ -1148,6 +1155,7 @@ typedef struct AlterExtensionStmt
 	NodeTag		type;
 	char	   *extname;
 	List	   *options;		/* List of DefElem nodes */
+	UpdateExtensionState update_ext_state;	/* update extension state, only used for ALTER EXTENSION UPDATE */
 } AlterExtensionStmt;
 
 typedef struct AlterExtensionContentsStmt

--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -7,4 +7,8 @@ include $(top_builddir)/src/Makefile.global
 SUBDIRS = test_planner
 SUBDIRS += test_extensions 
 
-$(recurse)
+check installcheck:
+	@CHECKERR=0; for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir $@ || CHECKERR=$$?; \
+	done; \
+	exit $$CHECKERR

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -3,8 +3,10 @@
 MODULE = test_extensions
 PGFILEDESC = "test_extensions - regression testing for EXTENSION support"
 
-EXTENSION = test_ext_cor
-DATA = test_ext_cor--1.0.sql
+EXTENSION = test_ext_cor test_ext_cau
+DATA = test_ext_cor--1.0.sql \
+       test_ext_cau--1.0--1.1.sql test_ext_cau--1.0.sql \
+       test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql
 
 REGRESS = test_extensions
 

--- a/src/test/modules/test_extensions/expected/test_extensions.out
+++ b/src/test/modules/test_extensions/expected/test_extensions.out
@@ -20,19 +20,19 @@ DROP FUNCTION ext_cor_func();
 CREATE VIEW ext_cor_view AS
   SELECT 'ext_cor_view: original'::text AS col;
 CREATE EXTENSION test_ext_cor;  -- fail
-ERROR:  view ext_cor_view is not a member of extension "test_ext_cor"
-DETAIL:  An extension is not allowed to replace an object that it does not own.
 SELECT ext_cor_func();
-ERROR:  function ext_cor_func() does not exist
-LINE 1: SELECT ext_cor_func();
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM ext_cor_view;
-          col           
-------------------------
- ext_cor_view: original
+         ext_cor_func         
+------------------------------
+ ext_cor_func: from extension
 (1 row)
 
+SELECT * FROM ext_cor_view;
+             col              
+------------------------------
+ ext_cor_view: from extension
+(1 row)
+
+drop extension test_ext_cor;
 DROP VIEW ext_cor_view;
 CREATE TYPE test_ext_type;
 CREATE EXTENSION test_ext_cor;  -- fail
@@ -48,6 +48,9 @@ ERROR:  operator <<@@(point,polygon) is not a member of extension "test_ext_cor"
 DETAIL:  An extension is not allowed to replace an object that it does not own.
 DROP OPERATOR <<@@ (point, polygon);
 CREATE EXTENSION test_ext_cor;  -- now it should work
+DROP FUNCTION ext_cor_func();
+ERROR:  cannot drop function ext_cor_func() because extension test_ext_cor requires it
+HINT:  You can drop extension test_ext_cor instead.
 SELECT ext_cor_func();
          ext_cor_func         
 ------------------------------
@@ -73,12 +76,163 @@ SELECT point(0,0) <<@@ polygon(circle(point(0,0),1));
 (1 row)
 
 \dx+ test_ext_cor
-Objects in extension "test_ext_cor"
-      Object Description      
-------------------------------
- function ext_cor_func()
- operator <<@@(point,polygon)
- type test_ext_type
- view ext_cor_view
-(4 rows)
+                       List of installed extensions
+     Name     | Version | Schema |              Description               
+--------------+---------+--------+----------------------------------------
+ test_ext_cor | 1.0     | public | Test extension using CREATE OR REPLACE
+(1 row)
 
+--
+-- Another test cases for problem https://github.com/greenplum-db/gpdb/issues/6716.
+-- Segments of gpdb builed with `--enable-cassert` stops with error like
+-- FailedAssertion(""!(stack->state == GUC_SAVE)" at next cases. At gpdb builed
+-- without `--enable-cassert` segments won't stop with errors, but there may be
+-- incorrect search_path.
+--
+--
+-- create extension in the same schema
+--
+begin;
+set search_path=pg_catalog;
+create extension test_ext_cau;
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+rollback;
+--
+-- create extension in the different schema
+--
+create schema differentschema;
+begin;
+set search_path=differentschema;
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+create extension test_ext_cau with schema pg_catalog;
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+end;
+-- check search_path after transaction commit
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+drop extension test_ext_cau;
+create extension test_ext_cau with version '1.0' schema differentschema;
+begin;
+set search_path=differentschema;
+alter extension test_ext_cau update to '1.1';
+end;
+-- check search_path after transaction commit
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+drop function differentschema.test_func1(int,int);
+drop extension test_ext_cau;
+--
+-- Test case for create extension from unpackaged
+--
+-- Create extension functions at existing schema (differentschema). Code copied from from test_ext_cau--1.0.sql
+create function test_func1(a int, b int) returns int
+as $$
+begin
+	return a + b;
+end;
+$$
+LANGUAGE plpgsql;
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;
+-- restore search path
+reset search_path;
+begin;
+-- change search_path
+set search_path=pg_catalog;
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+-- create extension in schema differentschema
+create extension test_ext_cau with schema differentschema version '1.1' from 'unpackaged';
+-- check that search path doesn't changed after create extension
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+-- show that functions belong to schema differentschema (check that create extension works correctly)
+set search_path=differentschema;
+\df
+                                List of functions
+     Schema      |    Name    | Result data type | Argument data types  |  Type  
+-----------------+------------+------------------+----------------------+--------
+ differentschema | test_func1 | integer          | a integer, b integer | normal
+ differentschema | test_func2 | integer          | a integer, b integer | normal
+(2 rows)
+
+SELECT e.extname, ne.nspname AS extschema, p.proname, np.nspname AS proschema
+FROM pg_catalog.pg_extension AS e
+    INNER JOIN pg_catalog.pg_depend AS d ON (d.refobjid = e.oid)
+    INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
+    INNER JOIN pg_catalog.pg_namespace AS ne ON (ne.oid = e.extnamespace)
+    INNER JOIN pg_catalog.pg_namespace AS np ON (np.oid = p.pronamespace)
+WHERE d.deptype = 'e' and e.extname = 'test_ext_cau'
+ORDER BY 1, 3;
+   extname    |    extschema    |  proname   |    proschema    
+--------------+-----------------+------------+-----------------
+ test_ext_cau | differentschema | test_func2 | differentschema
+(1 row)
+
+end;
+-- check search_path after transaction commit
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+reset search_path;
+drop function differentschema.test_func1(int,int);
+drop extension test_ext_cau;
+--
+-- check that alter extension (with search_path is set) won't fail (on gpdb builded with --enable-cassert)
+--
+create extension test_ext_cau with version '1.0' schema differentschema;
+begin;
+set search_path=differentschema;
+alter extension test_ext_cau update to '1.1';
+end;
+-- check search_path after transaction commit
+show search_path;
+   search_path   
+-----------------
+ differentschema
+(1 row)
+
+reset search_path;
+drop schema differentschema cascade;
+NOTICE:  drop cascades to function differentschema.test_func2(integer,integer)
+NOTICE:  drop cascades to extension test_ext_cau
+NOTICE:  drop cascades to function differentschema.test_func1(integer,integer)

--- a/src/test/modules/test_extensions/sql/test_extensions.sql
+++ b/src/test/modules/test_extensions/sql/test_extensions.sql
@@ -24,6 +24,8 @@ SELECT ext_cor_func();
 
 SELECT * FROM ext_cor_view;
 
+drop extension test_ext_cor;
+
 DROP VIEW ext_cor_view;
 
 CREATE TYPE test_ext_type;
@@ -43,6 +45,8 @@ DROP OPERATOR <<@@ (point, polygon);
 
 CREATE EXTENSION test_ext_cor;  -- now it should work
 
+DROP FUNCTION ext_cor_func();
+
 SELECT ext_cor_func();
 
 SELECT * FROM ext_cor_view;
@@ -52,3 +56,121 @@ SELECT 'x'::test_ext_type;
 SELECT point(0,0) <<@@ polygon(circle(point(0,0),1));
 
 \dx+ test_ext_cor
+
+
+
+--
+-- Another test cases for problem https://github.com/greenplum-db/gpdb/issues/6716.
+-- Segments of gpdb builed with `--enable-cassert` stops with error like
+-- FailedAssertion(""!(stack->state == GUC_SAVE)" at next cases. At gpdb builed
+-- without `--enable-cassert` segments won't stop with errors, but there may be
+-- incorrect search_path.
+--
+
+--
+-- create extension in the same schema
+--
+begin;
+set search_path=pg_catalog;
+create extension test_ext_cau;
+show search_path;
+rollback;
+
+--
+-- create extension in the different schema
+--
+create schema differentschema;
+
+begin;
+set search_path=differentschema;
+show search_path;
+create extension test_ext_cau with schema pg_catalog;
+show search_path;
+end;
+
+-- check search_path after transaction commit
+show search_path;
+
+drop extension test_ext_cau;
+
+create extension test_ext_cau with version '1.0' schema differentschema;
+begin;
+set search_path=differentschema;
+alter extension test_ext_cau update to '1.1';
+end;
+
+-- check search_path after transaction commit
+show search_path;
+drop function differentschema.test_func1(int,int);
+drop extension test_ext_cau;
+
+--
+-- Test case for create extension from unpackaged
+--
+
+-- Create extension functions at existing schema (differentschema). Code copied from from test_ext_cau--1.0.sql
+create function test_func1(a int, b int) returns int
+as $$
+begin
+	return a + b;
+end;
+$$
+LANGUAGE plpgsql;
+
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;
+
+-- restore search path
+reset search_path;
+
+begin;
+-- change search_path
+set search_path=pg_catalog;
+show search_path;
+
+-- create extension in schema differentschema
+create extension test_ext_cau with schema differentschema version '1.1' from 'unpackaged';
+
+-- check that search path doesn't changed after create extension
+show search_path;
+
+-- show that functions belong to schema differentschema (check that create extension works correctly)
+set search_path=differentschema;
+\df
+
+SELECT e.extname, ne.nspname AS extschema, p.proname, np.nspname AS proschema
+FROM pg_catalog.pg_extension AS e
+    INNER JOIN pg_catalog.pg_depend AS d ON (d.refobjid = e.oid)
+    INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
+    INNER JOIN pg_catalog.pg_namespace AS ne ON (ne.oid = e.extnamespace)
+    INNER JOIN pg_catalog.pg_namespace AS np ON (np.oid = p.pronamespace)
+WHERE d.deptype = 'e' and e.extname = 'test_ext_cau'
+ORDER BY 1, 3;
+end;
+
+-- check search_path after transaction commit
+show search_path;
+
+reset search_path;
+drop function differentschema.test_func1(int,int);
+drop extension test_ext_cau;
+
+--
+-- check that alter extension (with search_path is set) won't fail (on gpdb builded with --enable-cassert)
+--
+create extension test_ext_cau with version '1.0' schema differentschema;
+begin;
+set search_path=differentschema;
+alter extension test_ext_cau update to '1.1';
+end;
+
+-- check search_path after transaction commit
+show search_path;
+
+reset search_path;
+drop schema differentschema cascade;

--- a/src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql
@@ -1,0 +1,6 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION test_ext_cau" to load this file. \quit
+
+ALTER EXTENSION test_ext_cau DROP function test_func1(int, int);

--- a/src/test/modules/test_extensions/test_ext_cau--1.0.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.0.sql
@@ -1,0 +1,20 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau" to load this file. \quit
+
+create function test_func1(a int, b int) returns int
+as $$
+begin
+	return a + b;
+end;
+$$
+LANGUAGE plpgsql;
+
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;

--- a/src/test/modules/test_extensions/test_ext_cau--1.1.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.1.sql
@@ -1,0 +1,12 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau" to load this file. \quit
+
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;

--- a/src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql
@@ -1,0 +1,7 @@
+/* src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau FROM 'unpackaged'" to load this file. \quit
+
+ALTER EXTENSION test_ext_cau ADD function test_func1(int, int);
+ALTER EXTENSION test_ext_cau ADD function test_func2(int, int);

--- a/src/test/modules/test_extensions/test_ext_cau.control
+++ b/src/test/modules/test_extensions/test_ext_cau.control
@@ -1,0 +1,4 @@
+# test_ext_cau
+comment = 'Test extension using CREATE/ALTER extension (from unpackaged/update)'
+default_version = '1.1'
+relocatable = true

--- a/src/test/modules/test_planner/Makefile
+++ b/src/test/modules/test_planner/Makefile
@@ -26,5 +26,6 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
+installcheck: install
 test: clean all install
 	psql postgres -f sql/test_planner.sql 2>&1


### PR DESCRIPTION
gptkh installation on gpdb5 fails with error:
```
adb=# create extension if not exists gptkh; ERROR: cannot drop function local_tables(text,text,text,integer,text,text) because extension gptkh requires it HINT: You can drop extension gptkh instead.
```
The error is caused by an attempt to delete local_tables function. In gptkh 0.8 there was no attempt to drop this function within the installation script, but in newer version we try to drop some newly created functions, which causes the error.

There’s a difference in extension dependency control between gpdb 5 and gpdb 6. While the 5th forbids dropping extension’s dependencies, the 6th allows to drop dependencies to the extension itself.

Backported test doesn't fully match the test that's on 6x because 5x treats some objects differently. For example, it allows extensions dropping existing views which is forbidden in 5x. However, extensions are not allowed to drop existing functions

The backported commits are as follows:

- https://github.com/arenadata/gpdb/commit/b313cdf2e598fe05ce72a8882493d112f4c44c72 This commit resets extension related variables on segments

- https://github.com/arenadata/gpdb/commit/313786a74155cf04e4539f4d613a6993aab199d8 If the other object is the extension currently being created/altered, ignore this dependency and continue with the deletion.  This allows dropping of an extension's objects within the extension's scripts, as well as corner cases such as dropping a transient object created within such a script.

- https://github.com/arenadata/gpdb/commit/ad20725bf24ea6a85213e6e0379dbd1e665719a0 This patch fixes problem with incorrect handling of `search_path` GUC at QE: `create/alter extension` process sets up this GUC to the newer state, but GUC is not reset after this process finishes - as a result there will broken version of GUC inside transaction. The patch fixes this problem by saving the state of `GUCNestlevel` at QE variable to enable correct state machine work (of `create/alter extension` process) executed on QE.

- https://github.com/arenadata/gpdb/commit/3769eac6d28cfd59b808ff59bfafe264b68649dd The implementation of UPDATE EXTENSION is very similar to CREATE EXTENSION.
First, on QD, we update the pg_extension row to the new version, and update extension's dependency entries according to the new requires introduced by the new version specified control file.
Second, we dispatch the UPDATE EXTENSION statement to QEs to update pg_extension row and extension's dependency entries on QEs, and the global status like creating_extension, CurrentExtensionObject of QEs will be set.
Finally, we execute the update script file on QD. because of the correct set of creating_extension, CurrentExtensionObject on QEs, the dependency between object and extension will be handled correctly, so the CREATE/DROP object statement will be executed successfully.

Patch notes:

1. `test_extension.sql` from the patch differs from the 6x version in the following cases:

    - gpdb5 doesn't support `if not exists` expression, so the `test_ext_cine` test is irrelevant
    - `gp_inject_fault` test was dropped because of different internal organization of this extension
    - `btree_gin` extension doesn't exist in gpdb5 and was replaced by test_ext_cau which causes little differences across the test

2. Signature of ApplyExtensionUpdates was changed 
    This function is supposed to accept AlterExtensionStmt variable in 5x because it's used in ExecAlterExtensionStmt only. But in 6x it's used in CreateExtension as well and doesn't accept any statement at all. The redundant argument was dropped in 6c2e734

3. Add test case for extension dependent function
    Test if we can drop a function which is owned by an extension. In gpdb6 dependency control in handled by DEPENDENCY_INTERNAL_AUTO which doesn't exist in gpdb5, because of this we have to stick to the old dependecy control method. But due to the changes made by this patch, the old contol system broke which led to the situation when an extension couldn't drop its own object during creation or update. This problem was fixed and this test is supposed to check that 

4. Backport guc handling for all gucs
    guc handling was backported from 6x in https://github.com/arenadata/gpdb/commit/ee8daacb503023f9f756922a74fdd2cf8050a736, but GUC_ACTION_SAVE
parameter of set_config_option was lost which led to incorrect guc
handling within transactions. This commit restores original parameter
