### PR TITLE
ADBDEV-3793: arenadata_toolkit: implement calculation of skew

### DIFF
--- a/gpcontrib/arenadata_toolkit/Makefile
+++ b/gpcontrib/arenadata_toolkit/Makefile
@@ -5,7 +5,7 @@ MODULES = arenadata_toolkit
 EXTENSION = arenadata_toolkit
 DATA = arenadata_toolkit--1.0.sql
 
-REGRESS = arenadata_toolkit_test
+REGRESS = arenadata_toolkit_test arenadata_toolkit_skew_test
 REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
 
 ifdef USE_PGXS

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
@@ -49,7 +49,7 @@ JOIN pg_catalog.pg_class pgc
 JOIN pg_catalog.pg_namespace pgn
     ON (pgc.relnamespace = pgn.oid);
 
-GRANT SELECT ON TABLE arenadata_toolkit.adb_skew_coefficients TO public;
+GRANT SELECT ON arenadata_toolkit.adb_skew_coefficients TO public;
 
 /*
  This is part of arenadata_toolkit API for ADB Bundle.

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.0.sql
@@ -16,12 +16,13 @@ END$$;
 
 GRANT ALL ON SCHEMA arenadata_toolkit TO public;
 
-CREATE FUNCTION arenadata_toolkit.adb_relation_storage_size(reloid OID, forkName text default 'main')
-RETURNS bigint
+CREATE FUNCTION arenadata_toolkit.adb_relation_storage_size(reloid OID, forkName TEXT default 'main')
+RETURNS BIGINT
 AS '$libdir/arenadata_toolkit', 'adb_relation_storage_size'
 LANGUAGE C VOLATILE STRICT;
 
-COMMENT ON FUNCTION arenadata_toolkit.adb_relation_storage_size(oid, forkName text) IS 'Provides relation storage size details';
+GRANT EXECUTE ON FUNCTION arenadata_toolkit.adb_relation_storage_size(OID, TEXT) TO public;
+COMMENT ON FUNCTION arenadata_toolkit.adb_relation_storage_size(OID, TEXT) IS 'Provides relation storage size details';
 
 CREATE VIEW arenadata_toolkit.adb_skew_coefficients
 AS
@@ -42,7 +43,7 @@ SELECT
     skew.skewoid AS skcoid,
     pgn.nspname  AS skcnamespace,
     pgc.relname  AS skcrelname,
-    case when skewdev > 0 then skewdev/skewmean * 100.0 else 0 end AS skccoeff
+    CASE WHEN skewdev > 0 THEN skewdev/skewmean * 100.0 ELSE 0 END AS skccoeff
 FROM skew
 JOIN pg_catalog.pg_class pgc
     ON (skew.skewoid = pgc.oid)

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.c
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.c
@@ -1,4 +1,198 @@
+#include <sys/stat.h>
+
 #include "postgres.h"
+
+#include "access/aomd.h"
+#include "access/heapam.h"
+#include "cdb/cdbvars.h"
+#include "common/relpath.h"
 #include "fmgr.h"
+#include "miscadmin.h"
+#include "storage/lock.h"
+#include "utils/builtins.h"
+#include "utils/elog.h"
+#include "utils/rel.h"
+#include "utils/relcache.h"
 
 PG_MODULE_MAGIC;
+
+/*
+ * MAXPATHLEN_WITHSEGNO: size of path buffer for relation segment
+ * ('segno' may require 12 additional bytes).
+ */
+#define MAXPATHLEN_WITHSEGNO (MAXPGPATH + 12)
+
+static int64 calculate_relation_size(Relation rel, ForkNumber forknum);
+static int64 get_heap_storage_total_bytes(Relation rel,
+							 ForkNumber forknum, char *relpath);
+static int64 get_ao_storage_total_bytes(Relation rel, char *relpath);
+static bool calculate_ao_storage_perSegFile(const int segno, void *ctx);
+static void fill_relation_seg_path(char *buf, int bufLen,
+					   const char *relpath, int segNo);
+
+/*
+ * Structure used to accumulate the size of AO/CO relation from callback.
+ */
+struct calculate_ao_storage_callback_ctx
+{
+	char	   *relfilenode_path;
+	int64		total_size;
+};
+
+/*
+ * Function to calculate size of a relation by it's OID and optional forkNumber
+ * (by default it's MAIN). The implementation of function is based on
+ * pg_relation_size from dbsize.c
+ */
+PG_FUNCTION_INFO_V1(adb_relation_storage_size);
+Datum
+adb_relation_storage_size(PG_FUNCTION_ARGS)
+{
+	Oid			relOid = PG_GETARG_OID(0);
+	text	   *forkName = PG_GETARG_TEXT_P(1);
+	ForkNumber	forkNumber;
+	Relation	rel;
+	int64		size = 0;
+
+	rel = try_relation_open(relOid, AccessShareLock, false);
+	if (rel == NULL)
+		PG_RETURN_NULL();
+
+	forkNumber = forkname_to_number(text_to_cstring(forkName));
+
+	if (relOid == 0 || rel->rd_node.relNode == 0)
+		size = 0;
+	else
+		size = calculate_relation_size(rel, forkNumber);
+
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		char	   *sql = psprintf(
+			  "select arenadata_toolkit.adb_relation_storage_size(%u, '%s')",
+								   relOid, forkNames[forkNumber]
+		);
+
+		size += get_size_from_segDBs(sql);
+	}
+
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_INT64(size);
+}
+
+/*
+ * Function calculates the size of a relation (one fork of this relation)
+ *
+ * This function must preserve the behaviour of the eponymous function from
+ * dbsize.c. Thus calculation of size for heap/AO/CO relations is supported
+ * (AO/CO relations don't have any extra forks, so only main fork is supported)
+ * In other cases zero value is returned.
+ */
+static int64
+calculate_relation_size(Relation rel, ForkNumber forknum)
+{
+	bool		isAOMainFork = RelationIsAppendOptimized(rel) && forknum == MAIN_FORKNUM;
+
+	if (!(RelationIsHeap(rel) || isAOMainFork))
+		return 0;
+
+	char	   *relpath = relpathbackend(rel->rd_node, rel->rd_backend, forknum);
+
+	if (RelationIsHeap(rel))
+		return get_heap_storage_total_bytes(rel, forknum, relpath);
+
+	return get_ao_storage_total_bytes(rel, relpath);
+}
+
+static void
+fill_relation_seg_path(char *buf, int bufLen, const char *relpath, int segNo)
+{
+	if (segNo == 0)
+		snprintf(buf, bufLen, "%s", relpath);
+	else
+		snprintf(buf, bufLen, "%s.%u", relpath, segNo);
+}
+
+static bool
+calculate_ao_storage_perSegFile(const int segno, void *ctx)
+{
+	struct stat fst;
+	char		segPath[MAXPATHLEN_WITHSEGNO];
+	struct calculate_ao_storage_callback_ctx *calcCtx = ctx;
+
+	CHECK_FOR_INTERRUPTS();
+
+	fill_relation_seg_path(segPath, MAXPATHLEN_WITHSEGNO,
+						   calcCtx->relfilenode_path, segno);
+
+	if (stat(segPath, &fst) < 0)
+	{
+		if (errno == ENOENT)
+			return false;
+		ereport(ERROR, (errcode_for_file_access(),
+						errmsg("could not access file %s: %m", segPath)));
+	}
+	calcCtx->total_size += fst.st_size;
+
+	return true;
+}
+
+/*
+ * Function calculates the size of heap tables.
+ *
+ * The code is based on calculate_relation_size from dbsize.c
+ */
+static int64
+get_heap_storage_total_bytes(Relation rel, ForkNumber forknum, char *relpath)
+{
+	int64		totalsize = 0;
+	char		segPath[MAXPATHLEN_WITHSEGNO];
+
+	/*
+	 * Ordinary relation, including heap and index. They take form of
+	 * relationpath, or relationpath.%d There will be no holes, therefore, we
+	 * can stop when we reach the first non-existing file.
+	 */
+	for (int segno = 0;; segno++)
+	{
+		struct stat fst;
+
+		CHECK_FOR_INTERRUPTS();
+
+		fill_relation_seg_path(segPath, MAXPATHLEN_WITHSEGNO, relpath, segno);
+		if (stat(segPath, &fst) < 0)
+		{
+			if (errno == ENOENT)
+				break;
+			ereport(ERROR, (errcode_for_file_access(),
+							errmsg("could not stat file %s: %m", segPath)));
+		}
+		totalsize += fst.st_size;
+	}
+
+	return totalsize;
+}
+
+/*
+ * Function calculates the size of AO/CO tables.
+ */
+static int64
+get_ao_storage_total_bytes(Relation rel, char *relpath)
+{
+	struct calculate_ao_storage_callback_ctx ctx = {
+		.relfilenode_path = relpath,
+		.total_size = 0
+	};
+
+	/*
+	 * ao_foreach_extent_file starts execution of callback for relfilenode
+	 * file with extension 1 (segno=1) and ignores relfilenode file without
+	 * extension (segno=0), which may be not empty (in case of utility
+	 * operations (for ex: CTAS) zero segment will store tuples). Thus
+	 * calculate segno=0 manually.
+	 */
+	(void) calculate_ao_storage_perSegFile(0, &ctx);
+
+	ao_foreach_extent_file(calculate_ao_storage_perSegFile, &ctx);
+	return ctx.total_size;
+}

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_skew_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_skew_test.out
@@ -1,0 +1,214 @@
+CREATE EXTENSION arenadata_toolkit;
+----------------------------------------------------------------------------------------------------------
+-- test helpers
+----------------------------------------------------------------------------------------------------------
+SET search_path = arenadata_toolkit;
+-- start_matchsubs
+-- m/(.*)size=\d+/
+-- s/(.*)size=\d+/$1size/
+-- end_matchsubs
+-- function compares behaviour of pg_relation_size and adb_relation_storage_size functions for
+-- table and it's forks in case of AO/CO tables (and also external) there are no other forks except main
+CREATE FUNCTION compare_table_and_forks_size_calculation(tbl_oid OID)
+RETURNS TABLE(fork TEXT, result_equals BOOLEAN, is_empty BOOLEAN, tbl_size TEXT) AS $$
+BEGIN
+	RETURN QUERY
+		SELECT 'main', pg_relation_size(tbl_oid) = adb_relation_storage_size(tbl_oid),
+			pg_relation_size(tbl_oid) = 0, 'size=' || pg_relation_size(tbl_oid)::TEXT
+		UNION
+		SELECT 'fsm', pg_relation_size(tbl_oid, 'fsm') = adb_relation_storage_size(tbl_oid, 'fsm'),
+			pg_relation_size(tbl_oid, 'fsm') = 0, 'size=' || pg_relation_size(tbl_oid, 'fsm')::TEXT
+		UNION
+		SELECT 'vm', pg_relation_size(tbl_oid, 'vm') = adb_relation_storage_size(tbl_oid, 'vm'),
+			pg_relation_size(tbl_oid, 'vm') = 0, 'size=' || pg_relation_size(tbl_oid, 'vm')::TEXT
+		ORDER BY 1;
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION check_size_diff(tbl_oid OID) RETURNS TABLE(size_equals BOOLEAN, mul_factor INT) AS $$
+BEGIN
+	RETURN QUERY SELECT adb_relation_storage_size(tbl_oid) = pg_relation_size(tbl_oid),
+		round(adb_relation_storage_size(tbl_oid)::DECIMAL / pg_relation_size(tbl_oid))::INT;
+END;
+$$ LANGUAGE plpgsql;
+----------------------------------------------------------------------------------------------------------
+-- test adb_relation_storage_size function (in compare with pg_relation_size)
+----------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------
+-- test case 1: check that behaviour for not existing table the same
+----------------------------------------------------------------------
+SELECT (pg_relation_size(100000::OID) IS NULL) = (adb_relation_storage_size(100000::OID) IS NULL) AS equals;
+ equals 
+--------
+ t
+(1 row)
+
+----------------------------------------------------------------------
+-- test case 2: check behaviour equality for heap tables
+----------------------------------------------------------------------
+CREATE TABLE heap(i INT, j INT) WITH (appendonly = false) DISTRIBUTED BY (i);
+-- check emptiness of heap table
+SELECT adb_relation_storage_size('heap'::regclass::oid) = 0 AS is_empty;
+ is_empty 
+----------
+ t
+(1 row)
+
+-- compare size calculation on filled heap table (vm and fsm table sizes must
+-- be > 0 - 'is_empty' column must be false)
+INSERT INTO heap SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM heap;
+SELECT * FROM compare_table_and_forks_size_calculation('heap'::regclass::OID);
+ fork | result_equals | is_empty |   tbl_size   
+------+---------------+----------+--------------
+ fsm  | t             | f        | size=294912
+ main | t             | f        | size=3637248
+ vm   | t             | f        | size=98304
+(3 rows)
+
+DROP TABLE heap;
+----------------------------------------------------------------------
+-- test case 3: check behaviour equality for AO tables
+----------------------------------------------------------------------
+CREATE TABLE empty_ao(i INT, j INT) WITH (appendonly=true) DISTRIBUTED BY (i);
+-- check emptiness of AO table
+SELECT adb_relation_storage_size('empty_ao'::regclass::oid) = 0 AS is_empty;
+ is_empty 
+----------
+ t
+(1 row)
+
+-- compare size calculation of AO table (vm and fsm tables size must be empty - 'is_empty' column true).
+-- CTAS (utility) statement is used to check that zero (0) segment is taken into account
+-- (from src/backend/access/appendonly/README.md: utility mode inserts data to zero segment)
+CREATE TABLE ao WITH (appendonly=true) AS SELECT i, i AS j FROM generate_series(1, 10000) i DISTRIBUTED BY (i);
+INSERT INTO ao SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM ao;
+SELECT * FROM compare_table_and_forks_size_calculation('ao'::regclass::OID);
+ fork | result_equals | is_empty |   tbl_size   
+------+---------------+----------+--------------
+ fsm  | t             | t        | size=0
+ main | t             | f        | size=1982264
+ vm   | t             | t        | size=0
+(3 rows)
+
+DROP TABLE empty_ao, ao;
+----------------------------------------------------------------------
+-- test case 4: check behaviour equality for CO tables
+----------------------------------------------------------------------
+CREATE TABLE empty_co(i INT, j INT) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
+-- check emptiness of CO table
+SELECT adb_relation_storage_size('empty_co'::regclass::oid) = 0 AS is_empty;
+ is_empty 
+----------
+ t
+(1 row)
+
+-- compare size calculation of CO table (vm and fsm tables size must be empty - 'is_empty' column true).
+-- CTAS (utility) statement is used to check that zero (0) segment is taken into account
+-- (from src/backend/access/appendonly/README.md: utility mode inserts data to zero segment)
+CREATE TABLE co WITH (appendonly=true, orientation=column) AS
+	SELECT i, i AS j FROM generate_series(1, 10000) i DISTRIBUTED BY (i);
+INSERT INTO co SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM co;
+SELECT * FROM compare_table_and_forks_size_calculation('co'::regclass::OID);
+ fork | result_equals | is_empty |  tbl_size   
+------+---------------+----------+-------------
+ fsm  | t             | t        | size=0
+ main | t             | f        | size=881568
+ vm   | t             | t        | size=0
+(3 rows)
+
+DROP TABLE empty_co, co;
+------------------------------------------------ ----------------------
+-- test case 4: check behaviour equality for external tables
+-----------------------------------------------------------------------
+CREATE EXTERNAL WEB TABLE external_tbl(field TEXT) EXECUTE 'echo 1' FORMAT 'TEXT';
+-- size of table (and it's fork) must be 0
+SELECT * FROM compare_table_and_forks_size_calculation('external_tbl'::regclass::OID);
+ fork | result_equals | is_empty | tbl_size 
+------+---------------+----------+----------
+ fsm  | t             | t        | size=0
+ main | t             | t        | size=0
+ vm   | t             | t        | size=0
+(3 rows)
+
+DROP EXTERNAL TABLE external_tbl;
+------------------------------------------------ ----------------------
+-- test case 5: check behaviour difference (pg_relation_size and
+-- adb_relation_storage_size) for AO/CO table size (when insert transaction
+-- failed the physical size of table is returned by adb_relation_storage_size
+-- unlike 'virtual' size (as it's done at pg_relation_size)
+-----------------------------------------------------------------------
+CREATE TABLE ao(i INT, j INT) WITH (appendonly=true) DISTRIBUTED BY (i);
+INSERT INTO ao SELECT i, i AS j from generate_series(1, 1000) i;
+CREATE TABLE co(i INT, j INT) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
+INSERT INTO co SELECT i, i AS j from generate_series(1, 1000) i;
+SELECT * FROM check_size_diff('ao'::regclass::OID);
+ size_equals | mul_factor 
+-------------+------------
+ t           |          1
+(1 row)
+
+SELECT * FROM check_size_diff('co'::regclass::OID);
+ size_equals | mul_factor 
+-------------+------------
+ t           |          1
+(1 row)
+
+-- insert data and rollback it, to check that physical size was changed while 'virtual' not
+BEGIN;
+INSERT INTO co SELECT i, i AS j FROM generate_series(1, 1000) i;
+INSERT INTO ao SELECT i, i AS j FROM generate_series(1, 1000) i;
+ABORT;
+SELECT * FROM check_size_diff('ao'::regclass::OID);
+ size_equals | mul_factor 
+-------------+------------
+ f           |          2
+(1 row)
+
+SELECT * FROM check_size_diff('co'::regclass::OID);
+ size_equals | mul_factor 
+-------------+------------
+ f           |          2
+(1 row)
+
+DROP TABLE ao, co;
+----------------------------------------------------------------------------------------------------------
+-- test adb_skew_coefficients view
+----------------------------------------------------------------------------------------------------------
+CREATE TABLE heap(i INT, j INT) WITH (appendonly = false) DISTRIBUTED BY(i);
+CREATE TABLE ao  (i INT, j INT) WITH (appendonly = true) DISTRIBUTED BY(i);
+CREATE TABLE co  (i INT, j INT) WITH (appendonly = true, orientation = column) DISTRIBUTED BY(i);
+insert into heap SELECT i, i AS j FROM generate_series(1, 100000) i;
+insert into ao   SELECT i, i AS j FROM generate_series(1, 100000) i;
+insert into co   SELECT i, i AS j FROM generate_series(1, 100000) i;
+-- round is used to prevent test flakiness. Original values of coefficient for
+-- AO, CO, heap tables  differs (but for AO/CO them are close enough), because
+-- of different storage models. (Also zero value of skew coefficient for heap
+-- table is a kind of luck conditioned by NUM_SEG=3 and inserted 100000 tuples)
+SELECT skcnamespace, skcrelname, round(skccoeff, 2) as skccoeff_round FROM adb_skew_coefficients order by skcrelname;
+   skcnamespace    | skcrelname | skccoeff_round 
+-------------------+------------+----------------
+ arenadata_toolkit | ao         |           0.38
+ arenadata_toolkit | co         |           0.37
+ arenadata_toolkit | heap       |           0.00
+(3 rows)
+
+-- produce the skew
+insert into heap SELECT 1, i AS j FROM generate_series(1, 10000) i;
+insert into ao   SELECT 1, i AS j FROM generate_series(1, 10000) i;
+insert into co   SELECT 1, i AS j FROM generate_series(1, 10000) i;
+-- check that skewcoeff was increased
+SELECT skcnamespace, skcrelname, round(skccoeff, 2) as skccoeff_round FROM adb_skew_coefficients order by skcrelname;
+   skcnamespace    | skcrelname | skccoeff_round 
+-------------------+------------+----------------
+ arenadata_toolkit | ao         |          15.74
+ arenadata_toolkit | co         |          15.74
+ arenadata_toolkit | heap       |          15.62
+(3 rows)
+
+DROP TABLE heap, ao, co;
+DROP FUNCTION compare_table_and_forks_size_calculation(OID);
+DROP FUNCTION check_size_diff(OID);
+RESET search_path;
+DROP EXTENSION arenadata_toolkit;

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -88,7 +88,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
                objname               | objtype | objstorage |             objacl             
 -------------------------------------+---------+------------+--------------------------------
  adb_create_tables                   | proc    | -          | 
- adb_relation_storage_size           | proc    | -          | 
+ adb_relation_storage_size           | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients               | table   | v          | {owner=arwdDxt/owner,=r/owner}
  arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
  daily_operation                     | table   | a          | {owner=arwdDxt/owner}
@@ -129,7 +129,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
                objname               | objtype | objstorage |             objacl             
 -------------------------------------+---------+------------+--------------------------------
  adb_create_tables                   | proc    | -          | 
- adb_relation_storage_size           | proc    | -          | 
+ adb_relation_storage_size           | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients               | table   | v          | {owner=arwdDxt/owner,=r/owner}
  arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
  daily_operation                     | table   | a          | {owner=arwdDxt/owner}

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -88,6 +88,8 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
                objname               | objtype | objstorage |             objacl             
 -------------------------------------+---------+------------+--------------------------------
  adb_create_tables                   | proc    | -          | 
+ adb_relation_storage_size           | proc    | -          | 
+ adb_skew_coefficients               | table   | v          | {owner=arwdDxt/owner,=r/owner}
  arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
  daily_operation                     | table   | a          | {owner=arwdDxt/owner}
  db_files_current                    | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -95,17 +97,19 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part | table   | a          | 
  db_files_history_1_prt_p202306      | table   | a          | 
  operation_exclude                   | table   | a          | 
-(8 rows)
+(10 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
 	toolkit_objects_info objs ON d.objid = objs.objid JOIN
 	pg_extension e ON d.refobjid = e.oid
 WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
-      objname      | objtype |      extname      | deptype 
--------------------+---------+-------------------+---------
- adb_create_tables | proc    | arenadata_toolkit | e
-(1 row)
+          objname          | objtype |      extname      | deptype 
+---------------------------+---------+-------------------+---------
+ adb_create_tables         | proc    | arenadata_toolkit | e
+ adb_relation_storage_size | proc    | arenadata_toolkit | e
+ adb_skew_coefficients     | table   | arenadata_toolkit | e
+(3 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;
@@ -125,6 +129,8 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
                objname               | objtype | objstorage |             objacl             
 -------------------------------------+---------+------------+--------------------------------
  adb_create_tables                   | proc    | -          | 
+ adb_relation_storage_size           | proc    | -          | 
+ adb_skew_coefficients               | table   | v          | {owner=arwdDxt/owner,=r/owner}
  arenadata_toolkit                   | schema  | -          | {owner=UC/owner,=UC/owner}
  daily_operation                     | table   | a          | {owner=arwdDxt/owner}
  db_files_current                    | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -132,17 +138,19 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part | table   | a          | {owner=arwdDxt/owner}
  db_files_history_1_prt_p202306      | table   | a          | {owner=arwdDxt/owner}
  operation_exclude                   | table   | a          | {owner=arwdDxt/owner}
-(8 rows)
+(10 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
 	toolkit_objects_info objs ON d.objid = objs.objid JOIN
 	pg_extension e ON d.refobjid = e.oid
 WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
-      objname      | objtype |      extname      | deptype 
--------------------+---------+-------------------+---------
- adb_create_tables | proc    | arenadata_toolkit | e
-(1 row)
+          objname          | objtype |      extname      | deptype 
+---------------------------+---------+-------------------+---------
+ adb_create_tables         | proc    | arenadata_toolkit | e
+ adb_relation_storage_size | proc    | arenadata_toolkit | e
+ adb_skew_coefficients     | table   | arenadata_toolkit | e
+(3 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;

--- a/gpcontrib/arenadata_toolkit/sql/arenadata_toolkit_skew_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/arenadata_toolkit_skew_test.sql
@@ -1,0 +1,168 @@
+CREATE EXTENSION arenadata_toolkit;
+
+----------------------------------------------------------------------------------------------------------
+-- test helpers
+----------------------------------------------------------------------------------------------------------
+
+SET search_path = arenadata_toolkit;
+
+-- start_matchsubs
+-- m/(.*)size=\d+/
+-- s/(.*)size=\d+/$1size/
+-- end_matchsubs
+
+-- function compares behaviour of pg_relation_size and adb_relation_storage_size functions for
+-- table and it's forks in case of AO/CO tables (and also external) there are no other forks except main
+CREATE FUNCTION compare_table_and_forks_size_calculation(tbl_oid OID)
+RETURNS TABLE(fork TEXT, result_equals BOOLEAN, is_empty BOOLEAN, tbl_size TEXT) AS $$
+BEGIN
+	RETURN QUERY
+		SELECT 'main', pg_relation_size(tbl_oid) = adb_relation_storage_size(tbl_oid),
+			pg_relation_size(tbl_oid) = 0, 'size=' || pg_relation_size(tbl_oid)::TEXT
+		UNION
+		SELECT 'fsm', pg_relation_size(tbl_oid, 'fsm') = adb_relation_storage_size(tbl_oid, 'fsm'),
+			pg_relation_size(tbl_oid, 'fsm') = 0, 'size=' || pg_relation_size(tbl_oid, 'fsm')::TEXT
+		UNION
+		SELECT 'vm', pg_relation_size(tbl_oid, 'vm') = adb_relation_storage_size(tbl_oid, 'vm'),
+			pg_relation_size(tbl_oid, 'vm') = 0, 'size=' || pg_relation_size(tbl_oid, 'vm')::TEXT
+		ORDER BY 1;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION check_size_diff(tbl_oid OID) RETURNS TABLE(size_equals BOOLEAN, mul_factor INT) AS $$
+BEGIN
+	RETURN QUERY SELECT adb_relation_storage_size(tbl_oid) = pg_relation_size(tbl_oid),
+		round(adb_relation_storage_size(tbl_oid)::DECIMAL / pg_relation_size(tbl_oid))::INT;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------------------------------------------------
+-- test adb_relation_storage_size function (in compare with pg_relation_size)
+----------------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------
+-- test case 1: check that behaviour for not existing table the same
+----------------------------------------------------------------------
+SELECT (pg_relation_size(100000::OID) IS NULL) = (adb_relation_storage_size(100000::OID) IS NULL) AS equals;
+
+----------------------------------------------------------------------
+-- test case 2: check behaviour equality for heap tables
+----------------------------------------------------------------------
+CREATE TABLE heap(i INT, j INT) WITH (appendonly = false) DISTRIBUTED BY (i);
+
+-- check emptiness of heap table
+SELECT adb_relation_storage_size('heap'::regclass::oid) = 0 AS is_empty;
+
+-- compare size calculation on filled heap table (vm and fsm table sizes must
+-- be > 0 - 'is_empty' column must be false)
+INSERT INTO heap SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM heap;
+SELECT * FROM compare_table_and_forks_size_calculation('heap'::regclass::OID);
+
+DROP TABLE heap;
+
+----------------------------------------------------------------------
+-- test case 3: check behaviour equality for AO tables
+----------------------------------------------------------------------
+CREATE TABLE empty_ao(i INT, j INT) WITH (appendonly=true) DISTRIBUTED BY (i);
+
+-- check emptiness of AO table
+SELECT adb_relation_storage_size('empty_ao'::regclass::oid) = 0 AS is_empty;
+
+-- compare size calculation of AO table (vm and fsm tables size must be empty - 'is_empty' column true).
+-- CTAS (utility) statement is used to check that zero (0) segment is taken into account
+-- (from src/backend/access/appendonly/README.md: utility mode inserts data to zero segment)
+CREATE TABLE ao WITH (appendonly=true) AS SELECT i, i AS j FROM generate_series(1, 10000) i DISTRIBUTED BY (i);
+INSERT INTO ao SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM ao;
+SELECT * FROM compare_table_and_forks_size_calculation('ao'::regclass::OID);
+
+DROP TABLE empty_ao, ao;
+
+----------------------------------------------------------------------
+-- test case 4: check behaviour equality for CO tables
+----------------------------------------------------------------------
+CREATE TABLE empty_co(i INT, j INT) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
+
+-- check emptiness of CO table
+SELECT adb_relation_storage_size('empty_co'::regclass::oid) = 0 AS is_empty;
+
+-- compare size calculation of CO table (vm and fsm tables size must be empty - 'is_empty' column true).
+-- CTAS (utility) statement is used to check that zero (0) segment is taken into account
+-- (from src/backend/access/appendonly/README.md: utility mode inserts data to zero segment)
+CREATE TABLE co WITH (appendonly=true, orientation=column) AS
+	SELECT i, i AS j FROM generate_series(1, 10000) i DISTRIBUTED BY (i);
+INSERT INTO co SELECT i, i AS j FROM generate_series(1, 100000) i;
+VACUUM co;
+SELECT * FROM compare_table_and_forks_size_calculation('co'::regclass::OID);
+
+DROP TABLE empty_co, co;
+
+------------------------------------------------ ----------------------
+-- test case 4: check behaviour equality for external tables
+-----------------------------------------------------------------------
+CREATE EXTERNAL WEB TABLE external_tbl(field TEXT) EXECUTE 'echo 1' FORMAT 'TEXT';
+
+-- size of table (and it's fork) must be 0
+SELECT * FROM compare_table_and_forks_size_calculation('external_tbl'::regclass::OID);
+
+DROP EXTERNAL TABLE external_tbl;
+
+------------------------------------------------ ----------------------
+-- test case 5: check behaviour difference (pg_relation_size and
+-- adb_relation_storage_size) for AO/CO table size (when insert transaction
+-- failed the physical size of table is returned by adb_relation_storage_size
+-- unlike 'virtual' size (as it's done at pg_relation_size)
+-----------------------------------------------------------------------
+CREATE TABLE ao(i INT, j INT) WITH (appendonly=true) DISTRIBUTED BY (i);
+INSERT INTO ao SELECT i, i AS j from generate_series(1, 1000) i;
+CREATE TABLE co(i INT, j INT) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (i);
+INSERT INTO co SELECT i, i AS j from generate_series(1, 1000) i;
+
+SELECT * FROM check_size_diff('ao'::regclass::OID);
+SELECT * FROM check_size_diff('co'::regclass::OID);
+
+-- insert data and rollback it, to check that physical size was changed while 'virtual' not
+BEGIN;
+INSERT INTO co SELECT i, i AS j FROM generate_series(1, 1000) i;
+INSERT INTO ao SELECT i, i AS j FROM generate_series(1, 1000) i;
+ABORT;
+
+SELECT * FROM check_size_diff('ao'::regclass::OID);
+SELECT * FROM check_size_diff('co'::regclass::OID);
+
+DROP TABLE ao, co;
+
+----------------------------------------------------------------------------------------------------------
+-- test adb_skew_coefficients view
+----------------------------------------------------------------------------------------------------------
+
+CREATE TABLE heap(i INT, j INT) WITH (appendonly = false) DISTRIBUTED BY(i);
+CREATE TABLE ao  (i INT, j INT) WITH (appendonly = true) DISTRIBUTED BY(i);
+CREATE TABLE co  (i INT, j INT) WITH (appendonly = true, orientation = column) DISTRIBUTED BY(i);
+
+insert into heap SELECT i, i AS j FROM generate_series(1, 100000) i;
+insert into ao   SELECT i, i AS j FROM generate_series(1, 100000) i;
+insert into co   SELECT i, i AS j FROM generate_series(1, 100000) i;
+
+-- round is used to prevent test flakiness. Original values of coefficient for
+-- AO, CO, heap tables  differs (but for AO/CO them are close enough), because
+-- of different storage models. (Also zero value of skew coefficient for heap
+-- table is a kind of luck conditioned by NUM_SEG=3 and inserted 100000 tuples)
+SELECT skcnamespace, skcrelname, round(skccoeff, 2) as skccoeff_round FROM adb_skew_coefficients order by skcrelname;
+
+-- produce the skew
+insert into heap SELECT 1, i AS j FROM generate_series(1, 10000) i;
+insert into ao   SELECT 1, i AS j FROM generate_series(1, 10000) i;
+insert into co   SELECT 1, i AS j FROM generate_series(1, 10000) i;
+
+-- check that skewcoeff was increased
+SELECT skcnamespace, skcrelname, round(skccoeff, 2) as skccoeff_round FROM adb_skew_coefficients order by skcrelname;
+
+DROP TABLE heap, ao, co;
+
+DROP FUNCTION compare_table_and_forks_size_calculation(OID);
+DROP FUNCTION check_size_diff(OID);
+
+RESET search_path;
+DROP EXTENSION arenadata_toolkit;


### PR DESCRIPTION
arenadata_toolkit: implement calculation of skew

This patch extends `arenadata_toolkit` extension functionality to enable
calculation of cluster skew. What was done:
* `arenadata_toolkit.c` implements the `adb_relation_storage_size` function
  which may be called from sql and allows to calculate the size of
  relation
* `arenadata_toolkit--1.0.sql` extended with two new object:
  - `adb_relation_storage_size` sql function
  - `adb_skew_coefficients` view to calculate the skew of cluster

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
