### PR TITLE
ADBDEV-3536 Fix extension handling when it drops its dependent object 

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -641,7 +641,7 @@ recursiveDeletion(const ObjectAddress *object,
 				 * just ereport here, rather than proceeding, since no other
 				 * dependencies are likely to be interesting.)
 				 */
-				if (callingObject == NULL)
+				if (!creating_extension && callingObject == NULL)
 				{
 					char	   *otherObjDesc = getObjectDescription(&otherObject);
 
@@ -653,7 +653,8 @@ recursiveDeletion(const ObjectAddress *object,
 									 otherObjDesc)));
 				}
 
-				if (otherObject.classId == ExtensionRelationId &&
+				if (creating_extension &&
+					otherObject.classId == ExtensionRelationId &&
 					otherObject.objectId == CurrentExtensionObject)
 					break;
 

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -6,7 +6,8 @@ PGFILEDESC = "test_extensions - regression testing for EXTENSION support"
 EXTENSION = test_ext_cor test_ext_cau
 DATA = test_ext_cor--1.0.sql \
        test_ext_cau--1.0--1.1.sql test_ext_cau--1.0.sql \
-       test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql
+       test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql \
+	   test_ext_cau--1.1--1.2.sql
 
 REGRESS = test_extensions
 

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -7,7 +7,7 @@ EXTENSION = test_ext_cor test_ext_cau
 DATA = test_ext_cor--1.0.sql \
        test_ext_cau--1.0--1.1.sql test_ext_cau--1.0.sql \
        test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql \
-	   test_ext_cau--1.1--1.2.sql
+       test_ext_cau--1.1--1.2.sql
 
 REGRESS = test_extensions
 

--- a/src/test/modules/test_extensions/expected/test_extensions.out
+++ b/src/test/modules/test_extensions/expected/test_extensions.out
@@ -83,6 +83,12 @@ SELECT point(0,0) <<@@ polygon(circle(point(0,0),1));
 (1 row)
 
 --
+-- Test that extension can drop its own objects
+--
+create extension test_ext_cau version '1.1';
+alter extension test_ext_cau update to '1.2';
+drop extension test_ext_cau;
+--
 -- Another test cases for problem https://github.com/greenplum-db/gpdb/issues/6716.
 -- Segments of gpdb builed with `--enable-cassert` stops with error like
 -- FailedAssertion(""!(stack->state == GUC_SAVE)" at next cases. At gpdb builed

--- a/src/test/modules/test_extensions/sql/test_extensions.sql
+++ b/src/test/modules/test_extensions/sql/test_extensions.sql
@@ -57,7 +57,12 @@ SELECT point(0,0) <<@@ polygon(circle(point(0,0),1));
 
 \dx+ test_ext_cor
 
-
+--
+-- Test that extension can drop its own objects
+--
+create extension test_ext_cau version '1.1';
+alter extension test_ext_cau update to '1.2';
+drop extension test_ext_cau;
 
 --
 -- Another test cases for problem https://github.com/greenplum-db/gpdb/issues/6716.

--- a/src/test/modules/test_extensions/test_ext_cau--1.1--1.2.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.1--1.2.sql
@@ -1,0 +1,6 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.1--1.2.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION test_ext_cau" to load this file. \quit
+
+DROP function test_func2(int, int);


### PR DESCRIPTION
This is a quickfix for https://github.com/arenadata/gpdb/commit/478e5db7cd22037cd7722b784b49ddd2d4174bd6. That commit was supposed to fix
 extension creation and update when extension drop its dependent
 object, but it didn't handle it correctly. This commit fixes this
 problem and adds an additional test.