### PR TITLE
ADBDEV-3913: Refactoring. Declare methods as static if they work with static member variables only

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformFactory.h
@@ -114,7 +114,7 @@ public:
 	static GPOS_RESULT Init();
 
 	// destroy global factory instance
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CXformFactory
 

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -67,8 +67,7 @@ CColumnFactory::~CColumnFactory()
 	m_sht.Cleanup();
 
 	// destroy mem pool
-	CMemoryPoolManager *pmpm = CMemoryPoolManager::GetMemoryPoolMgr();
-	pmpm->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/init.cpp
+++ b/src/backend/gporca/libgpopt/src/init.cpp
@@ -72,9 +72,9 @@ gpopt_terminate()
 #ifdef GPOS_DEBUG
 	CMDCache::Shutdown();
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CSchedulerContext.cpp
@@ -53,7 +53,7 @@ CSchedulerContext::~CSchedulerContext()
 	// release local memory pool
 	if (FInit())
 	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(PmpLocal());
+		CMemoryPoolManager::Destroy(PmpLocal());
 	}
 }
 
@@ -77,7 +77,7 @@ CSchedulerContext::Init(CMemoryPool *pmpGlobal, CJobFactory *pjf,
 
 	GPOS_ASSERT(!FInit() && "Scheduling context is already initialized");
 
-	m_pmpLocal = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_pmpLocal = CMemoryPoolManager::CreateMemoryPool();
 
 	m_pmpGlobal = pmpGlobal;
 	m_pjf = pjf;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformFactory.cpp
@@ -356,13 +356,12 @@ CXformFactory::IsXformIdUsed(CXform::EXformId exfid)
 GPOS_RESULT
 CXformFactory::Init()
 {
-	GPOS_ASSERT(NULL == Pxff() && "Xform factory was already initialized");
+	GPOS_ASSERT(NULL == m_pxff && "Xform factory was already initialized");
 
 	GPOS_RESULT eres = GPOS_OK;
 
 	// create xform factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 	GPOS_TRY
 	{
 		// create xform factory instance
@@ -371,7 +370,7 @@ CXformFactory::Init()
 	GPOS_CATCH_EX(ex)
 	{
 		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 		m_pxff = NULL;
 
 		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
@@ -405,18 +404,18 @@ CXformFactory::Init()
 void
 CXformFactory::Shutdown()
 {
-	CXformFactory *pxff = CXformFactory::Pxff();
+	CXformFactory *pxff = m_pxff;
 
 	GPOS_ASSERT(NULL != pxff && "Xform factory has not been initialized");
 
 	CMemoryPool *mp = pxff->m_mp;
 
 	// destroy xform factory
-	CXformFactory::m_pxff = NULL;
+	m_pxff = NULL;
 	GPOS_DELETE(pxff);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CFSimulator.h
@@ -177,7 +177,7 @@ public:
 
 #ifdef GPOS_DEBUG
 	// destroy simulator
-	void Shutdown();
+	static void Shutdown();
 #endif	// GPOS_DEBUG
 
 	// accessor for global instance

--- a/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
+++ b/src/backend/gporca/libgpos/include/gpos/error/CMessageRepository.h
@@ -69,7 +69,7 @@ public:
 	// accessor for global singleton
 	static CMessageRepository *GetMessageRepository();
 
-	void Shutdown();
+	static void Shutdown();
 
 };	// class CMessageRepository
 }  // namespace gpos

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCache.h
@@ -365,7 +365,7 @@ private:
 		// destroy the object before deleting memory pool. This cover the case where object & cacheentry use same memory pool
 		CMemoryPool *mp = entry->Pmp();
 		GPOS_DELETE(entry);
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 
 	// evict entries by making one pass through the hash table buckets

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheAccessor.h
@@ -69,7 +69,7 @@ public:
 		// check if a memory pool was created but insertion failed
 		if (NULL != m_mp && !m_inserted)
 		{
-			CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+			CMemoryPoolManager::Destroy(m_mp);
 		}
 
 		// release entry if one was created
@@ -150,7 +150,7 @@ public:
 		GPOS_ASSERT(NULL == m_mp);
 
 		// construct a memory pool for cache entry
-		m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+		m_mp = CMemoryPoolManager::CreateMemoryPool();
 
 		return m_mp;
 	}

--- a/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CCacheFactory.h
@@ -68,7 +68,7 @@ public:
 	static GPOS_RESULT Init();
 
 	// destroy global instance
-	void Shutdown();
+	static void Shutdown();
 
 	// global accessor
 	inline static CCacheFactory *
@@ -84,10 +84,10 @@ public:
 				typename CCache<T, K>::HashFuncPtr hash_func,
 				typename CCache<T, K>::EqualFuncPtr equal_func)
 	{
-		GPOS_ASSERT(NULL != GetFactory() &&
+		GPOS_ASSERT(NULL != m_factory &&
 					"Cache factory has not been initialized");
 
-		CMemoryPool *mp = GetFactory()->Pmp();
+		CMemoryPool *mp = m_factory->Pmp();
 		CCache<T, K> *cache = GPOS_NEW(mp)
 			CCache<T, K>(mp, unique, cache_quota, CCACHE_GCLOCK_INIT_COUNTER,
 						 hash_func, equal_func);

--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPoolManager.h
@@ -69,7 +69,7 @@ private:
 	CMemoryPoolManager(const CMemoryPoolManager &);
 
 	// clean-up memory pools
-	void Cleanup();
+	static void Cleanup();
 
 	// destroy a memory pool at shutdown
 	static void DestroyMemoryPoolAtShutdown(CMemoryPool *mp);
@@ -130,10 +130,10 @@ protected:
 
 public:
 	// create new memory pool
-	CMemoryPool *CreateMemoryPool();
+	static CMemoryPool *CreateMemoryPool();
 
 	// release memory pool
-	void Destroy(CMemoryPool *);
+	static void Destroy(CMemoryPool *);
 
 #ifdef GPOS_DEBUG
 	// print internal contents of allocated memory pools
@@ -144,13 +144,14 @@ public:
 #endif	// GPOS_DEBUG
 
 	// delete memory pools and release manager
-	void Shutdown();
+	static void Shutdown();
 
 	// accessor of memory pool used in global new allocations
-	CMemoryPool *
+	static CMemoryPool *
 	GetGlobalMemoryPool()
 	{
-		return m_global_memory_pool;
+		GPOS_ASSERT(NULL != m_memory_pool_mgr);
+		return m_memory_pool_mgr->m_global_memory_pool;
 	}
 
 	virtual ~CMemoryPoolManager()

--- a/src/backend/gporca/libgpos/src/_api.cpp
+++ b/src/backend/gporca/libgpos/src/_api.cpp
@@ -138,14 +138,14 @@ gpos_init(struct gpos_init_params *params)
 
 	if (GPOS_OK != gpos::CWorkerPoolManager::Init())
 	{
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+		CMemoryPoolManager::Shutdown();
 		return;
 	}
 
 	if (GPOS_OK != gpos::CMessageRepository::Init())
 	{
-		CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+		CWorkerPoolManager::Shutdown();
+		CMemoryPoolManager::Shutdown();
 		return;
 	}
 
@@ -157,9 +157,9 @@ gpos_init(struct gpos_init_params *params)
 #ifdef GPOS_FPSIMULATOR
 	if (GPOS_OK != gpos::CFSimulator::Init())
 	{
-		CMessageRepository::GetMessageRepository()->Shutdown();
-		CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-		CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+		CMessageRepository::Shutdown();
+		CWorkerPoolManager::Shutdown();
+		CMemoryPoolManager::Shutdown();
 	}
 #endif	// GPOS_FPSIMULATOR
 
@@ -287,12 +287,12 @@ gpos_terminate()
 #endif
 #ifdef GPOS_DEBUG
 #ifdef GPOS_FPSIMULATOR
-	CFSimulator::FSim()->Shutdown();
+	CFSimulator::Shutdown();
 #endif	// GPOS_FPSIMULATOR
-	CMessageRepository::GetMessageRepository()->Shutdown();
-	CWorkerPoolManager::WorkerPoolManager()->Shutdown();
-	CCacheFactory::GetFactory()->Shutdown();
-	CMemoryPoolManager::GetMemoryPoolMgr()->Shutdown();
+	CMessageRepository::Shutdown();
+	CWorkerPoolManager::Shutdown();
+	CCacheFactory::Shutdown();
+	CMemoryPoolManager::Shutdown();
 #endif	// GPOS_DEBUG
 }
 

--- a/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
+++ b/src/backend/gporca/libgpos/src/common/CDebugCounter.cpp
@@ -78,7 +78,7 @@ CDebugCounter::Shutdown()
 
 		GPOS_DELETE(m_instance);
 		m_instance = NULL;
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 	}
 }
 

--- a/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
+++ b/src/backend/gporca/libgpos/src/error/CFSimulator.cpp
@@ -158,11 +158,11 @@ CFSimulator::Init()
 void
 CFSimulator::Shutdown()
 {
-	CMemoryPool *mp = m_mp;
-	GPOS_DELETE(CFSimulator::m_fsim);
-	CFSimulator::m_fsim = NULL;
+	CMemoryPool *mp = m_fsim->m_mp;
+	GPOS_DELETE(m_fsim);
+	m_fsim = NULL;
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 #endif	// GPOS_DEBUG
 

--- a/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
+++ b/src/backend/gporca/libgpos/src/error/CMessageRepository.cpp
@@ -115,7 +115,7 @@ CMessageRepository::Init()
 	repository->InitDirectory(mp);
 	repository->LoadStandardMessages();
 
-	CMessageRepository::m_repository = repository;
+	m_repository = repository;
 
 	// detach safety
 	(void) amp.Detach();
@@ -153,8 +153,9 @@ CMessageRepository::GetMessageRepository()
 void
 CMessageRepository::Shutdown()
 {
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
-	CMessageRepository::m_repository = NULL;
+	GPOS_ASSERT(NULL != m_repository);
+	CMemoryPoolManager::Destroy(m_repository->m_mp);
+	m_repository = NULL;
 }
 
 

--- a/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CAutoMemoryPool.cpp
@@ -42,7 +42,7 @@ using namespace gpos;
 CAutoMemoryPool::CAutoMemoryPool(ELeakCheck leak_check_type)
 	: m_leak_check_type(leak_check_type)
 {
-	m_mp = CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	m_mp = CMemoryPoolManager::CreateMemoryPool();
 }
 
 
@@ -105,7 +105,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 		}
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 	}
 	GPOS_CATCH_EX(ex)
 	{
@@ -113,7 +113,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 			GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiAssert));
 
 		// release pool
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+		CMemoryPoolManager::Destroy(m_mp);
 
 		GPOS_RETHROW(ex);
 	}
@@ -122,7 +122,7 @@ CAutoMemoryPool::~CAutoMemoryPool()
 #else  // GPOS_DEBUG
 
 	// hand in pool and return
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 
 #endif	// GPOS_DEBUG
 }

--- a/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CCacheFactory.cpp
@@ -60,25 +60,23 @@ CCacheFactory::Pmp() const
 GPOS_RESULT
 CCacheFactory::Init()
 {
-	GPOS_ASSERT(NULL == GetFactory() &&
-				"Cache factory was already initialized");
+	GPOS_ASSERT(NULL == m_factory && "Cache factory was already initialized");
 
 	GPOS_RESULT res = GPOS_OK;
 
 	// create cache factory memory pool
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 	GPOS_TRY
 	{
 		// create cache factory instance
-		CCacheFactory::m_factory = GPOS_NEW(mp) CCacheFactory(mp);
+		m_factory = GPOS_NEW(mp) CCacheFactory(mp);
 	}
 	GPOS_CATCH_EX(ex)
 	{
 		// destroy memory pool if global instance was not created
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 
-		CCacheFactory::m_factory = NULL;
+		m_factory = NULL;
 
 		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
 		{
@@ -105,17 +103,17 @@ CCacheFactory::Init()
 void
 CCacheFactory::Shutdown()
 {
-	CCacheFactory *factory = CCacheFactory::GetFactory();
+	CCacheFactory *factory = m_factory;
 
 	GPOS_ASSERT(NULL != factory && "Cache factory has not been initialized");
 
 	CMemoryPool *mp = factory->m_mp;
 
 	// destroy cache factory
-	CCacheFactory::m_factory = NULL;
+	m_factory = NULL;
 	GPOS_DELETE(factory);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 // EOF

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolManager.cpp
@@ -69,7 +69,7 @@ CMemoryPoolManager::Setup()
 GPOS_RESULT
 CMemoryPoolManager::Init()
 {
-	if (NULL == CMemoryPoolManager::m_memory_pool_mgr)
+	if (NULL == m_memory_pool_mgr)
 	{
 		return SetupGlobalMemoryPoolManager<CMemoryPoolManager,
 											CMemoryPoolTracker>();
@@ -82,14 +82,15 @@ CMemoryPoolManager::Init()
 CMemoryPool *
 CMemoryPoolManager::CreateMemoryPool()
 {
-	CMemoryPool *mp = NewMemoryPool();
+	GPOS_ASSERT(NULL != m_memory_pool_mgr);
+	CMemoryPool *mp = m_memory_pool_mgr->NewMemoryPool();
 
 	// accessor scope
 	{
 		// HERE BE DRAGONS
 		// See comment in CCache::InsertEntry
 		const ULONG_PTR hashKey = mp->GetHashKey();
-		MemoryPoolKeyAccessor acc(*m_ht_all_pools, hashKey);
+		MemoryPoolKeyAccessor acc(*m_memory_pool_mgr->m_ht_all_pools, hashKey);
 		acc.Insert(mp);
 	}
 
@@ -109,6 +110,7 @@ CMemoryPoolManager::NewMemoryPool()
 void
 CMemoryPoolManager::Destroy(CMemoryPool *mp)
 {
+	GPOS_ASSERT(NULL != m_memory_pool_mgr);
 	GPOS_ASSERT(NULL != mp);
 
 	// accessor scope
@@ -116,7 +118,7 @@ CMemoryPoolManager::Destroy(CMemoryPool *mp)
 		// HERE BE DRAGONS
 		// See comment in CCache::InsertEntry
 		const ULONG_PTR hashKey = mp->GetHashKey();
-		MemoryPoolKeyAccessor acc(*m_ht_all_pools, hashKey);
+		MemoryPoolKeyAccessor acc(*m_memory_pool_mgr->m_ht_all_pools, hashKey);
 		acc.Remove(mp);
 	}
 
@@ -241,22 +243,24 @@ CMemoryPoolManager::DestroyMemoryPoolAtShutdown(CMemoryPool *mp)
 void
 CMemoryPoolManager::Cleanup()
 {
+	GPOS_ASSERT(NULL != m_memory_pool_mgr);
+	GPOS_ASSERT(NULL != m_memory_pool_mgr->m_global_memory_pool);
 #ifdef GPOS_DEBUG
-	if (0 < m_global_memory_pool->TotalAllocatedSize())
+	if (0 < m_memory_pool_mgr->m_global_memory_pool->TotalAllocatedSize())
 	{
 		// allocations made by calling global new operator are not deleted
 		gpos::oswcerr << "Memory leaks detected" << std::endl
-					  << *m_global_memory_pool << std::endl;
+					  << *m_memory_pool_mgr->m_global_memory_pool << std::endl;
 	}
 #endif	// GPOS_DEBUG
 
-	GPOS_ASSERT(NULL != m_global_memory_pool);
-	Destroy(m_global_memory_pool);
+	Destroy(m_memory_pool_mgr->m_global_memory_pool);
 
 	// cleanup left-over memory pools;
 	// any such pool means that we have a leak
-	m_ht_all_pools->DestroyEntries(DestroyMemoryPoolAtShutdown);
-	GPOS_DELETE(m_ht_all_pools);
+	m_memory_pool_mgr->m_ht_all_pools->DestroyEntries(
+		DestroyMemoryPoolAtShutdown);
+	GPOS_DELETE(m_memory_pool_mgr->m_ht_all_pools);
 }
 
 
@@ -264,14 +268,15 @@ CMemoryPoolManager::Cleanup()
 void
 CMemoryPoolManager::Shutdown()
 {
+	GPOS_ASSERT(NULL != m_memory_pool_mgr);
 	// cleanup remaining memory pools
 	Cleanup();
 
 	// save off pointers for explicit deletion
-	CMemoryPool *internal = m_internal_memory_pool;
+	CMemoryPool *internal = m_memory_pool_mgr->m_internal_memory_pool;
 
-	::delete CMemoryPoolManager::m_memory_pool_mgr;
-	CMemoryPoolManager::m_memory_pool_mgr = NULL;
+	::delete m_memory_pool_mgr;
+	m_memory_pool_mgr = NULL;
 
 #ifdef GPOS_DEBUG
 	internal->AssertEmpty(oswcerr);

--- a/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
+++ b/src/backend/gporca/libgpos/src/memory/CMemoryPoolTracker.cpp
@@ -72,8 +72,7 @@ CMemoryPoolTracker::NewImpl(const ULONG bytes, const CHAR *file,
 	GPOS_ASSERT(bytes <= gpos::ulong_max);
 	GPOS_ASSERT_IMP(
 		(NULL != CMemoryPoolManager::GetMemoryPoolMgr()) &&
-			(this ==
-			 CMemoryPoolManager::GetMemoryPoolMgr()->GetGlobalMemoryPool()),
+			(this == CMemoryPoolManager::GetGlobalMemoryPool()),
 		CMemoryPoolManager::GetMemoryPoolMgr()->IsGlobalNewAllowed() &&
 			"Use of new operator without target memory pool is prohibited, use New(...) instead");
 

--- a/src/backend/gporca/libgpos/src/task/CTask.cpp
+++ b/src/backend/gporca/libgpos/src/task/CTask.cpp
@@ -75,7 +75,7 @@ CTask::~CTask()
 	GPOS_DELETE(m_task_ctxt);
 	GPOS_DELETE(m_err_ctxt);
 
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 

--- a/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
+++ b/src/backend/gporca/libgpos/src/task/CWorkerPoolManager.cpp
@@ -62,23 +62,21 @@ CWorkerPoolManager::CWorkerPoolManager(CMemoryPool *mp)
 GPOS_RESULT
 CWorkerPoolManager::Init()
 {
-	GPOS_ASSERT(NULL == WorkerPoolManager());
+	GPOS_ASSERT(NULL == m_worker_pool_manager);
 
-	CMemoryPool *mp =
-		CMemoryPoolManager::GetMemoryPoolMgr()->CreateMemoryPool();
+	CMemoryPool *mp = CMemoryPoolManager::CreateMemoryPool();
 
 	GPOS_TRY
 	{
 		// create worker pool
-		CWorkerPoolManager::m_worker_pool_manager =
-			GPOS_NEW(mp) CWorkerPoolManager(mp);
+		m_worker_pool_manager = GPOS_NEW(mp) CWorkerPoolManager(mp);
 	}
 	GPOS_CATCH_EX(ex)
 	{
 		// turn in memory pool in case of failure
-		CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+		CMemoryPoolManager::Destroy(mp);
 
-		CWorkerPoolManager::m_worker_pool_manager = NULL;
+		m_worker_pool_manager = NULL;
 
 		if (GPOS_MATCH_EX(ex, CException::ExmaSystem, CException::ExmiOOM))
 		{
@@ -104,8 +102,7 @@ CWorkerPoolManager::Init()
 void
 CWorkerPoolManager::Shutdown()
 {
-	CWorkerPoolManager *worker_pool_manager =
-		CWorkerPoolManager::m_worker_pool_manager;
+	CWorkerPoolManager *worker_pool_manager = m_worker_pool_manager;
 
 	GPOS_ASSERT(NULL != worker_pool_manager &&
 				"Worker pool has not been initialized");
@@ -119,11 +116,11 @@ CWorkerPoolManager::Shutdown()
 	CMemoryPool *mp = worker_pool_manager->m_mp;
 
 	// destroy worker pool
-	CWorkerPoolManager::m_worker_pool_manager = NULL;
+	m_worker_pool_manager = NULL;
 	GPOS_DELETE(worker_pool_manager);
 
 	// release allocated memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(mp);
+	CMemoryPoolManager::Destroy(mp);
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/init.cpp
+++ b/src/backend/gporca/libnaucrates/src/init.cpp
@@ -158,13 +158,13 @@ gpdxl_terminate()
 
 	if (NULL != pmpDXL)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpDXL);
+		CMemoryPoolManager::Destroy(pmpDXL);
 		pmpDXL = NULL;
 	}
 
 	if (NULL != pmpXerces)
 	{
-		(CMemoryPoolManager::GetMemoryPoolMgr())->Destroy(pmpXerces);
+		CMemoryPoolManager::Destroy(pmpXerces);
 		pmpXerces = NULL;
 	}
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/server/src/startup/main.cpp
+++ b/src/backend/gporca/server/src/startup/main.cpp
@@ -243,7 +243,7 @@ ConfigureTests()
 
 #ifdef GPOS_DEBUG
 	// reset xforms factory to exercise xforms ctors and dtors
-	CXformFactory::Pxff()->Shutdown();
+	CXformFactory::Shutdown();
 	GPOS_RESULT eres = CXformFactory::Init();
 
 	GPOS_ASSERT(GPOS_OK == eres);

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -163,7 +163,7 @@ CTestUtils::DestroyMDProvider()
 	CRefCount::SafeRelease(m_pmdpf);
 
 	// release local memory pool
-	CMemoryPoolManager::GetMemoryPoolMgr()->Destroy(m_mp);
+	CMemoryPoolManager::Destroy(m_mp);
 }
 
 


### PR DESCRIPTION
Refactoring. Declare methods as static if they work with static member variables only

- I made the CCacheFactory::Shutdown method static because it only uses static variables.
- I made the CFSimulator::Shutdown method static, which was previously called only on the static object m_fsim.
- I made the CMemoryPoolManager::Cleanup method static, which was previously called only on the static object m_memory_pool_mgr.
- I made the CMemoryPoolManager::CreateMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.
- I made the CMemoryPoolManager::Destroy method static, which was previously called only on the static object m_memory_pool_mgr.
- I made the CMemoryPoolManager::GetGlobalMemoryPool method static, which was previously called only on the static object m_memory_pool_mgr.
- I made the CMemoryPoolManager::Shutdown method static, which was previously called only on the static object m_memory_pool_mgr.
- I made the CMessageRepository::Shutdown method static, which was previously called on the static object m_repository.
- I made the CWorkerPoolManager::Shutdown method static because it uses only static variables.
- I made the CXformFactory::Shutdown method static because it uses only static variables.

I added assertions to make sure the pointers being dereferenced are not null.