### PR TITLE
ADBDEV-4059-2 Avoid rescan of modifying operations inside the correlated SubPlans.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -662,15 +662,14 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 	if (IsA(node, ModifyTable))
 	{
 		Plan   *mplan = (Plan *) node;
+
 		if (ctx->movement == MOVEMENT_BROADCAST)
 			broadcastPlan(mplan, false /* stable */ , false /* rescannable */,
 					ctx->currentPlanFlow->numsegments);
 		else
 			focusPlan(mplan, false /* stable */ , false /* rescannable */);
 
-		Plan   *mat = materialize_subplan((PlannerInfo *) ctx->base.node, mplan);
-
-		return (Node *) mat;
+		return (Node *) materialize_subplan((PlannerInfo *) ctx->base.node, mplan);
 	}
 
 	Node	   *result = plan_tree_mutator(node, ParallelizeCorrelatedSubPlanMutator, ctx);

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -661,13 +661,13 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 
 	if (IsA(node, ModifyTable))
 	{
-		Plan   *mplan = (Plan *) node;
+		Plan	   *mplan = (Plan *) node;
 
 		if (ctx->movement == MOVEMENT_BROADCAST)
-			broadcastPlan(mplan, false /* stable */ , false /* rescannable */,
-					ctx->currentPlanFlow->numsegments);
+			broadcastPlan(mplan, false /* stable */ , false /* rescannable */ ,
+						  ctx->currentPlanFlow->numsegments);
 		else
-			focusPlan(mplan, false /* stable */ , false /* rescannable */);
+			focusPlan(mplan, false /* stable */ , false /* rescannable */ );
 
 		return (Node *) materialize_subplan((PlannerInfo *) ctx->base.node, mplan);
 	}

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3176,7 +3176,7 @@ drop table t2;
 drop table t1;
 -- Test correlated SubPlans containing writable operation are
 -- planned and executed correctly. The result of modifying operations
--- should be broadcasted and materialized.
+-- should be broadcasted (or focused) and materialized.
 -- start_ignore
 drop table if exists t1;
 NOTICE:  table "t1" does not exist, skipping

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3191,7 +3191,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3218,7 +3218,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
  i 
@@ -3327,7 +3327,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3353,7 +3353,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
  i 

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3174,3 +3174,283 @@ select count(*) from t1;
 
 drop table t2;
 drop table t1;
+-- Test correlated SubPlans containing writable operation are
+-- planned and executed correctly. The result of modifying operations
+-- should be broadcasted and materialized.
+-- start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+--end_ignore
+create table t1(i int) distributed by (i);
+create table t2(i int) distributed by (i);
+insert into t2 values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: t2.i
+   ->  Sort
+         Sort Key: t2.i
+         ->  Seq Scan on t2
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t2.i = cte.i)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+--start_ignore
+drop table if exists t_repl;
+NOTICE:  table "t_repl" does not exist, skipping
+--end_ignore
+create table t_repl (i int) distributed replicated;
+insert into t_repl values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Sort
+         Sort Key: t_repl.i
+         ->  Seq Scan on t_repl
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t_repl.i = cte.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+drop table t_repl;
+drop table t2;
+drop table t1;

--- a/src/test/regress/expected/subselect_gp_1.out
+++ b/src/test/regress/expected/subselect_gp_1.out
@@ -3176,7 +3176,7 @@ drop table t2;
 drop table t1;
 -- Test correlated SubPlans containing writable operation are
 -- planned and executed correctly. The result of modifying operations
--- should be broadcasted and materialized.
+-- should be broadcasted (or focused) and materialized.
 -- start_ignore
 drop table if exists t1;
 NOTICE:  table "t1" does not exist, skipping

--- a/src/test/regress/expected/subselect_gp_1.out
+++ b/src/test/regress/expected/subselect_gp_1.out
@@ -3191,7 +3191,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3218,7 +3218,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
  i 
@@ -3327,7 +3327,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3353,7 +3353,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
  i 

--- a/src/test/regress/expected/subselect_gp_1.out
+++ b/src/test/regress/expected/subselect_gp_1.out
@@ -3174,3 +3174,283 @@ select count(*) from t1;
 
 drop table t2;
 drop table t1;
+-- Test correlated SubPlans containing writable operation are
+-- planned and executed correctly. The result of modifying operations
+-- should be broadcasted and materialized.
+-- start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+--end_ignore
+create table t1(i int) distributed by (i);
+create table t2(i int) distributed by (i);
+insert into t2 values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: t2.i
+   ->  Sort
+         Sort Key: t2.i
+         ->  Seq Scan on t2
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t2.i = cte.i)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+--start_ignore
+drop table if exists t_repl;
+NOTICE:  table "t_repl" does not exist, skipping
+--end_ignore
+create table t_repl (i int) distributed replicated;
+insert into t_repl values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Sort
+         Sort Key: t_repl.i
+         ->  Seq Scan on t_repl
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t_repl.i = cte.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+drop table t_repl;
+drop table t2;
+drop table t1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3317,7 +3317,7 @@ drop table t2;
 drop table t1;
 -- Test correlated SubPlans containing writable operation are
 -- planned and executed correctly. The result of modifying operations
--- should be broadcasted and materialized.
+-- should be broadcasted (or focused) and materialized.
 -- start_ignore
 drop table if exists t1;
 NOTICE:  table "t1" does not exist, skipping

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3332,7 +3332,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3359,7 +3359,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
  i 
@@ -3468,7 +3468,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
                                          QUERY PLAN                                         
@@ -3494,7 +3494,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
  i 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3315,3 +3315,283 @@ select count(*) from t1;
 
 drop table t2;
 drop table t1;
+-- Test correlated SubPlans containing writable operation are
+-- planned and executed correctly. The result of modifying operations
+-- should be broadcasted and materialized.
+-- start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+--end_ignore
+create table t1(i int) distributed by (i);
+create table t2(i int) distributed by (i);
+insert into t2 values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: t2.i
+   ->  Sort
+         Sort Key: t2.i
+         ->  Seq Scan on t2
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t2.i = cte.i)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on t2
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t2.i = cte.i)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+--start_ignore
+drop table if exists t_repl;
+NOTICE:  table "t_repl" does not exist, skipping
+--end_ignore
+create table t_repl (i int) distributed replicated;
+insert into t_repl values (1), (2);
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Sort
+         Sort Key: t_repl.i
+         ->  Seq Scan on t_repl
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice3; segments: 3)
+                 ->  Subquery Scan on cte
+                       Filter: (t_repl.i = cte.i)
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Insert on t1
+                                         ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                               Hash Key: i.i
+                                               ->  Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice3; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice3; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Update on t1
+                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                         Hash Key: "outer".i
+                                         ->  Split
+                                               ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from t1 where i = 1;
+ count 
+-------
+     5
+(1 row)
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 1:1  (slice2; segments: 1)
+   ->  Seq Scan on t_repl
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte
+                 Filter: (t_repl.i = cte.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                             ->  Delete on t1
+                                   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+ i 
+---
+ 1
+(1 row)
+
+select count(*) from t1;
+ count 
+-------
+     0
+(1 row)
+
+drop table t_repl;
+drop table t2;
+drop table t1;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1265,7 +1265,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
 
@@ -1273,7 +1273,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t2
+select * from t2
 where t2.i in (select i from cte where t2.i = cte.i)
 order by i;
 
@@ -1321,7 +1321,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
 
@@ -1329,7 +1329,7 @@ with cte as
 (insert into t1
  select i from generate_series(1, 5) i
  returning *)
- select * from t_repl
+select * from t_repl
 where t_repl.i in (select i from cte where t_repl.i = cte.i)
 order by i;
 

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1251,7 +1251,7 @@ drop table t1;
 
 -- Test correlated SubPlans containing writable operation are
 -- planned and executed correctly. The result of modifying operations
--- should be broadcasted and materialized.
+-- should be broadcasted (or focused) and materialized.
 -- start_ignore
 drop table if exists t1;
 drop table if exists t2;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1248,3 +1248,124 @@ select count(*) from t1;
 
 drop table t2;
 drop table t1;
+
+-- Test correlated SubPlans containing writable operation are
+-- planned and executed correctly. The result of modifying operations
+-- should be broadcasted and materialized.
+-- start_ignore
+drop table if exists t1;
+drop table if exists t2;
+--end_ignore
+create table t1(i int) distributed by (i);
+create table t2(i int) distributed by (i);
+insert into t2 values (1), (2);
+
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t2
+where t2.i in (select i from cte where t2.i = cte.i)
+order by i;
+
+select count(*) from t1;
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+
+select count(*) from t1;
+select count(*) from t1 where i = 1;
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+
+with cte as
+(delete from t1
+ returning *)
+select * from t2
+where t2.i in (select i from cte where t2.i = cte.i);
+
+select count(*) from t1;
+
+--start_ignore
+drop table if exists t_repl;
+--end_ignore
+create table t_repl (i int) distributed replicated;
+insert into t_repl values (1), (2);
+
+explain (costs off)
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+
+with cte as
+(insert into t1
+ select i from generate_series(1, 5) i
+ returning *)
+ select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i)
+order by i;
+
+select count(*) from t1;
+
+explain (costs off)
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+
+with cte as
+(update t1 set i = 1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+
+select count(*) from t1;
+select count(*) from t1 where i = 1;
+
+explain (costs off)
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+
+with cte as
+(delete from t1
+ returning *)
+select * from t_repl
+where t_repl.i in (select i from cte where t_repl.i = cte.i);
+
+select count(*) from t1;
+
+drop table t_repl;
+drop table t2;
+drop table t1;


### PR DESCRIPTION
When a query had a modifying command inside the correlated SubPlan, the
ModifyTable node could be rescanned for each outer tuple. That led to
execution errors (rescan of specific nodes is not supported). This happened
because the ParallelizeCorrelatedSubplanMutator function did not expect the
ModifyTable node inside the correlated SubPlans.

This patch adds the handling of ModifyTable node for correlated SubPlans. The
ParallelizeCorrelatedSubplanMutator function is extended with the ModifyTable
code branch, that simply broadcasts or focuses the result of ModifyTable,
depending on the target flow type. Then the result is materialized in order
to avoid rescan of underlying nodes.