### PR TITLE
ADBDEV-3535: fixes for parallel_retrieve_cursor tests

### DIFF
--- a/src/test/isolation2/expected/concurrent_vacuum_with_delete.out
+++ b/src/test/isolation2/expected/concurrent_vacuum_with_delete.out
@@ -162,3 +162,4 @@ EXECUTE 1000
 2q: ... <quitting>
 
 drop table sales_row;
+DROP

--- a/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
+++ b/src/test/isolation2/expected/dml_on_root_locks_all_parts.out
@@ -49,7 +49,9 @@ DELETE 0
 1: BEGIN;
 BEGIN
 -- UPDATE will acquire Exclusive lock on root and leaf partition on QD.
-1: UPDATE part_tbl SET c = 1; SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
+1: UPDATE part_tbl SET c = 1;
+UPDATE 0
+SELECT GRANTED FROM pg_locks WHERE relation = 'part_tbl_1_prt_1'::regclass::oid AND mode='ExclusiveLock' AND gp_segment_id=-1 AND locktype='relation';
  granted 
 ---------
  t       

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_heap_bitmap.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_heap_bitmap.out
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS reindex_crtab_heap_bitmap;
 DROP
 
-CREATE TABLE reindex_crtab_heap_bitmap (a INT); insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
-CREATE 1000
+CREATE TABLE reindex_crtab_heap_bitmap (a INT);
+CREATE
+insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
+INSERT 1000
 insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
 INSERT 1000
 create index idx_reindex_crtab_heap_bitmap on reindex_crtab_heap_bitmap(a);

--- a/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_heap_btree.out
+++ b/src/test/isolation2/expected/reindex/createidx_while_reindex_idx_heap_btree.out
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS reindex_crtab_heap_btree;
 DROP
 
-CREATE TABLE reindex_crtab_heap_btree (a INT); insert into reindex_crtab_heap_btree select generate_series(1,1000);
-CREATE 1000
+CREATE TABLE reindex_crtab_heap_btree (a INT);
+CREATE
+insert into reindex_crtab_heap_btree select generate_series(1,1000);
+INSERT 1000
 insert into reindex_crtab_heap_btree select generate_series(1,1000);
 INSERT 1000
 create index idx_reindex_crtab_heap_btree on reindex_crtab_heap_btree(a);

--- a/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_bitmap.out
+++ b/src/test/isolation2/expected/reindex/reindextable_while_reindex_idx_heap_bitmap.out
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS reindex_crtab_heap_bitmap;
 DROP
 
-CREATE TABLE reindex_crtab_heap_bitmap (a INT); insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
-CREATE 1000
+CREATE TABLE reindex_crtab_heap_bitmap (a INT);
+CREATE
+insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
+INSERT 1000
 insert into reindex_crtab_heap_bitmap select generate_series(1,1000);
 INSERT 1000
 create index idx_reindex_crtab_heap_bitmap on reindex_crtab_heap_bitmap USING BITMAP(a);

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree.out
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS reindex_heap;
 DROP
 
-CREATE TABLE reindex_heap (a INT); insert into reindex_heap select generate_series(1,1000);
-CREATE 1000
+CREATE TABLE reindex_heap (a INT);
+CREATE
+insert into reindex_heap select generate_series(1,1000);
+INSERT 1000
 insert into reindex_heap select generate_series(1,1000);
 INSERT 1000
 create index idx_btree_reindex_heap on reindex_heap(a);

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree_toast.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree_toast.out
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS reindex_toast_heap;
 DROP
 
-CREATE TABLE reindex_toast_heap (a text, b int); alter table reindex_toast_heap alter column a set storage external;
+CREATE TABLE reindex_toast_heap (a text, b int);
 CREATE
+alter table reindex_toast_heap alter column a set storage external;
+ALTER
 insert into reindex_toast_heap select repeat('123456789',10000), i from generate_series(1,100) i;
 INSERT 100
 create index idx_btree_reindex_toast_heap on reindex_toast_heap(b);

--- a/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
+++ b/src/test/isolation2/expected/segwalrep/max_slot_wal_keep_size.out
@@ -6,7 +6,7 @@
 include: helpers/server_helpers.sql;
 CREATE
 
-CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS $$ DECLARE i int; BEGIN i := 0; CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); LOOP IF i >= num THEN DROP TABLE t_dummy_switch; RETURN; END IF; PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; INSERT INTO t_dummy_switch SELECT generate_series(1,10); i := i + 1; END LOOP; DROP TABLE t_dummy_switch; END; $$ language plpgsql;
+CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS /*in func*/ $$ /*in func*/ DECLARE /*in func*/ i int; /*in func*/ BEGIN /*in func*/ i := 0; /*in func*/ CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); /*in func*/ LOOP /*in func*/ IF i >= num THEN /*in func*/ DROP TABLE t_dummy_switch; /*in func*/ RETURN; /*in func*/ END IF; /*in func*/ PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; /*in func*/ INSERT INTO t_dummy_switch SELECT generate_series(1,10); /*in func*/ i := i + 1; /*in func*/ END LOOP; /*in func*/ DROP TABLE t_dummy_switch; /*in func*/ END; /*in func*/ $$ language plpgsql;
 CREATE
 
 -- On content 0 primary, retain max 128MB (2 WAL files) for

--- a/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
+++ b/src/test/isolation2/sql/segwalrep/max_slot_wal_keep_size.sql
@@ -5,24 +5,24 @@
 
 include: helpers/server_helpers.sql;
 
-CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS
-$$
-DECLARE
-	i int; 
-BEGIN 
-    i := 0; 
-	CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); 
-	LOOP 
-		IF i >= num THEN 
-			DROP TABLE t_dummy_switch; 
-			RETURN; 
-		END IF; 
-		PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; 
-		INSERT INTO t_dummy_switch SELECT generate_series(1,10); 
-		i := i + 1; 
-	END LOOP; 
-	DROP TABLE t_dummy_switch; 
-END; 
+CREATE OR REPLACE FUNCTION advance_xlog_on_seg0(num int) RETURNS void AS /*in func*/
+$$ /*in func*/
+DECLARE /*in func*/
+	i int; /*in func*/
+BEGIN /*in func*/
+   i := 0; /*in func*/
+	CREATE TABLE t_dummy_switch(i int) DISTRIBUTED BY (i); /*in func*/
+	LOOP /*in func*/
+		IF i >= num THEN /*in func*/
+			DROP TABLE t_dummy_switch; /*in func*/
+			RETURN; /*in func*/
+		END IF; /*in func*/
+		PERFORM pg_switch_xlog() FROM gp_dist_random('gp_id') WHERE gp_segment_id=0; /*in func*/
+		INSERT INTO t_dummy_switch SELECT generate_series(1,10); /*in func*/
+		i := i + 1; /*in func*/
+	END LOOP; /*in func*/
+	DROP TABLE t_dummy_switch; /*in func*/
+END; /*in func*/
 $$ language plpgsql;
 
 -- On content 0 primary, retain max 128MB (2 WAL files) for

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -92,7 +92,7 @@ class ConnectionInfo(object):
 
 
 class GlobalShellExecutor(object):
-    BASH_PS1 = 'test_sh$>'
+    BASH_PS1 = 'GlobalShellExecutor>'
 
     class ExecutionError(Exception):
         ""
@@ -108,6 +108,7 @@ class GlobalShellExecutor(object):
                                         stdin=self.slave_fd,
                                         stdout=self.slave_fd,
                                         stderr=self.slave_fd,
+                                        start_new_session=True,
                                         universal_newlines=True)
         self.bash_log_file = open("%s.log" % self.initfile_prefix, "w+")
         self.__run_command("export PS1='%s'" % GlobalShellExecutor.BASH_PS1)
@@ -129,34 +130,34 @@ class GlobalShellExecutor(object):
         try:
             self.sh_proc.terminate()
         except OSError as e:
-            # Ignore the exception if the process doesn't exist.
+            # Log then ignore the exception if the process doesn't exist.
+            print("Failed to terminate bash process: %s" % e)
             pass
         self.sh_proc = None
 
     def __run_command(self, sh_cmd):
-        # Strip the newlines at the end. It will be added later.
+        # Strip extra new lines
         sh_cmd = sh_cmd.rstrip()
-        bytes_written = os.write(self.master_fd, sh_cmd.encode())
-        bytes_written += os.write(self.master_fd, b'\n')
+        os.write(self.master_fd, sh_cmd.encode()+b'\n')
 
         output = ""
         while self.sh_proc.poll() is None:
-            # If not returns in 10 seconds, consider it as an fatal error.
-            r, w, e = select.select([self.master_fd], [], [self.master_fd], 30)
+            # If times out, consider it as an fatal error.
+            r, _, e = select.select([self.master_fd], [], [self.master_fd], 30)
             if e:
                 # Terminate the shell when we get any output from stderr
                 o = os.read(self.master_fd, 10240)
                 self.bash_log_file.write(o)
                 self.bash_log_file.flush()
                 self.terminate(True)
-                raise GlobalShellExecutor.ExecutionError("Error happened to the bash daemon, see %s for details." % self.bash_log_file.name)
+                raise GlobalShellExecutor.ExecutionError("Error happened to the bash process, see %s for details." % self.bash_log_file.name)
 
             if r:
                 o = os.read(self.master_fd, 10240).decode()
                 self.bash_log_file.write(o)
                 self.bash_log_file.flush()
                 output += o
-                if o.endswith(GlobalShellExecutor.BASH_PS1):
+                if output.endswith(GlobalShellExecutor.BASH_PS1):
                     lines = output.splitlines()
                     return lines[len(sh_cmd.splitlines()):len(lines) - 1]
 

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -88,7 +88,7 @@ class ConnectionInfo(object):
         for content, host, port, role in conn_map:
             if real_content_id == content and role == role_name:
                 return (host, port)
-        raise Exception("Cannont find a connection with content_id=%d, role=%c" % (content_id, role_name))
+        raise Exception("Cannot find a connection with content_id=%d, role=%c" % (content_id, role_name))
 
 
 class GlobalShellExecutor(object):
@@ -120,7 +120,7 @@ class GlobalShellExecutor(object):
         # If write the matchsubs section directly to the output, the generated token id will be compared by gpdiff.pl
         # so here just write all matchsubs section into an auto generated init file when this test case file finished.
         if not with_error and self.initfile_prefix != None and len(self.initfile_prefix) > 1:
-            output_init_file = "%s.ini" % self.initfile_prefix
+            output_init_file = "%s.initfile" % self.initfile_prefix
             cmd = ''' [ ! -z "${MATCHSUBS}" ] && echo "-- start_matchsubs ${NL} ${MATCHSUBS} ${NL}-- end_matchsubs" > %s ''' % output_init_file
             self.exec_global_shell(cmd, False)
 
@@ -162,15 +162,15 @@ class GlobalShellExecutor(object):
 
             if not r and not e:
                 self.terminate(True)
-                raise GlobalShellExecutor.ExecutionError("Timeout happened to the bash daemon, see %s for details." % self.bash_log_file.name)
+                raise GlobalShellExecutor.ExecutionError("Timeout happened to the bash process, see %s for details." % self.bash_log_file.name)
 
         self.terminate(True)
-        raise GlobalShellExecutor.ExecutionError("Bash daemon has been stopped, see %s for details." % self.bash_log_file.name)
+        raise GlobalShellExecutor.ExecutionError("Bash process has been stopped, see %s for details." % self.bash_log_file.name)
 
-    # execute global shell cmd in bash deamon, and fetch result without blocking
+    # execute global shell cmd in bash process, and fetch result without blocking
     def exec_global_shell(self, sh_cmd, is_trip_output_end_blanklines):
         if self.sh_proc == None:
-            raise GlobalShellExecutor.ExecutionError("The bash daemon has been terminated abnormally, see %s for details." % self.bash_log_file.name)
+            raise GlobalShellExecutor.ExecutionError("The bash process has been terminated abnormally, see %s for details." % self.bash_log_file.name)
 
         # get the output of shell command
         output = self.__run_command(sh_cmd)
@@ -183,7 +183,7 @@ class GlobalShellExecutor(object):
 
         return output
 
-    # execute gobal shell:
+    # execute global shell:
     # 1) set input stream -> $RAW_STR
     # 2) execute shell command from input
     # if error, write error message to err_log_file
@@ -213,7 +213,7 @@ class GlobalShellExecutor(object):
         for i in range(start, len(input_str)):
             if end == 0 and input_str[i] == '\'':
                 if not is_start:
-                    # find shell begin postion
+                    # find shell begin position
                     is_start = True
                     start = i+1
                     continue
@@ -225,7 +225,7 @@ class GlobalShellExecutor(object):
                         break
                 if cnt % 2 == 1:
                     continue
-                # find shell end postion
+                # find shell end position
                 res_cmd = input_str[start: i]
                 end = i
                 continue
@@ -651,7 +651,7 @@ class SQLIsolationExecutor(object):
                 con_mode = "mirror"
             sql = m.groups()[2]
             sql = sql.lstrip()
-            # If db_name is specifed , it should be of the following syntax:
+            # If db_name is specified , it should be of the following syntax:
             # 1:@db_name <db_name>: <sql>
             if sql.startswith('@db_name'):
                 sql_parts = sql.split(':', 2)
@@ -813,7 +813,7 @@ class SQLIsolationExecutor(object):
                 #tinctest.logger.info("re.match: %s" %re.match(r"^\d+[q\\<]:$", line))
                 print >>output_file, line.strip(),
                 if line[0] == "!":
-                    command_part = line # shell commands can use -- for multichar options like --include
+                    command_part = line # shell commands can use -- for long options like --include
                 elif re.match(r";.*--", line) or re.match(r"^--", line):
                     command_part = line.partition("--")[0] # remove comment from line
                 else:
@@ -825,7 +825,7 @@ class SQLIsolationExecutor(object):
                     try:
                         self.process_command(command, output_file, shell_executor)
                     except GlobalShellExecutor.ExecutionError as e:
-                        # error in the daemon shell cannot be recovered
+                        # error of the GlobalShellExecutor cannot be recovered
                         raise
                     except Exception as e:
                         print >>output_file, "FAILED: ", e
@@ -874,7 +874,7 @@ class SQLIsolationTestCase:
             U<: join an existing utility mode session (does not currently support an asterisk target)
             I: include a file of sql statements (useful for loading reusable functions)
 
-            R|R&|R<: similar to 'U' meaning execept that the connect is in retrieve mode, here don't
+            R|R&|R<: similar to 'U' meaning except that the connect is in retrieve mode, here don't
                thinking about retrieve mode authentication, just using the normal authentication directly.
 
         An example is:
@@ -888,7 +888,7 @@ class SQLIsolationTestCase:
 
         The isolation tests are specified identical to sql-scripts in normal
         SQLTestCases. However, it is possible to prefix a SQL line with
-        an tranaction identifier followed by a colon (":").
+        an transaction identifier followed by a colon (":").
         The above example would be defined by
         1: BEGIN;
         2: BEGIN;
@@ -966,9 +966,9 @@ class SQLIsolationTestCase:
         Shell Execution for SQL or Output:
 
         @pre_run can be used for executing shell command to change input (i.e. each SQL statement) or get input info;
-        @post_run can be used for executing shell command to change ouput (i.e. the result set printed for each SQL execution)
+        @post_run can be used for executing shell command to change output (i.e. the result set printed for each SQL execution)
         or get output info. Just use the env variable ${RAW_STR} to refer to the input/out stream before shell execution,
-        and the output of the shell command will be used as the SQL exeucted or output printed into results file.
+        and the output of the shell command will be used as the SQL executed or output printed into results file.
 
         1: @post_run ' TOKEN1=` echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && export MATCHSUBS="${MATCHSUBS}${NL}m/${TOKEN1}/${NL}s/${TOKEN1}/token_id1/${NL}" && echo "${RAW_STR}" ': SELECT token,hostname,status FROM GP_ENDPOINTS WHERE cursorname='c1';
         2R: @pre_run ' echo "${RAW_STR}" | sed "s#@TOKEN1#${TOKEN1}#" ': RETRIEVE ALL FROM "@TOKEN1";
@@ -977,7 +977,7 @@ class SQLIsolationTestCase:
         - Sample 1: set env variable ${TOKEN1} to the cell (row 3, col 1) of the result set, and print the raw result.
           The env var ${MATCHSUBS} is used to store the matchsubs section so that we can store it into initfile when
           this test case file is finished executing.
-        - Sample 2: replaceing "@TOKEN1" by generated token which is fetch in sample1
+        - Sample 2: replace "@TOKEN1" by generated token which is fetched in sample1
 
         There are some helper functions which will be sourced automatically to make above
         cases easier. See global_sh_executor.sh for more information.

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -142,7 +142,7 @@ class GlobalShellExecutor(object):
         output = ""
         while self.sh_proc.poll() is None:
             # If not returns in 10 seconds, consider it as an fatal error.
-            r, w, e = select.select([self.master_fd], [], [self.master_fd], 10)
+            r, w, e = select.select([self.master_fd], [], [self.master_fd], 30)
             if e:
                 # Terminate the shell when we get any output from stderr
                 o = os.read(self.master_fd, 10240)

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -820,7 +820,7 @@ class SQLIsolationExecutor(object):
                     command_part = line
                 if command_part == "" or command_part == "\n":
                     print >>output_file
-                elif command_part.endswith(";\n") or re.match(r"^\d+[q\\<]:$", line) or re.match(r"^\*Rq:$", line) or re.match(r"^-?\d+[SUMR][q\\<]:$", line):
+                elif re.match(r".*;\s*$", command_part) or re.match(r"^\d+[q\\<]:\s*$", line) or re.match(r"^\*Rq:$", line) or re.match(r"^-?\d+[SUMR][q\\<]:\s*$", line):
                     command += command_part
                     try:
                         self.process_command(command, output_file, shell_executor)
@@ -1007,6 +1007,27 @@ class SQLIsolationTestCase:
         -- example contents for file.sql: create function some_test_function() returning void ...
         include: path/to/some/file.sql;
         select some_helper_function();
+
+        Line continuation:
+        If a line is not ended by a semicolon ';' which is followed by 0 or more spaces, the line will be combined with next line and
+        sent together as a single statement.
+
+        e.g.: Send to the server separately:
+        1: SELECT * FROM t1; -> send "SELECT * FROM t1;"
+        SELECT * FROM t2; -> send "SELECT * FROM t2;"
+
+        e.g.: Send to the server once:
+        1: SELECT * FROM
+        t1; SELECT * FROM t2; -> "send SELECT * FROM t1; SELECT * FROM t2;"
+
+        ATTENTION:
+        Send multi SQL statements once:
+        Multi SQL statements can be sent at once, but there are some known issues. Generally only the last query result will be printed.
+        But due to the difficulties of dealing with semicolons insides quotes, we always echo the first SQL command instead of the last
+        one if query() returns None. This created some strange issues like:
+
+        CREATE TABLE t1 (a INT); INSERT INTO t1 SELECT generate_series(1,1000);
+        CREATE 1000 (Should be INSERT 1000, but here the CREATE is taken due to the limitation)
     """
 
     def run_sql_file(self, sql_file, out_file = None, out_dir = None, optimizer = None):

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -1968,7 +1968,7 @@ results_differ(const char *testname, const char *resultsfile, const char *defaul
 	}
 
 	/* Add auto generated init file if it is generated */
-	snprintf(buf, sizeof(buf), "%s.ini", resultsfile);
+	snprintf(buf, sizeof(buf), "%s.initfile", resultsfile);
 	if (file_exists(buf))
 	{
 		snprintf(generated_initfile, sizeof(generated_initfile),


### PR DESCRIPTION

`parallel_retrieve_cursor` tests are flaky, and sometimes CI may fail at the `corner.sql/.out` test case with the next error message:

```
*R: @pre_run 'set_endpoint_variable @ENDPOINT2': RETRIEVE ALL FROM ENDPOINT "@ENDPOINT2";
Traceback (most recent call last):
  File "./sql_isolation_testcase.py", line 1065, in <module>
    executor.process_isolation_file(sys.stdin, sys.stdout, options.initfile_prefix)
  File "./sql_isolation_testcase.py", line 826, in process_isolation_file
    self.process_command(command, output_file, shell_executor)
  File "./sql_isolation_testcase.py", line 765, in process_command
    (retrieve_user, retrieve_token) = self.__get_retrieve_user_token(name, global_sh_executor)
  File "./sql_isolation_testcase.py", line 615, in __get_retrieve_user_token
    out = global_sh_executor.exec_global_shell("get_retrieve_token", True)
  File "./sql_isolation_testcase.py", line 176, in exec_global_shell
    output = self.__run_command(sh_cmd)
  File "./sql_isolation_testcase.py", line 165, in __run_command
    raise GlobalShellExecutor.ExecutionError("Timeout happened to the bash daemon, see %s for details." % self.bash_log_file.name)
__main__.ExecutionError: Timeout happened to the bash daemon, see /home/gpadmin/gpdb_src/src/test/isolation2/results/parallel_retrieve_cursor/corner.out.log for details.

#######################
## or something like this


Traceback (most recent call last):
  File "./sql_isolation_testcase.py", line 1061, in <module>
    executor.process_isolation_file(sys.stdin, sys.stdout, options.initfile_prefix)
  File "./sql_isolation_testcase.py", line 822, in process_isolation_file
    self.process_command(command, output_file, shell_executor)
  File "./sql_isolation_testcase.py", line 765, in process_command
    (retrieve_user, retrieve_token) = self.__get_retrieve_user_token(name, global_sh_executor)
  File "./sql_isolation_testcase.py", line 613, in __get_retrieve_user_token
    global_sh_executor.exec_global_shell("GP_HOSTNAME=%s" % hostname, True)
  File "./sql_isolation_testcase.py", line 176, in exec_global_shell
    output = self.__run_command(sh_cmd)
  File "./sql_isolation_testcase.py", line 165, in __run_command
    raise GlobalShellExecutor.ExecutionError("Timeout happened to the bash daemon, see %s for details." % self.bash_log_file.name)
__main__.ExecutionError: Timeout happened to the bash daemon, see /home/gpadmin/gpdb_src/src/test/isolation2/results/parallel_retrieve_cursor/corner.out.log for details.

```

Here is a source code of such backtrace (some lines at source code differs with lines at backtrace):
[Execution of tests starts, by calling `process_isolation_file`](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L1065). `process_isolation_file` function firstly [creates a `global_sh_executor`](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L809) and after that [here is a loop by each line from test file (`process_command` is called inside this loop)](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L810-L826). [process_command tries to retrieve user token, by calling `__get_retrieve_user_token`](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L765). Before retrieving user token, [exec_global_shell is called to export env variables](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L613). `exec_global_shell` [calls `__run_command`](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L176) and  here [exception may be raised](https://github.com/arenadata/gpdb/blob/4e64f32c313c2c27bb6d7f82880c26c6a5f86936/src/test/isolation2/sql_isolation_testcase.py#L165). So seems the problem is inside `sql_isolation_testcase`.

This file has diffs at 7.x and 6.x branches (for ex. 7.x have support of python3, also `pygresql` dependency is updated). 
At 7.x branch exists other fixes to `sql_isolation_testcase` (which wasn't ported to 6.x), the most interesting of them is (changes to prevent timeouts at CI):
- [ff009941](https://github.com/arenadata/gpdb/commit/ff00994153b37edd7c76286465574e514012f30c)
- [45bedf9](https://github.com/arenadata/gpdb/commit/45bedf97bf38deafa4151f189abd759fd882cca8).

Thus this patch is a backport of commits (which prevents timeouts), and there is two additional backported commits to minimize diff of `sql_isolation_testcase` between `6.x` and `7.x` branches.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
