### PR TITLE
ADBDEV-3890 Show planner error for SELECT INTO and CREATE TABLE AS queries with modifying CTEs 

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -438,6 +438,10 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 			/* If the query comes from 'CREATE TABLE AS' or 'SELECT INTO' */
 			if (query->parentStmtType != PARENTSTMTTYPE_NONE)
 			{
+				if (query->hasModifyingCTE)
+					ereport(ERROR,
+							(errcode(ERRCODE_GP_FEATURE_NOT_YET),
+					errmsg("cannot create plan with several writing gangs")));
 				if (query->intoPolicy != NULL)
 				{
 					targetPolicy = query->intoPolicy;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2338,4 +2338,43 @@ with cte as (
     returning i
 ) select count(*) from cte where i < (select avg(i) from cte);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+-- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
+-- queries contain modifying CTEs, because Greenplum cannot have two writer
+-- segworker groups, and during execution an error is thrown. Showing
+-- the error during planning stage would be more effective, therefore this test
+-- checks this behaviour.
+--start_ignore
+drop table if exists t_new;
+NOTICE:  table "t_new" does not exist, skipping
+--end_ignore
+explain (costs off)
+with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(update with_dml set j = j + 1 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(delete from with_dml where i > 0 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(update with_dml set j = j + 1 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(delete from with_dml where i > 0 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
 drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2341,4 +2341,43 @@ with cte as (
     returning i
 ) select count(*) from cte where i < (select avg(i) from cte);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+-- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
+-- queries contain modifying CTEs, because Greenplum cannot have two writer
+-- segworker groups, and during execution an error is thrown. Showing
+-- the error during planning stage would be more effective, therefore this test
+-- checks this behaviour.
+--start_ignore
+drop table if exists t_new;
+NOTICE:  table "t_new" does not exist, skipping
+--end_ignore
+explain (costs off)
+with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(update with_dml set j = j + 1 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(delete from with_dml where i > 0 returning *)
+select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(update with_dml set j = j + 1 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as (with cte as
+(delete from with_dml where i > 0 returning *)
+select * from cte);
+ERROR:  cannot create plan with several writing gangs
 drop table with_dml;


### PR DESCRIPTION
Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose queries contain modifying CTEs, because Greenplum cannot have two writer segworker groups for one query. In current implementation all the plans with
modifying CTE contain motion nodes, which separate slice with DML operation from the slice, where the new table is created. And during execution stage an error is thrown, telling that node with DML operation cannot be executed, because one writer segworker already exists. However, showing the error during planning stage would be more effective, therefore this commit proposes the display of the error during planning. The if-clause, that checks whether query contains modifying CTEs, was added. Is is used in block dedicated to SELECT INTO or CREATE TABLE AS case inside the `apply_motion` function. If the condition is true, the proper error is shown.

The error has the following message (the same error for CTAS case):
```
 create table with_dml (i int,j int) distributed by (i);
with cte as
(insert into with_dml select i, i * 100 from generate_series(1, 5) i returning *)
select into t_new from cte;
ERROR:  INSERT/UPDATE/DELETE must be executed by a writer segworker group (nodeModifyTable.c:1761)  (seg1 slice2 127.0.0.1:6003 pid=66594) (nodeModifyTable.c:1761)
```
In this patch we expect an error to be shown already at planning stage, not during execution. In other words, EXPLAIN should fail with the error.