### PR TITLE
Add prerequisites block to readme

### DIFF
--- a/arenadata/readme.md
+++ b/arenadata/readme.md
@@ -1,3 +1,7 @@
+# Prerequisities
+
+docker-compose v2 or newer is required
+
 # How to run tests
 
 ## Build docker gpdb image with developer options

--- a/arenadata/readme.md
+++ b/arenadata/readme.md
@@ -27,6 +27,11 @@ CI pushes docker images to the internal registry for each branch. We can pull it
   docker pull hub.adsw.io/library/gpdb6_regress:1353d81 
   ```
 
+After the assembly of your image is done, you need to set IMAGE env variable in order to use this image in your tests.
+You can use either image's name or its IMAGE ID. If you want to use IMAGE ID you need to specify it this way:
+
+* export IMAGE=sha256:YOUR_IMAGE_ID
+
 ## Full regression tests suite run
 
 We need to execute [../concourse/scripts/ic_gpdb.bash](../concourse/scripts/ic_gpdb.bash) in container to create demo cluster and run different test suites against it:


### PR DESCRIPTION
Docker fails to create an image if docker-compose is version 1. This patch explicitly states that it should be v2 or newer 
