### PR TITLE
Fix incorrect plan when using CTE with gp_cte_sharing enabled

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -908,6 +908,14 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 											 list_make1_int(root->is_split_update),
 											 rowMarks,
 											 SS_assign_special_param(root));
+			/*
+			 * Set up the visible plan targetlist as being the same as
+			 * the RETURNING list. This is for the use of
+			 * EXPLAIN; the executor won't pay any attention to the
+			 * targetlist. Also the targetlist might be needed by higher-level nodes,
+			 * such as Material, for correct operation.
+			 */
+			plan->targetlist = copyObject(parse->returningList);
 		}
 	}
 
@@ -1595,7 +1603,7 @@ inheritance_planner(PlannerInfo *root)
 		rowMarks = root->rowMarks;
 
 	/* And last, tack on a ModifyTable node to do the UPDATE/DELETE work */
-	return (Plan *) make_modifytable(root,
+	Plan* plan = (Plan *) make_modifytable(root,
 									 parse->commandType,
 									 parse->canSetTag,
 									 resultRelations,
@@ -1605,6 +1613,15 @@ inheritance_planner(PlannerInfo *root)
 									 is_split_updates,
 									 rowMarks,
 									 SS_assign_special_param(root));
+	/*
+	 * Set up the visible plan targetlist as being the same as
+	 * the RETURNING list. This is for the use of
+	 * EXPLAIN; the executor won't pay any attention to the
+	 * targetlist. Also the targetlist might be needed by higher-level nodes,
+	 * such as Material, for correct operation.
+	 */
+	plan->targetlist = copyObject(parse->returningList);
+	return plan;
 }
 
 #ifdef USE_ASSERT_CHECKING

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -1044,7 +1044,6 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 			{
 				ModifyTable *splan = (ModifyTable *) plan;
 
-				Assert(splan->plan.targetlist == NIL);
 				Assert(splan->plan.qual == NIL);
 
 				splan->withCheckOptionLists =
@@ -1079,16 +1078,6 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 						newRL = lappend(newRL, rlist);
 					}
 					splan->returningLists = newRL;
-
-					/*
-					 * Set up the visible plan targetlist as being the same as
-					 * the first RETURNING list. This is for the use of
-					 * EXPLAIN; the executor won't pay any attention to the
-					 * targetlist.  We postpone this step until here so that
-					 * we don't have to do set_returning_clause_references()
-					 * twice on identical targetlists.
-					 */
-					splan->plan.targetlist = copyObject(linitial(newRL));
 				}
 
 				foreach(l, splan->resultRelations)

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -529,3 +529,34 @@ EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
 FROM gp_dist_random('gp_id');
 ERROR:  division by zero  (seg0 slice1 172.17.0.2:6002 pid=13088)
 DROP TABLE t1;
+-- checking that the planner can build a plan with non-select CTE sharing.
+set gp_cte_sharing to on;
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+create table t1 (
+    c1 int,
+    c2 int)
+distributed randomly;
+explain (costs off) with cte1 as (insert into t1 values (1,2) returning *) select * from cte1 a join cte1 b using(c1);
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (share0_ref2.c1 = b.c1)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: share0_ref2.c1
+               ->  Shared Scan (share slice:id 1:0)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: b.c1
+                     ->  Subquery Scan on b
+                           ->  Shared Scan (share slice:id 3:0)
+                                 ->  Materialize
+                                       ->  Insert on t1
+                                             ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                                                   ->  Result
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+reset gp_cte_sharing;
+drop table t1;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -560,3 +560,32 @@ EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
 FROM gp_dist_random('gp_id');
 ERROR:  division by zero  (seg0 slice1 172.17.0.2:6002 pid=13088)
 DROP TABLE t1;
+-- checking that the planner can build a plan with non-select CTE sharing.
+set gp_cte_sharing to on;
+drop table if exists t1;
+create table t1 (
+    c1 int,
+    c2 int)
+distributed randomly;
+explain (costs off) with cte1 as (insert into t1 values (1,2) returning *) select * from cte1 a join cte1 b using(c1);
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: (share0_ref2.c1 = b.c1)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Hash Key: share0_ref2.c1
+               ->  Shared Scan (share slice:id 1:0)
+         ->  Hash
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Hash Key: b.c1
+                     ->  Subquery Scan on b
+                           ->  Shared Scan (share slice:id 3:0)
+                                 ->  Materialize
+                                       ->  Insert on t1
+                                             ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                                                   ->  Result
+GP_IGNORE:(16 rows)
+
+reset gp_cte_sharing;
+drop table t1;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -329,3 +329,14 @@ CREATE TABLE t1 (a int);
 EXPLAIN ANALYZE INSERT INTO t1 SELECT 1/gp_segment_id
 FROM gp_dist_random('gp_id');
 DROP TABLE t1;
+
+-- checking that the planner can build a plan with non-select CTE sharing.
+set gp_cte_sharing to on;
+drop table if exists t1;
+create table t1 (
+    c1 int,
+    c2 int)
+distributed randomly;
+explain (costs off) with cte1 as (insert into t1 values (1,2) returning *) select * from cte1 a join cte1 b using(c1);
+reset gp_cte_sharing;
+drop table t1;


### PR DESCRIPTION
The problem is that when creating a T_ModifyTable node, the targetlist is not specified for it, and therefore the targetlist is empty in the parent nodes T_Material and T_ShareInputScan, which leads to an error.

Fixed by specifying targetlist after creating T_ModifyTable node in subquery_planner function. targetlist is retrieved from the returningList of the Query structure. Also removing the Assert that the targetlist is empty and filling targetlist it in the set_plan_references function since it is now specified at an earlier stage.
