### PR TITLE
ADBDEV-3656: Vacuum make all segments inaccessible in case of concurrent transaction present

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -474,7 +474,7 @@ vacuum_assign_compaction_segno(Relation onerel,
 		return true;
 	}
 
-	if (HasSerializableBackends(false))
+	if (!ConditionalLockRelationOid(onerel->rd_id, AccessExclusiveLock) || HasSerializableBackends(false))
 	{
 		elog(LOG, "Skip compaction because of concurrent serializable transactions");
 		return false;


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
