### PR TITLE
ADBDEV-3675: Use junkfilter from relinfo instead of estate

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2527,7 +2527,7 @@ ExecBRUpdateTriggers(EState *estate, EPQState *epqstate,
 	 */
 	if (newSlot != NULL)
 	{
-		slot = ExecFilterJunk(estate->es_junkFilter, newSlot);
+		slot = ExecFilterJunk(relinfo->ri_junkFilter, newSlot);
 		slottuple = ExecFetchSlotHeapTuple(slot);
 		newtuple = slottuple;
 	}

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -377,3 +377,80 @@ DROP
 
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- test that execution of triggers in parallel transactions won't cause a segfault
+-- (checks that ExecFilterJunk is called from ExecBRUpdateTriggers with not null
+-- junkfilter argument - relinfo.ri_junkFilter is sended as argumetn instead of
+-- estate.es_junkFilter (which is a legacy of postgres 8.3))
+create table test_table (id serial, field int default 0 not null, rand_hash text);
+CREATE
+
+create or replace function test_table_bu() returns trigger language plpgsql volatile as $$ begin select md5(random()::text) into new.rand_hash; /* in func */ return new; /* in func */ end; /* in func */ $$;
+CREATE
+
+create trigger test_table_bu before insert or update on test_table for each row execute procedure test_table_bu();
+CREATE
+
+insert into test_table (field) values (0), (1);
+INSERT 2
+
+-- start_matchsubs
+-- m/[a-f0-9]{32}/
+-- s/[a-f0-9]{32}/hash/
+-- end_matchsubs
+
+-- run first update transaction
+1: begin;
+BEGIN
+1: update test_table set field = field + 1;
+UPDATE 2
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 1     | 58b20634174b539f7dd394a9394ef667 
+ 2  | 2     | d079008c0b1cc73975695fdec63d4d5b 
+(2 rows)
+
+-- run second update transaction,
+2: begin;
+BEGIN
+2&: update test_table set field = field + 1;  <waiting ...>
+
+
+-- after first transaction ended, second must continue execution (not cause a segfault)
+1: end;
+END
+2<:  <... completed>
+UPDATE 2
+2: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 2     | 13d168fab79edcc02397f76cc4a8bebd 
+ 2  | 3     | d295bc6ad53bad5ce929ac03f3f0fa28 
+(2 rows)
+
+-- check table data
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 1     | 58b20634174b539f7dd394a9394ef667 
+ 2  | 2     | d079008c0b1cc73975695fdec63d4d5b 
+(2 rows)
+2: end;
+END
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 2     | 13d168fab79edcc02397f76cc4a8bebd 
+ 2  | 3     | d295bc6ad53bad5ce929ac03f3f0fa28 
+(2 rows)
+
+1: drop trigger test_table_bu on test_table;
+DROP
+1: drop function test_table_bu();
+DROP
+1: drop table test_table;
+DROP
+
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -382,3 +382,80 @@ DROP
 
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- test that execution of triggers in parallel transactions won't cause a segfault
+-- (checks that ExecFilterJunk is called from ExecBRUpdateTriggers with not null
+-- junkfilter argument - relinfo.ri_junkFilter is sended as argumetn instead of
+-- estate.es_junkFilter (which is a legacy of postgres 8.3))
+create table test_table (id serial, field int default 0 not null, rand_hash text);
+CREATE
+
+create or replace function test_table_bu() returns trigger language plpgsql volatile as $$ begin select md5(random()::text) into new.rand_hash; /* in func */ return new; /* in func */ end; /* in func */ $$;
+CREATE
+
+create trigger test_table_bu before insert or update on test_table for each row execute procedure test_table_bu();
+CREATE
+
+insert into test_table (field) values (0), (1);
+INSERT 2
+
+-- start_matchsubs
+-- m/[a-f0-9]{32}/
+-- s/[a-f0-9]{32}/hash/
+-- end_matchsubs
+
+-- run first update transaction
+1: begin;
+BEGIN
+1: update test_table set field = field + 1;
+UPDATE 2
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 1     | 58b20634174b539f7dd394a9394ef667 
+ 2  | 2     | d079008c0b1cc73975695fdec63d4d5b 
+(2 rows)
+
+-- run second update transaction,
+2: begin;
+BEGIN
+2&: update test_table set field = field + 1;  <waiting ...>
+
+
+-- after first transaction ended, second must continue execution (not cause a segfault)
+1: end;
+END
+2<:  <... completed>
+UPDATE 2
+2: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 2     | 13d168fab79edcc02397f76cc4a8bebd 
+ 2  | 3     | d295bc6ad53bad5ce929ac03f3f0fa28 
+(2 rows)
+
+-- check table data
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 1     | 58b20634174b539f7dd394a9394ef667 
+ 2  | 2     | d079008c0b1cc73975695fdec63d4d5b 
+(2 rows)
+2: end;
+END
+1: select * from test_table order by id;
+ id | field | rand_hash                        
+----+-------+----------------------------------
+ 1  | 2     | 13d168fab79edcc02397f76cc4a8bebd 
+ 2  | 3     | d295bc6ad53bad5ce929ac03f3f0fa28 
+(2 rows)
+
+1: drop trigger test_table_bu on test_table;
+DROP
+1: drop function test_table_bu();
+DROP
+1: drop table test_table;
+DROP
+
+1q: ... <quitting>
+2q: ... <quitting>


### PR DESCRIPTION
## Problem description

The next sql commands will cause a `SIGSEGV` on `gpdb-6` with enabled `global_deadlock_detector`:

Setup:

```sql
create table test_table (id serial, field int default 0 not null, ch_ts timestamp);

create or replace function test_table_bu() returns trigger
    language plpgsql
volatile
as
$$
begin
  new.ch_ts = current_timestamp;
  return new;
end;
$$;

create trigger test_table_bu
    before insert or update
    on test_table
    for each row
execute procedure test_table_bu();

insert into test_table (field) values (0);
```

Scripts, that causes a SIGSEGV:

```bash
➜  gpdb git:(6X_STABLE) ✗ psql -d postgres -c "update test_table set field = field + 1 where id = 1;" &
psql -d postgres -c "update test_table set field = field + 1 where id = 1;" &
sleep 10
[1] 104097
[2] 104098
UPDATE 1
[2]  + 104098 done       psql -d postgres -c "update test_table set field = field + 1 where id = 1;"
➜  gpdb git:(6X_STABLE) ✗ 
➜  gpdb git:(6X_STABLE) ✗ ERROR:  Error on receive from seg0 127.0.1.1:6002 pid=104105: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

[1]  + 104097 exit 1     psql -d postgres -c "update test_table set field = field + 1 where id = 1;"
```

Here is a backtrace of an error:

```gdb
#0  CdbProgramErrorHandler (postgres_signal_arg=21907) at postgres.c:3544
#1  <signal handler called>
#2  0x00005593620b021b in ExecFilterJunk (junkfilter=0x0, slot=0x559369b48500) at execJunk.c:284
#3  0x000055936207b14a in ExecBRUpdateTriggers (estate=0x559369b32598, epqstate=0x559369b33e50, relinfo=0x559369b328b8, tupleid=0x7ffe4f445b12, fdw_trigtuple=0x0, slot=0x559369b2daf0) at trigger.c:2530
#4  0x00005593620f4c84 in ExecUpdate (tupleid=0x7ffe4f445b12, segid=0, oldtuple=0x0, slot=0x559369b2daf0, planSlot=0x559369b32bc0, epqstate=0x559369b33e50, estate=0x559369b32598, canSetTag=1 '\001')
    at nodeModifyTable.c:1400
#5  0x00005593620f5d0a in ExecModifyTable (node=0x559369b33c28) at nodeModifyTable.c:1950
...

(gdb) p junkfilter 
$2 = (JunkFilter *) 0x0
```

There occurs a `NULL`-pointer dereference at [`ExecFilterJunk`](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/executor/execJunk.c#L284), because [`ExecBRUpdateTriggers`](https://github.com/arenadata/gpdb/blob/dfe812f45701096a07a76c341ad8a92b3315555b/src/backend/commands/trigger.c#L2530) sends `NULL` `estate.es_junkFilter`.

Seems, this problem occurs, because of `postgres` changes wasn't completely ported at `gpdb-6` (all `gpdb/postgres` versions below were obtained with use of `git describe --tags`)
Here is a [patch in `postgres` at version `REL8_4_0-338-g8a5849b7ff`](https://github.com/postgres/postgres/commit/8a5849b7ff24c637a1140c26fc171e45c9142005), which introduced a new node `ModifyTable` and [refactored work with `junkfilter` at trigger.c](https://github.com/postgres/postgres/commit/8a5849b7ff24c637a1140c26fc171e45c9142005#diff-22c7dfe576c592c34381256d423de3f73266cd1047ab2c42ec7edcf598696b5cR1972) (now it fills as `relinfo->ri_junkFilter`, because logic that previously filled `estate.es_junkFilter` was moved ([here is a logic at execMain.c at previous commit - it fills junk filter of `resultRelInfo` too](https://github.com/postgres/postgres/blob/b865d2758255b767e30dc5f23c7c7d209e716f3b/src/backend/executor/execMain.c#L844-L906)) to [`ExecInitModifyTable` and now fills only `resultRelInfo.ri_junkFilter`](https://github.com/postgres/postgres/blob/8a5849b7ff24c637a1140c26fc171e45c9142005/src/backend/executor/nodeModifyTable.c#L911-L944)), so work with `relinfo` at `trigger.c` was added since this version. 
But the history of `trigger.c` changes at gpdb is next (`git log --pretty=oneline --follow src/backend/commands/trigger.c` or use `tig --follow src/backend/commands/trigger.c`): there are two "equal" commits which differs in arguments at `ExecFilterJunk` call ([original `postgres` verison `REL9_1_ALPHA3-439-ga210be7720`](https://github.com/postgres/postgres/commit/a210be772047575331fb6b0ab7b72043f81452ba) ([`ExecFilterJunk` is called with `relinfo.ri_junkFilter`](https://github.com/postgres/postgres/commit/a210be772047575331fb6b0ab7b72043f81452ba#diff-22c7dfe576c592c34381256d423de3f73266cd1047ab2c42ec7edcf598696b5cR2330)), and [commit at version `REL8_3_14-4-ge476eedd0c`](https://github.com/arenadata/gpdb/commit/e476eedd0c) ([`ExecFilterJunk` is called with `estate.es_junkFilter`](https://github.com/arenadata/gpdb/commit/e476eedd0c#diff-22c7dfe576c592c34381256d423de3f73266cd1047ab2c42ec7edcf598696b5cR1981)) - also this commit extsts at [postgres](https://github.com/postgres/postgres/commit/e476eedd0c), but only at `REL8_3_STABLE` branch (it looks like a backport from `master` to `REL8_3_STABLE` branch) and for unclear reasons it still exists at `gpdb-6`)
```
...
# this is a postgres commit (REL9_1_ALPHA3-439-ga210be7720) - exists in postgres master
a210be772047575331fb6b0ab7b72043f81452ba Fix dangling-pointer problem in before-row update trigger processing.

# this commit seems was cherry picked to postgres 8.3 (REL8_3_14-4-ge476eedd0c)
e476eedd0c06e81ee6d76fd8dc23eb5d54f1ba0b Fix dangling-pointer problem in before-row update trigger processing.
...
# this is a postgres commit introduced a new ModifyTable node and refactored work with
# junkfilter (REL8_4_0-338-g8a5849b7ff)
8a5849b7ff24c637a1140c26fc171e45c9142005 Split the processing of INSERT/UPDATE/DELETE operations out of execMain.c.
They are now handled by a new plan node type called ModifyTable, which is placed at the top of the plan tree....
...
```

To summarize: at `postgres 8.3` there was no `ModifyTable` node, in turn there was no refactor of working with `estate.es_junkFilter`), at postgres 8.4 this was introduced, but original commit from postgres `REL9_1_ALPHA3-439-ga210be7720` seems wasn't correctly ported, so now at `gpdb-6` `estate.es_junkFilter` is used instead of `relinfo.ri_junkFilter` (also `gpdb-7` has no such problem, because after [merging](https://github.com/greenplum-db/gpdb/commit/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4) with postgres-12 [`ri_junKFilter` is sended as `ExecJunkFilter` argument](https://github.com/greenplum-db/gpdb/blob/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4/src/backend/commands/trigger.c#L3141)). So instead of sending `estate.es_junkFilter` it worth to send `relinfo.ri_junkFilter`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
