### PR TITLE
Fix segment segfault when join lateral inner plan contains where clause.

### DIFF
--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1493,3 +1493,52 @@ where x.a + 1 in (select b from t2_dedupsemi_indexonly);
 
 drop table t1_dedupsemi_indexonly;
 drop table t2_dedupsemi_indexonly;
+-- test lateral join inner plan contains limit and where clause
+-- greenplum cannot pass params across motion so one need to prevent
+-- the bottom scan node from appending to its targetlist outer relation
+-- refs. Otherwise it may lead to segfault at the exectution stage.
+--start_ignore
+drop table if exists t1_lateral_where;
+NOTICE:  table "t1_lateral_where" does not exist, skipping
+drop table if exists t2_lateral_where;
+NOTICE:  table "t2_lateral_where" does not exist, skipping
+--end_ignore
+create table t1_lateral_where (c text) distributed by (c);
+create table t2_lateral_where (c text) distributed by (c);
+insert into t1_lateral_where values (1), (2), (3);
+insert into t2_lateral_where values (3), (4);
+explain verbose select * from t2_lateral_where as t2 inner join lateral
+(select * from t1_lateral_where as t1 where t2.c = t1.c limit 1) s on true;
+                                                  QUERY PLAN
+--------------------------------------------------------------------------------------------------------------
+ Nested Loop  (cost=10000000000.00..10000000001.80 rows=4 width=4)
+   Output: t2.c, t1.c
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.06 rows=2 width=2)
+         Output: t2.c
+         ->  Seq Scan on public.t2_lateral_where t2  (cost=0.00..1.02 rows=1 width=2)
+               Output: t2.c
+   ->  Materialize  (cost=0.00..0.72 rows=1 width=2)
+         Output: t1.c
+         ->  Limit  (cost=0.00..0.70 rows=1 width=2)
+               Output: t1.c
+               ->  Result  (cost=0.00..2.10 rows=3 width=2)
+                     Output: t1.c
+                     Filter: (t2.c = t1.c)
+                     ->  Materialize  (cost=0.00..2.10 rows=1 width=2)
+                           Output: t1.c
+                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..2.09 rows=3 width=2)
+                                 Output: t1.c
+                                 ->  Seq Scan on public.t1_lateral_where t1  (cost=0.00..2.03 rows=1 width=2)
+                                       Output: t1.c
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+select * from t2_lateral_where as t2 inner join lateral
+(select * from t1_lateral_where as t1 where t2.c = t1.c limit 1) s on true;
+ c | c
+---+---
+ 3 | 3
+(1 row)
+
+drop table t1_lateral_where;
+drop table t2_lateral_where;

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -584,11 +584,11 @@ update t1_13265 set b = 2 where
                ->  Seq Scan on public.t1_13265
                      Output: t1_13265.a, t1_13265.c, t1_13265.d, t1_13265.ctid, t1_13265.gp_segment_id
                ->  Materialize
-                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                     Output: t2_13265.ctid, t2_13265.c, t2_13265.d
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d, (2)
+                           Output: t2_13265.ctid, t2_13265.c, t2_13265.d
                            ->  Seq Scan on public.t2_13265
-                                 Output: t2_13265.ctid, t2_13265.c, t2_13265.d, 2
+                                 Output: t2_13265.ctid, t2_13265.c, t2_13265.d
                                  Filter: (t2_13265.a = 2)
  Optimizer: Postgres query optimizer
  Settings: optimizer=off


### PR DESCRIPTION
When join lateral subquery contains both LIMIT clause and WHERE clause, and WHERE clause's operands are refs to outer query relation, for the inner plan it may put these refs into targetList of the bottom scan node. This is not correct since it leads to passing params across motion nodes and it probably could lead to segfault when the executor accessing its attribute list. A typical case is shown below:

```
create table t1( t1c1 text ) distributed by (t1c1);
create table t2( t2c1 text ) distributed by (t2c1);
explain verbose select * from t2 join lateral
(select * from t1 where t2.t2c1 = t1.t1c1 limit 1) x on true;
                            QUERY PLAN
-----------------------------------------------------------------------
 Nested Loop
   Output: t2.t2c1, t1.t1c1
   ->  Gather Motion 3:1  (slice1; segments: 3)
          Output: t2.t2c1
         ->  Seq Scan on public.t2
               Output: t2.t2c1
   ->  Materialize
          Output: t1.t1c1
         ->  Limit
                Output: t1.t1c1
               ->  Result
                      Output: t1.t1c1
                     Filter: ((t2.t2c1) = t1.t1c1)
                     ->  Materialize
                            Output: t1.t1c1, (t2.t2c1)
                           ->  Gather Motion 3:1  (slice2; segments: 3)
                                  Output: t1.t1c1, (t2.t2c1)
                                 ->  Seq Scan on public.t1
                                        Output: t1.t1c1, t2.t2c1

```
The above plan is invalid because SeqScan of t1 on slice2 uses params that are scanned from t2 on slice1. And the presence of such params may lead to segfault during inner plan execution.

This commit fixes the bug by handling the targetList completion procedure, which takes place during plan creation for the subquery. The code of `disuse_physical_tlist` in createplan.c is modified in order to choose only T_Var entries from 
`plan->flow->hashExprs`  list, which consists of EquivalenceClass members for entires from original targetList. In some cases 
its appropriate to extend original targetList with equivalent expressions, but only if they are of type T_Var. The root of the problem is in appending extra entries of type T_Param (it occures in hashExprs due to where clause) to final targetList. Proposed solution filters out these extra params and prevents subplan from holding outer refs in such cases.