### PR TITLE
ADBDEV-3881 Throw error if query has multiple references to modifying CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2033,14 +2033,14 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	if (!root->config->gp_cte_sharing || cte->cterefcount == 1)
 	{
-	    /*
-	     * If plan sharing is disabled, we avoid performing DML inside CTE
-	     * for each reference. It'll cause duplicated DML operations or
-	     * mutation errors during cdbparallelize().
-	     */
-	    if (cte->cterefcount > 1 &&
-	        ((Query *) cte->ctequery)->commandType != CMD_SELECT)
-	        elog(ERROR, "Too much references to non-SELECT CTE");
+		/*
+		 * If plan sharing is disabled, we avoid performing DML inside CTE for
+		 * each reference. It'll cause duplicated DML operations or mutation
+		 * errors during cdbparallelize().
+		 */
+		if (cte->cterefcount > 1 &&
+			((Query *) cte->ctequery)->commandType != CMD_SELECT)
+			elog(ERROR, "Too much references to non-SELECT CTE");
 
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2033,6 +2033,15 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	if (!root->config->gp_cte_sharing || cte->cterefcount == 1)
 	{
+	    /*
+	     * If plan sharing is disabled, we avoid performing DML inside CTE
+	     * for each reference. It'll cause duplicated DML operations or
+	     * mutation errors during cdbparallelize().
+	     */
+	    if (cte->cterefcount > 1 &&
+	        ((Query *) cte->ctequery)->commandType != CMD_SELECT)
+	        elog(ERROR, "Too much references to non-SELECT CTE");
+
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 
 		/*

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2312,4 +2318,24 @@ select count(*) c from with_dml;
  5
 (1 row)
 
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations or planner errors.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
 drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -1,3 +1,9 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
 drop table if exists with_test1 cascade;
 NOTICE:  table "with_test1" does not exist, skipping
 create table with_test1 (i int, t text, value int) distributed by (i);
@@ -2315,4 +2321,24 @@ select count(*) c from with_dml;
  5
 (1 row)
 
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations or planner errors.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
 drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -1,3 +1,10 @@
+-- start_matchsubs
+--
+-- m/ERROR:  Too much references to non-SELECT CTE \(allpaths\.c:\d+\)/
+-- s/\d+/XXX/g
+--
+-- end_matchsubs
+
 drop table if exists with_test1 cascade;
 create table with_test1 (i int, t text, value int) distributed by (i);
 insert into with_test1 select i%10, 'text' || i%20, i%30 from generate_series(0, 99) i;
@@ -422,4 +429,22 @@ with cte as (
     returning i
 ) select count(*) from cte where i > 2;
 select count(*) c from with_dml;
+
+-- Test one cannot use DML CTE if multiple CTE references found.
+-- Otherwise it will cause duplicated DML operations or planner errors.
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1,5) i
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    update with_dml set j = j + 1
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    delete from with_dml where i > 0
+    returning i
+) select count(*) from cte where i < (select avg(i) from cte);
 drop table with_dml;


### PR DESCRIPTION
Multiple references to modifying CTEs can lead to DML operations being dublicated or cause planner errors. This commit proposes the restriction, in case of non-fulfillment of which the informative error is thrown. The if-clause, which checks whether current cte is referenced more than once and subplan sharing is disabled, is proposed. If it is true, the error is thrown. This solution should be replaced with more complex logic in future, allowing materialize and rescan modifying CTE.

For INSERT query the plan becomes incorrect, CTE is scanned twice: for `InitPlan` node and for main select part  (It is fair for both 7.x and 6.x).
```
create table with_dml (i int, j int) distributed by (i);
explain (costs off)
with cte as (
    insert into with_dml select i, i * 100 from generate_series(1,5) i
    returning i                                                    
) select count(*) from cte where i < (select avg(i) from cte);
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Aggregate
   InitPlan 1 (returns $1)  (slice3)
     ->  Finalize Aggregate
           ->  Gather Motion 3:1  (slice4; segments: 3)
                 ->  Partial Aggregate
                       ->  Insert on with_dml with_dml_1
                             ->  Redistribute Motion 1:3  (slice5; segments: 1)
                                   Hash Key: i_1.i
                                   ->  Function Scan on generate_series i_1
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Subquery Scan on cte
               Filter: ((cte.i)::numeric < $1)
               ->  Insert on with_dml
                     ->  Redistribute Motion 1:3  (slice2; segments: 1)
                           Hash Key: i.i
                           ->  Function Scan on generate_series i
 Optimizer: Postgres query optimizer
(17 rows)

```
As for UPDATE/DELETE we have the following situation.
For gpdb 7 the plan is built and executed, however the inlining of CTEs is taking place:
```
explain (costs off )
with cte as (
update with_dml set j = j + 1
returning i
) select count (*) from cte where i < (select avg(i) from cte);
                           QUERY PLAN                            
-----------------------------------------------------------------
 Finalize Aggregate
   InitPlan 1 (returns $1)  (slice2)
     ->  Finalize Aggregate
           ->  Gather Motion 3:1  (slice3; segments: 3)
                 ->  Partial Aggregate
                       ->  Update on with_dml with_dml_1
                             ->  Seq Scan on with_dml with_dml_1
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Partial Aggregate
               ->  Subquery Scan on cte
                     Filter: ((cte.i)::numeric < $1)
                     ->  Update on with_dml
                           ->  Seq Scan on with_dml
 Optimizer: Postgres query optimizer
(14 rows)
explain (costs off )
with cte as ( delete from with_dml 
returning i
) select count (*) from cte where i < (select avg(i) from cte);
                           QUERY PLAN                            
-----------------------------------------------------------------
 Finalize Aggregate
   InitPlan 1 (returns $1)  (slice2)
     ->  Finalize Aggregate
           ->  Gather Motion 3:1  (slice3; segments: 3)
                 ->  Partial Aggregate
                       ->  Delete on with_dml with_dml_1
                             ->  Seq Scan on with_dml with_dml_1
   ->  Gather Motion 3:1  (slice1; segments: 3)
         ->  Partial Aggregate
               ->  Subquery Scan on cte
                     Filter: ((cte.i)::numeric < $1)
                     ->  Delete on with_dml
                           ->  Seq Scan on with_dml
 Optimizer: Postgres query optimizer
(14 rows)
```
For gpdb 6 the planner fails with an assertion error:
```
explain (costs off )with cte as (
update with_dml set j = j + 1
returning i                                                    
) select count (*) from cte where i < (select avg(i) from cte);
FATAL:  Unexpected internal error (cdbmutate.c:1210)
DETAIL:  FailedAssertion("!(segidColIdx > 0 && segidColIdx <= list_length(lefttree->targetlist))", File: "cdbmutate.c", Line: 1210)
```
The error occurs in the [make_explicit_motion](https://github.com/arenadata/gpdb/blob/6b9f47498afda1b75e307a60a965b40ff594ff57/src/backend/cdb/cdbmutate.c#L1210) function during `apply_motion`, because the SeqScan plan of ModifyTable node has `flow->movement = MOTIONTYPE_EXPLICIT` and `segidColIdx = 0`, the `segId` attribute is not put into the targetList in order to perform correct return of the result. Probably the problem is in the type of Flow for this case. Anyway, the plans for 7.x and 6.x are the same (after changes related to disallowing pushing down quals inside the CTE).
 
Overall, current behaviour is erroneous and it would be better to show an error in order to avoid accidents with double data modification. 
