### PR TITLE
ABDEV-3882 Don't push upper predicates down to modifying CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2049,7 +2049,12 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 		config->honor_order_by = false;
 
-		if (!cte->cterecursive)
+		/*
+		 * Additionally to recursive CTE queries, don't try to push down quals
+		 * to non-SELECT queries. There can be DML operation with RETURNING
+		 * clause, and it's incorrect to push down upper quals to it.
+		*/
+		if (!cte->cterecursive && subquery->commandType == CMD_SELECT)
 		{
 			/*
 			 * Adjust the subquery so that 'root', i.e. this subquery, is the

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2271,3 +2271,46 @@ WITH e AS (
 
 DROP TABLE d;
 DROP TABLE r;
+-- Test planner not pushing down quals to non-SELECT queries inside CTE. There
+-- can be a DML operation, and it's incorrect to push down upper quals to it.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+insert into with_dml select i, i*100 from generate_series(1, 5) i;
+explain (costs off)
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Subquery Scan on cte
+         Filter: (cte.i > 2)
+         ->  Update on with_dml
+               ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+ i | j 
+---+---
+ 3 | 1
+ 4 | 1
+ 5 | 1
+(3 rows)
+
+select * from with_dml;
+ i | j 
+---+---
+ 1 | 1
+ 5 | 1
+ 2 | 1
+ 3 | 1
+ 4 | 1
+(5 rows)
+
+drop table with_dml;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2278,39 +2278,38 @@ drop table if exists with_dml;
 NOTICE:  table "with_dml" does not exist, skipping
 --end_ignore
 create table with_dml (i int, j int) distributed by (i);
-insert into with_dml select i, i*100 from generate_series(1, 5) i;
 explain (costs off)
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Subquery Scan on cte
-         Filter: (cte.i > 2)
-         ->  Update on with_dml
-               ->  Seq Scan on with_dml
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i > 2)
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
  Optimizer: Postgres query optimizer
-(6 rows)
+(10 rows)
 
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
- i | j 
----+---
- 3 | 1
- 4 | 1
- 5 | 1
-(3 rows)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
 
-select * from with_dml;
- i | j 
----+---
- 1 | 1
- 5 | 1
- 2 | 1
- 3 | 1
- 4 | 1
-(5 rows)
+select count(*) c from with_dml;
+ c 
+---
+ 5
+(1 row)
 
 drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2274,3 +2274,46 @@ WITH e AS (
 
 DROP TABLE d;
 DROP TABLE r;
+-- Test planner not pushing down quals to non-SELECT queries inside CTE. There
+-- can be a DML operation, and it's incorrect to push down upper quals to it.
+--start_ignore
+drop table if exists with_dml;
+NOTICE:  table "with_dml" does not exist, skipping
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+insert into with_dml select i, i*100 from generate_series(1, 5) i;
+explain (costs off)
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Subquery Scan on cte
+         Filter: (cte.i > 2)
+         ->  Update on with_dml
+               ->  Seq Scan on with_dml
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+ i | j 
+---+---
+ 3 | 1
+ 4 | 1
+ 5 | 1
+(3 rows)
+
+select * from with_dml;
+ i | j 
+---+---
+ 1 | 1
+ 5 | 1
+ 2 | 1
+ 3 | 1
+ 4 | 1
+(5 rows)
+
+drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2281,39 +2281,38 @@ drop table if exists with_dml;
 NOTICE:  table "with_dml" does not exist, skipping
 --end_ignore
 create table with_dml (i int, j int) distributed by (i);
-insert into with_dml select i, i*100 from generate_series(1, 5) i;
 explain (costs off)
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
-                QUERY PLAN                
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Subquery Scan on cte
-         Filter: (cte.i > 2)
-         ->  Update on with_dml
-               ->  Seq Scan on with_dml
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Aggregate
+   ->  Gather Motion 3:1  (slice2; segments: 3)
+         ->  Aggregate
+               ->  Subquery Scan on cte
+                     Filter: (cte.i > 2)
+                     ->  Insert on with_dml
+                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                 Hash Key: i.i
+                                 ->  Function Scan on generate_series i
  Optimizer: Postgres query optimizer
-(6 rows)
+(10 rows)
 
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
- i | j 
----+---
- 3 | 1
- 4 | 1
- 5 | 1
-(3 rows)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+ count 
+-------
+     3
+(1 row)
 
-select * from with_dml;
- i | j 
----+---
- 1 | 1
- 5 | 1
- 2 | 1
- 3 | 1
- 4 | 1
-(5 rows)
+select count(*) c from with_dml;
+ c 
+---
+ 5
+(1 row)
 
 drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -412,13 +412,14 @@ DROP TABLE r;
 drop table if exists with_dml;
 --end_ignore
 create table with_dml (i int, j int) distributed by (i);
-insert into with_dml select i, i*100 from generate_series(1, 5) i;
 explain (costs off)
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
-with cte as
-(update with_dml set j = 1 returning *)
-select * from cte where cte.i > 2;
-select * from with_dml;
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i > 2;
+select count(*) c from with_dml;
 drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -405,3 +405,20 @@ WITH e AS (
 ) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
 DROP TABLE d;
 DROP TABLE r;
+
+-- Test planner not pushing down quals to non-SELECT queries inside CTE. There
+-- can be a DML operation, and it's incorrect to push down upper quals to it.
+--start_ignore
+drop table if exists with_dml;
+--end_ignore
+create table with_dml (i int, j int) distributed by (i);
+insert into with_dml select i, i*100 from generate_series(1, 5) i;
+explain (costs off)
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+with cte as
+(update with_dml set j = 1 returning *)
+select * from cte where cte.i > 2;
+select * from with_dml;
+drop table with_dml;


### PR DESCRIPTION
For queries, which contain DML operations inside the WITH clause, pushing down restrictions from upper levels leads to conditional table modification. That behaviour is undesirable, because in context of modifying CTEs it is expected that the DML operation will affect the whole table, and the restriction at upper level is applied to the result of RETURNING clause.
Therefore, this commit proposes limitations that don't allow planner to push the predicates down from upper level to CTEs, whose `commandType` is non-SELECT.
The issue can be simply reproduced on queries like
```
create table t_hashed (i int, j int) distributed by (i);
explain (costs off)
with cte as (
    insert into t_hashed select i, i * 100 from generate_series(1,5) i
    returning i
) select count(*) from cte where i > 2;
                                QUERY PLAN                                  
------------------------------------------------------------------------------
 Aggregate
   ->  Gather Motion 3:1  (slice2; segments: 3)
         ->  Aggregate
               ->  Subquery Scan on cte
                     ->  Insert on t_hashed
                           ->  Redistribute Motion 1:3  (slice1; segments: 1)
                                 Hash Key: i.i
                                 ->  Function Scan on generate_series i
                                       Filter: (i > 2)
 Optimizer: Postgres query optimizer
(10 rows)
```
In case of UPDATE/DELETE we get an error
```
explain (costs off)
with cte as
(update with_dml set j = 1 returning *)
select * from cte where i > 2;
ERROR:  could not find replacement targetlist entry for attno 1 (rewriteManip.c:1409)
with cte as  
(delete from with_dml returning *)
select * from cte where i > 2;
ERROR:  could not find replacement targetlist entry for attno 1 (rewriteManip.c:1409)
```
