### PR TITLE
ADBDEV-3674-new: new shouldn't return NULL

### DIFF
--- a/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
@@ -47,11 +47,6 @@ CMemoryPoolPalloc::NewImpl(const ULONG bytes, const CHAR *, const ULONG,
 
 		void *ptr = gpdb::GPDBMemoryContextAlloc(m_cxt, alloc_size);
 
-		if (NULL == ptr)
-		{
-			return NULL;
-		}
-
 		SArrayAllocHeader *header = static_cast<SArrayAllocHeader *>(ptr);
 
 		header->m_user_size = bytes;

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
@@ -81,12 +81,6 @@ CMemoryPoolTracker::NewImpl(const ULONG bytes, const CHAR *file,
 
 	void *ptr = clib::Malloc(alloc_size);
 
-	// check if allocation failed
-	if (NULL == ptr)
-	{
-		return NULL;
-	}
-
 	GPOS_OOM_CHECK(ptr);
 
 	// successful allocation: update header information and any memory pool data


### PR DESCRIPTION
ORCA makes extensive use of the [GPOS_NEW](https://github.com/arenadata/gpdb/blob/88532d712d0258ab14e5992854bd04605d1e763f/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPool.h#LL299C9-L299C17) to allocate memory, not checking the result for NULL, but instead relying on throwing an exception.
[The implementation of this macro](https://github.com/arenadata/gpdb/blob/88532d712d0258ab14e5992854bd04605d1e763f/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPool.h#L276-L281) depends on the memory pool.
Depending on the variable [optimizer_use_gpdb_allocators](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/CGPOptimizer.cpp#L174-L177) can be used [either](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp#L53-L58) GreenPlum's memory pool manager [CMemoryPoolPalloc](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp#L33-L61) (default), [or](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp#L69-L79) ORCA's memory pool manager [CMemoryPoolTracker](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp#L67-L118).
When there is not enough memory for the GreenPlum's memory pool manager in the [gpdb::GPDBMemoryContextAlloc](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/gpdbwrappers.cpp#L2689-L2698) function an exception is thrown using the macro [GP_WRAP_END](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/gpdbwrappers.cpp#L44-L50) and therefore the lines, [testing for NULL](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp#L50-L53) are never run and can be safely removed.
And if there is not enough memory for the ORCA's memory pool manager in the [CMemoryPoolTracker::NewImpl](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp#L67-L118) function an exception is thrown using the macro [GPOS_OOM_CHECK](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp#LL90C22-L90C22), but for some reason [before that, the result is checked for NULL and NULL is returned](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp#L85-L88), which can lead to a segfault with further use of the NULL result, so the rows must be deleted.
Unfortunately there is no easy way to test this. We came up with a couple of options, but both of them are not very good: either make a fault-injector, or replace the allocator through preload.