### PR TITLE
Fix custom formatter handling logic. (#15052)

### DIFF
--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -109,8 +109,6 @@ typedef struct FileScanDescData
 	/* current file parse state */
 	struct CopyStateData *fs_pstate;
 
-	bool		raw_buf_done;
-
 	Form_pg_attribute *attr;
 	AttrNumber	num_phys_attrs;
 	Datum	   *values;


### PR DESCRIPTION
The function externalgettup_custom() is to handle custom formatter logic when loading data with external tables. But if custom protocol like PXF is used to loading data, the EOF is not reached when the last content of data is returned, the EOF is reached only when the last reading returns 0. So in the current logic of function externalgettup_custom(), it may lose the chance for custom formatter to handle the last line of data.

This commit removes the using of raw_buf_len, instead the formatter->fmt_databuf which provides the real data is used. So we check the length of this buffer to give custom formatter last chance to handle the last line of data. Even if the last line is not complete, it is the custom formatter's responsibility to report this.

The right way to return FMT_NEED_MORE_DATA in custom formatter is to check EOF flag before return. But currently, a lot of custom formatter does not implement in the right way. They just return FMT_NEED_MORE_DATA when they need more data in the current block of line without changing the formatter->fmt_databuf nor checking the EOF. So it will cause infinite loop.

In order to prevent infinite loop, we detect this by adding a count when eof flag is set. So this PR enables custom protocol to handle the last line of incomplete data if the custom formatter has taken care of the eof flag, and also prevent infinite loop regression.

Cherry-picked from: e859cd6c84a8c12c2878eee3dba61ebf7ae4874d
