### PR TITLE
unify handling of outer parameters for joins

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1190,6 +1190,10 @@ ExecReScanHashJoin(HashJoinState *node)
 	 * if it's a single-batch join, and there is no parameter change for the
 	 * inner subnode, then we can just re-use the existing hash table without
 	 * rebuilding it.
+	 *
+	 * GPDB: hybrid hash join was modified to spill out scanned batches
+	 * (including 0th batch) to disk to provide rescannability if it was
+	 * requested. See the SpillCurrentBatch comment for details.
 	 */
 	if (node->hj_HashTable != NULL)
 	{

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3650,12 +3650,12 @@ create_hashjoin_path(PlannerInfo *root,
 	/* final_cost_hashjoin will fill in pathnode->num_batches */
 
 	/*
-	 * GPDB hash tables was modified to be rescannable even in case of hash
-	 * table overflows to disk, and an ancestor node requests rescan
-	 * (e.g. because the HJ is in the inner subtree of a NJ).
-	 * See the SpillCurrentBatch comment for details
+	 * If hash table overflows to disk, and an ancestor node requests rescan
+	 * (e.g. because the HJ is in the inner subtree of a NJ), then the HJ has
+	 * to be redone, including rescanning the inner rel in order to rebuild
+	 * the hash table.
 	 */
-	pathnode->jpath.path.rescannable = outer_path->rescannable;
+	pathnode->jpath.path.rescannable = outer_path->rescannable && inner_path->rescannable;
 
 	/* see the comment above; we may have a motion hazard on our inner ?! */
 	if (pathnode->jpath.path.rescannable)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12588,7 +12588,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Nested Loop Semi Join  (cost=10000000001.07..10000000003.19 rows=4 width=8)
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
    Join Filter: ("out".b = COALESCE((count(*)), '99'::bigint))
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
          ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
@@ -12705,7 +12705,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Nested Loop Semi Join  (cost=10000000001.07..10000000003.19 rows=4 width=8)
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
    Join Filter: ("out".b = COALESCE((count(*)), '99'::bigint))
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
          ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -12588,15 +12588,16 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.19 rows=4 width=8)
    Join Filter: ("out".b = COALESCE((count(*)), '99'::bigint))
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
          ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
    ->  Materialize  (cost=1.07..2.16 rows=2 width=8)
          ->  Hash Left Join  (cost=1.07..2.14 rows=4 width=8)
                Hash Cond: (tcorr1.a = tcorr2.a)
-               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
-                     ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+               ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                           ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
                ->  Hash  (cost=1.06..1.06 rows=1 width=12)
                      ->  HashAggregate  (cost=1.04..1.05 rows=1 width=12)
                            Group Key: tcorr2.a
@@ -12606,7 +12607,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                        ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
                                              ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
-(18 rows)
+(19 rows)
 
 -- expect 1 row
 select *
@@ -12704,15 +12705,16 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.19 rows=4 width=8)
    Join Filter: ("out".b = COALESCE((count(*)), '99'::bigint))
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
          ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
    ->  Materialize  (cost=1.07..2.16 rows=2 width=8)
          ->  Hash Left Join  (cost=1.07..2.14 rows=4 width=8)
                Hash Cond: (tcorr1.a = tcorr2.a)
-               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
-                     ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+               ->  Materialize  (cost=0.00..1.03 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                           ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
                ->  Hash  (cost=1.06..1.06 rows=1 width=12)
                      ->  HashAggregate  (cost=1.04..1.05 rows=1 width=12)
                            Group Key: tcorr2.a
@@ -12722,7 +12724,7 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                        ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
                                              ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=8)
  Optimizer: Postgres query optimizer
-(18 rows)
+(19 rows)
 
 -- expect 1 row
 select *

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -5,6 +5,10 @@
 -- start_matchignore
 -- m/ERROR:  workfile compresssion is not supported by this build/
 -- end_matchignore
+-- start_matchsubs
+-- m/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/
+-- s/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/ERROR:  could not devise a query plan for the given query (pathnode.c:XX)/
+-- end_matchsubs
 --
 -- test numeric hash join
 --

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -5,6 +5,10 @@
 -- start_matchignore
 -- m/ERROR:  workfile compresssion is not supported by this build/
 -- end_matchignore
+-- start_matchsubs
+-- m/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/
+-- s/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/ERROR:  could not devise a query plan for the given query (pathnode.c:XX)/
+-- end_matchsubs
 --
 -- test numeric hash join
 --

--- a/src/test/regress/sql/join_gp.sql
+++ b/src/test/regress/sql/join_gp.sql
@@ -6,6 +6,10 @@
 -- start_matchignore
 -- m/ERROR:  workfile compresssion is not supported by this build/
 -- end_matchignore
+-- start_matchsubs
+-- m/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/
+-- s/ERROR:  could not devise a query plan for the given query \(pathnode.c:\d+\)/ERROR:  could not devise a query plan for the given query (pathnode.c:XX)/
+-- end_matchsubs
 
 --
 -- test numeric hash join


### PR DESCRIPTION
1. In opposite to Postgres, not all plan operators may be rescanned in gpdb. E.g., Motions must be scan only once. If we need to scan Motion output several times we should decorate it with Material operator.
2. The Nested loop operator may provide some outer parameters for the inner tree that depends on the current outer sub-tree tuple. Every time when the new outer tuple is fetched, inner sub-tree of the Nested Loop should be rescanned. Moreover, gpdb can't propagate outer parameters cross the slices, so the path to parameter's consumer may be considered as rescannable (there are no motions).

Currently, only the Nested Loop operator handles presence of outer parameters (e.g. from ancestor Nested Loop) and make sure that both subtrees are rescannable if rescan expected (see the 25763c22b7). Hash and Merge Joins are passive and provides rescannable status based on their children only. But it's not enough to say about absence of possibility to rescan itself in case of there is outer parameter from ancestor, because rescan come here anyway even through Materialize appended above. To fix possible issues with non-rescannable operators rescan (see a provided regression test) we've decided to unify joins behavior.

Hash Join has rescan implementation that differs from Postgres one. The hash table was modified to spill out all batches (including 0th) to disk (see the SpillCurrentBatch comment as a start point). So the hash join inner subtree always rescannable and hash join rescannability depends only on outer subtree.

According to ExecReScanMergeJoin, Merge Join always rescan both subtrees in case of receiving rescan request. So we should make sure that both subtrees are rescannable.

One plan was modified in gporca.sql regression tests file, and it becomes more consistent with ORCA plan.

