### PR TITLE
ADBDEV-3247-2 Fix gpstop error when the locale is not English

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -3,6 +3,10 @@ FROM centos:centos7 as base
 ARG sigar=https://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-1.6.5-1056.git2932df5.el7.x86_64.rpm
 ARG sigar_headers=http://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-headers-1.6.5-1056.git2932df5.el7.x86_64.rpm
 
+# Download langpacks
+RUN sed -i 's/\(override_install_langs*\)/# \1/' /etc/yum.conf
+RUN yum -y reinstall glibc-common
+
 # Install some basic utilities and build tools
 RUN yum makecache && yum update -y ca-certificates && \
     rpm --import https://mirror.yandex.ru/centos/RPM-GPG-KEY-CentOS-7 && \

--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -66,15 +66,15 @@ class ReadPostmasterTempFile(Command):
             raise ExecutionError("Command did not complete successfully rc: %d" % self.results.rc, self)   
     
     def getResults(self):
-        if self.results.stderr.find("No such file or directory") != -1:
+        if self.results.rc != 0:
             return (False,-1,None)
         if self.results.stdout is None:
-            return (False,-2,None)
-        
+            return (False,-1,None)
+
         lines = self.results.stdout.split()
-        
+
         if len(lines) < 2:
-            return (False,-3,None)
+            return (False,-1,None)
         
         PID=int(self.results.stdout.split()[0])
         datadir = self.results.stdout.split()[1]

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -38,3 +38,10 @@ Feature: gpstop behave tests
           And gpstop should print "invalid_host is unreachable.Skipping cleaning shared memory." to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable
+
+	@demo_cluster
+    Scenario: gpstop exits without a warning
+        Given the database is running
+        And "LC_ALL" is different from English
+		When the user runs "gpstop -a"
+        Then gpstop should not print "Failed to kill processes for segment"


### PR DESCRIPTION
Geenplum python scrips try to parse system command’s STDOUT and STDERR in english and fails if locale is different from en_US

For example, /usr/lib/gpdb/lib/python/gppylib/commands/pg.py contains class ReadPostmasterTempFile with method getResults, which try to find message "No such file or directory" and fails when locale non english. This method used in gpstop in _stop_master function and on Alt and Astra gpstop prints this error:
```
20221129:16:38:21:003241 gpstop:oan-astra1:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
20221129:16:38:21:003241 gpstop:oan-astra1:gpadmin-[INFO]:-Terminating processes for segment /data1/master/gpseg-1
20221129:16:38:21:003241 gpstop:oan-astra1:gpadmin-[ERROR]:-Failed to kill processes for segment /data1/master/gpseg-1: ([Errno 3] No such process)
20221129:16:38:21:003305 gpstop:oan-astra1:gpadmin-[INFO]:-Starting gpstop with args: -a -m -f -d /data1/master/gpseg-1 -B 64 -l /home/gpadmin/gpAdminLogs
```
On Centos with locale en_US there is no error in gpstop invocation:
```
20221128:12:19:07:016251 gpstop:oan-adb-pg-hba:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
20221128:12:19:07:016251 gpstop:oan-adb-pg-hba:gpadmin-[INFO]:-Terminating processes for segment /data1/master/gpseg-1
20221128:12:19:07:016318 gpstop:oan-adb-pg-hba:gpadmin-[INFO]:-Starting gpstop with args: -a -m -f -d /data1/master/gpseg-1 -B 64 -l /home/gpadmin/gpAdminLogs
```
This patch is a backport of 909c7f7e4f0d76151ab846ee73210efb57efb769

Also, this patch reinstalls glibc-common in docker container. This is necessary to get langpacks in docker because docker images don't contain them.