### PR TITLE
ADBDEV-3852-3 Fix ORCA invalid processing of nested SubLinks under the aggregates.

### DIFF
--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -373,8 +373,6 @@ LINE 4:                where sum(distinct a.four + b.four) = b.four)...
 select
   (select max((select i.unique2 from tenk1 i where i.unique1 = o.unique1)))
 from tenk1 o;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Query-to-DXL Translation: No variable entry found due to incorrect normalization of query
  max  
 ------
  9999

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1037,4 +1037,34 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under the aggregation. For ORCA the fallback
+-- shouldn't occur.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   Output: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (max((SubPlan 1)))
+         ->  Aggregate
+               Output: max((SubPlan 1))
+               ->  Seq Scan on public.t
+                     Output: t.i
+               SubPlan 1  (slice1; segments: 1)
+                 ->  Result
+                       Output: t.i
+   SubPlan 2  (slice0)
+     ->  Result
+           Output: max((max((SubPlan 1))))
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1101,4 +1101,40 @@ group by j, q1;
  2 | 1 |  2
 (1 row)
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under the aggregation. For ORCA the fallback
+-- shouldn't occur.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Result
+   Output: (SubPlan 2)
+   ->  Aggregate
+         Output: max((max((SubPlan 1))))
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: (max((SubPlan 1)))
+               ->  Aggregate
+                     Output: max((SubPlan 1))
+                     ->  Seq Scan on public.t
+                           Output: i
+                     SubPlan 1  (slice1; segments: 3)
+                       ->  Result
+                             Output: t.i
+                             ->  Result
+                                   Output: true
+   SubPlan 2  (slice0)
+     ->  Result
+           Output: (max((max((SubPlan 1)))))
+           ->  Result
+                 Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
+
+select (select max((select t.i))) from t;
+ max 
+-----
+   1
+(1 row)
+
 drop table t;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -553,4 +553,12 @@ select j, 1 as c,
 from t
 group by j, q1;
 
+-- Ensure that both planners produce valid plans for the query with the nested
+-- SubLink, and this SubLink is under the aggregation. For ORCA the fallback
+-- shouldn't occur.
+explain (verbose, costs off)
+select (select max((select t.i))) from t;
+
+select (select max((select t.i))) from t;
+
 drop table t;


### PR DESCRIPTION
The ORCA optimizer could produce an invalid query plan and fallback to the
legacy optimizer due to incorrect processing of nested SubLinks (SubLink
contains one more SubLink or rtable subquery inside) during query normalization.

The issue could arise when query had a AggRef inside a Sublink and that
AggRef contained one more SubLink inside (see the example of the
query in the tests section).

While mutating the SubLink inside RunExtractAggregatesMutator, the Aggref branch
is executed for SubLink's query targetList, which mutates args of the AggRef.
And if inside this AggRef arg some Var had varlevelsup value greater than the
m_agg_levels_up, i.e the Var referenced a relation that is higher than the
AggRef, the Var was not mutated at all. The varlevelsup field was not modified
and because of that, when AggRef was pulled up to the zero query level (by
appending it to the context.m_lower_table_tlist), the Var, whose varlevelsup
was higher than AggRef's, and which remained unchanged, started referencing
the wrong relation. This could lead to the fallback or invalid plan construction
when processing attributes at further planning stages.

This patch makes the RunExtractAggregatesMutator modify the varlevelsup of the
Var relatively the AggRef level in order to preserve proper query level.