### PR TITLE
ADBDEV-3951: Backport of "Implemented InPlaceUpdate to be used for updates made on non-distribution columns"

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelfUpdate.mdp
@@ -216,17 +216,17 @@ update t1 set b = c;
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.067764" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023462" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="c">
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -248,14 +248,14 @@ update t1 set b = c;
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23502">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -265,9 +265,6 @@ update t1 set b = c;
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -279,16 +276,13 @@ update t1 set b = c;
               </dxl:Not>
             </dxl:AssertConstraint>
           </dxl:AssertConstraintList>
-          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -299,48 +293,23 @@ update t1 set b = c;
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                <dxl:DMLAction/>
-              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="22"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="c">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="ctid">
-                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.47297780.1.1" TableName="t1">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Split>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.47297780.1.1" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Assert>
       </dxl:DMLUpdate>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateCheckConstraint.mdp
@@ -294,17 +294,17 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,11,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.117383" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.050903" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="11" Alias="b">
+            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="c">
             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -330,14 +330,14 @@
         </dxl:TableDescriptor>
         <dxl:Assert ErrorCode="23514">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000195" Rows="2.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000121" Rows="1.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="11" Alias="b">
+              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="c">
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -350,9 +350,6 @@
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="gp_segment_id">
               <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:AssertConstraintList>
@@ -377,14 +374,11 @@
           </dxl:AssertConstraintList>
           <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000165" Rows="2.000000" Width="30"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000108" Rows="1.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -398,8 +392,8 @@
               <dxl:ProjElem ColId="10" Alias="gp_segment_id">
                 <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-                <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="11" Alias="b">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:AssertConstraintList>
@@ -411,16 +405,16 @@
                 </dxl:Not>
               </dxl:AssertConstraint>
             </dxl:AssertConstraintList>
-            <dxl:Split DeleteColumns="0,1,2,3" InsertColumns="0,11,2,3" ActionCol="12" CtidCol="4" SegmentIdCol="10" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000135" Rows="2.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="1.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="b">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="c">
                   <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
@@ -434,32 +428,22 @@
                 <dxl:ProjElem ColId="10" Alias="gp_segment_id">
                   <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="b">
-                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="1.000000" Width="30"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="1.000000" Width="26"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="c">
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="d">
                     <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="11" Alias="b">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="4" Alias="ctid">
                     <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -468,56 +452,29 @@
                     <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="30"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="c">
-                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="d">
-                      <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="4" Alias="ctid">
-                      <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="gp_segment_id">
-                      <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="6.17005.1.1" TableName="r">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:Split>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="6.17005.1.1" TableName="r">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
           </dxl:Assert>
         </dxl:Assert>
       </dxl:DMLUpdate>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -302,18 +302,18 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLUpdate Columns="0,20,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324057.842928" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324054.226041" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
             <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="j">
-            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="20" Alias="j">
+            <dxl:Ident ColId="20" ColName="j" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="k">
             <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -335,14 +335,14 @@
         </dxl:TableDescriptor>
         <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324057.792147" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324054.204557" Rows="1.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
               <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="j">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="20" Alias="j">
+              <dxl:Ident ColId="20" ColName="j" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="k">
               <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -353,75 +353,55 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-              <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,20,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324054.204540" Rows="1.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="k">
-                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ctid">
-                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:DMLAction/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324057.792093" Rows="1.000000" Width="26"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="k">
-                  <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="20" Alias="j">
-                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                    <dxl:TestExpr/>
-                    <dxl:ParamList>
-                      <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ParamList>
-                    <dxl:Result>
+              <dxl:ProjElem ColId="20" Alias="j">
+                <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="12" Alias="c">
+                        <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="b">
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="12" Alias="c">
                           <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Materialize Eager="false">
+                      <dxl:Filter/>
+                      <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="11" Alias="b">
@@ -432,9 +412,10 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="11" Alias="b">
@@ -445,38 +426,47 @@
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:TableScan>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="11" Alias="b">
-                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="12" Alias="c">
-                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
-                              <dxl:Columns>
-                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
-                        </dxl:BroadcastMotion>
-                      </dxl:Materialize>
-                    </dxl:Result>
-                  </dxl:SubPlan>
+                          <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
+                            <dxl:Columns>
+                              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:BroadcastMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="k">
+                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="ctid">
+                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:Sequence>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="18"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="k">
+                  <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="ctid">
                   <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -485,18 +475,34 @@
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Sequence>
+              <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:PartEqFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartEqFilters>
+                <dxl:PartFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PartFilters>
+                <dxl:ResidualFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ResidualFilter>
+                <dxl:PropagationExpression>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PropagationExpression>
+                <dxl:PrintableFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:PrintableFilter>
+              </dxl:PartitionSelector>
+              <dxl:DynamicTableScan PartIndexId="1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="j">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="k">
                     <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
@@ -508,67 +514,24 @@
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:PartEqFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartEqFilters>
-                  <dxl:PartFilters>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PartFilters>
-                  <dxl:ResidualFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:ResidualFilter>
-                  <dxl:PropagationExpression>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:PropagationExpression>
-                  <dxl:PrintableFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:PrintableFilter>
-                </dxl:PartitionSelector>
-                <dxl:DynamicTableScan PartIndexId="1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="i">
-                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="j">
-                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="k">
-                      <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="ctid">
-                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:DynamicTableScan>
-              </dxl:Sequence>
-            </dxl:Result>
-          </dxl:Split>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+            </dxl:Sequence>
+          </dxl:Result>
         </dxl:RoutedDistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoEnforceConstraints.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoEnforceConstraints.mdp
@@ -238,21 +238,21 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="12" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLUpdate Columns="0,10,11" ActionCol="12" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.078182" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.033880" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="id">
             <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="notnullcol">
-            <dxl:Ident ColId="1" ColName="notnullcol" TypeMdid="0.25.1.0"/>
+          <dxl:ProjElem ColId="10" Alias="notnullcol">
+            <dxl:Ident ColId="10" ColName="notnullcol" TypeMdid="0.25.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="positivecol">
-            <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="11" Alias="positivecol">
+            <dxl:Ident ColId="11" ColName="positivecol" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="6.16410.1.0" TableName="constraints_tab">
@@ -269,19 +269,19 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
             <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,11" ActionCol="12" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000057" Rows="2.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="id">
               <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="notnullcol">
-              <dxl:Ident ColId="1" ColName="notnullcol" TypeMdid="0.25.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="notnullcol">
+              <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="positivecol">
-              <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="11" Alias="positivecol">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="-1"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="ctid">
               <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -289,29 +289,16 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Result>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="38"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="id">
                 <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="notnullcol">
-                <dxl:Ident ColId="1" ColName="notnullcol" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="positivecol">
-                <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="notnullcol">
-                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="positivecol">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="-1"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="3" Alias="ctid">
                 <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -321,46 +308,22 @@ update constraints_tab SET notnullcol = NULL, positivecol =-1;
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="26"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="id">
-                  <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="notnullcol">
-                  <dxl:Ident ColId="1" ColName="notnullcol" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="positivecol">
-                  <dxl:Ident ColId="2" ColName="positivecol" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="ctid">
-                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.16410.1.0" TableName="constraints_tab">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="notnullcol" TypeMdid="0.25.1.0" ColWidth="8"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="positivecol" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Result>
-        </dxl:Split>
+            <dxl:TableDescriptor Mdid="6.16410.1.0" TableName="constraints_tab">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="notnullcol" TypeMdid="0.25.1.0" ColWidth="8"/>
+                <dxl:Column ColId="2" Attno="3" ColName="positivecol" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateRandomDistr.mdp
@@ -195,15 +195,15 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLUpdate Columns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.085998" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.035189" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="1" Alias="b">
             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -222,13 +222,13 @@
             <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="2.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="b">
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -239,23 +239,16 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Result>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="a">
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="ctid">
                 <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -265,42 +258,21 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="18"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Result>
-        </dxl:Split>
+            <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -764,18 +764,18 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="41">
+      <dxl:DMLUpdate Columns="0,18" ActionCol="23" CtidCol="2" SegmentIdCol="8" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="870.723927" Rows="100.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="865.641202" Rows="100.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="18" Alias="b">
+            <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="6.284632.1.1" TableName="r">
@@ -791,16 +791,19 @@
             <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Assert ErrorCode="23502">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.130177" Rows="200.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.125577" Rows="100.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="b">
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:OpExpr>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="ctid">
               <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -808,22 +811,12 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-              <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:AssertConstraintList>
-            <dxl:AssertConstraint ErrorMessage="Not null constraint for column a of table r was violated">
-              <dxl:Not>
-                <dxl:IsNull>
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:IsNull>
-              </dxl:Not>
-            </dxl:AssertConstraint>
-          </dxl:AssertConstraintList>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:HashJoin JoinType="In">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.127977" Rows="200.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.124677" Rows="100.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -838,13 +831,18 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                <dxl:DMLAction/>
-              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Result>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.125777" Rows="100.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="18"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -852,12 +850,6 @@
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="18" Alias="b">
-                  <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:OpExpr>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">
                   <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -867,93 +859,45 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:HashJoin JoinType="In">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.124677" Rows="100.000000" Width="18"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="ctid">
-                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001045" Rows="100.000000" Width="18"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.284632.1.1" TableName="r">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="9" Alias="a">
-                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.284678.1.1" TableName="s">
-                    <dxl:Columns>
-                      <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:HashJoin>
-            </dxl:Result>
-          </dxl:Split>
-        </dxl:Assert>
+              <dxl:TableDescriptor Mdid="6.284632.1.1" TableName="r">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.010450" Rows="1000.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.284678.1.1" TableName="s">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:HashJoin>
+        </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWindowGatherMerge.mdp
@@ -14,28 +14,26 @@
   set i = tt.i 
   from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
   where t.j = tt.j;
-                                                             QUERY PLAN                                                           
-  --------------------------------------------------------------------------------------------------------------------------------
-  Update  (cost=0.00..868.82 rows=34 width=1)
-    ->  Result  (cost=0.00..862.05 rows=67 width=26)
-          ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..862.05 rows=67 width=22)
-                ->  Split  (cost=0.00..862.05 rows=67 width=22)
-                      ->  Hash Join  (cost=0.00..862.04 rows=34 width=22)
-                            Hash Cond: (window_agg_test.j = window_agg_test_1.j)
-                            ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.01 rows=100 width=8)
-                                  Hash Key: window_agg_test.j
-                                  ->  Result  (cost=0.00..431.01 rows=34 width=8)
-                                        ->  WindowAgg  (cost=0.00..431.01 rows=34 width=8)
-                                              Order By: window_agg_test.j
-                                              ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=100 width=8)
-                                                    Merge Key: window_agg_test.j
-                                                    ->  Sort  (cost=0.00..431.01 rows=34 width=8)
-                                                          Sort Key: window_agg_test.j
-                                                          ->  Seq Scan on window_agg_test  (cost=0.00..431.00 rows=34 width=8)
-                            ->  Hash  (cost=431.00..431.00 rows=34 width=18)
-                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=34 width=18)
-                                        Hash Key: window_agg_test_1.j
-                                        ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=34 width=18)
+                                                       QUERY PLAN                                                     
+  --------------------------------------------------------------------------------------------------------------------
+   Update  (cost=0.00..864.39 rows=34 width=1)
+     ->  Explicit Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..862.04 rows=34 width=18)
+           ->  Hash Join  (cost=0.00..862.04 rows=34 width=18)
+                 Hash Cond: (window_agg_test.j = window_agg_test_1.j)
+                 ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.01 rows=100 width=8)
+                       Hash Key: window_agg_test.j
+                       ->  Result  (cost=0.00..431.01 rows=34 width=8)
+                             ->  WindowAgg  (cost=0.00..431.01 rows=34 width=8)
+                                   Order By: window_agg_test.j
+                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=100 width=8)
+                                         Merge Key: window_agg_test.j
+                                         ->  Sort  (cost=0.00..431.01 rows=34 width=8)
+                                               Sort Key: window_agg_test.j
+                                               ->  Seq Scan on window_agg_test  (cost=0.00..431.00 rows=34 width=8)
+                 ->  Hash  (cost=431.00..431.00 rows=34 width=14)
+                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=34 width=14)
+                             Hash Key: window_agg_test_1.j
+                             ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=34 width=14)
   Optimizer: Pivotal Optimizer (GPORCA)
   (21 rows)
   ]]>
@@ -708,15 +706,15 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="20">
+      <dxl:DMLUpdate Columns="18,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="867.779091" Rows="100.000001" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="864.385336" Rows="100.000001" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="i">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="18" Alias="i">
+            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="1" Alias="j">
             <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
@@ -737,11 +735,11 @@
         </dxl:TableDescriptor>
         <dxl:RoutedDistributeMotion SegmentIdCol="8" InputSegments="0,1,2" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.049924" Rows="200.000002" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.041586" Rows="100.000001" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="i">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="18" Alias="i">
+              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="j">
               <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
@@ -752,19 +750,16 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:Split DeleteColumns="0,1" InsertColumns="18,1" ActionCol="19" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+          <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.045333" Rows="200.000002" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.039708" Rows="100.000001" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="18" Alias="i">
+                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="j">
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
@@ -775,42 +770,37 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                <dxl:DMLAction/>
-              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:HashJoin JoinType="Inner">
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.043867" Rows="100.000001" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.014700" Rows="100.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="10" Alias="j">
+                  <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="18" Alias="i">
                   <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr Opfamily="0.1977.1.0">
                   <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.014700" Rows="100.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.012623" Rows="100.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="j">
@@ -821,44 +811,41 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:Result>
+                <dxl:OneTimeFilter/>
+                <dxl:Window PartitionColumns="">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.012623" Rows="100.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="i">
+                      <dxl:WindowFunc Mdid="0.2132.1.0" TypeMdid="0.23.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="true" WindowStrategy="Immediate" WinSpecPos="0">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:WindowFunc>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="10" Alias="j">
                       <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="18" Alias="i">
-                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Window PartitionColumns="">
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.012623" Rows="100.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.011823" Rows="100.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="18" Alias="i">
-                        <dxl:WindowFunc Mdid="0.2132.1.0" TypeMdid="0.23.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="true" WindowStrategy="Immediate" WinSpecPos="0">
-                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:WindowFunc>
+                      <dxl:ProjElem ColId="9" Alias="i">
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="10" Alias="j">
                         <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.011823" Rows="100.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008842" Rows="100.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="i">
@@ -872,9 +859,11 @@
                       <dxl:SortingColumnList>
                         <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
                       </dxl:SortingColumnList>
-                      <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.008842" Rows="100.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -885,62 +874,63 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        </dxl:SortingColumnList>
-                        <dxl:LimitCount/>
-                        <dxl:LimitOffset/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="9" Alias="i">
-                              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="10" Alias="j">
-                              <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
-                            <dxl:Columns>
-                              <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Sort>
-                    </dxl:GatherMotion>
-                    <dxl:WindowKeyList>
-                      <dxl:WindowKey>
-                        <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        </dxl:SortingColumnList>
-                        <dxl:WindowFrame FrameSpec="Range" ExclusionStrategy="Nulls">
-                          <dxl:TrailingEdge TrailingBoundary="UnboundedPreceding"/>
-                          <dxl:LeadingEdge LeadingBoundary="CurrentRow"/>
-                        </dxl:WindowFrame>
-                      </dxl:WindowKey>
-                    </dxl:WindowKeyList>
-                  </dxl:Window>
-                </dxl:Result>
-              </dxl:RedistributeMotion>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:Sort>
+                  </dxl:GatherMotion>
+                  <dxl:WindowKeyList>
+                    <dxl:WindowKey>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:WindowFrame FrameSpec="Range" ExclusionStrategy="Nulls">
+                        <dxl:TrailingEdge TrailingBoundary="UnboundedPreceding"/>
+                        <dxl:LeadingEdge LeadingBoundary="CurrentRow"/>
+                      </dxl:WindowFrame>
+                    </dxl:WindowKey>
+                  </dxl:WindowKeyList>
+                </dxl:Window>
+              </dxl:Result>
+            </dxl:RedistributeMotion>
+            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.003025" Rows="100.000000" Width="14"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="j">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr Opfamily="0.1977.1.0">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:TableScan>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.003691" Rows="100.000000" Width="18"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="14"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="i">
-                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="1" Alias="j">
                     <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
@@ -952,48 +942,22 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="18"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="i">
-                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="j">
-                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:RedistributeMotion>
-            </dxl:HashJoin>
-          </dxl:Split>
+                <dxl:TableDescriptor Mdid="6.251337.1.0" TableName="window_agg_test">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:RedistributeMotion>
+          </dxl:HashJoin>
         </dxl:RoutedDistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithHashJoin.mdp
@@ -300,10 +300,10 @@
         </dxl:LogicalJoin>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="5">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="867.746299" Rows="100.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="864.359415" Rows="100.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -327,9 +327,9 @@
             <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="0,1" ActionCol="18" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.017132" Rows="200.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.015665" Rows="100.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -344,13 +344,22 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:HashJoin JoinType="Inner">
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.015665" Rows="100.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -367,75 +376,44 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:Cast>
-                <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:Cast>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="18"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000623" Rows="100.000000" Width="2"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.32775.1.0" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="2"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:HashJoin>
-        </dxl:Split>
+            <dxl:TableDescriptor Mdid="6.32769.1.0" TableName="s">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000623" Rows="100.000000" Width="2"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.32775.1.0" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="2"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateWithTriggers.mdp
@@ -204,17 +204,17 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.813202" Rows="8.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.344228" Rows="8.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="t1">
             <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="t2">
-            <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="10" Alias="t2">
+            <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="t3">
             <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
@@ -234,16 +234,16 @@
             <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:RowTrigger RelationMdid="6.187777.1.1" Type="19" OldColumns="0,1,2" NewColumns="0,10,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000702" Rows="16.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="8.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="t1">
               <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="t2">
-              <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="t2">
+              <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="t3">
               <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
@@ -254,13 +254,10 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000494" Rows="8.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000390" Rows="8.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="t1">
@@ -273,7 +270,7 @@
                 <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="t2">
-                <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="3" Alias="ctid">
                 <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -284,22 +281,19 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:RowTrigger RelationMdid="6.187777.1.1" Type="19" OldColumns="0,1,2" NewColumns="0,10,2">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000494" Rows="8.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="t1">
                   <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="t2">
-                  <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="1" Alias="t2">
+                  <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="t3">
                   <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="t2">
-                  <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="ctid">
                   <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -308,73 +302,24 @@
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000390" Rows="8.000000" Width="26"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="t1">
-                    <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="t2">
-                    <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="t3">
-                    <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="t2">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="4"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="ctid">
-                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="26"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="t1">
-                      <dxl:Ident ColId="0" ColName="t1" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="t2">
-                      <dxl:Ident ColId="1" ColName="t2" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="t3">
-                      <dxl:Ident ColId="2" ColName="t3" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="ctid">
-                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.187777.1.1" TableName="t_trig">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Result>
-            </dxl:RowTrigger>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.187777.1.1" TableName="t_trig">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
           </dxl:Result>
-        </dxl:Split>
+        </dxl:RowTrigger>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateZeroRows.mdp
@@ -409,229 +409,168 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="1"/>
-        </dxl:Properties>
-        <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="x">
-            <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="y">
-            <dxl:Ident ColId="1" ColName="y" TypeMdid="0.25.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="z">
-            <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="6.795132.1.1" TableName="insert_tbl">
-          <dxl:Columns>
-            <dxl:Column ColId="12" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="13" Attno="2" ColName="y" TypeMdid="0.25.1.0"/>
-            <dxl:Column ColId="14" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-          </dxl:Columns>
-        </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="30"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="x">
-              <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="y">
-              <dxl:Ident ColId="1" ColName="y" TypeMdid="0.25.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="z">
-              <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="3" Alias="ctid">
-              <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-              <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashExprList>
-            <dxl:HashExpr>
-              <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-            </dxl:HashExpr>
-          </dxl:HashExprList>
-          <dxl:Assert ErrorCode="23514">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="30"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="x">
-                <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="y">
-                <dxl:Ident ColId="1" ColName="y" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="z">
-                <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ctid">
-                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:AssertConstraintList>
-              <dxl:AssertConstraint ErrorMessage="Check constraint insert_tbl_check for table insert_tbl was violated">
-                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                      <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-                    </dxl:OpExpr>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                  </dxl:Comparison>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                </dxl:IsDistinctFrom>
-              </dxl:AssertConstraint>
-              <dxl:AssertConstraint ErrorMessage="Check constraint insert_con for table insert_tbl was violated">
-                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
-                  <dxl:And>
-                    <dxl:And>
-                      <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
-                        <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
-                        <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAEGNoZWNrIGZhaWxlZA==" LintValue="555254574"/>
-                      </dxl:Comparison>
-                    </dxl:And>
-                    <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                      <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
-                    </dxl:Comparison>
-                  </dxl:And>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                </dxl:IsDistinctFrom>
-              </dxl:AssertConstraint>
-            </dxl:AssertConstraintList>
-            <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="38"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="x">
-                  <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="y">
-                  <dxl:Ident ColId="1" ColName="y" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="z">
-                  <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="ctid">
-                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="y">
-                  <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="34"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="x">
-                    <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="y">
-                    <dxl:Ident ColId="1" ColName="y" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="z">
-                    <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="y">
-                    <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="ctid">
-                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="34"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="x">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="y">
-                      <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="z">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="10" Alias="y">
-                      <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="ctid">
-                      <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="4" Alias="xmin">
-                      <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="5" Alias="cmin">
-                      <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="6" Alias="xmax">
-                      <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="7" Alias="cmax">
-                      <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="tableoid">
-                      <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                  </dxl:OneTimeFilter>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:Assert>
-        </dxl:RedistributeMotion>
-      </dxl:DMLUpdate>
-    </dxl:Plan>
+     <dxl:Plan Id="0" SpaceSize="1">
+       <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
+         <dxl:Properties>
+           <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="1"/>
+         </dxl:Properties>
+         <dxl:DirectDispatchInfo/>
+         <dxl:ProjList>
+           <dxl:ProjElem ColId="0" Alias="x">
+             <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+           </dxl:ProjElem>
+           <dxl:ProjElem ColId="10" Alias="y">
+             <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
+           </dxl:ProjElem>
+           <dxl:ProjElem ColId="2" Alias="z">
+             <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
+           </dxl:ProjElem>
+         </dxl:ProjList>
+         <dxl:TableDescriptor Mdid="6.795132.1.1" TableName="insert_tbl">
+           <dxl:Columns>
+             <dxl:Column ColId="12" Attno="1" ColName="x" TypeMdid="0.23.1.0"/>
+             <dxl:Column ColId="13" Attno="2" ColName="y" TypeMdid="0.25.1.0"/>
+             <dxl:Column ColId="14" Attno="3" ColName="z" TypeMdid="0.23.1.0"/>
+             <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+             <dxl:Column ColId="16" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+             <dxl:Column ColId="17" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+             <dxl:Column ColId="18" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+             <dxl:Column ColId="19" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+             <dxl:Column ColId="20" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+             <dxl:Column ColId="21" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+           </dxl:Columns>
+         </dxl:TableDescriptor>
+         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+           <dxl:Properties>
+             <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="26"/>
+           </dxl:Properties>
+           <dxl:ProjList>
+             <dxl:ProjElem ColId="0" Alias="x">
+               <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="10" Alias="y">
+               <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="2" Alias="z">
+               <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="3" Alias="ctid">
+               <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+             </dxl:ProjElem>
+           </dxl:ProjList>
+           <dxl:Filter/>
+           <dxl:SortingColumnList/>
+           <dxl:HashExprList>
+             <dxl:HashExpr>
+               <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+             </dxl:HashExpr>
+           </dxl:HashExprList>
+           <dxl:Assert ErrorCode="23514">
+             <dxl:Properties>
+               <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="26"/>
+             </dxl:Properties>
+             <dxl:ProjList>
+               <dxl:ProjElem ColId="0" Alias="x">
+                 <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="10" Alias="y">
+                 <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="2" Alias="z">
+                 <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="3" Alias="ctid">
+                 <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+               </dxl:ProjElem>
+             </dxl:ProjList>
+             <dxl:AssertConstraintList>
+               <dxl:AssertConstraint ErrorMessage="Check constraint insert_tbl_check for table insert_tbl was violated">
+                 <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                     <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                       <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+                       <dxl:Ident ColId="2" ColName="z" TypeMdid="0.23.1.0"/>
+                     </dxl:OpExpr>
+                     <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                   </dxl:Comparison>
+                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                 </dxl:IsDistinctFrom>
+               </dxl:AssertConstraint>
+               <dxl:AssertConstraint ErrorMessage="Check constraint insert_con for table insert_tbl was violated">
+                 <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                   <dxl:And>
+                     <dxl:And>
+                       <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+                         <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+                         <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                       </dxl:Comparison>
+                       <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+                         <dxl:Ident ColId="10" ColName="y" TypeMdid="0.25.1.0"/>
+                         <dxl:ConstValue TypeMdid="0.25.1.0" Value="AAAAEGNoZWNrIGZhaWxlZA==" LintValue="555254574"/>
+                       </dxl:Comparison>
+                     </dxl:And>
+                     <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                       <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="8"/>
+                     </dxl:Comparison>
+                   </dxl:And>
+                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                 </dxl:IsDistinctFrom>
+               </dxl:AssertConstraint>
+             </dxl:AssertConstraintList>
+             <dxl:Result>
+               <dxl:Properties>
+                 <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="26"/>
+               </dxl:Properties>
+               <dxl:ProjList>
+                 <dxl:ProjElem ColId="0" Alias="x">
+                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="1" Alias="y">
+                   <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="2" Alias="z">
+                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="3" Alias="ctid">
+                   <dxl:ConstValue TypeMdid="0.27.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="4" Alias="xmin">
+                   <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="5" Alias="cmin">
+                   <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="6" Alias="xmax">
+                   <dxl:ConstValue TypeMdid="0.28.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="7" Alias="cmax">
+                   <dxl:ConstValue TypeMdid="0.29.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="8" Alias="tableoid">
+                   <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="10" Alias="y">
+                   <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" LintValue="0"/>
+                 </dxl:ProjElem>
+               </dxl:ProjList>
+               <dxl:Filter/>
+               <dxl:OneTimeFilter>
+                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+               </dxl:OneTimeFilter>
+             </dxl:Result>
+           </dxl:Assert>
+         </dxl:RedistributeMotion>
+       </dxl:DMLUpdate>
+     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingNonDistColSameTable.mdp
@@ -234,17 +234,17 @@
       </dxl:LogicalUpdate>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+      <dxl:DMLUpdate Columns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.072958" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031273" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="v_date_old">
             <dxl:Ident ColId="0" ColName="v_date_old" TypeMdid="0.1114.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="v_varchar1_old">
-            <dxl:Ident ColId="1" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
+          <dxl:ProjElem ColId="2" Alias="s_varchar_old">
+            <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="2" Alias="s_varchar_old">
             <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
@@ -264,16 +264,16 @@
             <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,2,2" ActionCol="10" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+        <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="2.000000" Width="28"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="v_date_old">
               <dxl:Ident ColId="0" ColName="v_date_old" TypeMdid="0.1114.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="v_varchar1_old">
-              <dxl:Ident ColId="1" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
+            <dxl:ProjElem ColId="2" Alias="s_varchar_old">
+              <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="s_varchar_old">
               <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
@@ -284,48 +284,23 @@
             <dxl:ProjElem ColId="9" Alias="gp_segment_id">
               <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="24"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="v_date_old">
-                <dxl:Ident ColId="0" ColName="v_date_old" TypeMdid="0.1114.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="v_varchar1_old">
-                <dxl:Ident ColId="1" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="s_varchar_old">
-                <dxl:Ident ColId="2" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ctid">
-                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.49159.1.0" TableName="test">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="v_date_old" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                <dxl:Column ColId="1" Attno="2" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="0"/>
-                <dxl:Column ColId="2" Attno="3" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="6"/>
-                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:Split>
+          <dxl:Filter/>
+          <dxl:TableDescriptor Mdid="6.49159.1.0" TableName="test">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="v_date_old" TypeMdid="0.1114.1.0" ColWidth="8"/>
+              <dxl:Column ColId="1" Attno="2" ColName="v_varchar1_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="0"/>
+              <dxl:Column ColId="2" Attno="3" ColName="s_varchar_old" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdatingNonDistributionColumnFunc.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatingNonDistributionColumnFunc.mdp
@@ -238,18 +238,18 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLUpdate Columns="0,9" ActionCol="10" CtidCol="2" SegmentIdCol="8" IsSplitUpdate="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="438.817446" Rows="100.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="434.387848" Rows="100.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
+          <dxl:ProjElem ColId="9" Alias="b">
+            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.1043.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:TableDescriptor Mdid="6.40973.1.0" TableName="s">
@@ -265,16 +265,24 @@
             <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="0,9" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.004946" Rows="200.000000" Width="30"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.002431" Rows="100.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
+            <dxl:ProjElem ColId="9" Alias="b">
+              <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
+                <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0" FuncVariadic="false">
+                  <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
+                  </dxl:Cast>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                </dxl:FuncExpr>
+              </dxl:Cast>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="ctid">
               <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -282,31 +290,16 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-              <dxl:DMLAction/>
-            </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Result>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.002946" Rows="100.000000" Width="34"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="b">
-                <dxl:Cast TypeMdid="0.1043.1.0" FuncId="0.0.0.0">
-                  <dxl:FuncExpr FuncId="0.877.1.0" FuncRetSet="false" TypeMdid="0.25.1.0">
-                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
-                    </dxl:Cast>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:FuncExpr>
-                </dxl:Cast>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="ctid">
                 <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -316,42 +309,21 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000697" Rows="100.000000" Width="18"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.40973.1.0" TableName="s">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:Result>
-        </dxl:Split>
+            <dxl:TableDescriptor Mdid="6.40973.1.0" TableName="s">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/parse_tests/q60-DMLUpdate.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q60-DMLUpdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Plan Id="0" SpaceSize="0">
-    <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+    <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" CtidCol="3" SegmentIdCol="9" IsSplitUpdate="false" PreserveOids="false">
       <dxl:Properties>
         <dxl:Cost StartupCost="0" TotalCost="100.000000" Rows="0" Width="1"/>
       </dxl:Properties>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -213,6 +213,9 @@ private:
 	static CExpression *PexprTransposeSelectAndProject(CMemoryPool *mp,
 													   CExpression *pexpr);
 
+	static CExpression *ConvertSplitUpdateToInPlaceUpdate(CMemoryPool *mp,
+														  CExpression *expr);
+
 	static CExpression *CollapseSelectAndReplaceColref(CMemoryPool *mp,
 													   CExpression *expr,
 													   CColRef *pcolref,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
@@ -40,7 +40,6 @@ public:
 		EdmlSentinel
 	};
 
-	static const WCHAR m_rgwszDml[EdmlSentinel][10];
 
 private:
 	// dml operator
@@ -67,6 +66,9 @@ private:
 	// tuple oid column if one exists
 	CColRef *m_pcrTupleOid;
 
+	// Split Update
+	BOOL m_fSplit;
+
 	// private copy ctor
 	CLogicalDML(const CLogicalDML &);
 
@@ -78,7 +80,7 @@ public:
 	CLogicalDML(CMemoryPool *mp, EDMLOperator edmlop,
 				CTableDescriptor *ptabdesc, CColRefArray *colref_array,
 				CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				CColRef *pcrSegmentId, CColRef *pcrTupleOid);
+				CColRef *pcrSegmentId, CColRef *pcrTupleOid, BOOL fSplit);
 
 	// dtor
 	virtual ~CLogicalDML();
@@ -151,6 +153,13 @@ public:
 	PcrTupleOid() const
 	{
 		return m_pcrTupleOid;
+	}
+
+	// Is update using split
+	BOOL
+	FSplit() const
+	{
+		return m_fSplit;
 	}
 
 	// operator specific hash function
@@ -244,6 +253,9 @@ public:
 
 	// debug print
 	virtual IOstream &OsPrint(IOstream &) const;
+
+	// Helper function to print DML operator type.
+	static void PrintOperatorType(IOstream &os, EDMLOperator, BOOL fSplit);
 
 };	// class CLogicalDML
 }  // namespace gpopt

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
@@ -49,6 +49,9 @@ private:
 	// tuple oid column
 	CColRef *m_pcrTupleOid;
 
+	// Is Split Update
+	BOOL m_fSplit;
+
 	// private copy ctor
 	CLogicalUpdate(const CLogicalUpdate &);
 
@@ -60,7 +63,7 @@ public:
 	CLogicalUpdate(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 				   CColRefArray *pdrgpcrDelete, CColRefArray *pdrgpcrInsert,
 				   CColRef *pcrCtid, CColRef *pcrSegmentId,
-				   CColRef *pcrTupleOid);
+				   CColRef *pcrTupleOid, BOOL fSplit);
 
 	// dtor
 	virtual ~CLogicalUpdate();
@@ -119,6 +122,13 @@ public:
 	Ptabdesc() const
 	{
 		return m_ptabdesc;
+	}
+
+	// Is update using split
+	BOOL
+	FSplit() const
+	{
+		return m_fSplit;
 	}
 
 	// operator specific hash function

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
@@ -69,6 +69,9 @@ private:
 	// compute required order spec
 	COrderSpec *PosComputeRequired(CMemoryPool *mp, CTableDescriptor *ptabdesc);
 
+	// Split Update
+	BOOL m_fSplit;
+
 	// compute local required columns
 	void ComputeRequiredLocalColumns(CMemoryPool *mp);
 
@@ -80,7 +83,7 @@ public:
 	CPhysicalDML(CMemoryPool *mp, CLogicalDML::EDMLOperator edmlop,
 				 CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrSource,
 				 CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				 CColRef *pcrSegmentId, CColRef *pcrTupleOid);
+				 CColRef *pcrSegmentId, CColRef *pcrTupleOid, BOOL fSplit);
 
 	// dtor
 	virtual ~CPhysicalDML();
@@ -146,6 +149,13 @@ public:
 	PdrgpcrSource() const
 	{
 		return m_pdrgpcrSource;
+	}
+
+	// Is update using split
+	BOOL
+	FSplit() const
+	{
+		return m_fSplit;
 	}
 
 	// match function

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -39,6 +39,7 @@
 #include "gpopt/operators/CLogicalSetOp.h"
 #include "gpopt/operators/CLogicalUnion.h"
 #include "gpopt/operators/CLogicalUnionAll.h"
+#include "gpopt/operators/CLogicalUpdate.h"
 #include "gpopt/operators/CNormalizer.h"
 #include "gpopt/operators/COrderedAggPreprocessor.h"
 #include "gpopt/operators/CPredicateUtils.h"
@@ -3057,6 +3058,89 @@ CExpressionPreprocessor::PexprTransposeSelectAndProject(CMemoryPool *mp,
 	}
 }
 
+// Preprocessor function to decide if the Update operator to be proceeded with
+// split update or inplace update based on the columns modified by the update
+// operation.
+
+// Split Update if any of the modified columns is a distribution column or a partition key,
+// InPlace Update if all the modified columns are non-distribution columns and not partition keys.
+
+// Example: Update Modified non-distribution columns.
+// Input:
+// +--CLogicalUpdate ("foo"), Split Update, Delete Columns: ["a" (0), "b" (1)], Insert Columns: ["a" (0), "b" (9)], "ctid" (2), "gp_segment_id" (8)
+//   +--CLogicalProject
+//      |--CLogicalGet
+//      +--CScalarProjectList
+//
+// Output:
+// +--CLogicalUpdate ("foo"), In-place Update, Delete Columns: ["a" (0), "b" (1)], Insert Columns: ["a" (0), "b" (9)], "ctid" (2), "gp_segment_id" (8)
+//	 +--CLogicalProject
+//		|--CLogicalGet
+//		+--CScalarProjectList
+
+CExpression *
+CExpressionPreprocessor::ConvertSplitUpdateToInPlaceUpdate(CMemoryPool *mp,
+														   CExpression *pexpr)
+{
+	GPOS_ASSERT(NULL != mp);
+	GPOS_ASSERT(NULL != pexpr);
+	COperator *pop = pexpr->Pop();
+	if (COperator::EopLogicalUpdate != pop->Eopid())
+	{
+		pexpr->AddRef();
+		return pexpr;
+	}
+	CLogicalUpdate *popUpdate = CLogicalUpdate::PopConvert(pop);
+	CTableDescriptor *tabdesc = popUpdate->Ptabdesc();
+	CColRefArray *pdrgpcrInsert = popUpdate->PdrgpcrInsert();
+	CColRefArray *pdrgpcrDelete = popUpdate->PdrgpcrDelete();
+	const ULONG num_cols = pdrgpcrInsert->Size();
+	BOOL split_update = false;
+	CColRefArray *ppartColRefs = GPOS_NEW(mp) CColRefArray(mp);
+	const ULongPtrArray *pdrgpulPart = tabdesc->PdrgpulPart();
+	const ULONG ulPartKeys = pdrgpulPart->Size();
+
+	// Uses split update if any of the modified columns are either
+	// distribution or partition keys.
+	for (ULONG ul = 0; ul < ulPartKeys; ul++)
+	{
+		ULONG *pulPartKey = (*pdrgpulPart)[ul];
+		CColRef *colref = (*pdrgpcrInsert)[*pulPartKey];
+		ppartColRefs->Append(colref);
+	}
+
+	for (ULONG ul = 0; ul < num_cols; ul++)
+	{
+		CColRef *pcrInsert = (*pdrgpcrInsert)[ul];
+		CColRef *pcrDelete = (*pdrgpcrDelete)[ul];
+		// Checking if column is either distribution or partition key.
+		if (pcrInsert != pcrDelete &&
+			(pcrDelete->IsDistCol() || ppartColRefs->Find(pcrInsert) != NULL))
+		{
+			split_update = true;
+			break;
+		}
+	}
+	ppartColRefs->Release();
+	if (!split_update)
+	{
+		CExpression *pexprChild = (*pexpr)[0];
+		pexprChild->AddRef();
+		pdrgpcrInsert->AddRef();
+		pdrgpcrDelete->AddRef();
+		tabdesc->AddRef();
+		CExpression *pexprNew = GPOS_NEW(mp) CExpression(
+			mp,
+			GPOS_NEW(mp) CLogicalUpdate(
+				mp, tabdesc, pdrgpcrDelete, pdrgpcrInsert, popUpdate->PcrCtid(),
+				popUpdate->PcrSegmentId(), popUpdate->PcrTupleOid(), false),
+			pexprChild);
+		return pexprNew;
+	}
+	pexpr->AddRef();
+	return pexpr;
+}
+
 // main driver, pre-processing of input logical expression
 CExpression *
 CExpressionPreprocessor::PexprPreprocess(
@@ -3257,11 +3341,17 @@ CExpressionPreprocessor::PexprPreprocess(
 		PexprTransposeSelectAndProject(mp, pexprExistWithPredFromINSubq);
 	pexprExistWithPredFromINSubq->Release();
 
-	// (28) normalize expression again
-	CExpression *pexprNormalized2 =
-		CNormalizer::PexprNormalize(mp, pexprTransposeSelectAndProject);
+	// (28) convert split update to inplace update
+	CExpression *pexprSplitUpdateToInplace =
+		ConvertSplitUpdateToInPlaceUpdate(mp, pexprTransposeSelectAndProject);
 	GPOS_CHECK_ABORT;
 	pexprTransposeSelectAndProject->Release();
+
+	// (29) normalize expression again
+	CExpression *pexprNormalized2 =
+		CNormalizer::PexprNormalize(mp, pexprSplitUpdateToInplace);
+	GPOS_CHECK_ABORT;
+	pexprSplitUpdateToInplace->Release();
 
 	return pexprNormalized2;
 }

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -1490,12 +1490,12 @@ CTranslatorDXLToExpr::PexprLogicalUpdate(const CDXLNode *dxlnode)
 		pcrTupleOid = LookupColRef(m_phmulcr, tuple_oid);
 	}
 
-	return GPOS_NEW(m_mp)
-		CExpression(m_mp,
-					GPOS_NEW(m_mp) CLogicalUpdate(m_mp, ptabdesc, pdrgpcrDelete,
-												  pdrgpcrInsert, pcrCtid,
-												  pcrSegmentId, pcrTupleOid),
-					pexprChild);
+	return GPOS_NEW(m_mp) CExpression(
+		m_mp,
+		GPOS_NEW(m_mp)
+			CLogicalUpdate(m_mp, ptabdesc, pdrgpcrDelete, pdrgpcrInsert,
+						   pcrCtid, pcrSegmentId, pcrTupleOid, true),
+		pexprChild);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5786,9 +5786,10 @@ CTranslatorExprToDXL::PdxlnDML(CExpression *pexpr,
 
 	CDXLDirectDispatchInfo *dxl_direct_dispatch_info =
 		GetDXLDirectDispatchInfo(pexpr);
-	CDXLPhysicalDML *pdxlopDML = GPOS_NEW(m_mp) CDXLPhysicalDML(
-		m_mp, dxl_dml_type, table_descr, pdrgpul, action_colid, ctid_colid,
-		segid_colid, preserve_oids, tuple_oid, dxl_direct_dispatch_info);
+	CDXLPhysicalDML *pdxlopDML = GPOS_NEW(m_mp)
+		CDXLPhysicalDML(m_mp, dxl_dml_type, table_descr, pdrgpul, action_colid,
+						ctid_colid, segid_colid, preserve_oids, tuple_oid,
+						dxl_direct_dispatch_info, popDML->FSplit());
 
 	// project list
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
@@ -89,6 +89,7 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CColRef *pcrCtid = popDML->PcrCtid();
 	CColRef *pcrSegmentId = popDML->PcrSegmentId();
 	CColRef *pcrTupleOid = popDML->PcrTupleOid();
+	BOOL fSplit = popDML->FSplit();
 
 	// child of DML operator
 	CExpression *pexprChild = (*pexpr)[0];
@@ -99,7 +100,7 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		mp,
 		GPOS_NEW(mp)
 			CPhysicalDML(mp, edmlop, ptabdesc, pdrgpcrSource, pbsModified,
-						 pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid),
+						 pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid, fSplit),
 		pexprChild);
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
@@ -87,6 +87,7 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CColRef *pcrCtid = popUpdate->PcrCtid();
 	CColRef *pcrSegmentId = popUpdate->PcrSegmentId();
 	CColRef *pcrTupleOid = popUpdate->PcrTupleOid();
+	BOOL fSplit = popUpdate->FSplit();
 
 	// child of update operator
 	CExpression *pexprChild = (*pexpr)[0];
@@ -109,23 +110,32 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CMDAccessor *md_accessor = poctxt->Pmda();
 	CColumnFactory *col_factory = poctxt->Pcf();
 
-	pdrgpcrDelete->AddRef();
-	pdrgpcrInsert->AddRef();
-
 	const IMDType *pmdtype = md_accessor->PtMDType<IMDTypeInt4>();
 	CColRef *pcrAction = col_factory->PcrCreate(pmdtype, default_type_modifier);
 
-	CExpression *pexprProjElem = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CScalarProjectElement(mp, pcrAction),
-		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarDMLAction(mp)));
+	CExpression *pexprSplit = NULL;
+	if (fSplit)
+	{
+		pdrgpcrDelete->AddRef();
+		pdrgpcrInsert->AddRef();
+		CExpression *pexprProjElem = GPOS_NEW(mp) CExpression(
+			mp, GPOS_NEW(mp) CScalarProjectElement(mp, pcrAction),
+			GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarDMLAction(mp)));
 
-	CExpression *pexprProjList = GPOS_NEW(mp)
-		CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprProjElem);
-	CExpression *pexprSplit = GPOS_NEW(mp) CExpression(
-		mp,
-		GPOS_NEW(mp) CLogicalSplit(mp, pdrgpcrDelete, pdrgpcrInsert, pcrCtid,
-								   pcrSegmentId, pcrAction, pcrTupleOid),
-		pexprChild, pexprProjList);
+		CExpression *pexprProjList = GPOS_NEW(mp)
+			CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp), pexprProjElem);
+		pexprSplit = GPOS_NEW(mp) CExpression(
+			mp,
+			GPOS_NEW(mp)
+				CLogicalSplit(mp, pdrgpcrDelete, pdrgpcrInsert, pcrCtid,
+							  pcrSegmentId, pcrAction, pcrTupleOid),
+			pexprChild, pexprProjList);
+	}
+	else
+	{
+		pexprSplit = pexprChild;
+	}
+
 
 	// add assert checking that no NULL values are inserted for nullable columns or no check constraints are violated
 	COptimizerConfig *optimizer_config =
@@ -143,28 +153,45 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 
 	const ULONG num_cols = pdrgpcrInsert->Size();
 
-	CBitSet *pbsModified = GPOS_NEW(mp) CBitSet(mp, ptabdesc->ColumnCount());
-	for (ULONG ul = 0; ul < num_cols; ul++)
-	{
-		CColRef *pcrInsert = (*pdrgpcrInsert)[ul];
-		CColRef *pcrDelete = (*pdrgpcrDelete)[ul];
-		if (pcrInsert != pcrDelete)
-		{
-			// delete columns refer to the original tuple's descriptor, if it's different
-			// from the corresponding insert column, then we're modifying the column
-			// at that position
-			pbsModified->ExchangeSet(ul);
-		}
-	}
+	CExpression *pexprDML = NULL;
 	// create logical DML
 	ptabdesc->AddRef();
-	pdrgpcrDelete->AddRef();
-	CExpression *pexprDML = GPOS_NEW(mp) CExpression(
-		mp,
-		GPOS_NEW(mp) CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
-								 pdrgpcrDelete, pbsModified, pcrAction, pcrCtid,
-								 pcrSegmentId, pcrTupleOid),
-		pexprAssertConstraints);
+	if (fSplit)
+	{
+		CBitSet *pbsModified =
+			GPOS_NEW(mp) CBitSet(mp, ptabdesc->ColumnCount());
+		for (ULONG ul = 0; ul < num_cols; ul++)
+		{
+			CColRef *pcrInsert = (*pdrgpcrInsert)[ul];
+			CColRef *pcrDelete = (*pdrgpcrDelete)[ul];
+			if (pcrInsert != pcrDelete)
+			{
+				// delete columns refer to the original tuple's descriptor, if it's different
+				// from the corresponding insert column, then we're modifying the column
+				// at that position
+				pbsModified->ExchangeSet(ul);
+			}
+		}
+		pdrgpcrDelete->AddRef();
+		pexprDML = GPOS_NEW(mp) CExpression(
+			mp,
+			GPOS_NEW(mp)
+				CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
+							pdrgpcrDelete, pbsModified, pcrAction, pcrCtid,
+							pcrSegmentId, pcrTupleOid, fSplit),
+			pexprAssertConstraints);
+	}
+	else
+	{
+		pdrgpcrInsert->AddRef();
+		pexprDML = GPOS_NEW(mp) CExpression(
+			mp,
+			GPOS_NEW(mp)
+				CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
+							pdrgpcrInsert, GPOS_NEW(mp) CBitSet(mp), pcrAction,
+							pcrCtid, pcrSegmentId, NULL, fSplit),
+			pexprAssertConstraints);
+	}
 
 	// TODO:  - Oct 30, 2012; detect and handle AFTER triggers on update
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1358,7 +1358,7 @@ CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
 		GPOS_NEW(mp)
 			CLogicalDML(mp, edmlop, ptabdesc, colref_array,
 						GPOS_NEW(mp) CBitSet(mp) /*pbsModified*/, pcrAction,
-						pcrCtid, pcrSegmentId, NULL /*pcrTupleOid*/),
+						pcrCtid, pcrSegmentId, NULL /*pcrTupleOid*/, true),
 		pexprProject);
 
 	CExpression *pexprOutput = pexprDML;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
@@ -69,6 +69,9 @@ private:
 	// direct dispatch info for insert statements
 	CDXLDirectDispatchInfo *m_direct_dispatch_info;
 
+	// Is Split Update
+	BOOL m_fSplit;
+
 	// private copy ctor
 	CDXLPhysicalDML(const CDXLPhysicalDML &);
 
@@ -79,7 +82,8 @@ public:
 					ULongPtrArray *src_colids_array, ULONG action_colid,
 					ULONG ctid_colid, ULONG segid_colid, BOOL preserve_oids,
 					ULONG tuple_oid,
-					CDXLDirectDispatchInfo *dxl_direct_dispatch_info);
+					CDXLDirectDispatchInfo *dxl_direct_dispatch_info,
+					BOOL fSplit);
 
 	// dtor
 	virtual ~CDXLPhysicalDML();
@@ -151,6 +155,13 @@ public:
 	GetDXLDirectDispatchInfo() const
 	{
 		return m_direct_dispatch_info;
+	}
+
+	// Is update using split
+	BOOL
+	FSplit() const
+	{
+		return m_fSplit;
 	}
 
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
@@ -59,6 +59,9 @@ private:
 	// private copy ctor
 	CParseHandlerPhysicalDML(const CParseHandlerPhysicalDML &);
 
+	// Split Update
+	BOOL m_fSplit;
+
 	// process the start of an element
 	void StartElement(
 		const XMLCh *const element_uri,			// URI of element's namespace

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -367,6 +367,7 @@ enum Edxltoken
 	EdxltokenGpSegmentIdColId,
 	EdxltokenTupleOidColId,
 	EdxltokenUpdatePreservesOids,
+	EdxltokenSplitUpdate,
 
 	EdxltokenInputSegments,
 	EdxltokenOutputSegments,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
@@ -32,7 +32,8 @@ CDXLPhysicalDML::CDXLPhysicalDML(
 	CMemoryPool *mp, const EdxlDmlType dxl_dml_type,
 	CDXLTableDescr *table_descr, ULongPtrArray *src_colids_array,
 	ULONG action_colid, ULONG ctid_colid, ULONG segid_colid, BOOL preserve_oids,
-	ULONG tuple_oid, CDXLDirectDispatchInfo *dxl_direct_dispatch_info)
+	ULONG tuple_oid, CDXLDirectDispatchInfo *dxl_direct_dispatch_info,
+	BOOL fSplit)
 	: CDXLPhysical(mp),
 	  m_dxl_dml_type(dxl_dml_type),
 	  m_dxl_table_descr(table_descr),
@@ -42,7 +43,8 @@ CDXLPhysicalDML::CDXLPhysicalDML(
 	  m_segid_colid(segid_colid),
 	  m_preserve_oids(preserve_oids),
 	  m_tuple_oid(tuple_oid),
-	  m_direct_dispatch_info(dxl_direct_dispatch_info)
+	  m_direct_dispatch_info(dxl_direct_dispatch_info),
+	  m_fSplit(fSplit)
 {
 	GPOS_ASSERT(EdxldmlSentinel > dxl_dml_type);
 	GPOS_ASSERT(NULL != table_descr);
@@ -133,11 +135,17 @@ CDXLPhysicalDML::SerializeToDXL(CXMLSerializer *xml_serializer,
 	if (Edxldmlupdate == m_dxl_dml_type)
 	{
 		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenSplitUpdate), m_fSplit);
+	}
+
+	if (Edxldmlupdate == m_dxl_dml_type && !m_fSplit)
+	{
+		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenUpdatePreservesOids),
 			m_preserve_oids);
 	}
 
-	if (m_preserve_oids)
+	if (m_preserve_oids && !m_fSplit)
 	{
 		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenTupleOidColId), m_tuple_oid);

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
@@ -43,7 +43,8 @@ CParseHandlerPhysicalDML::CParseHandlerPhysicalDML(
 	  m_ctid_colid(0),
 	  m_segid_colid(0),
 	  m_preserve_oids(false),
-	  m_tuple_oid_colid(0)
+	  m_tuple_oid_colid(0),
+	  m_fSplit(true)
 {
 }
 
@@ -124,6 +125,16 @@ CParseHandlerPhysicalDML::StartElement(const XMLCh *const,	// element_uri,
 			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
 			EdxltokenTupleOidColId, EdxltokenPhysicalDMLUpdate);
 	}
+
+	const XMLCh *fSplit =
+		attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenSplitUpdate));
+	if (NULL != fSplit)
+	{
+		m_fSplit = CDXLOperatorFactory::ConvertAttrValueToBool(
+			m_parse_handler_mgr->GetDXLMemoryManager(), fSplit,
+			EdxltokenSplitUpdate, EdxltokenPhysicalDMLUpdate);
+	}
+
 
 	// parse handler for physical operator
 	CParseHandlerBase *child_parse_handler =
@@ -225,7 +236,7 @@ CParseHandlerPhysicalDML::EndElement(const XMLCh *const,  // element_uri,
 	CDXLPhysicalDML *dxl_op = GPOS_NEW(m_mp) CDXLPhysicalDML(
 		m_mp, m_dxl_dml_type, table_descr, m_src_colids_array, m_action_colid,
 		m_ctid_colid, m_segid_colid, m_preserve_oids, m_tuple_oid_colid,
-		dxl_direct_dispatch_info);
+		dxl_direct_dispatch_info, m_fSplit);
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
 
 	// set statistics and physical properties

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -416,6 +416,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenGpSegmentIdColId, GPOS_WSZ_LIT("SegmentIdCol")},
 		{EdxltokenTupleOidColId, GPOS_WSZ_LIT("TupleOidCol")},
 		{EdxltokenUpdatePreservesOids, GPOS_WSZ_LIT("PreserveOids")},
+		{EdxltokenSplitUpdate, GPOS_WSZ_LIT("IsSplitUpdate")},
 
 		{EdxltokenInputSegments, GPOS_WSZ_LIT("InputSegments")},
 		{EdxltokenOutputSegments, GPOS_WSZ_LIT("OutputSegments")},

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -1813,7 +1813,7 @@ CTestUtils::PexprLogicalUpdate(CMemoryPool *mp)
 	return GPOS_NEW(mp) CExpression(
 		mp,
 		GPOS_NEW(mp) CLogicalUpdate(mp, ptabdesc, pdrgpcrDelete, pdrgpcrInsert,
-									colref, colref, NULL /*pcrTupleOid*/),
+									colref, colref, NULL /*pcrTupleOid*/, true),
 		pexprGet);
 }
 

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -59,7 +59,8 @@ ExecUpdate(ItemPointer tupleid,
 		   TupleTableSlot *planSlot,
 		   EPQState *epqstate,
 		   EState *estate,
-		   bool canSetTag);
+		   bool canSetTag,
+		   PlanGenerator planGen);
 
 
 #endif   /* EXECDML_H */

--- a/src/test/isolation/expected/create_index_hot.out
+++ b/src/test/isolation/expected/create_index_hot.out
@@ -1,6 +1,6 @@
 Parsed test spec with 2 sessions
 
-starting permutation: s2begin s2select s1optimizeroff s1update s1createindexonc s2select s2forceindexscan s2select
+starting permutation: s2begin s2select s1update s1createindexonc s2select s2forceindexscan s2select
 step s2begin: BEGIN ISOLATION LEVEL SERIALIZABLE;
 step s2select: select '#' as expected, c from hot where c = '#'
                   union all
@@ -8,7 +8,6 @@ step s2select: select '#' as expected, c from hot where c = '#'
 expected       c              
 
 #              #              
-step s1optimizeroff: set optimizer = off;
 step s1update: update hot set c = '$' where c = '#';
 step s1createindexonc: create index idx_c on hot (c);
 step s2select: select '#' as expected, c from hot where c = '#'

--- a/src/test/isolation/specs/create_index_hot.spec
+++ b/src/test/isolation/specs/create_index_hot.spec
@@ -23,9 +23,7 @@ teardown
 
 # Update a row, and create an index on the updated column. This produces
 # a broken HOT chain.
-#FIXME do not turn off the optimizer when ORCA stops always using Split Update.
 session "s1"
-step "s1optimizeroff" { set optimizer = off; }
 step "s1update" { update hot set c = '$' where c = '#'; }
 step "s1createindexonc" { create index idx_c on hot (c); }
 
@@ -41,7 +39,6 @@ permutation
   "s2begin"
   "s2select"
 
-  "s1optimizeroff"
   "s1update"
   "s1createindexonc"
 

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -353,29 +353,29 @@ UPDATE 1
 -- make sure planner will contain InitPlan
 -- NOTE: orca does not generate InitPlan.
 2: explain update t_epq_subplans set b = b + 1 where a > -1.5 * (select max(a) from t_epq_subplans);
- QUERY PLAN                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------
- Update  (cost=0.00..1324032.68 rows=1 width=1)                                                                                                                                                                                       
-   ->  Split  (cost=0.00..1324032.61 rows=1 width=22)
-         ->  Result  (cost=0.00..1324032.61 rows=1 width=22)
-               ->  Seq Scan on t_epq_subplans  (cost=0.00..1324032.61 rows=1 width=18)
-                     Filter: ((a)::numeric > ((-1.5) * ((SubPlan 1))::numeric))
-                     SubPlan 1  (slice0; segments: 3)
-                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                             ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=4)
-                                   ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                                     ->  Seq Scan on t_epq_subplans t_epq_subplans_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)                                                                                                         
-(14 rows)
+ QUERY PLAN                                                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..1324032.63 rows=1 width=1)                                                                                    
+   ->  Result  (cost=0.00..1324032.61 rows=1 width=18)                                                                             
+         ->  Seq Scan on t_epq_subplans  (cost=0.00..1324032.61 rows=1 width=18)                                                   
+               Filter: ((a)::numeric > ('-1.5'::numeric * ((SubPlan 1))::numeric))                                                 
+               SubPlan 1  (slice0; segments: 3)                                                                                    
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)                                                               
+                       ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=3 width=4)                         
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)                                                     
+                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)                
+                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)                                         
+                                               ->  Seq Scan on t_epq_subplans t_epq_subplans_1  (cost=0.00..431.00 rows=1 width=4) 
+ Optimizer: Pivotal Optimizer (GPORCA)                                                                                             
+(12 rows)
 2&: update t_epq_subplans set b = b + 1 where a > -1.5 * (select max(a) from t_epq_subplans);  <waiting ...>
 
 1: end;
 END
 -- session 2 should throw error and not PANIC
 2<:  <... completed>
-ERROR:  tuple to be updated was already moved to another segment due to concurrent update  (seg1 127.0.1.1:6003 pid=116712)
+ERROR:  could not serialize access due to concurrent update  (seg1 172.17.0.2:6003 pid=86009)
+HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting
 
 1: drop table t_epq_subplans;
 DROP

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -107,25 +107,24 @@ ABORT
 -- TODO: this case is for planner, it will not error out on 6X now,
 --       because 6x does not remove explicit motion yet.
 explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
- QUERY PLAN                                                                      
----------------------------------------------------------------------------------
- Update                                                                          
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)                            
-         Hash Key: tab1.b                                                        
-         ->  Split                                                               
-               ->  Result                                                        
-                     ->  Hash Join                                               
-                           Hash Cond: (tab2.a = tab1.a)                          
-                           ->  Seq Scan on tab2                                  
-                           ->  Hash                                              
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3) 
-                                       ->  Hash Join                             
-                                             Hash Cond: (tab3.b = tab1.b)        
-                                             ->  Seq Scan on tab3                
-                                             ->  Hash                            
-                                                   ->  Seq Scan on tab1          
- Optimizer: Pivotal Optimizer (GPORCA)                                           
-(16 rows)
+ QUERY PLAN                                                                
+---------------------------------------------------------------------------
+ Update                                                                    
+   ->  Result                                                              
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)                
+               Hash Key: tab1.b                                            
+               ->  Hash Join                                               
+                     Hash Cond: (tab2.a = tab1.a)                          
+                     ->  Seq Scan on tab2                                  
+                     ->  Hash                                              
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3) 
+                                 ->  Hash Join                             
+                                       Hash Cond: (tab3.b = tab1.b)        
+                                       ->  Seq Scan on tab3                
+                                       ->  Hash                            
+                                             ->  Seq Scan on tab1          
+ Optimizer: Pivotal Optimizer (GPORCA)                                     
+(15 rows)
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
@@ -163,26 +162,25 @@ ABORT
 
 -- For orca, this will error out
 explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;
- QUERY PLAN                                                                                        
----------------------------------------------------------------------------------------------------
- Update                                                                                            
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)                                              
-         Hash Key: tab1.b                                                                          
-         ->  Split                                                                                 
-               ->  Result                                                                          
-                     ->  Hash Join                                                                 
-                           Hash Cond: (tab3.a = tab1.b)                                            
-                           ->  Seq Scan on tab3                                                    
-                           ->  Hash                                                                
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)                   
-                                       ->  Hash Join                                               
-                                             Hash Cond: (tab2.a = tab1.a)                          
-                                             ->  Seq Scan on tab2                                  
-                                             ->  Hash                                              
-                                                   ->  Broadcast Motion 3:3  (slice1; segments: 3) 
-                                                         ->  Seq Scan on tab1                      
- Optimizer: Pivotal Optimizer (GPORCA)                                                             
-(17 rows)
+ QUERY PLAN                                                                                  
+---------------------------------------------------------------------------------------------
+ Update                                                                                      
+   ->  Result                                                                                
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)                                  
+               Hash Key: tab1.b                                                              
+               ->  Hash Join                                                                 
+                     Hash Cond: (tab3.a = tab1.b)                                            
+                     ->  Seq Scan on tab3                                                    
+                     ->  Hash                                                                
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)                   
+                                 ->  Hash Join                                               
+                                       Hash Cond: (tab2.a = tab1.a)                          
+                                       ->  Seq Scan on tab2                                  
+                                       ->  Hash                                              
+                                             ->  Broadcast Motion 3:3  (slice1; segments: 3) 
+                                                   ->  Seq Scan on tab1                      
+ Optimizer: Pivotal Optimizer (GPORCA)                                                       
+(16 rows)
 begin;
 BEGIN
 update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.a;

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -24,7 +24,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -56,22 +55,21 @@ delete from s;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Update  (cost=0.00..868.53 rows=34 width=1)
-   ->  Split  (cost=0.00..862.80 rows=67 width=22)
-         ->  Result  (cost=0.00..862.80 rows=34 width=22)
-               ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
-                     Hash Cond: (s.a = r.b)
-                     ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
-                           Filter: (NOT (a IS NULL))
-                     ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
-                           ->  Result  (cost=0.00..431.15 rows=3334 width=4)
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
-                                       Hash Key: r.b
-                                       ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
+                                                     QUERY PLAN
+---------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..865.14 rows=34 width=1)
+   ->  Result  (cost=0.00..862.80 rows=34 width=18)
+         ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
+               Hash Cond: (s.a = r.b)
+               ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
+                     Filter: (NOT (a IS NULL))
+               ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
+                     ->  Result  (cost=0.00..431.15 rows=3334 width=4)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
+                                 Hash Key: r.b
+                                 ->  Seq Scan on r  (cost=0.00..431.07 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(12 rows)
 
 update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
 explain delete from s where exists (select 1 from r where s.a = r.b);
@@ -110,7 +108,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg2 rhel62-vm1:25434 pid=32307)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -162,7 +159,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -214,7 +210,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg2 rhel62-vm1:25434 pid=32307)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -266,7 +261,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -318,7 +312,6 @@ insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
 insert into s select generate_series(1, 100), generate_series(1, 100) * 4;
 update r set b = r.b + 1 from s where r.a = s.a;
 update r set b = r.b + 1 from s where r.a in (select a from s);
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 delete from r using s where r.a = s.a;
 delete from r;
 insert into r select generate_series(1, 10000), generate_series(1, 10000) * 3;
@@ -1346,32 +1339,16 @@ select r.* from r,s,sales where s.a = sales.day and sales.month = r.b;
 (6 rows)
 
 update r set b = r.b + 1 from s,sales where s.a = sales.day and sales.month = r.b;
-ERROR:  multiple updates to a row by the same query is not allowed  (seg1 rhel62-vm1:25433 pid=32305)
 select r.* from r,s,sales where s.a = sales.day and sales.month = r.b-1;
  a | b  
 ---+----
- 1 |  3
- 1 |  3
- 1 |  3
- 1 |  3
- 2 |  6
- 2 |  6
- 2 |  6
- 2 |  6
- 2 |  6
- 2 |  6
- 2 |  6
- 3 |  9
- 3 |  9
- 3 |  9
- 3 |  9
- 3 |  9
- 4 | 12
- 4 | 12
- 4 | 12
- 4 | 12
- 4 | 12
-(21 rows)
+ 2 |  7
+ 3 | 10
+ 3 | 10
+ 4 | 13
+ 1 |  4
+ 1 |  4
+(6 rows)
 
 -- ----------------------------------------------------------------------
 -- Test: query02.sql
@@ -1662,14 +1639,13 @@ select distinct sales_par.* from sales_par,s where sales_par.id in (s.b, s.b+1) 
 (4 rows)
 
 update sales_par set month = month+1 from s where sales_par.id in (s.b, s.b+1) and region = 'europe';
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 select distinct sales_par.* from sales_par,s where sales_par.id in (s.b, s.b+1) and region='europe';
  id | year | month | day | region 
 ----+------+-------+-----+--------
- 13 | 2008 |     2 |  14 | europe
-  5 | 2007 |     6 |   6 | europe
- 17 | 2005 |     6 |  18 | europe
-  9 | 2004 |    10 |  10 | europe
+  5 | 2007 |     7 |   6 | europe
+  9 | 2004 |    11 |  10 | europe
+ 13 | 2008 |     3 |  14 | europe
+ 17 | 2005 |     7 |  18 | europe
 (4 rows)
 
 -- direct dispatch: partitioned table: delete --
@@ -1762,14 +1738,13 @@ select distinct sales_par.* from sales_par,s where sales_par.id in (s.b, s.b+1) 
 
 PREPARE plan3 AS update sales_par set month = month+1 from s where sales_par.id in (s.b, s.b+1) and region = 'europe';
 EXECUTE plan3;
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 rhel62-vm1:25432 pid=32303)
 select distinct sales_par.* from sales_par,s where sales_par.id in (s.b, s.b+1) and region='europe';
  id | year | month | day | region 
 ----+------+-------+-----+--------
- 13 | 2008 |     2 |  14 | europe
-  5 | 2007 |     6 |   6 | europe
- 17 | 2005 |     6 |  18 | europe
-  9 | 2004 |    10 |  10 | europe
+  5 | 2007 |     7 |   6 | europe
+  9 | 2004 |    11 |  10 | europe
+ 13 | 2008 |     3 |  14 | europe
+ 17 | 2005 |     7 |  18 | europe
 (4 rows)
 
 -- direct dispatch: partitioned table: delete --

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -183,14 +183,13 @@ drop table m;
 create table update_pk_test (a int primary key, b int) distributed by (a);
 insert into update_pk_test values(1,1);
 explain update update_pk_test set b = 5;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Update  (cost=0.00..431.06 rows=1 width=1)
-   ->  Split  (cost=0.00..431.00 rows=1 width=22)
-         ->  Result  (cost=0.00..431.00 rows=1 width=22)
-               ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
+                                 QUERY PLAN
+-----------------------------------------------------------------------------
+ Update  (cost=0.00..431.02 rows=1 width=1)
+   ->  Result  (cost=0.00..431.00 rows=1 width=18)
+         ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=14)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(4 rows)
 
 update update_pk_test set b = 5;
 select * from update_pk_test order by 1,2;
@@ -596,19 +595,18 @@ create table bar (a int, b int) distributed randomly;
 insert into foo (a, b) values (1, 2);
 insert into bar (a, b) values (1, 2);
 explain update foo set a=4 from bar where foo.a=bar.a;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Update  (cost=0.00..862.06 rows=1 width=1)
-   ->  Split  (cost=0.00..862.00 rows=1 width=22)
-         ->  Result  (cost=0.00..862.00 rows=1 width=22)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
-                     Hash Cond: (foo.a = bar.a)
-                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..862.02 rows=1 width=1)
+   ->  Result  (cost=0.00..862.00 rows=1 width=18)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=14)
+               Hash Cond: (foo.a = bar.a)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(9 rows)
 
 update foo set a=4 from bar where foo.a=bar.a;
 select * from foo;

--- a/src/test/regress/expected/bfv_legacy_optimizer.out
+++ b/src/test/regress/expected/bfv_legacy_optimizer.out
@@ -86,10 +86,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into bfv_int4_tbl values(123456), (-2147483647), (0), (-123456), (2147483647);
 update bfv_s set c_v = 11
 from bfv_int4_tbl a join bfv_int4_tbl b on (a.f1 = (select f1 from bfv_int4_tbl c where c.f1=b.f1));
-ERROR:  multiple updates to a row by the same query is not allowed
 update bfv_s set c_v = 11
 from bfv_int4_tbl a join bfv_int4_tbl b on (a.f1 = (select f1 from bfv_int4_tbl c where c.f1=b.f1));
-ERROR:  multiple updates to a row by the same query is not allowed
 --
 --
 --

--- a/src/test/regress/expected/gp_unique_rowid.out
+++ b/src/test/regress/expected/gp_unique_rowid.out
@@ -116,8 +116,6 @@ explain (costs off ) update rank_12402 set rank = 1 where id in (select id from 
 
 -- Test for fake ctid works well
 -- issue: https://github.com/greenplum-db/gpdb/issues/12512
--- NOTE: orca use split-update, planner use update, behavior is different when
--- tuple is updated by self.
 -- test ctid for subquery in update
 create table t_12512(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/gp_unique_rowid_optimizer.out
+++ b/src/test/regress/expected/gp_unique_rowid_optimizer.out
@@ -64,37 +64,34 @@ NOTICE:  CREATE TABLE will create partition "rank1_12402_1_prt_2" for table "ran
 -- It should create a unique_rowid plan.
 -- but it creates a semi-join plan, due to we disallow unique_rowid path in inheritance_planner.
 explain (costs off ) update rank_12402 set rank = 1 where id in (select id from rank1_12402) and value in (select value from rank1_12402);
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Result
+   ->  Result
+         ->  Hash Semi Join
+               Hash Cond: (rank_12402.value = rank1_12402_1.value)
                ->  Hash Semi Join
-                     Hash Cond: (rank_12402.value = rank1_12402_1.value)
-                     ->  Hash Semi Join
-                           Hash Cond: (rank_12402.id = rank1_12402.id)
-                           ->  Sequence
-                                 ->  Partition Selector for rank_12402 (dynamic scan id: 1)
-                                       Partitions selected: 2 (out of 2)
-                                 ->  Dynamic Seq Scan on rank_12402 (dynamic scan id: 1)
-                           ->  Hash
-                                 ->  Sequence
-                                       ->  Partition Selector for rank1_12402 (dynamic scan id: 2)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on rank1_12402 (dynamic scan id: 2)
+                     Hash Cond: (rank_12402.id = rank1_12402.id)
+                     ->  Sequence
+                           ->  Partition Selector for rank_12402 (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on rank_12402 (dynamic scan id: 1)
                      ->  Hash
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                 ->  Sequence
-                                       ->  Partition Selector for rank1_12402 (dynamic scan id: 3)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on rank1_12402 rank1_12402_1 (dynamic scan id: 3)
+                           ->  Sequence
+                                 ->  Partition Selector for rank1_12402 (dynamic scan id: 2)
+                                       Partitions selected: 2 (out of 2)
+                                 ->  Dynamic Seq Scan on rank1_12402 (dynamic scan id: 2)
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Sequence
+                                 ->  Partition Selector for rank1_12402 (dynamic scan id: 3)
+                                       Partitions selected: 2 (out of 2)
+                                 ->  Dynamic Seq Scan on rank1_12402 rank1_12402_1 (dynamic scan id: 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(22 rows)
 
 -- Test for fake ctid works well
 -- issue: https://github.com/greenplum-db/gpdb/issues/12512
--- NOTE: orca use split-update, planner use update, behavior is different when
--- tuple is updated by self.
 -- test ctid for subquery in update
 create table t_12512(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -120,29 +117,28 @@ where e.x in
     select b from t2_12512
     )
 ;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Result
-               ->  Hash Semi Join
-                     Hash Cond: ((sum(t1_12512.a)) = (t2_12512.b)::bigint)
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Seq Scan on t_12512
-                           ->  Materialize
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                       ->  Result
-                                             ->  HashAggregate
-                                                   Group Key: t1_12512.b
-                                                   ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                         Hash Key: t1_12512.b
-                                                         ->  Seq Scan on t1_12512
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on t2_12512
+   ->  Result
+         ->  Hash Semi Join
+               Hash Cond: ((sum(t1_12512.a)) = (t2_12512.b)::bigint)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Seq Scan on t_12512
+                     ->  Materialize
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                 ->  Result
+                                       ->  HashAggregate
+                                             Group Key: t1_12512.b
+                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                                   Hash Key: t1_12512.b
+                                                   ->  Seq Scan on t1_12512
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                           ->  Seq Scan on t2_12512
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(19 rows)
 
 update t_12512 set b = 1
     from
@@ -155,7 +151,6 @@ where e.x in
     select b from t2_12512
     )
 ;
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 127.0.1.1:6002 pid=31136)
 -- test fake ctid for functions
 explain (costs off)
 update t_12512 set b = 1
@@ -168,24 +163,23 @@ where e.x in
     select b from t2_12512
     )
 ;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Result
-               ->  Hash Semi Join
-                     Hash Cond: ("outer".x = t2_12512.b)
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Seq Scan on t_12512
-                           ->  Materialize
+   ->  Result
+         ->  Hash Semi Join
+               Hash Cond: ("outer".x = t2_12512.b)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Seq Scan on t_12512
+                     ->  Materialize
+                           ->  Result
                                  ->  Result
-                                       ->  Result
-                     ->  Hash
-                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                 ->  Seq Scan on t2_12512
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on t2_12512
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(14 rows)
 
 update t_12512 set b = 1
     from
@@ -209,27 +203,21 @@ where e.x in
     select b from t2_12512
     )
 ;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Update
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-         Hash Key: t_12512.a
-         ->  Split
-               ->  Result
-                     ->  Hash Semi Join
-                           Hash Cond: ("Values".column1 = t2_12512.b)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                 Hash Key: "Values".column1
-                                 ->  Nested Loop
-                                       Join Filter: true
-                                       ->  Seq Scan on t_12512
-                                       ->  Values Scan on "Values"
-                           ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                       Hash Key: t2_12512.b
-                                       ->  Seq Scan on t2_12512
+   ->  Result
+         ->  Hash Semi Join
+               Hash Cond: ("Values".column1 = t2_12512.b)
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Seq Scan on t_12512
+                     ->  Values Scan on "Values"
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Seq Scan on t2_12512
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(12 rows)
 
 update t_12512 set b = 1
     from
@@ -241,7 +229,6 @@ where e.x in
     select b from t2_12512
     )
 ;
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 127.0.1.1:6002 pid=31136)
 -- test fake ctid for external scan
 CREATE OR REPLACE FUNCTION write_to_file_12512() RETURNS integer AS
    '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE;
@@ -269,26 +256,25 @@ where e.x in
     select b from t2_12512
     )
 ;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Update
-   ->  Redistribute Motion 3:3  (slice3; segments: 3)
-         Hash Key: t_12512.a
-         ->  Split
-               ->  Result
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 ->  Seq Scan on t_12512
-                           ->  Materialize
-                                 ->  Hash Semi Join
-                                       Hash Cond: (ext_r_12512.a = t2_12512.b)
-                                       ->  External Scan on ext_r_12512
-                                       ->  Hash
-                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                                   ->  Seq Scan on t2_12512
+   ->  Result
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
+               Hash Key: t_12512.a
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on t_12512
+                     ->  Materialize
+                           ->  Hash Semi Join
+                                 Hash Cond: (ext_r_12512.a = t2_12512.b)
+                                 ->  External Scan on ext_r_12512
+                                 ->  Hash
+                                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                             ->  Seq Scan on t2_12512
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 update t_12512 set b = 1
     from
@@ -300,7 +286,6 @@ where e.x in
     select b from t2_12512
     )
 ;
-ERROR:  multiple updates to a row by the same query is not allowed  (seg0 127.0.1.1:6002 pid=31136)
 -- reset fault injector
 select gp_inject_fault('low_unique_rowid_path_cost', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14688,25 +14688,24 @@ update window_agg_test t
 set i = tt.i 
 from (select (min(i) over (order by j)) as i, j from window_agg_test) tt
 where t.j = tt.j;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Update  (cost=0.00..862.06 rows=1 width=1)
-   ->  Explicit Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=2 width=22)
-         ->  Split  (cost=0.00..862.00 rows=1 width=22)
-               ->  Hash Join  (cost=0.00..862.00 rows=1 width=22)
-                     Hash Cond: (window_agg_test.j = window_agg_test_1.j)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
-                           ->  Seq Scan on window_agg_test  (cost=0.00..431.00 rows=1 width=18)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-                           ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                                 Order By: window_agg_test_1.j
-                                 ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       Merge Key: window_agg_test_1.j
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: window_agg_test_1.j
-                                             ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=1 width=8)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..862.02 rows=1 width=1)
+   ->  Explicit Redistribute Motion 1:3  (slice3; segments: 1)  (cost=0.00..862.00 rows=1 width=18)
+         ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
+               Hash Cond: (window_agg_test.j = window_agg_test_1.j)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Seq Scan on window_agg_test  (cost=0.00..431.00 rows=1 width=14)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                     ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
+                           Order By: window_agg_test_1.j
+                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Merge Key: window_agg_test_1.j
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       Sort Key: window_agg_test_1.j
+                                       ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(15 rows)
 
 ----------------------------------
 -- Test ORCA support for const TVF

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3084,30 +3084,29 @@ from (
 ) src
 where  trg.key1 = src.key1
         and trg.key1 = 2;
-                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Hash Join
-               Hash Cond: (t_part1.key1 = t_part1_1.key1)
-               ->  Sequence
-                     ->  Partition Selector for t_part1 (dynamic scan id: 1)
-                           Partitions selected: 1 (out of 399)
-                     ->  Dynamic Seq Scan on t_part1 (dynamic scan id: 1)
-                           Filter: (key1 = 2)
-               ->  Hash
-                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                           ->  Result
-                                 Filter: (t_part1_1.key1 = 2)
-                                 ->  WindowAgg
-                                       ->  Gather Motion 3:1  (slice1; segments: 3)
-                                             ->  Sequence
-                                                   ->  Partition Selector for t_part1 (dynamic scan id: 2)
-                                                         Partitions selected: 1 (out of 399)
-                                                   ->  Dynamic Seq Scan on t_part1 t_part1_1 (dynamic scan id: 2)
-                                                         Filter: (key1 = 2)
+   ->  Hash Join
+         Hash Cond: (t_part1.key1 = t_part1_1.key1)
+         ->  Sequence
+               ->  Partition Selector for t_part1 (dynamic scan id: 1)
+                     Partitions selected: 1 (out of 399)
+               ->  Dynamic Seq Scan on t_part1 (dynamic scan id: 1)
+                     Filter: (key1 = 2)
+         ->  Hash
+               ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                     ->  Result
+                           Filter: (t_part1_1.key1 = 2)
+                           ->  WindowAgg
+                                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                                       ->  Sequence
+                                             ->  Partition Selector for t_part1 (dynamic scan id: 2)
+                                                   Partitions selected: 1 (out of 399)
+                                             ->  Dynamic Seq Scan on t_part1 t_part1_1 (dynamic scan id: 2)
+                                                   Filter: (key1 = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(20 rows)
 
 DROP TABLE t_part1;
 -- Test that the dynamic partition pruning should not be performed if the partition's opclass and the

--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -4050,8 +4050,8 @@ SELECT SUM(b) FROM dml_heap_r;
 (1 row)
 
 --Negative test - Update WHERE join returns more than one tuple with different values.
-CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
-CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
+CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i distributed by (a);
+CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i distributed by (a);
 SELECT SUM(a) FROM dml_heap_v;
  sum 
 -----

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -4068,8 +4068,8 @@ SELECT SUM(b) FROM dml_heap_r;
 (1 row)
 
 --Negative test - Update WHERE join returns more than one tuple with different values.
-CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
-CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
+CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i distributed by (a);
+CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i distributed by (a);
 SELECT SUM(a) FROM dml_heap_v;
  sum 
 -----

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -57,14 +57,13 @@ DETAIL:  Feature not supported: UPDATE with constraints
 
 set optimizer_enable_dml_constraints=on;
 explain update constr_tab set b = 10;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Update  (cost=0.00..431.08 rows=1 width=1)
-   ->  Split  (cost=0.00..431.00 rows=1 width=30)
-         ->  Result  (cost=0.00..431.00 rows=1 width=30)
-               ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Update  (cost=0.00..431.03 rows=1 width=1)
+   ->  Result  (cost=0.00..431.00 rows=1 width=26)
+         ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=22)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(4 rows)
 
 -- Same, with NOT NULL constraint.
 DROP TABLE IF EXISTS constr_tab;

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -642,21 +642,20 @@ SELECT * FROM rw_view2;
 (2 rows)
 
 EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+                                  QUERY PLAN
+-------------------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Hash Join
-               Hash Cond: (base_tbl.a = base_tbl_1.a)
-               ->  Index Scan using base_tbl_pkey on base_tbl
-                     Index Cond: (a = 2)
-               ->  Hash
-                     ->  Result
-                           Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                                 Index Cond: (a > 0)
+   ->  Hash Join
+         Hash Cond: (base_tbl.a = base_tbl_1.a)
+         ->  Index Scan using base_tbl_pkey on base_tbl
+               Index Cond: (a = 2)
+         ->  Hash
+               ->  Result
+                     Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
+                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           Index Cond: (a > 0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
                                      QUERY PLAN                                      
@@ -2071,22 +2070,21 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
  Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
  
  Update
-   ->  Split
-         ->  Result
-               ->  Nested Loop Semi Join
-                     Join Filter: true
-                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
-                           Index Cond: (id = 2)
-                     ->  Materialize
-                           ->  Broadcast Motion 1:3  (slice2; segments: 1)
+   ->  Result
+         ->  Nested Loop Semi Join
+               Join Filter: true
+               ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                     Index Cond: (id = 2)
+               ->  Materialize
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                           ->  Result
                                  ->  Result
-                                       ->  Result
-                                             ->  Limit
-                                                   ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                         ->  Index Scan using base_tbl_pkey on base_tbl
-                                                               Index Cond: (id = 2)
+                                       ->  Limit
+                                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                                   ->  Index Scan using base_tbl_pkey on base_tbl
+                                                         Index Cond: (id = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(37 rows)
+(36 rows)
 
 INSERT INTO rw_view1 VALUES (2, 'New row 2');
 SELECT * FROM base_tbl;

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -123,45 +123,44 @@ EXPLAIN (COSTS OFF) UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
                 (SELECT min (keo4.keo_para_budget_date) FROM keo4)))
     ) t1
 WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update
-   ->  Split
-         ->  Result
+   ->  Result
+         ->  Hash Join
+               Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
                ->  Hash Join
-                     Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
-                     ->  Hash Join
-                           Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
-                           ->  Seq Scan on keo1
-                           ->  Hash
-                                 ->  Broadcast Motion 1:3  (slice5; segments: 1)
-                                       ->  Hash Join
-                                             Hash Cond: ((keo1_1.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
-                                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                   ->  Seq Scan on keo1 keo1_1
-                                             ->  Hash
-                                                   ->  Aggregate
-                                                         ->  Hash Join
-                                                               Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
-                                                               ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                     ->  Seq Scan on keo3
-                                                               ->  Hash
-                                                                     ->  Assert
-                                                                           Assert Cond: ((row_number() OVER (?)) = 1)
-                                                                           ->  WindowAgg
-                                                                                 ->  Hash Join
-                                                                                       Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
-                                                                                       ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                                                             ->  Seq Scan on keo4
-                                                                                       ->  Hash
-                                                                                             ->  Aggregate
-                                                                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                         ->  Seq Scan on keo4 keo4_1
+                     Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
+                     ->  Seq Scan on keo1
                      ->  Hash
-                           ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                 ->  Seq Scan on keo2
+                           ->  Broadcast Motion 1:3  (slice5; segments: 1)
+                                 ->  Hash Join
+                                       Hash Cond: ((keo1_1.user_vie_fiscal_year_period_sk)::text = (max((keo3.sky_per)::text)))
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Seq Scan on keo1 keo1_1
+                                       ->  Hash
+                                             ->  Aggregate
+                                                   ->  Hash Join
+                                                         Hash Cond: ((keo3.bky_per)::text = (keo4.keo_para_required_period)::text)
+                                                         ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                               ->  Seq Scan on keo3
+                                                         ->  Hash
+                                                               ->  Assert
+                                                                     Assert Cond: ((row_number() OVER (?)) = 1)
+                                                                     ->  WindowAgg
+                                                                           ->  Hash Join
+                                                                                 Hash Cond: ((keo4.keo_para_budget_date)::text = (min((keo4_1.keo_para_budget_date)::text)))
+                                                                                 ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                                                       ->  Seq Scan on keo4
+                                                                                 ->  Hash
+                                                                                       ->  Aggregate
+                                                                                             ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                                                                   ->  Seq Scan on keo4 keo4_1
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                           ->  Seq Scan on keo2
  Optimizer: Pivotal Optimizer (GPORCA)
-(36 rows)
+(35 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/sql/gp_unique_rowid.sql
+++ b/src/test/regress/sql/gp_unique_rowid.sql
@@ -51,8 +51,6 @@ explain (costs off ) update rank_12402 set rank = 1 where id in (select id from 
 
 -- Test for fake ctid works well
 -- issue: https://github.com/greenplum-db/gpdb/issues/12512
--- NOTE: orca use split-update, planner use update, behavior is different when
--- tuple is updated by self.
 
 -- test ctid for subquery in update
 create table t_12512(a int, b int, c int);

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -1735,8 +1735,8 @@ UPDATE dml_heap_r SET b = MAX(dml_heap_s.b) FROM dml_heap_s WHERE dml_heap_r.b =
 SELECT SUM(b) FROM dml_heap_r;
 
 --Negative test - Update WHERE join returns more than one tuple with different values.
-CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i;
-CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i;
+CREATE TABLE dml_heap_u as SELECT i as a, 1 as b  FROM generate_series(1,10)i distributed by (a);
+CREATE TABLE dml_heap_v as SELECT i as a ,i as b FROM generate_series(1,10)i distributed by (a);
 SELECT SUM(a) FROM dml_heap_v;
 UPDATE dml_heap_v SET a = dml_heap_u.a FROM dml_heap_u WHERE dml_heap_u.b = dml_heap_v.b;
 SELECT SUM(a) FROM dml_heap_v;


### PR DESCRIPTION
Implemented InPlaceUpdate to be used for updates made on non-distribution columns.
Currently, ORCA uses Split-Update for updates on both distribution
and non-distribution columns. With this commit,
ORCA uses an InPlaceUpdate whenever updates are made to
non-distribution columns or non-partition keys, and Split Update 
if any of modified columns are either distribution or partition keys.  
Consider below setup where we are updating
non-distibution column, b in the table foo.

`
create table foo(a int, b int);
explain update foo set b=4;
`
ORCA produces plan with Split and Update nodes

```
 Update
   Output: foo.a, foo.b, (DMLAction), foo.ctid
   ->  Split
         Output: foo.a, foo.b, foo.ctid, foo.gp_segment_id, DMLAction
         ->  Result
               Output: foo.a, foo.b, 4, foo.ctid, foo.gp_segment_id
               ->  Seq Scan on public.foo
                     Output: foo.a, foo.b, foo.ctid, foo.gp_segment_id

```

There is no point in using a Split and Update for this as we are updating a
non-distribution column which do not require any redistribution. This
commit uses an InPlace Update to perform updates on non-distribution
columns like Planner. Below is the new plan produced with this commit.

New Plan
```
 Update
   Output: foo.a, "outer".b, foo.ctid
   ->  Result
         Output: foo.a, 4, foo.ctid, foo.gp_segment_id
         ->  Seq Scan on public.foo
               Output: foo.a, foo.ctid, foo.gp_segment_id

```

greenplum 6 specific changes:
1. Some constructors have been changed because the list of arguments in 6X and 7X
are different.
2. fixed a bug in CParseHandlerPhysicalDML::startElement where preserve_oids_xml
was used instead of fSplit, which could lead to SIGSEGV during DML node parsing.
3. Changed create_index_hot test. Removed disabling the optimizer before updating
since ORCA no longer uses split update in this case.
4. Implement In-Place Update for DML node. Added the exec Update call in the DML
node. Added partitioning selection in case of In-Place update by sorted table.
Added a call to reconstructMatchingTupleSlot in execUpdate to update plans
generated by ORCA to handle cases of dropped attributes.


original commit: https://github.com/greenplum-db/gpdb/commit/3ced85b65732728edff66fd9a2ce6d7485d65a06