### PR TITLE
ADBDEV-3537: alter trigger: fix `depends on` behaviour

### DIFF
--- a/src/backend/commands/alter.c
+++ b/src/backend/commands/alter.c
@@ -457,7 +457,6 @@ ExecRenameStmt(RenameStmt *stmt)
  * argument which, if not null, receives the address of the object that the
  * altered object now depends on.
  */
-// TODO test it on the both dispatcher and segment
 ObjectAddress
 ExecAlterObjectDependsStmt(AlterObjectDependsStmt *stmt, ObjectAddress *refAddress)
 {

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -15,7 +15,7 @@ DATA = test_ext1--1.0.sql test_ext2--1.0.sql test_ext3--1.0.sql \
        test_ext_cau--1.0--1.1.sql test_ext_cau--1.0.sql \
        test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql
 
-REGRESS = test_extensions #test_extdepend TODO: enable this test after https://github.com/greenplum-db/gpdb/issues/14532
+REGRESS = test_extensions test_extdepend
 
 # force C locale for output stability
 NO_LOCALE = 1

--- a/src/test/modules/test_extensions/expected/test_extdepend.out
+++ b/src/test/modules/test_extensions/expected/test_extdepend.out
@@ -7,48 +7,48 @@
 CREATE TABLE test_extdep_commands (i int, command text);
 COPY test_extdep_commands FROM stdin WITH DELIMITER ',';
 SELECT command FROM test_extdep_commands ORDER BY i;
-                                 command                                 
--------------------------------------------------------------------------
-  CREATE SCHEMA test_ext
-  CREATE EXTENSION test_ext5 SCHEMA test_ext
-  SET search_path TO test_ext
-  CREATE TABLE a (a1 int)
- 
-  CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS               +
-    $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
-  ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
- 
-  CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
-  ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
- 
-  CREATE MATERIALIZED VIEW d AS SELECT * FROM a
-  ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
- 
-  CREATE INDEX e ON a (a1)
-  ALTER INDEX e DEPENDS ON EXTENSION test_ext5
-  RESET search_path
-(17 rows)
-
--- First, test that dependent objects go away when the extension is dropped.
-SELECT * FROM test_extdep_commands \gexec
+                                command                                 
+------------------------------------------------------------------------
  CREATE SCHEMA test_ext
  CREATE EXTENSION test_ext5 SCHEMA test_ext
  SET search_path TO test_ext
  CREATE TABLE a (a1 int)
-
- CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
-   $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
+ 
+ CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS               +
+    $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
  ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
-
+ 
  CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
  ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
-
+ 
  CREATE MATERIALIZED VIEW d AS SELECT * FROM a
  ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
-
+ 
  CREATE INDEX e ON a (a1)
  ALTER INDEX e DEPENDS ON EXTENSION test_ext5
  RESET search_path
+(17 rows)
+
+-- First, test that dependent objects go away when the extension is dropped.
+SELECT command FROM test_extdep_commands ORDER BY i \gexec
+CREATE SCHEMA test_ext
+CREATE EXTENSION test_ext5 SCHEMA test_ext
+SET search_path TO test_ext
+CREATE TABLE a (a1 int)
+
+CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
+   $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
+ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
+
+CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
+ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
+
+CREATE MATERIALIZED VIEW d AS SELECT * FROM a
+ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
+
+CREATE INDEX e ON a (a1)
+ALTER INDEX e DEPENDS ON EXTENSION test_ext5
+RESET search_path
 -- A dependent object made dependent again has no effect
 ALTER FUNCTION test_ext.b() DEPENDS ON EXTENSION test_ext5;
 -- make sure we have the right dependencies on the extension
@@ -79,25 +79,25 @@ DROP SCHEMA test_ext CASCADE;
 NOTICE:  drop cascades to table test_ext.a
 -- Second test: If we drop the table, the objects are dropped too and no
 -- vestige remains in pg_depend.
-SELECT * FROM test_extdep_commands \gexec
- CREATE SCHEMA test_ext
- CREATE EXTENSION test_ext5 SCHEMA test_ext
- SET search_path TO test_ext
- CREATE TABLE a (a1 int)
+SELECT command FROM test_extdep_commands ORDER BY i \gexec
+CREATE SCHEMA test_ext
+CREATE EXTENSION test_ext5 SCHEMA test_ext
+SET search_path TO test_ext
+CREATE TABLE a (a1 int)
 
- CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
+CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
    $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
- ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
+ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
 
- CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
- ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
+CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
+ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
 
- CREATE MATERIALIZED VIEW d AS SELECT * FROM a
- ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
+CREATE MATERIALIZED VIEW d AS SELECT * FROM a
+ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
 
- CREATE INDEX e ON a (a1)
- ALTER INDEX e DEPENDS ON EXTENSION test_ext5
- RESET search_path
+CREATE INDEX e ON a (a1)
+ALTER INDEX e DEPENDS ON EXTENSION test_ext5
+RESET search_path
 DROP TABLE test_ext.a;		-- should fail, require cascade
 ERROR:  cannot drop table test_ext.a because other objects depend on it
 DETAIL:  materialized view test_ext.d depends on table test_ext.a
@@ -117,25 +117,25 @@ SELECT deptype, i.*
 DROP EXTENSION test_ext5;
 DROP SCHEMA test_ext CASCADE;
 -- Third test: we can drop the objects individually
-SELECT * FROM test_extdep_commands \gexec
- CREATE SCHEMA test_ext
- CREATE EXTENSION test_ext5 SCHEMA test_ext
- SET search_path TO test_ext
- CREATE TABLE a (a1 int)
+SELECT command FROM test_extdep_commands ORDER BY i \gexec
+CREATE SCHEMA test_ext
+CREATE EXTENSION test_ext5 SCHEMA test_ext
+SET search_path TO test_ext
+CREATE TABLE a (a1 int)
 
- CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
+CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
    $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$
- ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
+ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5
 
- CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
- ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
+CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b()
+ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5
 
- CREATE MATERIALIZED VIEW d AS SELECT * FROM a
- ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
+CREATE MATERIALIZED VIEW d AS SELECT * FROM a
+ALTER MATERIALIZED VIEW d DEPENDS ON EXTENSION test_ext5
 
- CREATE INDEX e ON a (a1)
- ALTER INDEX e DEPENDS ON EXTENSION test_ext5
- RESET search_path
+CREATE INDEX e ON a (a1)
+ALTER INDEX e DEPENDS ON EXTENSION test_ext5
+RESET search_path
 SET search_path TO test_ext;
 DROP TRIGGER c ON a;
 DROP FUNCTION b();

--- a/src/test/modules/test_extensions/sql/test_extdepend.sql
+++ b/src/test/modules/test_extensions/sql/test_extdepend.sql
@@ -27,7 +27,7 @@ COPY test_extdep_commands FROM stdin WITH DELIMITER ',';
 \.
 SELECT command FROM test_extdep_commands ORDER BY i;
 -- First, test that dependent objects go away when the extension is dropped.
-SELECT * FROM test_extdep_commands ORDER BY i \gexec
+SELECT command FROM test_extdep_commands ORDER BY i \gexec
 -- A dependent object made dependent again has no effect
 ALTER FUNCTION test_ext.b() DEPENDS ON EXTENSION test_ext5;
 -- make sure we have the right dependencies on the extension


### PR DESCRIPTION
alter trigger: fix `depends on` behaviour

The `alter trigger depends on extension` command is broken at gpdb,
for example the next script would fail:

```
CREATE SCHEMA test_ext;
CREATE EXTENSION test_ext5 SCHEMA test_ext;
SET search_path TO test_ext;
CREATE TABLE a (a1 int);

CREATE FUNCTION b() RETURNS TRIGGER LANGUAGE plpgsql AS
   $$ BEGIN NEW.a1 := NEW.a1 + 42; RETURN NEW; END; $$;
ALTER FUNCTION b() DEPENDS ON EXTENSION test_ext5;

CREATE TRIGGER c BEFORE INSERT ON a FOR EACH ROW EXECUTE PROCEDURE b();
ALTER TRIGGER c ON a DEPENDS ON EXTENSION test_ext5;
ERROR:  schema "a" does not exist  (seg2 127.0.1.1:7004 pid=123007)
```

There problem is next: when the alter command executes - QD calls `ExecAlterObjectDependsStmt` with `AlterObjectDependsStmt` argument, where  stmt->object is not NULL (it's a List containing the trigger name) and  stmt->relation is a not NULL RangeVar (see [gram.y](https://github.com/greenplum-db/gpdb/blob/7af9e83612803e7e9902868cfced4c4e94e2de56/src/backend/parser/gram.y#L11687-L11695)) after that  `get_object_address_rv` (which calculates an ObjectAddress based on a RangeVar and an object name) [is called](https://github.com/greenplum-db/gpdb/blob/7af9e83612803e7e9902868cfced4c4e94e2de56/src/backend/commands/alter.c#L468-L470) with these arguments and because of the `rel` argument (stmt->relation) is not NULL the [if branch](https://github.com/greenplum-db/gpdb/blob/7af9e83612803e7e9902868cfced4c4e94e2de56/src/backend/catalog/objectaddress.c#L1157-L1164) executes and the stmt->object which is passed by reference (it's not NULL too) is mutated (relation name prepended to the List) inside `if` block of this function as a result the original AlterObjectDependsStmt is mutated. Finally the mutated statement is passed to the QE and QE executes the same function call chain (the relname is prepended to mutated list again) and call of `get_object_address_relobject` (it's called by next  chain `get_object_address_rv -> get_object_address -> get_object_address_relobject`) fails because of [makeRangeVarFromNameList](https://github.com/greenplum-db/gpdb/blob/7af9e83612803e7e9902868cfced4c4e94e2de56/src/backend/catalog/objectaddress.c#L1379-L1382) is called with a mutated list and it returns the incorrect RangeVar with filled `schemaname`, so `table_openrv_extended` can't find the table and fails.

This patch fixes such behavior - to prevent the mutation of `List` the `get_object_address_rv` now works with it's copy.

Closes greenplum-db/gpdb#14532