### PR TITLE
ADBDEV-3674: ORCA initialization refactoring

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -245,7 +245,19 @@ InitGPOPT()
 {
 	GPOS_TRY
 	{
-		return CGPOptimizer::InitGPOPT();
+		try
+		{
+			CGPOptimizer::InitGPOPT();
+		}
+		catch (CException ex)
+		{
+			throw ex;
+		}
+		catch (...)
+		{
+			// unexpected failure
+			GPOS_RAISE(CException::ExmaUnhandled, CException::ExmiUnhandled);
+		}
 	}
 	GPOS_CATCH_EX(ex)
 	{
@@ -253,6 +265,10 @@ InitGPOPT()
 		{
 			PG_RE_THROW();
 		}
+
+		errstart(ERROR, ex.Filename(), ex.Line(), NULL, TEXTDOMAIN);
+		errfinish(errcode(ERRCODE_INTERNAL_ERROR),
+				  errmsg("optimizer failed to init"));
 	}
 	GPOS_CATCH_END;
 }

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -50,11 +50,11 @@ CMemoryPoolPallocManager::UserSizeOfAlloc(const void *ptr)
 	return CMemoryPoolPalloc::UserSizeOfAlloc(ptr);
 }
 
-GPOS_RESULT
+void
 CMemoryPoolPallocManager::Init()
 {
-	return CMemoryPoolManager::SetupGlobalMemoryPoolManager<
-		CMemoryPoolPallocManager, CMemoryPoolPalloc>();
+	CMemoryPoolManager::SetupGlobalMemoryPoolManager<CMemoryPoolPallocManager,
+													 CMemoryPoolPalloc>();
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/include/gpopt/exception.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/exception.h
@@ -43,7 +43,7 @@ enum ExMinor
 };
 
 // message initialization for GPOS exceptions
-gpos::GPOS_RESULT EresExceptionInit(gpos::CMemoryPool *mp);
+void EresExceptionInit(gpos::CMemoryPool *mp);
 
 }  // namespace gpopt
 

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -111,7 +111,7 @@ public:
 	}
 
 	// initialize global factory instance
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// destroy global factory instance
 	void Shutdown();

--- a/src/backend/gporca/libgpopt/src/exception.cpp
+++ b/src/backend/gporca/libgpopt/src/exception.cpp
@@ -24,7 +24,7 @@ using namespace gpos;
 //		Message initialization for GPOPT exceptions
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 gpopt::EresExceptionInit(CMemoryPool *mp)
 {
 	//---------------------------------------------------------------------------
@@ -113,30 +113,15 @@ gpopt::EresExceptionInit(CMemoryPool *mp)
 				 GPOS_WSZ_WSZLEN("Missing group stats")),
 	};
 
-	GPOS_RESULT eres = GPOS_FAILED;
+	// copy exception array into heap
+	CMessage *rgpmsg[gpopt::ExmiSentinel];
+	CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
 
-	GPOS_TRY
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
 	{
-		// copy exception array into heap
-		CMessage *rgpmsg[gpopt::ExmiSentinel];
-		CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
-
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
-		{
-			rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
-			pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
-		}
-
-		eres = GPOS_OK;
+		rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
+		pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
 	}
-	GPOS_CATCH_EX(ex)
-	{
-		return GPOS_FAILED;
-	}
-
-	GPOS_CATCH_END;
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -13,7 +13,6 @@
 #include "gpopt/init.h"
 
 #include "gpos/_api.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 #include "gpos/task/CWorker.h"
 
 #include "gpopt/exception.h"
@@ -41,21 +40,11 @@ static CMemoryPool *mp = NULL;
 void
 gpopt_init()
 {
-	{
-		CAutoMemoryPool amp;
-		mp = amp.Pmp();
+	mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-		// add standard exception messages
-		(void) gpopt::EresExceptionInit(mp);
+	gpopt::EresExceptionInit(mp);
 
-		// detach safety
-		(void) amp.Detach();
-	}
-
-	if (GPOS_OK != gpopt::CXformFactory::Init())
-	{
-		return;
-	}
+	CXformFactory::Init();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -353,44 +353,20 @@ CXformFactory::IsXformIdUsed(CXform::EXformId exfid)
 //		Initializes global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CXformFactory::Init()
 {
 	GPOS_ASSERT(NULL == Pxff() && "Xform factory was already initialized");
 
-	GPOS_RESULT eres = GPOS_OK;
-
 	// create xform factory memory pool
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
-	GPOS_TRY
-	{
-		// create xform factory instance
-		m_pxff = GPOS_NEW(mp) CXformFactory(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
-		m_pxff = NULL;
 
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			eres = GPOS_OOM;
-		}
-		else
-		{
-			eres = GPOS_FAILED;
-		}
-
-		return eres;
-	}
-	GPOS_CATCH_END;
+	// create xform factory instance
+	m_pxff = GPOS_NEW(mp) CXformFactory(mp);
 
 	// instantiating the factory
 	m_pxff->Instantiate();
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
@@ -173,7 +173,7 @@ public:
 	static CFSimulator *m_fsim;
 
 	// initializer for global f-simulator
-	static GPOS_RESULT Init();
+	static void Init();
 
 #ifdef GPOS_DEBUG
 	// destroy simulator

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -64,7 +64,7 @@ public:
 	void AddMessage(ELocale locale, CMessage *msg);
 
 	// initializer for global singleton
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -65,7 +65,7 @@ public:
 	}
 
 	// initialize global memory pool
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// destroy global instance
 	void Shutdown();

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -102,7 +102,7 @@ protected:
 
 	// Initialize global memory pool manager using given types
 	template <typename ManagerType, typename PoolType>
-	static GPOS_RESULT
+	static void
 	SetupGlobalMemoryPoolManager()
 	{
 		// raw allocation of memory for internal memory pools
@@ -110,22 +110,12 @@ protected:
 
 		GPOS_OOM_CHECK(alloc_internal);
 
-		GPOS_TRY
-		{
-			// create internal memory pool
-			CMemoryPool *internal = ::new (alloc_internal) PoolType();
+		// create internal memory pool
+		CMemoryPool *internal = ::new (alloc_internal) PoolType();
 
-			// instantiate manager
-			m_memory_pool_mgr = ::new ManagerType(internal, EMemoryPoolTracker);
-			m_memory_pool_mgr->Setup();
-		}
-		GPOS_CATCH_EX(ex)
-		{
-			gpos::clib::Free(alloc_internal);
-			GPOS_RETHROW(ex);
-		}
-		GPOS_CATCH_END;
-		return GPOS_OK;
+		// instantiate manager
+		m_memory_pool_mgr = ::new ManagerType(internal, EMemoryPoolTracker);
+		m_memory_pool_mgr->Setup();
 	}
 
 public:
@@ -188,7 +178,7 @@ public:
 	virtual ULONG UserSizeOfAlloc(const void *ptr);
 
 	// initialize global instance
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// global accessor
 	static CMemoryPoolManager *

--- a/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CWorkerPoolManager.h
@@ -136,7 +136,7 @@ public:
 	}
 
 	// initialize worker pool manager
-	static GPOS_RESULT Init();
+	static void Init();
 
 	// de-init global instance
 	static void Shutdown();

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -131,36 +131,13 @@ gpos_init(struct gpos_init_params *params)
 {
 	CWorker::abort_requested_by_system = params->abort_requested;
 
-	if (GPOS_OK != gpos::CMemoryPoolManager::Init())
-	{
-		return;
-	}
-
-	if (GPOS_OK != gpos::CWorkerPoolManager::Init())
-	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CMessageRepository::Init())
-	{
-		CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-		return;
-	}
-
-	if (GPOS_OK != gpos::CCacheFactory::Init())
-	{
-		return;
-	}
+	CMemoryPoolManager::Init();
+	CWorkerPoolManager::Init();
+	CMessageRepository::Init();
+	CCacheFactory::Init();
 
 #ifdef GPOS_FPSIMULATOR
-	if (GPOS_OK != gpos::CFSimulator::Init())
-	{
-		CMessageRepository::GetMessageRepository()->Shutdown();
-		CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
-	}
+	CFSimulator::Init();
 #endif	// GPOS_FPSIMULATOR
 
 #ifdef GPOS_DEBUG_COUNTERS

--- a/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
+++ b/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
@@ -13,7 +13,6 @@
 #include "gpos/common/CDebugCounter.h"
 
 #include "gpos/error/CAutoTrace.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 
 using namespace gpos;
 
@@ -59,14 +58,12 @@ CDebugCounter::~CDebugCounter()
 void
 CDebugCounter::Init()
 {
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
-
 	GPOS_RTL_ASSERT(NULL == m_instance);
-	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 
-	// detach safety
-	(void) amp.Detach();
+	CMemoryPool *mp =
+		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+
+	m_instance = GPOS_NEW(mp) CDebugCounter(mp);
 }
 
 void

--- a/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
+++ b/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
@@ -19,7 +19,6 @@
 #ifdef GPOS_FPSIMULATOR
 
 #include "gpos/common/CAutoP.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 #include "gpos/memory/CMemoryPoolManager.h"
 #include "gpos/task/CAutoTraceFlag.h"
 
@@ -131,18 +130,13 @@ CFSimulator::NewStack(ULONG major, ULONG minor)
 //		Initialize global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CFSimulator::Init()
 {
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
+	CMemoryPool *mp =
+		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	CFSimulator::m_fsim = GPOS_NEW(mp) CFSimulator(mp, GPOS_FSIM_RESOLUTION);
-
-	// detach safety
-	(void) amp.Detach();
-
-	return GPOS_OK;
+	m_fsim = GPOS_NEW(mp) CFSimulator(mp, GPOS_FSIM_RESOLUTION);
 }
 
 

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -12,7 +12,6 @@
 #include "gpos/error/CMessageRepository.h"
 
 #include "gpos/common/CSyncHashtableAccessByKey.h"
-#include "gpos/memory/CAutoMemoryPool.h"
 #include "gpos/utils.h"
 
 
@@ -103,24 +102,17 @@ CMessageRepository::LookupMessage(CException exc, ELocale locale)
 //		Initialize global instance of message repository
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CMessageRepository::Init()
 {
 	GPOS_ASSERT(NULL == m_repository);
 
-	CAutoMemoryPool amp;
-	CMemoryPool *mp = amp.Pmp();
+	CMemoryPool *mp =
+		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	CMessageRepository *repository = GPOS_NEW(mp) CMessageRepository(mp);
-	repository->InitDirectory(mp);
-	repository->LoadStandardMessages();
-
-	CMessageRepository::m_repository = repository;
-
-	// detach safety
-	(void) amp.Detach();
-
-	return GPOS_OK;
+	m_repository = GPOS_NEW(mp) CMessageRepository(mp);
+	m_repository->InitDirectory(mp);
+	m_repository->LoadStandardMessages();
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -57,40 +57,18 @@ CCacheFactory::Pmp() const
 //		Initializes global instance
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CCacheFactory::Init()
 {
 	GPOS_ASSERT(NULL == GetFactory() &&
 				"Cache factory was already initialized");
 
-	GPOS_RESULT res = GPOS_OK;
-
 	// create cache factory memory pool
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
-	GPOS_TRY
-	{
-		// create cache factory instance
-		CCacheFactory::m_factory = GPOS_NEW(mp) CCacheFactory(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
 
-		CCacheFactory::m_factory = NULL;
-
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			res = GPOS_OOM;
-		}
-		else
-		{
-			res = GPOS_FAILED;
-		}
-	}
-	GPOS_CATCH_END;
-	return res;
+	// create cache factory instance
+	m_factory = GPOS_NEW(mp) CCacheFactory(mp);
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -66,16 +66,13 @@ CMemoryPoolManager::Setup()
 }
 
 // Initialize global memory pool manager using CMemoryPoolTracker
-GPOS_RESULT
+void
 CMemoryPoolManager::Init()
 {
 	if (NULL == CMemoryPoolManager::m_memory_pool_mgr)
 	{
-		return SetupGlobalMemoryPoolManager<CMemoryPoolManager,
-											CMemoryPoolTracker>();
+		SetupGlobalMemoryPoolManager<CMemoryPoolManager, CMemoryPoolTracker>();
 	}
-
-	return GPOS_OK;
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -59,7 +59,7 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 //		Initializer for global worker pool manager
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 CWorkerPoolManager::Init()
 {
 	GPOS_ASSERT(NULL == WorkerPoolManager());
@@ -67,29 +67,8 @@ CWorkerPoolManager::Init()
 	CMemoryPool *mp =
 		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
-	GPOS_TRY
-	{
-		// create worker pool
-		CWorkerPoolManager::m_worker_pool_manager =
-			GPOS_NEW(mp) CWorkerPoolManager(mp);
-	}
-	GPOS_CATCH_EX(ex)
-	{
-		// turn in memory pool in case of failure
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
-
-		CWorkerPoolManager::m_worker_pool_manager = NULL;
-
-		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
-		{
-			return GPOS_OOM;
-		}
-
-		return GPOS_FAILED;
-	}
-	GPOS_CATCH_END;
-
-	return GPOS_OK;
+	// create worker pool
+	m_worker_pool_manager = GPOS_NEW(mp) CWorkerPoolManager(mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/exception.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/exception.h
@@ -80,7 +80,7 @@ enum ExMinor
 };
 
 // message initialization for GPOS exceptions
-gpos::GPOS_RESULT EresExceptionInit(gpos::CMemoryPool *mp);
+void EresExceptionInit(gpos::CMemoryPool *mp);
 
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/src/exception.cpp
+++ b/src/backend/gporca/libnaucrates/src/exception.cpp
@@ -26,7 +26,7 @@ using namespace gpdxl;
 //		Message initialization for DXL exceptions
 //
 //---------------------------------------------------------------------------
-GPOS_RESULT
+void
 gpdxl::EresExceptionInit(CMemoryPool *mp)
 {
 	//---------------------------------------------------------------------------
@@ -279,32 +279,19 @@ gpdxl::EresExceptionInit(CMemoryPool *mp)
 
 	};
 
-	GPOS_RESULT eres = GPOS_FAILED;
-
-	GPOS_TRY
+	// copy exception array into heap
+	CMessage *rgpmsg[ExmiDXLSentinel];
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
 	{
-		// copy exception array into heap
-		CMessage *rgpmsg[ExmiDXLSentinel];
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgpmsg); i++)
-		{
-			rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
-		}
-
-		CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
-
-		for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgmsg); i++)
-		{
-			pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
-		}
-
-		eres = GPOS_OK;
+		rgpmsg[i] = GPOS_NEW(mp) CMessage(rgmsg[i]);
 	}
-	GPOS_CATCH_EX(ex)
+
+	CMessageRepository *pmr = CMessageRepository::GetMessageRepository();
+
+	for (ULONG i = 0; i < GPOS_ARRAY_SIZE(rgmsg); i++)
 	{
+		pmr->AddMessage(ElocEnUS_Utf8, rgpmsg[i]);
 	}
-	GPOS_CATCH_END;
-
-	return eres;
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -15,8 +15,6 @@
 #include <xercesc/framework/MemBufInputSource.hpp>
 #include <xercesc/util/XMLString.hpp>
 
-#include "gpos/memory/CAutoMemoryPool.h"
-
 #include "naucrates/dxl/parser/CParseHandlerFactory.h"
 #include "naucrates/dxl/xml/CDXLMemoryManager.h"
 #include "naucrates/dxl/xml/dxltokens.h"
@@ -122,23 +120,13 @@ void
 gpdxl_init()
 {
 	// create memory pool for Xerces global allocations
-	{
-		CAutoMemoryPool amp;
-
-		// detach safety
-		pmpXerces = amp.Detach();
-	}
+	pmpXerces = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
 	// create memory pool for DXL global allocations
-	{
-		CAutoMemoryPool amp;
-
-		// detach safety
-		pmpDXL = amp.Detach();
-	}
+	pmpDXL = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
 
 	// add standard exception messages
-	(void) EresExceptionInit(pmpDXL);
+	EresExceptionInit(pmpDXL);
 }
 
 

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -244,9 +244,7 @@ ConfigureTests()
 #ifdef GPOS_DEBUG
 	// reset xforms factory to exercise xforms ctors and dtors
 	CXformFactory::Pxff()->Shutdown();
-	GPOS_RESULT eres = CXformFactory::Init();
-
-	GPOS_ASSERT(GPOS_OK == eres);
+	CXformFactory::Init();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/include/gpopt/utils/CMemoryPoolPallocManager.h
+++ b/src/include/gpopt/utils/CMemoryPoolPallocManager.h
@@ -40,8 +40,7 @@ public:
 	// get user requested size of allocation
 	ULONG UserSizeOfAlloc(const void *ptr);
 
-
-	static GPOS_RESULT Init();
+	static void Init();
 };
 }  // namespace gpos
 


### PR DESCRIPTION
ORCA initialization refactoring

When initializing ([CGPOptimizer::InitGPOPT](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/CGPOptimizer.cpp#L171-L184)) in the [gpos_init](https://github.com/arenadata/gpdb/blob/88532d712d0258ab14e5992854bd04605d1e763f/src/backend/gporca/libgpos/src/_api.cpp#L129-L169) function, ORCA mixed a C approach (it returned error codes and then checked them) and a C++ approach (it threw exceptions and then caught them).

1\. In case of low memory or any other exception, the [CWorkerPoolManager::Init](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp#L83-L88) function did not return GPOS_OK, and then the [gpos_init](https://github.com/arenadata/gpdb/blob/88532d712d0258ab14e5992854bd04605d1e763f/src/backend/gporca/libgpos/src/_api.cpp#L141) function called the [CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp#L274) function, which reset CMemoryPoolManager::m_memory_pool_mgr.
In this case, all the exceptions that arose were not rethrown, which means that the execution continued, and the following [gpdxl_init]((https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libnaucrates/src/init.cpp#L126)) function was called, in which the [CAutoMemoryPool](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp#L42-L46) class was initialized.
In the constructor of this class, the static method [CMemoryPoolManager::GetMemoryPoolMgr](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h#L194-L198) was called, which returned NULL, because we nullified m_memory_pool_mgr up the stack. Thus, a segfault could occur.

We can emulate OOM by setting the block variable to zero on this stack
```gdb
AllocSetAllocImpl(MemoryContext context, Size size, bool isHeader) (aset.c:1377)
AllocSetAlloc(MemoryContext context, Size size) (aset.c:1454)
MemoryContextAlloc(MemoryContext context, Size size) (mcxt.c:1196)
gpdb::GPDBMemoryContextAlloc(MemoryContext context, Size size) (gpdbwrappers.cpp:2694)
gpos::CMemoryPoolPalloc::NewImpl(gpos::CMemoryPoolPalloc * const this, const gpos::ULONG bytes, gpos::CMemoryPool::EAllocationType eat) (CMemoryPoolPalloc.cpp:40)
operator new(gpos::SIZE_T size, gpos::CMemoryPool * mp, const gpos::CHAR * filename, gpos::ULONG line) (CMemoryPool.h:280)
gpos::CWorkerPoolManager::Init() (CWorkerPoolManager.cpp:74)
gpos_init(gpos_init_params * params) (_api.cpp:139)
CGPOptimizer::InitGPOPT() (CGPOptimizer.cpp:181)
InitGPOPT() (CGPOptimizer.cpp:248)
InitPostgres(const char * in_dbname, Oid dboid, const char * username, char * out_dbname) (postinit.c:664)
PostgresMain(int argc, char ** argv, const char * dbname, const char * username) (postgres.c:4898)
BackendRun(Port * port) (postmaster.c:4831)
BackendStartup(Port * port) (postmaster.c:4495)
ServerLoop() (postmaster.c:1956)
PostmasterMain(int argc, char ** argv) (postmaster.c:1526)
main(int argc, char ** argv) (main.c:245)
```
Or we can emulate it more simply by explicitly throwing an exception
```diff
diff --git a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
index 7f98380d3e..7a40aa0908 100644
--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -69,6 +69,7 @@ CWorkerPoolManager::Init()
 
        GPOS_TRY
        {
+               GPOS_ASSERT(!"fail");
                // create worker pool
                CWorkerPoolManager::m_worker_pool_manager =
                        GPOS_NEW(mp) CWorkerPoolManager(mp);
```
```gdb
#0  raise () from /lib64/libpthread.so.0
#1  StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=0x14ee852 "Process", postgres_signal_arg=11) at elog.c:5529
#2  CdbProgramErrorHandler (postgres_signal_arg=11) at postgres.c:3587
#3  <signal handler called>
#4  gpos::CMemoryPoolManager::CreateMemoryPool (this=0x0) at CMemoryPoolManager.cpp:85
#5  gpos::CAutoMemoryPool::CAutoMemoryPool (this=0x7ffc149f6080, leak_check_type=gpos::CAutoMemoryPool::ElcExc) at CAutoMemoryPool.cpp:45
#6  gpdxl_init () at init.cpp:126
#7  CGPOptimizer::InitGPOPT () at CGPOptimizer.cpp:182
#8  InitGPOPT () at CGPOptimizer.cpp:248
#9  InitPostgres (in_dbname=0x8b915d0 "postgres", dboid=0, username=0x8b54be8 "postgres", out_dbname=0x0) at postinit.c:662
#10 PostgresMain (argc=1, argv=0x8b91630, dbname=0x8b915d0 "postgres", username=0x8b54be8 "postgres") at postgres.c:4898
#11 BackendRun (port=0x8b7be00) at postmaster.c:4831
#12 BackendStartup (port=0x8b7be00) at postmaster.c:4495
#13 ServerLoop () at postmaster.c:1956
#14 PostmasterMain (argc=7, argv=0x8b52940) at postmaster.c:1526
#15 main (argc=7, argv=0x8b52940) at main.c:245
```

2\. If during the initialization of ORCA an exception occurred that was not caught by the initialization functions, then it was caught in the [InitGPOPT](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/CGPOptimizer.cpp#L242-L259) function
and was silently ignored, simply disabling ORCA. Further, when the process terminated (even successfully), the [gpopt_terminate](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/CGPOptimizer.cpp#L197) function was called.
On a debug build, it tried to free the [CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp)](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpopt/src/init.cpp#L75) memory pool.
But due to an exception during ORCA initialization, this memory pool was not created and therefore assert [GPOS_ASSERT(NULL != mp)](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp#L112) fired.
In a debug build, assert turned into an exception that was caught and silently ignored in the [TerminateGPOPT](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gpopt/CGPOptimizer.cpp#L269-L286) function.
In this case, the Shutdown method of the CWorkerPoolManager class was not called, in which the [CWorkerPoolManager::m_worker_pool_manager](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp#L122) variable would be set to zero.
When deleting the context [MemoryContextDelete(OptimizerMemoryContext)](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/utils/init/postinit.c#L1413) on a debug build, all freed memory was filled with the sequence 7f,
including the m_single_worker variable of the m_worker_pool_manager instance of the CWorkerPoolManager class.
At the very end of the process, the destructor CGroupExpression::~CGroupExpression of the global static variable [CGroupExpression::m_gexprInvalid](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpopt/src/search/CGroupExpression.cpp#L38) was called.
And then the destructor of its parent class CRefCount::~CRefCount, in which (again, on a debug build) a sequence of methods was called
[ITask::Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/include/gpos/common/CRefCount.h#L68)
[IWorker *worker = IWorker::Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/ITask.cpp#LL29C2-L29C36)
[worker = CWorkerPoolManager::WorkerPoolManager()->Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/IWorker.cpp#LL35C3-L35C60)
which resulted in worker = 0x7f7f7f7f7f7f7f7f and a segfault occurred when calling [return worker->GetTask](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/ITask.cpp#LL32C3-L32C27).

We can emulate OOM by setting the block variable to zero on this stack
```gdb
AllocSetAllocImpl(MemoryContext context, Size size, bool isHeader) (aset.c:1377)
AllocSetAlloc(MemoryContext context, Size size) (aset.c:1454)
MemoryContextAlloc(MemoryContext context, Size size) (mcxt.c:1196)
gpdb::GPDBMemoryContextAlloc(MemoryContext context, Size size) (gpdbwrappers.cpp:2694)
gpos::CMemoryPoolPalloc::NewImpl(gpos::CMemoryPoolPalloc * const this, const gpos::ULONG bytes, gpos::CMemoryPool::EAllocationType eat) (CMemoryPoolPalloc.cpp:40)
operator new(gpos::SIZE_T size, gpos::CMemoryPool * mp, const gpos::CHAR * filename, gpos::ULONG line) (CMemoryPool.h:280)
gpopt::CXformFactory::Init() (CXformFactory.cpp:369)
gpopt_init() (init.cpp:55)
CGPOptimizer::InitGPOPT() (CGPOptimizer.cpp:183)
InitGPOPT() (CGPOptimizer.cpp:248)
InitPostgres(const char * in_dbname, Oid dboid, const char * username, char * out_dbname) (postinit.c:664)
PostgresMain(int argc, char ** argv, const char * dbname, const char * username) (postgres.c:4898)
BackendRun(Port * port) (postmaster.c:4831)
BackendStartup(Port * port) (postmaster.c:4495)
ServerLoop() (postmaster.c:1956)
PostmasterMain(int argc, char ** argv) (postmaster.c:1526)
main(int argc, char ** argv) (main.c:245)
```
Or we can emulate it more simply by explicitly throwing an exception
```diff
diff --git a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
index dcfd0e2187..578f2b13f6 100644
--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -362,6 +362,7 @@ CXformFactory::Init()
        CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
        GPOS_TRY
        {
+               GPOS_ASSERT(!"fail");
                // create xform factory instance
                m_pxff = GPOS_NEW(mp) CXformFactory(mp);
        }
```
```gdb
#0  raise (sig=11) at ../nptl/sysdeps/unix/sysv/linux/pt-raise.c:36
#1  StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=0x14ee852 "Process", postgres_signal_arg=11) at elog.c:5529
#2  CdbProgramErrorHandler (postgres_signal_arg=11) at postgres.c:3587
#3  <signal handler called>
#4  gpos::ITask::Self () at ITask.cpp:32
#5  gpos::CRefCount::~CRefCount (this=0x775fda0 <gpopt::CGroupExpression::m_gexprInvalid>, __in_chrg=<optimized out>) at ../../../../../../src/backend/gporca/libgpos/include/gpos/common/CRefCount.h:68
#6  gpopt::CGroupExpression::~CGroupExpression (this=0x775fda0 <gpopt::CGroupExpression::m_gexprInvalid>, __in_chrg=<optimized out>) at CGroupExpression.cpp:112
#7  __run_exit_handlers (status=0, listp=0x7f243d5c76c8 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true) at exit.c:77
#8  __GI_exit (status=<optimized out>) at exit.c:99
#9  proc_exit (code=0) at ipc.c:145
#10 PostgresMain (argc=1, argv=0x8e079f0, dbname=0x8e07990 "postgres", username=0x8e07968 "postgres") at postgres.c:5764
#11 BackendRun (port=0x8e2efb0) at postmaster.c:4831
#12 BackendStartup (port=0x8e2efb0) at postmaster.c:4495
#13 ServerLoop () at postmaster.c:1956
#14 PostmasterMain (argc=6, argv=0x8e05950) at postmaster.c:1526
#15 main (argc=6, argv=0x8e05950) at main.c:245
```

3\. A single instance of the CWorker class was created only in the [gpos_exec](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/_api.cpp#L207) function, which was called not when the backend was initialized, but much later - when planning the request.
At the same time, the CWorker::CWorker constructor [registered](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/CWorker.cpp#L43) it in an instance of the CWorkerPoolManager class.
Thus, when initializing ORCA, the CWorkerPoolManager::WorkerPoolManager()->Self method returned NULL.
If an exception occurred when using the CAutoMemoryPool class allocated on the stack, for example, there was not enough memory, then the CAutoMemoryPool::~CAutoMemoryPool destructor was still called.
On the debug build, a sequence of methods was called in it
[ITask *task = ITask::Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp#L91)
[IWorker *worker = IWorker::Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/ITask.cpp#LL29C2-L29C36)
[worker = CWorkerPoolManager::WorkerPoolManager()->Self](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/task/IWorker.cpp#LL35C3-L35C60)which, when initializing ORCA, led to task = NULL and if ElcExc == m_leak_check_type, then assert [GPOS_ASSERT_IMP(ElcExc == m_leak_check_type, NULL != task)](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp#LL94C18-L94C45) was triggered.
On the debug build, the assert turned into an exception, and now two exceptions became active in the destructor at the same time, which led to a crash.

We can emulate OOM by setting the block variable to zero on this stack
```gdb
AllocSetAllocImpl(MemoryContext context, Size size, bool isHeader) (aset.c:1377)
AllocSetAlloc(MemoryContext context, Size size) (aset.c:1454)
MemoryContextAlloc(MemoryContext context, Size size) (mcxt.c:1196)
gpdb::GPDBMemoryContextAlloc(MemoryContext context, Size size) (gpdbwrappers.cpp:2694)
gpos::CMemoryPoolPalloc::NewImpl(gpos::CMemoryPoolPalloc * const this, const gpos::ULONG bytes, gpos::CMemoryPool::EAllocationType eat) (CMemoryPoolPalloc.cpp:40)
operator new(gpos::SIZE_T size, gpos::CMemoryPool * mp, const gpos::CHAR * filename, gpos::ULONG line) (CMemoryPool.h:280)
gpos::CMessageRepository::Init() (CMessageRepository.cpp:114)
gpos_init(gpos_init_params * params) (_api.cpp:136)
CGPOptimizer::InitGPOPT() (CGPOptimizer.cpp:181)
InitGPOPT() (CGPOptimizer.cpp:260)
InitPostgres(const char * in_dbname, Oid dboid, const char * username, char * out_dbname) (postinit.c:664)
PostgresMain(int argc, char ** argv, const char * dbname, const char * username) (postgres.c:4898)
BackendRun(Port * port) (postmaster.c:4831)
BackendStartup(Port * port) (postmaster.c:4495)
ServerLoop() (postmaster.c:1956)
PostmasterMain(int argc, char ** argv) (postmaster.c:1526)
main(int argc, char ** argv) (main.c:245)
```
Or we can emulate it more simply by explicitly throwing an exception
```diff
diff --git a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
index 5785eaea5a..ab8e3704be 100644
--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -115,6 +115,7 @@ CMessageRepository::Init()
        repository->InitDirectory(mp);
        repository->LoadStandardMessages();
 
+       GPOS_ASSERT(!"fail");
        CMessageRepository::m_repository = repository;
 
        // detach safety
```
```gdb
#0  __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:55
#1  __GI_abort () at abort.c:90
#2  __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#3  __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:38
#4  __cxa_call_terminate (ue_header=0x9438b50) at ../../../../libstdc++-v3/libsupc++/eh_call.cc:54
#5  __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=<optimized out>, exception_class=<optimized out>, ue_header=<optimized out>, context=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_personality.cc:676
#6  _Unwind_RaiseException_Phase2 (exc=exc@entry=0x9438b50, context=context@entry=0x7fff11b65940) at ../../../libgcc/unwind.inc:62
#7  _Unwind_Resume (exc=0x9438b50) at ../../../libgcc/unwind.inc:230
#8  gpos::CAutoMemoryPool::~CAutoMemoryPool (this=0x7fff11b65ae0, __in_chrg=<optimized out>) at CAutoMemoryPool.cpp:128
#9  gpos::CMessageRepository::Init () at CMessageRepository.cpp:125
#10 gpos_init (params=0x7fff11b65b48) at _api.cpp:145
#11 CGPOptimizer::InitGPOPT () at CGPOptimizer.cpp:181
#12 InitGPOPT () at CGPOptimizer.cpp:248
#13 InitPostgres (in_dbname=0x944cfe0 "postgres", dboid=0, username=0x9410be8 "postgres", out_dbname=0x0) at postinit.c:662
#14 PostgresMain (argc=1, argv=0x944d040, dbname=0x944cfe0 "postgres", username=0x9410be8 "postgres") at postgres.c:4898
#15 BackendRun (port=0x9437e00) at postmaster.c:4831
#16 BackendStartup (port=0x9437e00) at postmaster.c:4495
#17 ServerLoop () at postmaster.c:1956
#18 PostmasterMain (argc=7, argv=0x940e940) at postmaster.c:1526
#19 main (argc=7, argv=0x940e940) at main.c:245
```

The patch refactors the ORCA initialization code, getting rid of the C-approach, i.e. removes the return of error codes and their checking, and adds a C++ approach, i.e. catching exceptions and rethrowing them.
It also causes the backend to terminate with error on any exception during ORCA initialization.
The gpdxl_init function has been changed, because the auto memory pool is used to automatically free memory when it goes out of scope, but here it is immediately removed from it, and in fact, it is not needed at all.