### PR TITLE
ADBDEV-3914 Fix CTAS queries logging

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -34,6 +34,7 @@
 #include "commands/prepare.h"
 #include "commands/tablecmds.h"
 #include "commands/view.h"
+#include "commands/queue.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
@@ -59,6 +60,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/memquota.h"
 #include "utils/metrics_utils.h"
+#include "utils/resscheduler.h"
 
 typedef struct
 {
@@ -417,6 +419,18 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 	queryDesc = CreateQueryDesc(plan, queryString,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, params, 0);
+
+	if (gp_enable_gpperfmon 
+			&& Gp_role == GP_ROLE_DISPATCH 
+			&& log_min_messages < DEBUG4)
+	{		
+		gpmon_qlog_query_submit(queryDesc->gpmon_pkt);
+		gpmon_qlog_query_text(queryDesc->gpmon_pkt,
+				queryString,
+				application_name,
+				GetResqueueName(GetResQueueId()),
+				GetResqueuePriority(GetResQueueId()));
+	}
 
 	/* GPDB hook for collecting query info */
 	if (query_info_collect_hook)

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -744,6 +744,19 @@ execute_sql_string(const char *sql, const char *filename)
 										GetActiveSnapshot(), NULL,
 										dest, NULL, GP_INSTRUMENT_OPTS);
 
+				if (gp_enable_gpperfmon
+					&& Gp_role == GP_ROLE_DISPATCH
+					&& log_min_messages < DEBUG4)
+				{
+					Assert(qdesc->sourceText);
+					gpmon_qlog_query_submit(qdesc->gpmon_pkt);
+					gpmon_qlog_query_text(qdesc->gpmon_pkt,
+							qdesc->sourceText,
+							application_name,
+							NULL,
+							NULL);
+				}
+
 				ExecutorStart(qdesc, 0);
 				ExecutorRun(qdesc, ForwardScanDirection, 0);
 				ExecutorFinish(qdesc);

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -440,6 +440,17 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 								GetActiveSnapshot(), InvalidSnapshot,
 								dest, NULL, 0);
 
+	if (gp_enable_gpperfmon && Gp_role == GP_ROLE_DISPATCH)
+	{
+		Assert(queryString);
+		gpmon_qlog_query_submit(queryDesc->gpmon_pkt);
+		gpmon_qlog_query_text(queryDesc->gpmon_pkt,
+				queryString,
+				application_name,
+				NULL,
+				NULL);
+	}
+
 	RestoreOidAssignments(saved_dispatch_oids);
 
 	/* call ExecutorStart to prepare the plan for execution */

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -1278,8 +1278,6 @@ PG_TRY();
 		gp_enable_gpperfmon = false;
 	}
 
-	gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-
 	/*
 	 * Execute each command in the function one after another until we either
 	 * run out of commands or get a result row from a lazily-evaluated SELECT.


### PR DESCRIPTION
gpdb doesn't initialize gpmon packet for queries considered as complex in `PortalStart` like it does for some other query types, each subquery is in charge of creating its own. CTAS queries are considered as complex, but gpmon packet initialization for them is not made, so this patch fixes this