### PR TITLE
Add filter to prohibit using encoding for columns at foreign tables

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -4493,7 +4493,7 @@ transformAttributeEncoding(List *stenc, CreateStmt *stmt, CreateStmtContext *cxt
 {
 	ListCell *lc;
 	bool found_enc = stenc != NIL;
-	bool can_enc = is_aocs(stmt->options);
+	bool can_enc = is_aocs(stmt->options) && !cxt->isforeign;
 	ColumnReferenceStorageDirective *deflt = NULL;
 	List *newenc = NIL;
 	List *tmpenc;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13709,7 +13709,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 						 * Dump the encoding clause also to maintain a consistent
 						 * catalog entry in pg_attribute_encoding post upgrade.
 						 */
-						if (tbinfo->attencoding[j] != NULL)
+						if (tbinfo->relkind != RELKIND_FOREIGN_TABLE &&
+							tbinfo->attencoding[j] != NULL)
 							appendPQExpBuffer(q, " ENCODING (%s)", tbinfo->attencoding[j]);
 
 						/* Skip all the rest */
@@ -13746,7 +13747,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 						appendPQExpBufferStr(q, " NOT NULL");
 
 					/* Column Storage attributes */
-					if (tbinfo->attencoding[j] != NULL)
+					if (tbinfo->relkind != RELKIND_FOREIGN_TABLE &&
+						tbinfo->attencoding[j] != NULL)
 						appendPQExpBuffer(q, " ENCODING (%s)",
 										  tbinfo->attencoding[j]);
 				}

--- a/src/test/regress/expected/foreign_data.out
+++ b/src/test/regress/expected/foreign_data.out
@@ -1268,7 +1268,123 @@ ERROR:  cannot drop desired object(s) because other objects depend on them
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP OWNED BY regress_test_role2 CASCADE;
 NOTICE:  drop cascades to user mapping for regress_test_role on server s5
+------------------------------------------------------------------------------
+-- Test to check column encoding at foreign tables.
+-- Not use column encoding at foreign tables.
+------------------------------------------------------------------------------
+CREATE DATABASE foreign_tables_test_db;
+\c foreign_tables_test_db
+CREATE FOREIGN DATA WRAPPER dummy;
+CREATE SERVER test FOREIGN DATA WRAPPER dummy;
+-- Do not create foreign tables with encoding clause
+-- Expect: failure
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+ERROR:  ENCODING clause only supported with column oriented tables
+SET gp_default_storage_options = 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=3,checksum=true,orientation=column';
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+ERROR:  ENCODING clause only supported with column oriented tables
+-- Check that created foreign table does not apply gp_default_storage_options
+-- Expect: success
+CREATE FOREIGN TABLE foreign_table (
+    a integer
+) SERVER test;
+ALTER FOREIGN TABLE public.foreign_table OWNER to foreign_data_user;
+\d+ foreign_table
+                       Foreign table "public.foreign_table"
+ Column |  Type   | Modifiers | FDW Options | Storage | Stats target | Description 
+--------+---------+-----------+-------------+---------+--------------+-------------
+ a      | integer |           |             | plain   |              | 
+Server: test
+
+-- Check that pg_dump generates valid table definition
+-- Expect: success
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+--
+-- Greenplum Database database dump
+--
+
+SET gp_default_storage_options = '';
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: foreign_table; Type: FOREIGN TABLE; Schema: public; Owner: foreign_data_user; Tablespace: 
+--
+
+CREATE FOREIGN TABLE public.foreign_table (
+    a integer
+)
+SERVER test
+;
+
+
+ALTER FOREIGN TABLE public.foreign_table OWNER TO foreign_data_user;
+
+--
+-- Greenplum Database database dump complete
+--
+
+-- End of pg_dump output
+-- Check that pg_dump generates valid table definition after resetting gp_default_storage_options
+-- Expect: success
+RESET gp_default_storage_options;
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+--
+-- Greenplum Database database dump
+--
+
+SET gp_default_storage_options = '';
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: foreign_table; Type: FOREIGN TABLE; Schema: public; Owner: foreign_data_user; Tablespace: 
+--
+
+CREATE FOREIGN TABLE public.foreign_table (
+    a integer
+)
+SERVER test
+;
+
+
+ALTER FOREIGN TABLE public.foreign_table OWNER TO foreign_data_user;
+
+--
+-- Greenplum Database database dump complete
+--
+
+-- End of pg_dump output
 -- Cleanup
+DROP FOREIGN TABLE foreign_table;
+DROP SERVER test;
+DROP FOREIGN DATA WRAPPER dummy;
+\c regression
+DROP DATABASE foreign_tables_test_db;
 DROP SCHEMA foreign_schema CASCADE;
 DROP ROLE regress_test_role;                                -- ERROR
 ERROR:  role "regress_test_role" cannot be dropped because some objects depend on it


### PR DESCRIPTION
If set `ENCODING` to `gp_default_storage_options`, this metadata will be
added to foreign tables. Column `ENCODING` is useless for foreign tables,
but it will be printed from metadata if `pg_dump` is executed.

This patch fixes:
1) Commands parser to exclude saving `ENCODING` if table is foreign.
2) `pg_dump`: not to print `ENCODING` for foreign tables even if there is
`ENCODING` at table's metadata.

## Steps to reproduce:

1. change GUC value
   ```
   gpconfig -c 'gp_default_storage_options' -v 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=3,checksum=true,orientation=column'
   gpstop -u
   ```
2. create foreign table in the `test` database 
   ```
   CREATE FOREIGN DATA WRAPPER dummy;
   create server test foreign data wrapper dummy;
   create foreign table test (a int) server test;
   ```
3. change GUC values back
   ```
   gpconfig -r 'gp_default_storage_options'
   gpstop -u
   ```
4. create dump with table
   ```
   pg_dump -t public.test test
   ```
## Actual behavior

Output contains invalid foreign definition. This definition can't be used to recreate this table.
```sql
...
CREATE FOREIGN TABLE public.test (
    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
)
SERVER test
;
...
```
## Result after fixes
```sql
...
CREATE FOREIGN TABLE public.test (
    a integer
)
SERVER test
;
...
```

### Another way to get the problem
1) Create demo cluster
2) Set `gp_default_storage_options`
```
gpconfig -c 'gp_default_storage_options' -v 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=3,checksum=true,orientation=column'
gpstop -u
```
3) Add foreign table to `regression`
```
createdb regression
psql regression <<EOF
    CREATE FOREIGN DATA WRAPPER dummy;
    CREATE SERVER test FOREIGN DATA WRAPPER dummy;
    CREATE FOREIGN TABLE foreign_table (
        a integer,
        b integer,
        c integer
    ) SERVER test;
    ALTER FOREIGN TABLE foreign_table drop column b;
EOF
```
4) Run tests for `pg_upgrade`:
```
createdb isolation2test
make -C contrib/pg_upgrade installcheck
```
5) Result:
Test fails with error:
```
Restoring database schemas in the new cluster
  regression                                                
*failure*

Consult the last few lines of "pg_upgrade_dump_16384.log" for
the probable cause of the failure.
Failure, exiting

real    0m3.982s
user    0m0.091s
sys     0m0.317s
ERROR: Failure encountered in upgrading qd node
~/gpdb/adb-6.x-gpdb/contrib/pg_upgrade ~/gpdb/adb-6.x-gpdb/contrib/pg_upgrade/tmp_check/upgrade/qd ~/gpdb/adb-6.x-gpdb/contrib/pg_upgrade
make: *** [Makefile:49: installcheck] Error 1
make: Leaving directory '/home/evgeniy/gpdb/adb-6.x-gpdb/contrib/pg_upgrade'
```
Incorrect command, which generated by `pg_dump`:
```
CREATE FOREIGN TABLE ""public"".""foreign_table"" (
    ""a"" integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    ""........pg.dropped.2........"" INTEGER /* dummy */ ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3),
    ""c"" integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
)
SERVER ""test""
;
ALTER FOREIGN TABLE ""public"".""foreign_table"" DROP COLUMN ""........pg.dropped.2........"";
```
Error log:
```
ENCODING clause only supported with column oriented tables
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
