### PR TITLE
ADBDEV-3747: initial implemention of arenadata_toolkit extension

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -24,7 +24,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_array_agg \
                gp_percentile_agg \
                gp_error_handling \
-               gp_subtransaction_overflow
+               gp_subtransaction_overflow \
+			   arenadata_toolkit
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -35,7 +36,8 @@ else
                gp_array_agg \
                gp_percentile_agg \
                gp_error_handling \
-               gp_subtransaction_overflow
+               gp_subtransaction_overflow \
+			   arenadata_toolkit
 endif
 
 ifeq "$(with_zstd)" "yes"
@@ -99,3 +101,5 @@ installcheck:
 	$(MAKE) -C gp_sparse_vector installcheck
 	$(MAKE) -C gp_percentile_agg installcheck
 	$(MAKE) -C gp_subtransaction_overflow installcheck
+	$(MAKE) -C arenadata_toolkit installcheck
+

--- a/gpcontrib/arenadata_toolkit/.gitignore
+++ b/gpcontrib/arenadata_toolkit/.gitignore
@@ -1,0 +1,4 @@
+# Generated subdirectories and files
+/results/
+regression.diffs
+regression.out

--- a/gpcontrib/arenadata_toolkit/Makefile
+++ b/gpcontrib/arenadata_toolkit/Makefile
@@ -1,0 +1,20 @@
+# gpcontrib/arenadata_toolkit/Makefile
+
+MODULES = arenadata_toolkit
+
+EXTENSION = arenadata_toolkit
+DATA = arenadata_toolkit--1.0.sql
+
+REGRESS = arenadata_toolkit_test
+REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/arenadata_toolkit
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
@@ -1,0 +1,131 @@
+/* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION arenadata_toolkit" to load this file. \quit
+
+DO $$
+BEGIN
+	-- For new deployments create arenadata_toolkit schema, but disconnect it from extension,
+	-- since user's tables like arenadata_toolkit.db_files_history need to be out of extension.
+	IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'arenadata_toolkit')
+	THEN
+		CREATE SCHEMA arenadata_toolkit;
+		ALTER EXTENSION arenadata_toolkit DROP SCHEMA arenadata_toolkit;
+	END IF;
+END$$;
+
+GRANT ALL ON SCHEMA arenadata_toolkit TO public;
+
+/*
+ This is part of arenadata_toolkit API for ADB Bundle.
+ This function creates tables for performing adb_collect_table_stats.
+ */
+CREATE FUNCTION arenadata_toolkit.adb_create_tables()
+RETURNS VOID
+AS $$
+BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_tables
+					WHERE schemaname = 'arenadata_toolkit' AND tablename  = 'db_files_history')
+	THEN
+		EXECUTE FORMAT($fmt$CREATE TABLE arenadata_toolkit.db_files_history(
+			oid BIGINT,
+			table_name TEXT,
+			table_schema TEXT,
+			type CHAR(1),
+			storage CHAR(1),
+			table_parent_table TEXT,
+			table_parent_schema TEXT,
+			table_database TEXT,
+			table_tablespace TEXT,
+			"content" INTEGER,
+			segment_preferred_role CHAR(1),
+			hostname TEXT,
+			address TEXT,
+			file TEXT,
+			modifiedtime TIMESTAMP WITHOUT TIME ZONE,
+			file_size BIGINT,
+			collecttime TIMESTAMP WITHOUT TIME ZONE
+		)
+		WITH (appendonly=true, compresstype=zlib, compresslevel=9)
+		DISTRIBUTED RANDOMLY
+		PARTITION BY RANGE (collecttime)
+		(
+			PARTITION %1$I START (date %2$L) INCLUSIVE
+			END (date %3$L) EXCLUSIVE
+			EVERY (INTERVAL '1 month'),
+			DEFAULT PARTITION default_part
+		);$fmt$,
+		'p' || to_char(NOW(), 'YYYYMM'),
+		to_char(NOW(), 'YYYY-MM-01'),
+		to_char(NOW() + interval '1 month','YYYY-MM-01'));
+		REVOKE ALL ON TABLE arenadata_toolkit.db_files_history FROM public;
+	END IF;
+
+	CREATE TABLE IF NOT EXISTS arenadata_toolkit.daily_operation
+	(
+		schema_name TEXT,
+		table_name TEXT,
+		action TEXT,
+		status TEXT,
+		time BIGINT,
+		processed_dttm TIMESTAMP
+	)
+	WITH (appendonly=true, compresstype=zlib, compresslevel=1)
+	DISTRIBUTED RANDOMLY;
+
+	REVOKE ALL ON TABLE arenadata_toolkit.daily_operation FROM public;
+
+	IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_tables
+					WHERE schemaname = 'arenadata_toolkit' AND tablename  = 'operation_exclude')
+	THEN
+
+		CREATE TABLE arenadata_toolkit.operation_exclude (schema_name TEXT)
+		WITH (appendonly=true, compresstype=zlib, compresslevel=1)
+		DISTRIBUTED RANDOMLY;
+
+		REVOKE ALL ON TABLE arenadata_toolkit.operation_exclude FROM public;
+
+		INSERT INTO arenadata_toolkit.operation_exclude (schema_name)
+		VALUES ('gp_toolkit'),
+				('information_schema'),
+				('pg_aoseg'),
+				('pg_bitmapindex'),
+				('pg_catalog'),
+				('pg_toast');
+	END IF;
+
+	IF NOT EXISTS (SELECT 1 FROM pg_tables
+					WHERE schemaname = 'arenadata_toolkit' AND tablename = 'db_files_current')
+	THEN
+		CREATE TABLE arenadata_toolkit.db_files_current
+		(
+			oid BIGINT,
+			table_name TEXT,
+			table_schema TEXT,
+			type CHAR(1),
+			storage CHAR(1),
+			table_parent_table TEXT,
+			table_parent_schema TEXT,
+			table_database TEXT,
+			table_tablespace TEXT,
+			"content" INTEGER,
+			segment_preferred_role CHAR(1),
+			hostname TEXT,
+			address TEXT,
+			file TEXT,
+			modifiedtime TIMESTAMP WITHOUT TIME ZONE,
+			file_size BIGINT
+		)
+		WITH (appendonly = false) DISTRIBUTED RANDOMLY;
+	END IF;
+
+	GRANT SELECT ON TABLE arenadata_toolkit.db_files_current TO public;
+
+	IF EXISTS (SELECT 1 FROM pg_tables
+				WHERE schemaname = 'arenadata_toolkit' AND tablename = 'db_files')
+	THEN
+		DROP EXTERNAL TABLE arenadata_toolkit.db_files;
+	END IF;
+END$$
+LANGUAGE plpgsql VOLATILE
+EXECUTE ON MASTER;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.c
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.c
@@ -1,0 +1,4 @@
+#include "postgres.h"
+#include "fmgr.h"
+
+PG_MODULE_MAGIC;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
@@ -1,0 +1,5 @@
+# arenadata_toolkit extension
+comment = 'extension is used for manipulation of objects created by adb-bundle'
+default_version = '1.0'
+module_pathname = '$libdir/arenadata_toolkit'
+relocatable = false

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -1,0 +1,151 @@
+----------------------------------------------------------------------------------------------------------
+-- test helpers
+----------------------------------------------------------------------------------------------------------
+SET client_min_messages=WARNING;
+-- start_matchsubs
+-- m/(.*)prt_p\d{6}/
+-- s/(.*)prt_p\d{6}/$1prt_pYYYYMM/
+-- end_matchsubs
+-- function that mocks manual installation of arenadata_toolkit from bundle
+CREATE FUNCTION mock_manual_installation() RETURNS VOID AS $$
+BEGIN
+	CREATE SCHEMA arenadata_toolkit;
+	EXECUTE 'GRANT ALL ON SCHEMA arenadata_toolkit to ' || CURRENT_USER;
+	EXECUTE FORMAT($fmt$CREATE TABLE arenadata_toolkit.db_files_history(collecttime TIMESTAMP WITHOUT TIME ZONE)
+			WITH (appendonly=true, compresstype=zlib, compresslevel=9) DISTRIBUTED RANDOMLY
+			PARTITION BY RANGE (collecttime)
+			(
+				PARTITION %1$I START (date %2$L) INCLUSIVE
+				END (date %3$L) EXCLUSIVE
+				EVERY (INTERVAL '1 month'),
+				DEFAULT PARTITION default_part
+			);$fmt$,
+			'p' || to_char(NOW(), 'YYYYMM'),
+			to_char(NOW(), 'YYYY-MM-01'),
+			to_char(NOW() + interval '1 month','YYYY-MM-01'));
+	CREATE TABLE arenadata_toolkit.daily_operation(field INT) WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+	CREATE TABLE arenadata_toolkit.operation_exclude(schema_name TEXT) WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+	CREATE EXTERNAL WEB TABLE arenadata_toolkit.db_files (field TEXT) EXECUTE 'echo 1' FORMAT 'TEXT';
+END;
+$$ LANGUAGE plpgsql;
+-- view that returns information about tables that belongs to the arenadata_toolkit schema (and schema itself)
+CREATE VIEW toolkit_objects_info AS
+	SELECT oid as objid, 'schema'  as objtype, nspname as objname,
+		'-'::"char" as objstorage,
+		replace(nspacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_namespace WHERE nspname = 'arenadata_toolkit'
+	UNION
+	SELECT oid as objid, 'table' as objtype, relname as objname,
+		relstorage as objstorage,
+		replace(relacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_class WHERE relname IN (SELECT table_name FROM information_schema.tables WHERE table_schema = 'arenadata_toolkit')
+	UNION
+	SELECT oid as objid, 'proc' as objtype, proname as objname,
+		'-'::"char" as objstorage,
+		replace(proacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_proc WHERE pronamespace = (SELECT oid from pg_namespace WHERE nspname = 'arenadata_toolkit')
+	;
+----------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------
+-- test case 1: arenadata_toolkit was installed
+----------------------------------------------------------------------------------------------------------
+-- setup
+SELECT mock_manual_installation();
+ mock_manual_installation 
+--------------------------
+ 
+(1 row)
+
+-- check that created toolkit objects doesn't depend on extension
+SELECT * FROM pg_depend d JOIN toolkit_objects_info objs ON d.objid = objs.objid AND d.deptype='e';
+ classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype | objid | objtype | objname | objstorage | objacl 
+---------+-------+----------+------------+----------+-------------+---------+-------+---------+---------+------------+--------
+(0 rows)
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+               objname               | objtype | objstorage |      objacl      
+-------------------------------------+---------+------------+------------------
+ arenadata_toolkit                   | schema  | -          | {owner=UC/owner}
+ daily_operation                     | table   | a          | 
+ db_files                            | table   | x          | 
+ db_files_history                    | table   | a          | 
+ db_files_history_1_prt_default_part | table   | a          | 
+ db_files_history_1_prt_p202306      | table   | a          | 
+ operation_exclude                   | table   | a          | 
+(7 rows)
+
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+ adb_create_tables 
+-------------------
+ 
+(1 row)
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema after creating
+-- extension and calling adb_create_tables
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+               objname               | objtype | objstorage |             objacl             
+-------------------------------------+---------+------------+--------------------------------
+ adb_create_tables                   | proc    | -          | 
+ arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
+ daily_operation                     | table   | a          | {owner=arwdDxt/owner}
+ db_files_current                    | table   | h          | {owner=arwdDxt/owner,=r/owner}
+ db_files_history                    | table   | a          | 
+ db_files_history_1_prt_default_part | table   | a          | 
+ db_files_history_1_prt_p202306      | table   | a          | 
+ operation_exclude                   | table   | a          | 
+(8 rows)
+
+-- check that toolkit objects now depends on extension
+SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
+	toolkit_objects_info objs ON d.objid = objs.objid JOIN
+	pg_extension e ON d.refobjid = e.oid
+WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
+      objname      | objtype |      extname      | deptype 
+-------------------+---------+-------------------+---------
+ adb_create_tables | proc    | arenadata_toolkit | e
+(1 row)
+
+DROP EXTENSION arenadata_toolkit;
+DROP SCHEMA arenadata_toolkit cascade;
+----------------------------------------------------------------------------------------------------------
+-- test case 2: arenadata_toolkit wasn't installed
+----------------------------------------------------------------------------------------------------------
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+ adb_create_tables 
+-------------------
+ 
+(1 row)
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema after creating
+-- extension and calling adb_create_tables
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+               objname               | objtype | objstorage |             objacl             
+-------------------------------------+---------+------------+--------------------------------
+ adb_create_tables                   | proc    | -          | 
+ arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
+ daily_operation                     | table   | a          | {owner=arwdDxt/owner}
+ db_files_current                    | table   | h          | {owner=arwdDxt/owner,=r/owner}
+ db_files_history                    | table   | a          | {owner=arwdDxt/owner}
+ db_files_history_1_prt_default_part | table   | a          | {owner=arwdDxt/owner}
+ db_files_history_1_prt_p202306      | table   | a          | {owner=arwdDxt/owner}
+ operation_exclude                   | table   | a          | {owner=arwdDxt/owner}
+(8 rows)
+
+-- check that toolkit objects now depends on extension
+SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
+	toolkit_objects_info objs ON d.objid = objs.objid JOIN
+	pg_extension e ON d.refobjid = e.oid
+WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
+      objname      | objtype |      extname      | deptype 
+-------------------+---------+-------------------+---------
+ adb_create_tables | proc    | arenadata_toolkit | e
+(1 row)
+
+DROP EXTENSION arenadata_toolkit;
+DROP SCHEMA arenadata_toolkit cascade;
+DROP FUNCTION mock_manual_installation();
+DROP VIEW toolkit_objects_info;
+RESET client_min_messages;

--- a/gpcontrib/arenadata_toolkit/sql/arenadata_toolkit_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/arenadata_toolkit_test.sql
@@ -1,0 +1,102 @@
+----------------------------------------------------------------------------------------------------------
+-- test helpers
+----------------------------------------------------------------------------------------------------------
+SET client_min_messages=WARNING;
+-- start_matchsubs
+-- m/(.*)prt_p\d{6}/
+-- s/(.*)prt_p\d{6}/$1prt_pYYYYMM/
+-- end_matchsubs
+-- function that mocks manual installation of arenadata_toolkit from bundle
+CREATE FUNCTION mock_manual_installation() RETURNS VOID AS $$
+BEGIN
+	CREATE SCHEMA arenadata_toolkit;
+	EXECUTE 'GRANT ALL ON SCHEMA arenadata_toolkit to ' || CURRENT_USER;
+	EXECUTE FORMAT($fmt$CREATE TABLE arenadata_toolkit.db_files_history(collecttime TIMESTAMP WITHOUT TIME ZONE)
+			WITH (appendonly=true, compresstype=zlib, compresslevel=9) DISTRIBUTED RANDOMLY
+			PARTITION BY RANGE (collecttime)
+			(
+				PARTITION %1$I START (date %2$L) INCLUSIVE
+				END (date %3$L) EXCLUSIVE
+				EVERY (INTERVAL '1 month'),
+				DEFAULT PARTITION default_part
+			);$fmt$,
+			'p' || to_char(NOW(), 'YYYYMM'),
+			to_char(NOW(), 'YYYY-MM-01'),
+			to_char(NOW() + interval '1 month','YYYY-MM-01'));
+	CREATE TABLE arenadata_toolkit.daily_operation(field INT) WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+	CREATE TABLE arenadata_toolkit.operation_exclude(schema_name TEXT) WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+	CREATE EXTERNAL WEB TABLE arenadata_toolkit.db_files (field TEXT) EXECUTE 'echo 1' FORMAT 'TEXT';
+END;
+$$ LANGUAGE plpgsql;
+
+-- view that returns information about tables that belongs to the arenadata_toolkit schema (and schema itself)
+CREATE VIEW toolkit_objects_info AS
+	SELECT oid as objid, 'schema'  as objtype, nspname as objname,
+		'-'::"char" as objstorage,
+		replace(nspacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_namespace WHERE nspname = 'arenadata_toolkit'
+	UNION
+	SELECT oid as objid, 'table' as objtype, relname as objname,
+		relstorage as objstorage,
+		replace(relacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_class WHERE relname IN (SELECT table_name FROM information_schema.tables WHERE table_schema = 'arenadata_toolkit')
+	UNION
+	SELECT oid as objid, 'proc' as objtype, proname as objname,
+		'-'::"char" as objstorage,
+		replace(proacl::text, CURRENT_USER, 'owner') AS objacl -- replace current_user to static string, to prevent test flakiness
+		FROM pg_proc WHERE pronamespace = (SELECT oid from pg_namespace WHERE nspname = 'arenadata_toolkit')
+	;
+----------------------------------------------------------------------------------------------------------
+
+---------------------------------------------------------------------------------------------------------
+-- test case 1: arenadata_toolkit was installed
+----------------------------------------------------------------------------------------------------------
+
+-- setup
+SELECT mock_manual_installation();
+
+-- check that created toolkit objects doesn't depend on extension
+SELECT * FROM pg_depend d JOIN toolkit_objects_info objs ON d.objid = objs.objid AND d.deptype='e';
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema after creating
+-- extension and calling adb_create_tables
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+
+-- check that toolkit objects now depends on extension
+SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
+	toolkit_objects_info objs ON d.objid = objs.objid JOIN
+	pg_extension e ON d.refobjid = e.oid
+WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
+
+DROP EXTENSION arenadata_toolkit;
+DROP SCHEMA arenadata_toolkit cascade;
+
+----------------------------------------------------------------------------------------------------------
+-- test case 2: arenadata_toolkit wasn't installed
+----------------------------------------------------------------------------------------------------------
+
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+
+-- show toolkit objects (and their grants) that belongs to arenadata_toolkit schema after creating
+-- extension and calling adb_create_tables
+SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY objname;
+
+-- check that toolkit objects now depends on extension
+SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
+	toolkit_objects_info objs ON d.objid = objs.objid JOIN
+	pg_extension e ON d.refobjid = e.oid
+WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
+
+DROP EXTENSION arenadata_toolkit;
+DROP SCHEMA arenadata_toolkit cascade;
+
+DROP FUNCTION mock_manual_installation();
+DROP VIEW toolkit_objects_info;
+RESET client_min_messages;


### PR DESCRIPTION
arenadata_toolkit: initial implementation of extension

This patch provides initial version of `arenadata_toolkit` extension to simplify versioning of `arenadata_toolkit` objects (and work with them) at `adb-bundle`. What was done:
- added `arenadata_toolkit--1.0` script, which creates toolkit schema and provides functinon to create toolkit tables (extension doesn't create them due to problems with handling AO tables at extension)
- added initiall version of arenadata_toolkit.c for further development
- changed builing process of gpdb to enable build of this extension

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
