### PR TITLE
ADBDEV-4081-old: some need backports

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -115,8 +115,7 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp)
 
 	segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
 
-	simple_heap_insert(segrel, segtup);
-	CatalogUpdateIndexes(segrel, segtup);
+	CatalogTupleInsert(segrel, segtup);
 
 	heap_freetuple(segtup);
 	heap_close(segrel, RowExclusiveLock);

--- a/src/backend/access/appendonly/appendonly_visimap_store.c
+++ b/src/backend/access/appendonly/appendonly_visimap_store.c
@@ -149,14 +149,12 @@ AppendOnlyVisimapStore_Store(
 	 */
 	if (ItemPointerIsValid(&visiMapEntry->tupleTid))
 	{
-		simple_heap_update(visimapRelation, &visiMapEntry->tupleTid, tuple);
+		CatalogTupleUpdate(visimapRelation, &visiMapEntry->tupleTid, tuple);
 	}
 	else
 	{
-		simple_heap_insert(visimapRelation, tuple);
+		CatalogTupleInsert(visimapRelation, tuple);
 	}
-
-	CatalogUpdateIndexes(visimapRelation, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/access/appendonly/appendonly_visimap_store.c
+++ b/src/backend/access/appendonly/appendonly_visimap_store.c
@@ -331,7 +331,7 @@ AppendOnlyVisimapStore_DeleteSegmentFile(
 										  NULL,
 										  &tid))
 	{
-		simple_heap_delete(visiMapStore->visimapRelation,
+		CatalogTupleDelete(visiMapStore->visimapRelation,
 						   &tid);
 	}
 	AppendOnlyVisimapStore_EndScan(visiMapStore, indexScan);

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -828,7 +828,7 @@ AppendOnlyBlockDirectory_DeleteSegmentFile(Relation aoRel,
 
 	while ((tuple = index_getnext(indexScan, ForwardScanDirection)) != NULL)
 	{
-		simple_heap_delete(blkdirRel,
+		CatalogTupleDelete(blkdirRel,
 						   &tuple->t_self);
 	}
 	index_endscan(indexScan);

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -1194,7 +1194,7 @@ write_minipage(AppendOnlyBlockDirectory *blockDirectory,
 						  columnGroupNo, minipageInfo->numMinipageEntries,
 						  minipageInfo->minipage->entry[0].firstRowNum)));
 
-		simple_heap_update(blkdirRel, &minipageInfo->tupleTid, tuple);
+		CatalogTupleUpdate(blkdirRel, &minipageInfo->tupleTid, tuple);
 	}
 	else
 	{
@@ -1206,10 +1206,8 @@ write_minipage(AppendOnlyBlockDirectory *blockDirectory,
 						  columnGroupNo, minipageInfo->numMinipageEntries,
 						  minipageInfo->minipage->entry[0].firstRowNum)));
 
-		simple_heap_insert(blkdirRel, tuple);
+		CatalogTupleInsert(blkdirRel, tuple);
 	}
-
-	CatalogUpdateIndexes(blkdirRel, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1406,7 +1406,7 @@ SetDefaultACL(InternalDefaultACL *iacls)
 			values[Anum_pg_default_acl_defaclacl - 1] = PointerGetDatum(new_acl);
 
 			newtuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
-			simple_heap_insert(rel, newtuple);
+			CatalogTupleInsert(rel, newtuple);
 		}
 		else
 		{
@@ -1416,11 +1416,8 @@ SetDefaultACL(InternalDefaultACL *iacls)
 
 			newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel),
 										 values, nulls, replaces);
-			simple_heap_update(rel, &newtuple->t_self, newtuple);
+			CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 		}
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(rel, newtuple);
 
 		/* these dependencies don't change in an update */
 		if (isNew)
@@ -1851,10 +1848,7 @@ ExecGrant_Attribute(InternalGrant *istmt, Oid relOid, const char *relname,
 		newtuple = heap_modify_tuple(attr_tuple, RelationGetDescr(attRelation),
 									 values, nulls, replaces);
 
-		simple_heap_update(attRelation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(attRelation, newtuple);
+		CatalogTupleUpdate(attRelation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(RelationRelationId, relOid, attnum,
@@ -2112,10 +2106,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 			newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation),
 										 values, nulls, replaces);
 
-			simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-			/* keep the catalog indexes up to date */
-			CatalogUpdateIndexes(relation, newtuple);
+			CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 			/* Update the shared dependency ACL info */
 			updateAclDependencies(RelationRelationId, relOid, 0,
@@ -2302,10 +2293,7 @@ CopyRelationAcls(Oid srcId, Oid destId)
 	newTuple = heap_modify_tuple(destTuple, RelationGetDescr(pg_class_rel),
 								 values, nulls, replaces);
 
-	simple_heap_update(pg_class_rel, &newTuple->t_self, newTuple);
-
-	/* keep the catalog indexes up to date */
-	CatalogUpdateIndexes(pg_class_rel, newTuple);
+	CatalogTupleUpdate(pg_class_rel, &newTuple->t_self, newTuple);
 
 	/* Update the shared dependency ACL info */
 	ownerId = pg_class_tuple->relowner;
@@ -2361,10 +2349,7 @@ CopyRelationAcls(Oid srcId, Oid destId)
 		newTuple = heap_modify_tuple(attDestTuple, RelationGetDescr(pg_attribute_rel),
 									 values, nulls, replaces);
 
-		simple_heap_update(pg_attribute_rel, &newTuple->t_self, newTuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(pg_attribute_rel, newTuple);
+		CatalogTupleUpdate(pg_attribute_rel, &newTuple->t_self, newTuple);
 
 		/* Update the shared dependency ACL info */
 		ownerId = pg_class_tuple->relowner;
@@ -2486,10 +2471,7 @@ ExecGrant_Database(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* MPP-6929: metadata tracking */
 		if (Gp_role == GP_ROLE_DISPATCH)
@@ -2620,10 +2602,7 @@ ExecGrant_Fdw(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(ForeignDataWrapperRelationId,
@@ -2745,10 +2724,7 @@ ExecGrant_ForeignServer(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(ForeignServerRelationId,
@@ -2869,10 +2845,7 @@ ExecGrant_Function(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(ProcedureRelationId, funcId, 0,
@@ -2999,10 +2972,7 @@ ExecGrant_Language(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(LanguageRelationId, HeapTupleGetOid(tuple), 0,
@@ -3138,10 +3108,7 @@ ExecGrant_Largeobject(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation),
 									 values, nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(LargeObjectRelationId,
@@ -3263,10 +3230,7 @@ ExecGrant_Namespace(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* MPP-6929: metadata tracking */
 		if (Gp_role == GP_ROLE_DISPATCH)
@@ -3396,10 +3360,7 @@ ExecGrant_Tablespace(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* MPP-6929: metadata tracking */
 		if (Gp_role == GP_ROLE_DISPATCH)
@@ -3542,10 +3503,7 @@ ExecGrant_Type(InternalGrant *istmt)
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
 									 nulls, replaces);
 
-		simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relation, newtuple);
+		CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
 		/* Update the shared dependency ACL info */
 		updateAclDependencies(TypeRelationId, typId, 0,
@@ -3710,10 +3668,7 @@ ExecGrant_ExtProtocol(InternalGrant *istmt)
         newtuple = heap_modify_tuple(tuple, RelationGetDescr(relation), values,
                                      nulls, replaces);
 
-        simple_heap_update(relation, &newtuple->t_self, newtuple);
-
-        /* keep the catalog indexes up to date */
-        CatalogUpdateIndexes(relation, newtuple);
+        CatalogTupleUpdate(relation, &newtuple->t_self, newtuple);
 
         /* Update the shared dependency ACL info */
         updateAclDependencies(ExtprotocolRelationId,

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1624,7 +1624,7 @@ RemoveDefaultACLById(Oid defaclOid)
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "could not find tuple for default ACL %u", defaclOid);
 
-	simple_heap_delete(rel, &tuple->t_self);
+	CatalogTupleDelete(rel, &tuple->t_self);
 
 	systable_endscan(scan);
 	heap_close(rel, RowExclusiveLock);

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1142,7 +1142,7 @@ deleteOneObject(const ObjectAddress *object, Relation *depRel, int flags)
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(*depRel, &tup->t_self);
+		CatalogTupleDelete(*depRel, &tup->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -77,15 +77,13 @@ InsertInitialFastSequenceEntries(Oid objid)
 	/* Insert enrty for segfile 0 */
 	values[Anum_gp_fastsequence_objmod - 1] = Int64GetDatum(RESERVED_SEGNO);
 	tuple = heaptuple_form_to(tupleDesc, values, nulls, NULL, NULL);
-	simple_heap_insert(gp_fastsequence_rel, tuple);
-	CatalogUpdateIndexes(gp_fastsequence_rel, tuple);
+	CatalogTupleInsert(gp_fastsequence_rel, tuple);
 	heap_freetuple(tuple);
 
 	/* Insert entry for segfile 1 */
 	values[Anum_gp_fastsequence_objmod - 1] = Int64GetDatum(1);
 	tuple = heaptuple_form_to(tupleDesc, values, nulls, NULL, NULL);
-	simple_heap_insert(gp_fastsequence_rel, tuple);
-	CatalogUpdateIndexes(gp_fastsequence_rel, tuple);
+	CatalogTupleInsert(gp_fastsequence_rel, tuple);
 	heap_freetuple(tuple);
 
 	heap_close(gp_fastsequence_rel, RowExclusiveLock);
@@ -181,8 +179,7 @@ insert_or_update_fastsequence(Relation gp_fastsequence_rel,
 
 		newTuple = heaptuple_form_to(tupleDesc, values, nulls, NULL, NULL);
 
-		frozen_heap_insert(gp_fastsequence_rel, newTuple);
-		CatalogUpdateIndexes(gp_fastsequence_rel, newTuple);
+		CatalogTupleInsertFrozen(gp_fastsequence_rel, newTuple);
 
 		heap_freetuple(newTuple);
 	}

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -326,7 +326,7 @@ RemoveFastSequenceEntry(Oid objid)
 
 	while ((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 	}
 
 	systable_endscan(sscan);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -937,9 +937,10 @@ void MetaTrackDropObject(Oid		classid,
  * attribute to insert (but we ignore attacl and attoptions, which are always
  * initialized to NULL).
  *
- * indstate is the index state for CatalogIndexInsert.  It can be passed as
- * NULL, in which case we'll fetch the necessary info.  (Don't do this when
- * inserting multiple attributes, because it's a tad more expensive.)
+ * indstate is the index state for CatalogTupleInsertWithInfo.  It can be
+ * passed as NULL, in which case we'll fetch the necessary info.  (Don't do
+ * this when inserting multiple attributes, because it's a tad more
+ * expensive.)
  */
 void
 InsertPgAttributeTuple(Relation pg_attribute_rel,
@@ -981,18 +982,10 @@ InsertPgAttributeTuple(Relation pg_attribute_rel,
 	tup = heap_form_tuple(RelationGetDescr(pg_attribute_rel), values, nulls);
 
 	/* finally insert the new tuple, update the indexes, and clean up */
-	simple_heap_insert(pg_attribute_rel, tup);
-
 	if (indstate != NULL)
-		CatalogIndexInsert(indstate, tup);
+		CatalogTupleInsertWithInfo(pg_attribute_rel, tup, indstate);
 	else
-	{
-		CatalogIndexState indstate;
-
-		indstate = CatalogOpenIndexes(pg_attribute_rel);
-		CatalogIndexInsert(indstate, tup);
-		CatalogCloseIndexes(indstate);
-	}
+		CatalogTupleInsert(pg_attribute_rel, tup);
 
 	heap_freetuple(tup);
 }

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -922,7 +922,7 @@ void MetaTrackDropObject(Oid		classid,
 	}
 
 	while (HeapTupleIsValid(tuple = systable_getnext(desc)))
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 
 	systable_endscan(desc);
 	heap_close(rel, RowExclusiveLock);
@@ -1931,7 +1931,7 @@ RelationRemoveInheritance(Oid relid)
 							  NULL, 1, &key);
 
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-		simple_heap_delete(catalogRelation, &tuple->t_self);
+		CatalogTupleDelete(catalogRelation, &tuple->t_self);
 
 	systable_endscan(scan);
 	heap_close(catalogRelation, RowExclusiveLock);
@@ -1978,11 +1978,11 @@ RemovePartitioning(Oid relid)
 		rule_scan = systable_beginscan(pgrule, PartitionRuleParoidParparentruleParruleordIndexId, true,
 									   NULL, 1, &rule_key);
 		while (HeapTupleIsValid(rule_tuple = systable_getnext(rule_scan)))
-			simple_heap_delete(pgrule, &rule_tuple->t_self);
+			CatalogTupleDelete(pgrule, &rule_tuple->t_self);
 		systable_endscan(rule_scan);
 
 		/* remove ourself */
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 	}
 	systable_endscan(scan);
 	heap_close(rel, NoLock);
@@ -1997,7 +1997,7 @@ RemovePartitioning(Oid relid)
 	scan = systable_beginscan(pgrule, PartitionRuleParchildrelidIndexId, true,
 							  NULL, 1, &key);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-		simple_heap_delete(pgrule, &tuple->t_self);
+		CatalogTupleDelete(pgrule, &tuple->t_self);
 	systable_endscan(scan);
 	heap_close(pgrule, NoLock);
 
@@ -2026,7 +2026,7 @@ DeleteRelationTuple(Oid relid)
 		elog(ERROR, "cache lookup failed for relation %u", relid);
 
 	/* delete the relation tuple from pg_class, and finish up */
-	simple_heap_delete(pg_class_desc, &tup->t_self);
+	CatalogTupleDelete(pg_class_desc, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -2063,7 +2063,7 @@ DeleteAttributeTuples(Oid relid)
 
 	/* Delete all the matching tuples */
 	while ((atttup = systable_getnext(scan)) != NULL)
-		simple_heap_delete(attrel, &atttup->t_self);
+		CatalogTupleDelete(attrel, &atttup->t_self);
 
 	/* Clean up after the scan */
 	systable_endscan(scan);
@@ -2104,7 +2104,7 @@ DeleteSystemAttributeTuples(Oid relid)
 
 	/* Delete all the matching tuples */
 	while ((atttup = systable_getnext(scan)) != NULL)
-		simple_heap_delete(attrel, &atttup->t_self);
+		CatalogTupleDelete(attrel, &atttup->t_self);
 
 	/* Clean up after the scan */
 	systable_endscan(scan);
@@ -2151,7 +2151,7 @@ RemoveAttributeById(Oid relid, AttrNumber attnum)
 	{
 		/* System attribute (probably OID) ... just delete the row */
 
-		simple_heap_delete(attr_rel, &tuple->t_self);
+		CatalogTupleDelete(attr_rel, &tuple->t_self);
 	}
 	else
 	{
@@ -2331,7 +2331,7 @@ RemoveAttrDefaultById(Oid attrdefId)
 	myrel = relation_open(myrelid, AccessExclusiveLock);
 
 	/* Now we can delete the pg_attrdef row */
-	simple_heap_delete(attrdef_rel, &tuple->t_self);
+	CatalogTupleDelete(attrdef_rel, &tuple->t_self);
 
 	systable_endscan(scan);
 	heap_close(attrdef_rel, RowExclusiveLock);
@@ -2416,7 +2416,7 @@ heap_drop_with_catalog(Oid relid)
 		if (!HeapTupleIsValid(tuple))
 			elog(ERROR, "cache lookup failed for foreign table %u", relid);
 
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 
 		ReleaseSysCache(tuple);
 		heap_close(rel, RowExclusiveLock);
@@ -3359,7 +3359,7 @@ RemoveStatistics(Oid relid, AttrNumber attnum)
 
 	/* we must loop even when attnum != 0, in case of inherited stats */
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
-		simple_heap_delete(pgstatistic, &tuple->t_self);
+		CatalogTupleDelete(pgstatistic, &tuple->t_self);
 
 	systable_endscan(scan);
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2145,8 +2145,8 @@ index_update_stats(Relation rel,
 	 * 1. In bootstrap mode, we have no choice --- UPDATE wouldn't work.
 	 *
 	 * 2. We could be reindexing pg_class itself, in which case we can't move
-	 * its pg_class row because CatalogUpdateIndexes might not know about all
-	 * the indexes yet (see reindex_relation).
+	 * its pg_class row because CatalogTupleInsert/CatalogTupleUpdate might
+	 * not know about all the indexes yet (see reindex_relation).
 	 *
 	 * 3. Because we execute CREATE INDEX with just share lock on the parent
 	 * rel (to allow concurrent index creations), an ordinary update could

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -716,10 +716,7 @@ UpdateIndexRelation(Oid indexoid,
 	/*
 	 * insert the tuple into the pg_index catalog
 	 */
-	simple_heap_insert(pg_index, tuple);
-
-	/* update the indexes on pg_index */
-	CatalogUpdateIndexes(pg_index, tuple);
+	CatalogTupleInsert(pg_index, tuple);
 
 	/*
 	 * close the relation and free the tuple
@@ -1482,8 +1479,7 @@ index_constraint_create(Relation heapRelation,
 
 		if (dirty)
 		{
-			simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-			CatalogUpdateIndexes(pg_index, indexTuple);
+			CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 
 			InvokeObjectPostAlterHookArg(IndexRelationId, indexRelationId, 0,
 										 InvalidOid, is_internal);
@@ -2411,8 +2407,7 @@ index_build(Relation heapRelation,
 		Assert(!indexForm->indcheckxmin);
 
 		indexForm->indcheckxmin = true;
-		simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-		CatalogUpdateIndexes(pg_index, indexTuple);
+		CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 
 		heap_freetuple(indexTuple);
 		heap_close(pg_index, RowExclusiveLock);
@@ -3994,8 +3989,7 @@ reindex_index(Oid indexId, bool skip_constraint_checks)
 			indexForm->indisvalid = true;
 			indexForm->indisready = true;
 			indexForm->indislive = true;
-			simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-			CatalogUpdateIndexes(pg_index, indexTuple);
+			CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 
 			/*
 			 * Invalidate the relcache for the table, so that after we commit

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1740,7 +1740,7 @@ index_drop(Oid indexId, bool concurrent)
 
 	hasexprs = !heap_attisnull(tuple, Anum_pg_index_indexprs);
 
-	simple_heap_delete(indexRelation, &tuple->t_self);
+	CatalogTupleDelete(indexRelation, &tuple->t_self);
 
 	ReleaseSysCache(tuple);
 	heap_close(indexRelation, RowExclusiveLock);

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -68,7 +68,7 @@ CatalogCloseIndexes(CatalogIndexState indstate)
  *
  * This is effectively a cut-down version of ExecInsertIndexTuples.
  */
-void
+static void
 CatalogIndexInsert(CatalogIndexState indstate, HeapTuple heapTuple)
 {
 	int			i;
@@ -165,18 +165,20 @@ CatalogIndexInsert(CatalogIndexState indstate, HeapTuple heapTuple)
 /*
  * CatalogTupleInsert - do heap and indexing work for a new catalog tuple
  *
+ * Insert the tuple data in "tup" into the specified catalog relation.
+ * The Oid of the inserted tuple is returned.
+ *
  * This is a convenience routine for the common case of inserting a single
  * tuple in a system catalog; it inserts a new heap tuple, keeping indexes
- * current.  Avoid using it for multiple tuples, since opening the indexes and
- * building the index info structures is moderately expensive.
- *
- * The Oid of the inserted tuple is returned.
+ * current.  Avoid using it for multiple tuples, since opening the indexes
+ * and building the index info structures is moderately expensive.
+ * (Use CatalogTupleInsertWithInfo in such cases.)
  */
 Oid
 CatalogTupleInsert(Relation heapRel, HeapTuple tup)
 {
 	CatalogIndexState indstate;
-	Oid		oid;
+	Oid			oid;
 
 	indstate = CatalogOpenIndexes(heapRel);
 
@@ -189,13 +191,36 @@ CatalogTupleInsert(Relation heapRel, HeapTuple tup)
 }
 
 /*
+ * CatalogTupleInsertWithInfo - as above, but with caller-supplied index info
+ *
+ * This should be used when it's important to amortize CatalogOpenIndexes/
+ * CatalogCloseIndexes work across multiple insertions.  At some point we
+ * might cache the CatalogIndexState data somewhere (perhaps in the relcache)
+ * so that callers needn't trouble over this ... but we don't do so today.
+ */
+Oid
+CatalogTupleInsertWithInfo(Relation heapRel, HeapTuple tup,
+						   CatalogIndexState indstate)
+{
+	Oid			oid;
+
+	oid = simple_heap_insert(heapRel, tup);
+
+	CatalogIndexInsert(indstate, tup);
+
+	return oid;
+}
+
+/*
  * CatalogTupleUpdate - do heap and indexing work for updating a catalog tuple
  *
+ * Update the tuple identified by "otid", replacing it with the data in "tup".
+ *
  * This is a convenience routine for the common case of updating a single
- * tuple in a system catalog; it updates one heap tuple (identified by otid)
- * with tup, keeping indexes current.  Avoid using it for multiple tuples,
- * since opening the indexes and building the index info structures is
- * moderately expensive.
+ * tuple in a system catalog; it updates one heap tuple, keeping indexes
+ * current.  Avoid using it for multiple tuples, since opening the indexes
+ * and building the index info structures is moderately expensive.
+ * (Use CatalogTupleUpdateWithInfo in such cases.)
  */
 void
 CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup)
@@ -211,14 +236,36 @@ CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup)
 }
 
 /*
+ * CatalogTupleUpdateWithInfo - as above, but with caller-supplied index info
+ *
+ * This should be used when it's important to amortize CatalogOpenIndexes/
+ * CatalogCloseIndexes work across multiple updates.  At some point we
+ * might cache the CatalogIndexState data somewhere (perhaps in the relcache)
+ * so that callers needn't trouble over this ... but we don't do so today.
+ */
+void
+CatalogTupleUpdateWithInfo(Relation heapRel, ItemPointer otid, HeapTuple tup,
+						   CatalogIndexState indstate)
+{
+	simple_heap_update(heapRel, otid, tup);
+
+	CatalogIndexInsert(indstate, tup);
+}
+
+/*
  * CatalogTupleDelete - do heap and indexing work for deleting a catalog tuple
  *
- * Delete the tuple identified by tid in the specified catalog.
+ * Delete the tuple identified by "tid" in the specified catalog.
  *
  * With Postgres heaps, there is no index work to do at deletion time;
  * cleanup will be done later by VACUUM.  However, callers of this function
  * shouldn't have to know that; we'd like a uniform abstraction for all
  * catalog tuple changes.  Hence, provide this currently-trivial wrapper.
+ *
+ * The abstraction is a bit leaky in that we don't provide an optimized
+ * CatalogTupleDeleteWithInfo version, because there is currently nothing to
+ * optimize.  If we ever need that, rather than touching a lot of call sites,
+ * it might be better to do something about caching CatalogIndexState.
  */
 void
 CatalogTupleDelete(Relation heapRel, ItemPointer tid)

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -163,19 +163,67 @@ CatalogIndexInsert(CatalogIndexState indstate, HeapTuple heapTuple)
 }
 
 /*
- * CatalogUpdateIndexes - do all the indexing work for a new catalog tuple
+ * CatalogTupleInsert - do heap and indexing work for a new catalog tuple
  *
- * This is a convenience routine for the common case where we only need
- * to insert or update a single tuple in a system catalog.  Avoid using it for
- * multiple tuples, since opening the indexes and building the index info
- * structures is moderately expensive.
+ * This is a convenience routine for the common case of inserting a single
+ * tuple in a system catalog; it inserts a new heap tuple, keeping indexes
+ * current.  Avoid using it for multiple tuples, since opening the indexes and
+ * building the index info structures is moderately expensive.
+ *
+ * The Oid of the inserted tuple is returned.
+ */
+Oid
+CatalogTupleInsert(Relation heapRel, HeapTuple tup)
+{
+	CatalogIndexState indstate;
+	Oid		oid;
+
+	indstate = CatalogOpenIndexes(heapRel);
+
+	oid = simple_heap_insert(heapRel, tup);
+
+	CatalogIndexInsert(indstate, tup);
+	CatalogCloseIndexes(indstate);
+
+	return oid;
+}
+
+/*
+ * CatalogTupleUpdate - do heap and indexing work for updating a catalog tuple
+ *
+ * This is a convenience routine for the common case of updating a single
+ * tuple in a system catalog; it updates one heap tuple (identified by otid)
+ * with tup, keeping indexes current.  Avoid using it for multiple tuples,
+ * since opening the indexes and building the index info structures is
+ * moderately expensive.
  */
 void
-CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple)
+CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup)
 {
 	CatalogIndexState indstate;
 
 	indstate = CatalogOpenIndexes(heapRel);
-	CatalogIndexInsert(indstate, heapTuple);
+
+	simple_heap_update(heapRel, otid, tup);
+
+	CatalogIndexInsert(indstate, tup);
+	CatalogCloseIndexes(indstate);
+}
+
+/*
+ * Greenplum: this interface is used to insert tuples into gp_fastsequence
+ * and aoseg relations during an appendoptimized (row as well as column)
+ * insert transaction.
+ */
+void
+CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup)
+{
+	CatalogIndexState indstate;
+
+	indstate = CatalogOpenIndexes(heapRel);
+
+	frozen_heap_insert(heapRel, tup);
+
+	CatalogIndexInsert(indstate, tup);
 	CatalogCloseIndexes(indstate);
 }

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -211,6 +211,22 @@ CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup)
 }
 
 /*
+ * CatalogTupleDelete - do heap and indexing work for deleting a catalog tuple
+ *
+ * Delete the tuple identified by tid in the specified catalog.
+ *
+ * With Postgres heaps, there is no index work to do at deletion time;
+ * cleanup will be done later by VACUUM.  However, callers of this function
+ * shouldn't have to know that; we'd like a uniform abstraction for all
+ * catalog tuple changes.  Hence, provide this currently-trivial wrapper.
+ */
+void
+CatalogTupleDelete(Relation heapRel, ItemPointer tid)
+{
+	simple_heap_delete(heapRel, tid);
+}
+
+/*
  * Greenplum: this interface is used to insert tuples into gp_fastsequence
  * and aoseg relations during an appendoptimized (row as well as column)
  * insert transaction.

--- a/src/backend/catalog/pg_aggregate.c
+++ b/src/backend/catalog/pg_aggregate.c
@@ -676,9 +676,7 @@ AggregateCreate(const char *aggName,
 	tupDesc = aggdesc->rd_att;
 
 	tup = heap_form_tuple(tupDesc, values, nulls);
-	simple_heap_insert(aggdesc, tup);
-
-	CatalogUpdateIndexes(aggdesc, tup);
+	CatalogTupleInsert(aggdesc, tup);
 
 	heap_close(aggdesc, RowExclusiveLock);
 

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -91,8 +91,7 @@ InsertAppendOnlyEntry(Oid relid,
 	pg_appendonly_tuple = heap_form_tuple(RelationGetDescr(pg_appendonly_rel), values, nulls);
 
 	/* insert a new tuple */
-	simple_heap_insert(pg_appendonly_rel, pg_appendonly_tuple);
-	CatalogUpdateIndexes(pg_appendonly_rel, pg_appendonly_tuple);
+	CatalogTupleInsert(pg_appendonly_rel, pg_appendonly_tuple);
 
 	/*
      * Close the pg_appendonly_rel relcache entry without unlocking.
@@ -308,8 +307,7 @@ UpdateAppendOnlyEntryAuxOids(Oid relid,
 	}
 	newTuple = heap_modify_tuple(tuple, RelationGetDescr(pg_appendonly),
 								 newValues, newNulls, replace);
-	simple_heap_update(pg_appendonly, &newTuple->t_self, newTuple);
-	CatalogUpdateIndexes(pg_appendonly, newTuple);
+	CatalogTupleUpdate(pg_appendonly, &newTuple->t_self, newTuple);
 
 	heap_freetuple(newTuple);
 
@@ -528,8 +526,7 @@ TransferAppendonlyEntry(Oid sourceRelId, Oid targetRelId)
 	tupleCopy = heap_modify_tuple(tupleCopy, pg_appendonly_dsc,
 								  newValues, newNulls, replace);
 
-	simple_heap_insert(pg_appendonly_rel, tupleCopy);
-	CatalogUpdateIndexes(pg_appendonly_rel, tupleCopy);
+	CatalogTupleInsert(pg_appendonly_rel, tupleCopy);
 
 	heap_freetuple(tupleCopy);
 
@@ -622,8 +619,7 @@ SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2)
 	tupleCopy1 = heap_modify_tuple(tupleCopy1, pg_appendonly_dsc,
 								  newValues, newNulls, replace);
 
-	simple_heap_insert(pg_appendonly_rel, tupleCopy1);
-	CatalogUpdateIndexes(pg_appendonly_rel, tupleCopy1);
+	CatalogTupleInsert(pg_appendonly_rel, tupleCopy1);
 
 	heap_freetuple(tupleCopy1);
 
@@ -632,8 +628,7 @@ SwapAppendonlyEntries(Oid entryRelId1, Oid entryRelId2)
 	tupleCopy2 = heap_modify_tuple(tupleCopy2, pg_appendonly_dsc,
 								  newValues, newNulls, replace);
 
-	simple_heap_insert(pg_appendonly_rel, tupleCopy2);
-	CatalogUpdateIndexes(pg_appendonly_rel, tupleCopy2);
+	CatalogTupleInsert(pg_appendonly_rel, tupleCopy2);
 
 	heap_freetuple(tupleCopy2);
 

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -59,8 +59,7 @@ add_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum attoptions)
 	tuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
 	/* insert a new tuple */
-	simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/catalog/pg_collation.c
+++ b/src/backend/catalog/pg_collation.c
@@ -238,7 +238,7 @@ RemoveCollationById(Oid collationOid)
 	tuple = systable_getnext(scandesc);
 
 	if (HeapTupleIsValid(tuple))
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 	else
 		elog(ERROR, "could not find tuple for collation %u", collationOid);
 

--- a/src/backend/catalog/pg_collation.c
+++ b/src/backend/catalog/pg_collation.c
@@ -181,11 +181,8 @@ CollationCreate(const char *collname, Oid collnamespace,
 	tup = heap_form_tuple(tupDesc, values, nulls);
 
 	/* insert a new tuple */
-	oid = simple_heap_insert(rel, tup);
+	oid = CatalogTupleInsert(rel, tup);
 	Assert(OidIsValid(oid));
-
-	/* update the index if any */
-	CatalogUpdateIndexes(rel, tup);
 
 	/* set up dependencies for the new collation */
 	myself.classId = CollationRelationId;

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -603,7 +603,7 @@ RemoveConstraintById(Oid conId)
 		elog(ERROR, "constraint %u is not of a known type", conId);
 
 	/* Fry the constraint itself */
-	simple_heap_delete(conDesc, &tup->t_self);
+	CatalogTupleDelete(conDesc, &tup->t_self);
 
 	/* Clean up */
 	ReleaseSysCache(tup);

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -225,10 +225,7 @@ CreateConstraintEntry(const char *constraintName,
 
 	tup = heap_form_tuple(RelationGetDescr(conDesc), values, nulls);
 
-	conOid = simple_heap_insert(conDesc, tup);
-
-	/* update catalog indexes */
-	CatalogUpdateIndexes(conDesc, tup);
+	conOid = CatalogTupleInsert(conDesc, tup);
 
 	conobject.classId = ConstraintRelationId;
 	conobject.objectId = conOid;
@@ -583,9 +580,7 @@ RemoveConstraintById(Oid conId)
 					 RelationGetRelationName(rel));
 			classForm->relchecks--;
 
-			simple_heap_update(pgrel, &relTup->t_self, relTup);
-
-			CatalogUpdateIndexes(pgrel, relTup);
+			CatalogTupleUpdate(pgrel, &relTup->t_self, relTup);
 
 			heap_freetuple(relTup);
 
@@ -681,10 +676,7 @@ RenameConstraintById(Oid conId, const char *newname)
 	/* OK, do the rename --- tuple is a copy, so OK to scribble on it */
 	namestrcpy(&(con->conname), newname);
 
-	simple_heap_update(conDesc, &tuple->t_self, tuple);
-
-	/* update the system catalog indexes */
-	CatalogUpdateIndexes(conDesc, tuple);
+	CatalogTupleUpdate(conDesc, &tuple->t_self, tuple);
 
 	InvokeObjectPostAlterHook(ConstraintRelationId, conId, 0);
 
@@ -750,8 +742,7 @@ AlterConstraintNamespaces(Oid ownerId, Oid oldNspId,
 
 			conform->connamespace = newNspId;
 
-			simple_heap_update(conRel, &tup->t_self, tup);
-			CatalogUpdateIndexes(conRel, tup);
+			CatalogTupleUpdate(conRel, &tup->t_self, tup);
 
 			/*
 			 * Note: currently, the constraint will not have its own
@@ -801,8 +792,7 @@ ConstraintSetParentConstraint(Oid childConstrId, Oid parentConstrId)
 		constrForm->conislocal = false;
 		constrForm->coninhcount++;
 
-		simple_heap_update(constrRel, &tuple->t_self, newtup);
-		CatalogUpdateIndexes(constrRel, newtup);
+		CatalogTupleUpdate(constrRel, &tuple->t_self, newtup);
 
 		ObjectAddressSet(referenced, ConstraintRelationId, parentConstrId);
 		ObjectAddressSet(depender, ConstraintRelationId, childConstrId);
@@ -820,8 +810,7 @@ ConstraintSetParentConstraint(Oid childConstrId, Oid parentConstrId)
 		deleteDependencyRecordsForClass(ConstraintRelationId, childConstrId,
 										ConstraintRelationId,
 										DEPENDENCY_INTERNAL_AUTO);
-		simple_heap_update(constrRel, &tuple->t_self, newtup);
-		CatalogUpdateIndexes(constrRel, newtup);
+		CatalogTupleUpdate(constrRel, &tuple->t_self, newtup);
 	}
 	
 	ReleaseSysCache(tuple);

--- a/src/backend/catalog/pg_conversion.c
+++ b/src/backend/catalog/pg_conversion.c
@@ -106,11 +106,8 @@ ConversionCreate(const char *conname, Oid connamespace,
 	tup = heap_form_tuple(tupDesc, values, nulls);
 
 	/* insert a new tuple */
-	oid = simple_heap_insert(rel, tup);
+	oid = CatalogTupleInsert(rel, tup);
 	Assert(OidIsValid(oid));
-
-	/* update the index if any */
-	CatalogUpdateIndexes(rel, tup);
 
 	myself.classId = ConversionRelationId;
 	myself.objectId = HeapTupleGetOid(tup);

--- a/src/backend/catalog/pg_conversion.c
+++ b/src/backend/catalog/pg_conversion.c
@@ -167,7 +167,7 @@ RemoveConversionById(Oid conversionOid)
 
 	/* search for the target tuple */
 	if (HeapTupleIsValid(tuple = heap_getnext(scan, ForwardScanDirection)))
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 	else
 		elog(ERROR, "could not find tuple for conversion %u", conversionOid);
 	heap_endscan(scan);

--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -96,10 +96,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 
 				newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel),
 											 repl_val, repl_null, repl_repl);
-				simple_heap_update(rel, &tuple->t_self, newtuple);
-
-				/* Update indexes */
-				CatalogUpdateIndexes(rel, newtuple);
+				CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
 			}
 			else
 				simple_heap_delete(rel, &tuple->t_self);
@@ -137,10 +134,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 
 			newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel),
 										 repl_val, repl_null, repl_repl);
-			simple_heap_update(rel, &tuple->t_self, newtuple);
-
-			/* Update indexes */
-			CatalogUpdateIndexes(rel, newtuple);
+			CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
 		}
 		else
 			simple_heap_delete(rel, &tuple->t_self);
@@ -163,10 +157,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 		values[Anum_pg_db_role_setting_setconfig - 1] = PointerGetDatum(a);
 		newtuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
-		simple_heap_insert(rel, newtuple);
-
-		/* Update indexes */
-		CatalogUpdateIndexes(rel, newtuple);
+		CatalogTupleInsert(rel, newtuple);
 	}
 
 	InvokeObjectPostAlterHookArg(DbRoleSettingRelationId,

--- a/src/backend/catalog/pg_db_role_setting.c
+++ b/src/backend/catalog/pg_db_role_setting.c
@@ -99,7 +99,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 				CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
 			}
 			else
-				simple_heap_delete(rel, &tuple->t_self);
+				CatalogTupleDelete(rel, &tuple->t_self);
 		}
 	}
 	else if (HeapTupleIsValid(tuple))
@@ -137,7 +137,7 @@ AlterSetting(Oid databaseid, Oid roleid, VariableSetStmt *setstmt)
 			CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
 		}
 		else
-			simple_heap_delete(rel, &tuple->t_self);
+			CatalogTupleDelete(rel, &tuple->t_self);
 	}
 	else if (valuestr)
 	{
@@ -319,7 +319,7 @@ DropSetting(Oid databaseid, Oid roleid)
 	scan = heap_beginscan_catalog(relsetting, numkeys, keys);
 	while (HeapTupleIsValid(tup = heap_getnext(scan, ForwardScanDirection)))
 	{
-		simple_heap_delete(relsetting, &tup->t_self);
+		CatalogTupleDelete(relsetting, &tup->t_self);
 	}
 	heap_endscan(scan);
 

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -107,13 +107,11 @@ recordMultipleDependencies(const ObjectAddress *depender,
 
 			tup = heap_form_tuple(dependDesc->rd_att, values, nulls);
 
-			simple_heap_insert(dependDesc, tup);
-
-			/* keep indexes current */
+			/* fetch index info only when we know we need it */
 			if (indstate == NULL)
 				indstate = CatalogOpenIndexes(dependDesc);
 
-			CatalogIndexInsert(indstate, tup);
+			CatalogTupleInsertWithInfo(dependDesc, tup, indstate);
 
 			heap_freetuple(tup);
 		}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -426,8 +426,7 @@ changeDependencyFor(Oid classId, Oid objectId,
 
 				depform->refobjid = newRefObjectId;
 
-				simple_heap_update(depRel, &tup->t_self, tup);
-				CatalogUpdateIndexes(depRel, tup);
+				CatalogTupleUpdate(depRel, &tup->t_self, tup);
 
 				heap_freetuple(tup);
 			}

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -283,7 +283,7 @@ deleteDependencyRecordsFor(Oid classId, Oid objectId,
 		  ((Form_pg_depend) GETSTRUCT(tup))->deptype == DEPENDENCY_EXTENSION)
 			continue;
 
-		simple_heap_delete(depRel, &tup->t_self);
+		CatalogTupleDelete(depRel, &tup->t_self);
 		count++;
 	}
 
@@ -333,7 +333,7 @@ deleteDependencyRecordsForClass(Oid classId, Oid objectId,
 
 		if (depform->refclassid == refclassId && depform->deptype == deptype)
 		{
-			simple_heap_delete(depRel, &tup->t_self);
+			CatalogTupleDelete(depRel, &tup->t_self);
 			count++;
 		}
 	}
@@ -417,7 +417,7 @@ changeDependencyFor(Oid classId, Oid objectId,
 			depform->refobjid == oldRefObjectId)
 		{
 			if (newIsPinned)
-				simple_heap_delete(depRel, &tup->t_self);
+				CatalogTupleDelete(depRel, &tup->t_self);
 			else
 			{
 				/* make a modifiable copy */

--- a/src/backend/catalog/pg_enum.c
+++ b/src/backend/catalog/pg_enum.c
@@ -167,7 +167,7 @@ EnumValuesDelete(Oid enumTypeOid)
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(pg_enum, &tup->t_self);
+		CatalogTupleDelete(pg_enum, &tup->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/pg_enum.c
+++ b/src/backend/catalog/pg_enum.c
@@ -131,8 +131,7 @@ EnumValuesCreate(Oid enumTypeOid, List *vals)
 		tup = heap_form_tuple(RelationGetDescr(pg_enum), values, nulls);
 		HeapTupleSetOid(tup, oids[elemno]);
 
-		simple_heap_insert(pg_enum, tup);
-		CatalogUpdateIndexes(pg_enum, tup);
+		CatalogTupleInsert(pg_enum, tup);
 		heap_freetuple(tup);
 
 		elemno++;
@@ -450,8 +449,7 @@ restart:
 	values[Anum_pg_enum_enumlabel - 1] = NameGetDatum(&enumlabel);
 	enum_tup = heap_form_tuple(RelationGetDescr(pg_enum), values, nulls);
 	HeapTupleSetOid(enum_tup, newOid);
-	simple_heap_insert(pg_enum, enum_tup);
-	CatalogUpdateIndexes(pg_enum, enum_tup);
+	CatalogTupleInsert(pg_enum, enum_tup);
 	heap_freetuple(enum_tup);
 
 	heap_close(pg_enum, RowExclusiveLock);
@@ -504,9 +502,7 @@ RenumberEnumType(Relation pg_enum, HeapTuple *existing, int nelems)
 		{
 			en->enumsortorder = newsortorder;
 
-			simple_heap_update(pg_enum, &newtup->t_self, newtup);
-
-			CatalogUpdateIndexes(pg_enum, newtup);
+			CatalogTupleUpdate(pg_enum, &newtup->t_self, newtup);
 		}
 
 		heap_freetuple(newtup);

--- a/src/backend/catalog/pg_extprotocol.c
+++ b/src/backend/catalog/pg_extprotocol.c
@@ -144,9 +144,7 @@ ExtProtocolCreate(const char *protocolName,
 	tup = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
 	/* insert a new tuple */
-	protOid = simple_heap_insert(rel, tup);
-
-	CatalogUpdateIndexes(rel, tup);
+	protOid = CatalogTupleInsert(rel, tup);
 
 	heap_close(rel, RowExclusiveLock);
 

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -500,7 +500,7 @@ RemoveExtTableEntry(Oid relid)
 	 */
 	do
 	{
-		simple_heap_delete(pg_exttable_rel, &tuple->t_self);
+		CatalogTupleDelete(pg_exttable_rel, &tuple->t_self);
 	}
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)));
 

--- a/src/backend/catalog/pg_exttable.c
+++ b/src/backend/catalog/pg_exttable.c
@@ -173,9 +173,7 @@ InsertExtTableEntry(Oid 	tbloid,
 	pg_exttable_tuple = heap_form_tuple(RelationGetDescr(pg_exttable_rel), values, nulls);
 
 	/* insert a new tuple */
-	simple_heap_insert(pg_exttable_rel, pg_exttable_tuple);
-
-	CatalogUpdateIndexes(pg_exttable_rel, pg_exttable_tuple);
+	CatalogTupleInsert(pg_exttable_rel, pg_exttable_tuple);
 
 	/*
      * Close the pg_exttable relcache entry without unlocking.

--- a/src/backend/catalog/pg_inherits.c
+++ b/src/backend/catalog/pg_inherits.c
@@ -479,7 +479,7 @@ DeleteInheritsTuple(Oid inhrelid, Oid inhparent)
 		parent = ((Form_pg_inherits) GETSTRUCT(inheritsTuple))->inhparent;
 		if (!OidIsValid(inhparent) || parent == inhparent)
 		{
-			simple_heap_delete(catalogRelation, &inheritsTuple->t_self);
+			CatalogTupleDelete(catalogRelation, &inheritsTuple->t_self);
 			found = true;
 		}
 	}

--- a/src/backend/catalog/pg_inherits.c
+++ b/src/backend/catalog/pg_inherits.c
@@ -435,8 +435,7 @@ StoreSingleInheritance(Oid relationId, Oid parentOid, int32 seqNumber)
 
 	tuple = heap_form_tuple(RelationGetDescr(inhRelation), values, nulls);
 
-	simple_heap_insert(inhRelation, tuple);
-	CatalogUpdateIndexes(inhRelation, tuple);
+	CatalogTupleInsert(inhRelation, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/catalog/pg_largeobject.c
+++ b/src/backend/catalog/pg_largeobject.c
@@ -110,7 +110,7 @@ LargeObjectDrop(Oid loid)
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("large object %u does not exist", loid)));
 
-	simple_heap_delete(pg_lo_meta, &tuple->t_self);
+	CatalogTupleDelete(pg_lo_meta, &tuple->t_self);
 
 	systable_endscan(scan);
 
@@ -127,7 +127,7 @@ LargeObjectDrop(Oid loid)
 							  NULL, 1, skey);
 	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
 	{
-		simple_heap_delete(pg_largeobject, &tuple->t_self);
+		CatalogTupleDelete(pg_largeobject, &tuple->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/pg_largeobject.c
+++ b/src/backend/catalog/pg_largeobject.c
@@ -63,10 +63,8 @@ LargeObjectCreate(Oid loid)
 	if (OidIsValid(loid))
 		HeapTupleSetOid(ntup, loid);
 
-	loid_new = simple_heap_insert(pg_lo_meta, ntup);
+	loid_new = CatalogTupleInsert(pg_lo_meta, ntup);
 	Assert(!OidIsValid(loid) || loid == loid_new);
-
-	CatalogUpdateIndexes(pg_lo_meta, ntup);
 
 	heap_freetuple(ntup);
 

--- a/src/backend/catalog/pg_namespace.c
+++ b/src/backend/catalog/pg_namespace.c
@@ -76,10 +76,8 @@ NamespaceCreate(const char *nspName, Oid ownerId, bool isTemp)
 
 	tup = heap_form_tuple(tupDesc, values, nulls);
 
-	nspoid = simple_heap_insert(nspdesc, tup);
+	nspoid = CatalogTupleInsert(nspdesc, tup);
 	Assert(OidIsValid(nspoid));
-
-	CatalogUpdateIndexes(nspdesc, tup);
 
 	heap_close(nspdesc, RowExclusiveLock);
 

--- a/src/backend/catalog/pg_operator.c
+++ b/src/backend/catalog/pg_operator.c
@@ -265,9 +265,7 @@ OperatorShellMake(const char *operatorName,
 	/*
 	 * insert our "shell" operator tuple
 	 */
-	operatorObjectId = simple_heap_insert(pg_operator_desc, tup);
-
-	CatalogUpdateIndexes(pg_operator_desc, tup);
+	operatorObjectId = CatalogTupleInsert(pg_operator_desc, tup);
 
 	/* Add dependencies for the entry */
 	makeOperatorDependencies(tup, false);
@@ -529,7 +527,7 @@ OperatorCreate(const char *operatorName,
 								nulls,
 								replaces);
 
-		simple_heap_update(pg_operator_desc, &tup->t_self, tup);
+		CatalogTupleUpdate(pg_operator_desc, &tup->t_self, tup);
 	}
 	else
 	{
@@ -538,11 +536,8 @@ OperatorCreate(const char *operatorName,
 		tupDesc = pg_operator_desc->rd_att;
 		tup = heap_form_tuple(tupDesc, values, nulls);
 
-		operatorObjectId = simple_heap_insert(pg_operator_desc, tup);
+		operatorObjectId = CatalogTupleInsert(pg_operator_desc, tup);
 	}
-
-	/* Must update the indexes in either case */
-	CatalogUpdateIndexes(pg_operator_desc, tup);
 
 	/* Add dependencies for the entry */
 	makeOperatorDependencies(tup, isUpdate);
@@ -705,9 +700,7 @@ OperatorUpd(Oid baseId, Oid commId, Oid negId)
 										nulls,
 										replaces);
 
-				simple_heap_update(pg_operator_desc, &tup->t_self, tup);
-
-				CatalogUpdateIndexes(pg_operator_desc, tup);
+				CatalogTupleUpdate(pg_operator_desc, &tup->t_self, tup);
 			}
 		}
 
@@ -730,9 +723,7 @@ OperatorUpd(Oid baseId, Oid commId, Oid negId)
 								nulls,
 								replaces);
 
-		simple_heap_update(pg_operator_desc, &tup->t_self, tup);
-
-		CatalogUpdateIndexes(pg_operator_desc, tup);
+		CatalogTupleUpdate(pg_operator_desc, &tup->t_self, tup);
 
 		values[Anum_pg_operator_oprcom - 1] = (Datum) NULL;
 		replaces[Anum_pg_operator_oprcom - 1] = false;
@@ -754,9 +745,7 @@ OperatorUpd(Oid baseId, Oid commId, Oid negId)
 								nulls,
 								replaces);
 
-		simple_heap_update(pg_operator_desc, &tup->t_self, tup);
-
-		CatalogUpdateIndexes(pg_operator_desc, tup);
+		CatalogTupleUpdate(pg_operator_desc, &tup->t_self, tup);
 	}
 
 	heap_close(pg_operator_desc, RowExclusiveLock);

--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -629,7 +629,7 @@ ProcedureCreate(const char *procedureName,
 
 		/* Okay, do it... */
 		tup = heap_modify_tuple(oldtup, tupDesc, values, nulls, replaces);
-		simple_heap_update(rel, &tup->t_self, tup);
+		CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 		ReleaseSysCache(oldtup);
 		is_update = true;
@@ -647,12 +647,10 @@ ProcedureCreate(const char *procedureName,
 			nulls[Anum_pg_proc_proacl - 1] = true;
 
 		tup = heap_form_tuple(tupDesc, values, nulls);
-		simple_heap_insert(rel, tup);
+		CatalogTupleInsert(rel, tup);
 		is_update = false;
 	}
 
-	/* Need to update indexes for either the insert or update case */
-	CatalogUpdateIndexes(rel, tup);
 
 	retval = HeapTupleGetOid(tup);
 

--- a/src/backend/catalog/pg_proc_callback.c
+++ b/src/backend/catalog/pg_proc_callback.c
@@ -109,8 +109,7 @@ addProcCallback(Oid profnoid, Oid procallback, char promethod)
 	tup = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 	
 	/* Insert tuple into the relation */
-	simple_heap_insert(rel, tup);
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleInsert(rel, tup);
 
 	heap_close(rel, RowExclusiveLock);
 }

--- a/src/backend/catalog/pg_range.c
+++ b/src/backend/catalog/pg_range.c
@@ -129,7 +129,7 @@ RangeDelete(Oid rangeTypeOid)
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(pg_range, &tup->t_self);
+		CatalogTupleDelete(pg_range, &tup->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/pg_range.c
+++ b/src/backend/catalog/pg_range.c
@@ -58,8 +58,7 @@ RangeCreate(Oid rangeTypeOid, Oid rangeSubType, Oid rangeCollation,
 
 	tup = heap_form_tuple(RelationGetDescr(pg_range), values, nulls);
 
-	simple_heap_insert(pg_range, tup);
-	CatalogUpdateIndexes(pg_range, tup);
+	CatalogTupleInsert(pg_range, tup);
 	heap_freetuple(tup);
 
 	/* record type's dependencies on range-related items */

--- a/src/backend/catalog/pg_shdepend.c
+++ b/src/backend/catalog/pg_shdepend.c
@@ -245,7 +245,7 @@ shdepChangeDep(Relation sdepRel,
 	{
 		/* No new entry needed, so just delete existing entry if any */
 		if (oldtup)
-			simple_heap_delete(sdepRel, &oldtup->t_self);
+			CatalogTupleDelete(sdepRel, &oldtup->t_self);
 	}
 	else if (oldtup)
 	{
@@ -791,7 +791,7 @@ dropDatabaseDependencies(Oid databaseId)
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(sdepRel, &tup->t_self);
+		CatalogTupleDelete(sdepRel, &tup->t_self);
 	}
 
 	systable_endscan(scan);
@@ -944,7 +944,7 @@ shdepDropDependency(Relation sdepRel,
 			continue;
 
 		/* OK, delete it */
-		simple_heap_delete(sdepRel, &tup->t_self);
+		CatalogTupleDelete(sdepRel, &tup->t_self);
 	}
 
 	systable_endscan(scan);

--- a/src/backend/catalog/pg_shdepend.c
+++ b/src/backend/catalog/pg_shdepend.c
@@ -256,10 +256,7 @@ shdepChangeDep(Relation sdepRel,
 		shForm->refclassid = refclassid;
 		shForm->refobjid = refobjid;
 
-		simple_heap_update(sdepRel, &oldtup->t_self, oldtup);
-
-		/* keep indexes current */
-		CatalogUpdateIndexes(sdepRel, oldtup);
+		CatalogTupleUpdate(sdepRel, &oldtup->t_self, oldtup);
 	}
 	else
 	{
@@ -283,10 +280,7 @@ shdepChangeDep(Relation sdepRel,
 		 * it's certainly a new tuple
 		 */
 		oldtup = heap_form_tuple(RelationGetDescr(sdepRel), values, nulls);
-		simple_heap_insert(sdepRel, oldtup);
-
-		/* keep indexes current */
-		CatalogUpdateIndexes(sdepRel, oldtup);
+		CatalogTupleInsert(sdepRel, oldtup);
 	}
 
 	if (oldtup)
@@ -755,10 +749,7 @@ copyTemplateDependencies(Oid templateDbId, Oid newDbId)
 		HeapTuple	newtup;
 
 		newtup = heap_modify_tuple(tup, sdepDesc, values, nulls, replace);
-		simple_heap_insert(sdepRel, newtup);
-
-		/* Keep indexes current */
-		CatalogIndexInsert(indstate, newtup);
+		CatalogTupleInsert(sdepRel, newtup);
 
 		heap_freetuple(newtup);
 	}
@@ -878,10 +869,7 @@ shdepAddDependency(Relation sdepRel,
 
 	tup = heap_form_tuple(sdepRel->rd_att, values, nulls);
 
-	simple_heap_insert(sdepRel, tup);
-
-	/* keep indexes current */
-	CatalogUpdateIndexes(sdepRel, tup);
+	CatalogTupleInsert(sdepRel, tup);
 
 	/* clean up */
 	heap_freetuple(tup);

--- a/src/backend/catalog/pg_shdepend.c
+++ b/src/backend/catalog/pg_shdepend.c
@@ -749,7 +749,7 @@ copyTemplateDependencies(Oid templateDbId, Oid newDbId)
 		HeapTuple	newtup;
 
 		newtup = heap_modify_tuple(tup, sdepDesc, values, nulls, replace);
-		CatalogTupleInsert(sdepRel, newtup);
+		CatalogTupleInsertWithInfo(sdepRel, newtup, indstate);
 
 		heap_freetuple(newtup);
 	}

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -426,10 +426,7 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	if (!IsBootstrapProcessingMode())
 	{
 		/* normal case, use a transactional update */
-		simple_heap_update(class_rel, &reltup->t_self, reltup);
-
-		/* Keep catalog indexes current */
-		CatalogUpdateIndexes(class_rel, reltup);
+		CatalogTupleUpdate(class_rel, &reltup->t_self, reltup);
 	}
 	else
 	{

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -549,8 +549,7 @@ GpPolicyStore(Oid tbloid, const GpPolicy *policy)
 	gp_policy_tuple = heap_form_tuple(RelationGetDescr(gp_policy_rel), values, nulls);
 
 	/* Insert tuple into the relation */
-	simple_heap_insert(gp_policy_rel, gp_policy_tuple);
-	CatalogUpdateIndexes(gp_policy_rel, gp_policy_tuple);
+	CatalogTupleInsert(gp_policy_rel, gp_policy_tuple);
 
 	/*
 	 * Register the table as dependent on the operator classes used in the
@@ -666,16 +665,14 @@ GpPolicyReplace(Oid tbloid, const GpPolicy *policy)
 												 RelationGetDescr(gp_policy_rel),
 												 values, nulls, repl);
 
-		simple_heap_update(gp_policy_rel, &gp_policy_tuple->t_self, newtuple);
-		CatalogUpdateIndexes(gp_policy_rel, newtuple);
+		CatalogTupleUpdate(gp_policy_rel, &gp_policy_tuple->t_self, newtuple);
 
 		heap_freetuple(newtuple);
 	}
 	else
 	{
 		gp_policy_tuple = heap_form_tuple(gp_policy_rel->rd_att, values, nulls);
-		(void) simple_heap_insert(gp_policy_rel, gp_policy_tuple);
-		CatalogUpdateIndexes(gp_policy_rel, gp_policy_tuple);
+		(void) CatalogTupleInsert(gp_policy_rel, gp_policy_tuple);
 	}
 	systable_endscan(scan);
 

--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -731,7 +731,7 @@ GpPolicyRemove(Oid tbloid)
 
 	while ((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(gp_policy_rel, &tuple->t_self);
+		CatalogTupleDelete(gp_policy_rel, &tuple->t_self);
 	}
 
 	systable_endscan(sscan);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1897,7 +1897,7 @@ del_part_template(Oid rootrelid, int16 parlevel, Oid parent)
 		return 2;
 	}
 
-	simple_heap_delete(part_rel, &tid);
+	CatalogTupleDelete(part_rel, &tid);
 
 	systable_endscan(sscan);
 
@@ -1916,7 +1916,7 @@ del_part_template(Oid rootrelid, int16 parlevel, Oid parent)
 
 	while ((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(part_rule_rel, &tuple->t_self);
+		CatalogTupleDelete(part_rule_rel, &tuple->t_self);
 	}
 
 	systable_endscan(sscan);
@@ -8713,7 +8713,7 @@ remove_partition_encoding_entry(Oid paroid, AttrNumber attnum)
 			if (ppe->parencattnum != attnum)
 				continue;
 		}
-		simple_heap_delete(rel, &tup->t_self);
+		CatalogTupleDelete(rel, &tup->t_self);
 	}
 
 	systable_endscan(sscan);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -1722,8 +1722,7 @@ add_partition(Partition *part)
 	tup = heap_form_tuple(RelationGetDescr(partrel), values, isnull);
 
 	/* Insert tuple into the relation */
-	part->partid = simple_heap_insert(partrel, tup);
-	CatalogUpdateIndexes(partrel, tup);
+	part->partid = CatalogTupleInsert(partrel, tup);
 
 	heap_close(partrel, NoLock);
 }
@@ -1792,8 +1791,7 @@ add_partition_rule(PartitionRule *rule)
 	tup = heap_form_tuple(RelationGetDescr(rulerel), values, isnull);
 
 	/* Insert tuple into the relation */
-	rule->parruleid = simple_heap_insert(rulerel, tup);
-	CatalogUpdateIndexes(rulerel, tup);
+	rule->parruleid = CatalogTupleInsert(rulerel, tup);
 
 	heap_close(rulerel, NoLock);
 }
@@ -2330,8 +2328,7 @@ parruleord_open_gap(Oid partid, int16 level, Oid parent, int16 ruleord,
 
 		closegap ? rule_desc->parruleord-- : rule_desc->parruleord++;
 
-		simple_heap_update(rel, &tuple->t_self, tuple);
-		CatalogUpdateIndexes(rel, tuple);
+		CatalogTupleUpdate(rel, &tuple->t_self, tuple);
 
 		heap_freetuple(tuple);
 	}
@@ -7330,8 +7327,7 @@ exchange_part_rule(Oid oldrelid, Oid newrelid)
 
 		((Form_pg_partition_rule) GETSTRUCT(tuple))->parchildrelid = newrelid;
 
-		simple_heap_update(catalogRelation, &tuple->t_self, tuple);
-		CatalogUpdateIndexes(catalogRelation, tuple);
+		CatalogTupleUpdate(catalogRelation, &tuple->t_self, tuple);
 
 		heap_freetuple(tuple);
 	}
@@ -7381,8 +7377,7 @@ exchange_permissions(Oid oldrelid, Oid newrelid)
 	replace_tuple = heap_modify_tuple(oldtuple,
 									  RelationGetDescr(rel),
 									  values, nulls, replaces);
-	simple_heap_update(rel, &oldtuple->t_self, replace_tuple);
-	CatalogUpdateIndexes(rel, replace_tuple);
+	CatalogTupleUpdate(rel, &oldtuple->t_self, replace_tuple);
 
 	/* XXX: Update the shared dependency ACL info */
 
@@ -7400,8 +7395,7 @@ exchange_permissions(Oid oldrelid, Oid newrelid)
 	replace_tuple = heap_modify_tuple(newtuple,
 									  RelationGetDescr(rel),
 									  values, nulls, replaces);
-	simple_heap_update(rel, &newtuple->t_self, replace_tuple);
-	CatalogUpdateIndexes(rel, replace_tuple);
+	CatalogTupleUpdate(rel, &newtuple->t_self, replace_tuple);
 
 	/* update shared dependency */
 
@@ -8685,8 +8679,7 @@ add_partition_encoding(Oid relid, Oid paroid, AttrNumber attnum, List *encoding)
 	tuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
 	/* Insert tuple into the relation */
-	simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/commands/alter.c
+++ b/src/backend/commands/alter.c
@@ -289,8 +289,7 @@ AlterObjectRename_internal(Relation rel, Oid objectId, const char *new_name)
 							   values, nulls, replaces);
 
 	/* Perform actual update */
-	simple_heap_update(rel, &oldtup->t_self, newtup);
-	CatalogUpdateIndexes(rel, newtup);
+	CatalogTupleUpdate(rel, &oldtup->t_self, newtup);
 
 	InvokeObjectPostAlterHook(classId, objectId, 0);
 
@@ -707,8 +706,7 @@ AlterObjectNamespace_internal(Relation rel, Oid objid, Oid nspOid)
 							   values, nulls, replaces);
 
 	/* Perform actual update */
-	simple_heap_update(rel, &tup->t_self, newtup);
-	CatalogUpdateIndexes(rel, newtup);
+	CatalogTupleUpdate(rel, &tup->t_self, newtup);
 
 	/* Release memory */
 	pfree(values);
@@ -986,8 +984,7 @@ AlterObjectOwner_internal(Relation rel, Oid objectId, Oid new_ownerId)
 								   values, nulls, replaces);
 
 		/* Perform actual update */
-		simple_heap_update(rel, &newtup->t_self, newtup);
-		CatalogUpdateIndexes(rel, newtup);
+		CatalogTupleUpdate(rel, &newtup->t_self, newtup);
 
 		/* Update owner dependency reference */
 		if (classId == LargeObjectMetadataRelationId)

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2944,17 +2944,14 @@ update_attstats(Oid relid, bool inh, int natts, VacAttrStats **vacattrstats)
 									 nulls,
 									 replaces);
 			ReleaseSysCache(oldtup);
-			simple_heap_update(sd, &stup->t_self, stup);
+			CatalogTupleUpdate(sd, &stup->t_self, stup);
 		}
 		else
 		{
 			/* No, insert new tuple */
 			stup = heap_form_tuple(RelationGetDescr(sd), values, nulls);
-			simple_heap_insert(sd, stup);
+			CatalogTupleInsert(sd, stup);
 		}
-
-		/* update indexes too */
-		CatalogUpdateIndexes(sd, stup);
 
 		heap_freetuple(stup);
 	}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -612,8 +612,7 @@ mark_index_clustered(Relation rel, Oid indexOid, bool is_internal)
 		if (indexForm->indisclustered)
 		{
 			indexForm->indisclustered = false;
-			simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-			CatalogUpdateIndexes(pg_index, indexTuple);
+			CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 		}
 		else if (thisIndexOid == indexOid)
 		{
@@ -621,8 +620,7 @@ mark_index_clustered(Relation rel, Oid indexOid, bool is_internal)
 			if (!IndexIsValid(indexForm))
 				elog(ERROR, "cannot cluster on invalid index %u", indexOid);
 			indexForm->indisclustered = true;
-			simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-			CatalogUpdateIndexes(pg_index, indexTuple);
+			CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 		}
 
 		InvokeObjectPostAlterHookArg(IndexRelationId, thisIndexOid, 0,
@@ -1266,12 +1264,7 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 
 	/* Don't update the stats for pg_class.  See swap_relation_files. */
 	if (OIDOldHeap != RelationRelationId)
-	{
-		simple_heap_update(relRelation, &reltup->t_self, reltup);
-
-		/* keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relRelation, reltup);
-	}
+		CatalogTupleUpdate(relRelation, &reltup->t_self, reltup);
 	else
 		CacheInvalidateRelcacheByTuple(reltup);
 
@@ -1807,8 +1800,7 @@ finish_heap_swap(Oid OIDOldHeap, Oid OIDNewHeap,
 		relform->relfrozenxid = frozenXid;
 		relform->relminmxid = cutoffMulti;
 
-		simple_heap_update(relRelation, &reltup->t_self, reltup);
-		CatalogUpdateIndexes(relRelation, reltup);
+		CatalogTupleUpdate(relRelation, &reltup->t_self, reltup);
 
 		heap_close(relRelation, RowExclusiveLock);
 	}

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -1372,7 +1372,6 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 				relfilenode2;
 	Oid			swaptemp;
 	char		swapchar;
-	CatalogIndexState indstate;
 	bool		isAO1, isAO2;
 
 	/* We need writable copies of both pg_class tuples. */
@@ -1561,13 +1560,13 @@ swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class,
 	 */
 	if (!target_is_pg_class)
 	{
-		simple_heap_update(relRelation, &reltup1->t_self, reltup1);
-		simple_heap_update(relRelation, &reltup2->t_self, reltup2);
+		CatalogIndexState indstate;
 
-		/* Keep system catalogs current */
 		indstate = CatalogOpenIndexes(relRelation);
-		CatalogIndexInsert(indstate, reltup1);
-		CatalogIndexInsert(indstate, reltup2);
+		CatalogTupleUpdateWithInfo(relRelation, &reltup1->t_self, reltup1,
+								   indstate);
+		CatalogTupleUpdateWithInfo(relRelation, &reltup2->t_self, reltup2,
+								   indstate);
 		CatalogCloseIndexes(indstate);
 	}
 	else

--- a/src/backend/commands/comment.c
+++ b/src/backend/commands/comment.c
@@ -220,7 +220,7 @@ CreateComments(Oid oid, Oid classoid, int32 subid, char *comment)
 		/* Found the old tuple, so delete or update it */
 
 		if (comment == NULL)
-			simple_heap_delete(description, &oldtuple->t_self);
+			CatalogTupleDelete(description, &oldtuple->t_self);
 		else
 		{
 			newtuple = heap_modify_tuple(oldtuple, RelationGetDescr(description), values,
@@ -310,7 +310,7 @@ CreateSharedComments(Oid oid, Oid classoid, char *comment)
 		/* Found the old tuple, so delete or update it */
 
 		if (comment == NULL)
-			simple_heap_delete(shdescription, &oldtuple->t_self);
+			CatalogTupleDelete(shdescription, &oldtuple->t_self);
 		else
 		{
 			newtuple = heap_modify_tuple(oldtuple, RelationGetDescr(shdescription),
@@ -384,7 +384,7 @@ DeleteComments(Oid oid, Oid classoid, int32 subid)
 							NULL, nkeys, skey);
 
 	while ((oldtuple = systable_getnext(sd)) != NULL)
-		simple_heap_delete(description, &oldtuple->t_self);
+		CatalogTupleDelete(description, &oldtuple->t_self);
 
 	/* Done */
 
@@ -420,7 +420,7 @@ DeleteSharedComments(Oid oid, Oid classoid)
 							NULL, 2, skey);
 
 	while ((oldtuple = systable_getnext(sd)) != NULL)
-		simple_heap_delete(shdescription, &oldtuple->t_self);
+		CatalogTupleDelete(shdescription, &oldtuple->t_self);
 
 	/* Done */
 

--- a/src/backend/commands/comment.c
+++ b/src/backend/commands/comment.c
@@ -225,7 +225,7 @@ CreateComments(Oid oid, Oid classoid, int32 subid, char *comment)
 		{
 			newtuple = heap_modify_tuple(oldtuple, RelationGetDescr(description), values,
 										 nulls, replaces);
-			simple_heap_update(description, &oldtuple->t_self, newtuple);
+			CatalogTupleUpdate(description, &oldtuple->t_self, newtuple);
 		}
 
 		break;					/* Assume there can be only one match */
@@ -239,15 +239,11 @@ CreateComments(Oid oid, Oid classoid, int32 subid, char *comment)
 	{
 		newtuple = heap_form_tuple(RelationGetDescr(description),
 								   values, nulls);
-		simple_heap_insert(description, newtuple);
+		CatalogTupleInsert(description, newtuple);
 	}
 
-	/* Update indexes, if necessary */
 	if (newtuple != NULL)
-	{
-		CatalogUpdateIndexes(description, newtuple);
 		heap_freetuple(newtuple);
-	}
 
 	/* Done */
 
@@ -319,7 +315,7 @@ CreateSharedComments(Oid oid, Oid classoid, char *comment)
 		{
 			newtuple = heap_modify_tuple(oldtuple, RelationGetDescr(shdescription),
 										 values, nulls, replaces);
-			simple_heap_update(shdescription, &oldtuple->t_self, newtuple);
+			CatalogTupleUpdate(shdescription, &oldtuple->t_self, newtuple);
 		}
 
 		break;					/* Assume there can be only one match */
@@ -333,15 +329,11 @@ CreateSharedComments(Oid oid, Oid classoid, char *comment)
 	{
 		newtuple = heap_form_tuple(RelationGetDescr(shdescription),
 								   values, nulls);
-		simple_heap_insert(shdescription, newtuple);
+		CatalogTupleInsert(shdescription, newtuple);
 	}
 
-	/* Update indexes, if necessary */
 	if (newtuple != NULL)
-	{
-		CatalogUpdateIndexes(shdescription, newtuple);
 		heap_freetuple(newtuple);
-	}
 
 	/* Done */
 

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -548,10 +548,7 @@ createdb(const CreatedbStmt *stmt)
 
 	HeapTupleSetOid(tuple, dboid);
 
-	simple_heap_insert(pg_database_rel, tuple);
-
-	/* Update indexes */
-	CatalogUpdateIndexes(pg_database_rel, tuple);
+	CatalogTupleInsert(pg_database_rel, tuple);
 
 	if (shouldDispatch)
 	{
@@ -1119,8 +1116,7 @@ RenameDatabase(const char *oldname, const char *newname)
 	if (!HeapTupleIsValid(newtup))
 		elog(ERROR, "cache lookup failed for database %u", db_id);
 	namestrcpy(&(((Form_pg_database) GETSTRUCT(newtup))->datname), newname);
-	simple_heap_update(rel, &newtup->t_self, newtup);
-	CatalogUpdateIndexes(rel, newtup);
+	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
 
 	/* MPP-6929: metadata tracking */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -1389,10 +1385,7 @@ movedb(const char *dbname, const char *tblspcname)
 		newtuple = heap_modify_tuple(oldtuple, RelationGetDescr(pgdbrel),
 									 new_record,
 									 new_record_nulls, new_record_repl);
-		simple_heap_update(pgdbrel, &oldtuple->t_self, newtuple);
-
-		/* Update indexes */
-		CatalogUpdateIndexes(pgdbrel, newtuple);
+		CatalogTupleUpdate(pgdbrel, &oldtuple->t_self, newtuple);
 
 		InvokeObjectPostAlterHook(DatabaseRelationId,
 								  HeapTupleGetOid(newtuple), 0);
@@ -1613,10 +1606,7 @@ AlterDatabase(AlterDatabaseStmt *stmt, bool isTopLevel)
 
 	newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel), new_record,
 								 new_record_nulls, new_record_repl);
-	simple_heap_update(rel, &tuple->t_self, newtuple);
-
-	/* Update indexes */
-	CatalogUpdateIndexes(rel, newtuple);
+	CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
 
 	InvokeObjectPostAlterHook(DatabaseRelationId,
 							  HeapTupleGetOid(newtuple), 0);
@@ -1773,8 +1763,7 @@ AlterDatabaseOwner(const char *dbname, Oid newOwnerId)
 		}
 
 		newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel), repl_val, repl_null, repl_repl);
-		simple_heap_update(rel, &newtuple->t_self, newtuple);
-		CatalogUpdateIndexes(rel, newtuple);
+		CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 
 		heap_freetuple(newtuple);
 

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -962,7 +962,7 @@ dropdb(const char *dbname, bool missing_ok)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "cache lookup failed for database %u", db_id);
 
-	simple_heap_delete(pgdbrel, &tup->t_self);
+	CatalogTupleDelete(pgdbrel, &tup->t_self);
 
 	ReleaseSysCache(tup);
 

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -333,8 +333,7 @@ insert_event_trigger_tuple(char *trigname, char *eventname, Oid evtOwner,
 
 	/* Insert heap tuple. */
 	tuple = heap_form_tuple(tgrel->rd_att, values, nulls);
-	trigoid = simple_heap_insert(tgrel, tuple);
-	CatalogUpdateIndexes(tgrel, tuple);
+	trigoid = CatalogTupleInsert(tgrel, tuple);
 	heap_freetuple(tuple);
 
 	/* Depend on owner. */
@@ -452,8 +451,7 @@ AlterEventTrigger(AlterEventTrigStmt *stmt)
 	evtForm = (Form_pg_event_trigger) GETSTRUCT(tup);
 	evtForm->evtenabled = tgenabled;
 
-	simple_heap_update(tgrel, &tup->t_self, tup);
-	CatalogUpdateIndexes(tgrel, tup);
+	CatalogTupleUpdate(tgrel, &tup->t_self, tup);
 
 	InvokeObjectPostAlterHook(EventTriggerRelationId,
 							  trigoid, 0);
@@ -546,8 +544,7 @@ AlterEventTriggerOwner_internal(Relation rel, HeapTuple tup, Oid newOwnerId)
 			 errhint("The owner of an event trigger must be a superuser.")));
 
 	form->evtowner = newOwnerId;
-	simple_heap_update(rel, &tup->t_self, tup);
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 	/* Update owner dependency reference */
 	changeDependencyOnOwner(EventTriggerRelationId,

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -412,7 +412,7 @@ RemoveEventTriggerById(Oid trigOid)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "cache lookup failed for event trigger %u", trigOid);
 
-	simple_heap_delete(tgrel, &tup->t_self);
+	CatalogTupleDelete(tgrel, &tup->t_self);
 
 	ReleaseSysCache(tup);
 

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1655,8 +1655,7 @@ InsertExtensionTuple(const char *extName, Oid extOwner,
 
 	tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-	extensionOid = simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	extensionOid = CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 	heap_close(rel, RowExclusiveLock);
@@ -2336,8 +2335,7 @@ pg_extension_config_dump(PG_FUNCTION_ARGS)
 	extTup = heap_modify_tuple(extTup, RelationGetDescr(extRel),
 							   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(extRel, &extTup->t_self, extTup);
-	CatalogUpdateIndexes(extRel, extTup);
+	CatalogTupleUpdate(extRel, &extTup->t_self, extTup);
 
 	systable_endscan(extScan);
 
@@ -2514,8 +2512,7 @@ extension_config_remove(Oid extensionoid, Oid tableoid)
 	extTup = heap_modify_tuple(extTup, RelationGetDescr(extRel),
 							   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(extRel, &extTup->t_self, extTup);
-	CatalogUpdateIndexes(extRel, extTup);
+	CatalogTupleUpdate(extRel, &extTup->t_self, extTup);
 
 	systable_endscan(extScan);
 
@@ -2690,8 +2687,7 @@ AlterExtensionNamespace(List *names, const char *newschema)
 	/* Now adjust pg_extension.extnamespace */
 	extForm->extnamespace = nspOid;
 
-	simple_heap_update(extRel, &extTup->t_self, extTup);
-	CatalogUpdateIndexes(extRel, extTup);
+	CatalogTupleUpdate(extRel, &extTup->t_self, extTup);
 
 	heap_close(extRel, RowExclusiveLock);
 
@@ -2954,8 +2950,7 @@ ApplyExtensionUpdates(Oid extensionOid,
 		extTup = heap_modify_tuple(extTup, RelationGetDescr(extRel),
 								   values, nulls, repl);
 
-		simple_heap_update(extRel, &extTup->t_self, extTup);
-		CatalogUpdateIndexes(extRel, extTup);
+		CatalogTupleUpdate(extRel, &extTup->t_self, extTup);
 
 		systable_endscan(extScan);
 

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1736,7 +1736,7 @@ RemoveExtensionById(Oid extId)
 
 	/* We assume that there can be at most one matching tuple */
 	if (HeapTupleIsValid(tuple))
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 
 	systable_endscan(scandesc);
 

--- a/src/backend/commands/extprotocolcmds.c
+++ b/src/backend/commands/extprotocolcmds.c
@@ -139,7 +139,7 @@ RemoveExtProtocolById(Oid protOid)
 
 	while (HeapTupleIsValid(tup = systable_getnext(scan)))
 	{
-		simple_heap_delete(rel, &tup->t_self);
+		CatalogTupleDelete(rel, &tup->t_self);
 		found = true;
 	}
 	systable_endscan(scan);

--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -874,7 +874,7 @@ RemoveForeignDataWrapperById(Oid fdwId)
 	if (!HeapTupleIsValid(tp))
 		elog(ERROR, "cache lookup failed for foreign-data wrapper %u", fdwId);
 
-	simple_heap_delete(rel, &tp->t_self);
+	CatalogTupleDelete(rel, &tp->t_self);
 
 	ReleaseSysCache(tp);
 
@@ -1121,7 +1121,7 @@ RemoveForeignServerById(Oid srvId)
 	if (!HeapTupleIsValid(tp))
 		elog(ERROR, "cache lookup failed for foreign server %u", srvId);
 
-	simple_heap_delete(rel, &tp->t_self);
+	CatalogTupleDelete(rel, &tp->t_self);
 
 	ReleaseSysCache(tp);
 
@@ -1452,7 +1452,7 @@ RemoveUserMappingById(Oid umId)
 	if (!HeapTupleIsValid(tp))
 		elog(ERROR, "cache lookup failed for user mapping %u", umId);
 
-	simple_heap_delete(rel, &tp->t_self);
+	CatalogTupleDelete(rel, &tp->t_self);
 
 	ReleaseSysCache(tp);
 

--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -275,8 +275,7 @@ AlterForeignDataWrapperOwner_internal(Relation rel, HeapTuple tup, Oid newOwnerI
 		tup = heap_modify_tuple(tup, RelationGetDescr(rel), repl_val, repl_null,
 								repl_repl);
 
-		simple_heap_update(rel, &tup->t_self, tup);
-		CatalogUpdateIndexes(rel, tup);
+		CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 		/* Update owner dependency reference */
 		changeDependencyOnOwner(ForeignDataWrapperRelationId,
@@ -413,8 +412,7 @@ AlterForeignServerOwner_internal(Relation rel, HeapTuple tup, Oid newOwnerId)
 		tup = heap_modify_tuple(tup, RelationGetDescr(rel), repl_val, repl_null,
 								repl_repl);
 
-		simple_heap_update(rel, &tup->t_self, tup);
-		CatalogUpdateIndexes(rel, tup);
+		CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 		/* Update owner dependency reference */
 		changeDependencyOnOwner(ForeignServerRelationId, HeapTupleGetOid(tup),
@@ -641,8 +639,7 @@ CreateForeignDataWrapper(CreateFdwStmt *stmt)
 
 	tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-	fdwId = simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	fdwId = CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 
@@ -805,8 +802,7 @@ AlterForeignDataWrapper(AlterFdwStmt *stmt)
 	tp = heap_modify_tuple(tp, RelationGetDescr(rel),
 						   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(rel, &tp->t_self, tp);
-	CatalogUpdateIndexes(rel, tp);
+	CatalogTupleUpdate(rel, &tp->t_self, tp);
 
 	heap_freetuple(tp);
 
@@ -969,9 +965,7 @@ CreateForeignServer(CreateForeignServerStmt *stmt)
 
 	tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-	srvId = simple_heap_insert(rel, tuple);
-
-	CatalogUpdateIndexes(rel, tuple);
+	srvId = CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 
@@ -1091,8 +1085,7 @@ AlterForeignServer(AlterForeignServerStmt *stmt)
 	tp = heap_modify_tuple(tp, RelationGetDescr(rel),
 						   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(rel, &tp->t_self, tp);
-	CatalogUpdateIndexes(rel, tp);
+	CatalogTupleUpdate(rel, &tp->t_self, tp);
 
 	InvokeObjectPostAlterHook(ForeignServerRelationId, srvId, 0);
 
@@ -1227,9 +1220,7 @@ CreateUserMapping(CreateUserMappingStmt *stmt)
 
 	tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-	umId = simple_heap_insert(rel, tuple);
-
-	CatalogUpdateIndexes(rel, tuple);
+	umId = CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 
@@ -1350,8 +1341,7 @@ AlterUserMapping(AlterUserMappingStmt *stmt)
 	tp = heap_modify_tuple(tp, RelationGetDescr(rel),
 						   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(rel, &tp->t_self, tp);
-	CatalogUpdateIndexes(rel, tp);
+	CatalogTupleUpdate(rel, &tp->t_self, tp);
 
 	heap_freetuple(tp);
 
@@ -1533,8 +1523,7 @@ CreateForeignTable(CreateForeignTableStmt *stmt, Oid relid)
 
 	tuple = heap_form_tuple(ftrel->rd_att, values, nulls);
 
-	simple_heap_insert(ftrel, tuple);
-	CatalogUpdateIndexes(ftrel, tuple);
+	CatalogTupleInsert(ftrel, tuple);
 
 	heap_freetuple(tuple);
 

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1425,7 +1425,7 @@ RemoveFunctionById(Oid funcOid)
 
 	isagg = ((Form_pg_proc) GETSTRUCT(tup))->proisagg;
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -1445,7 +1445,7 @@ RemoveFunctionById(Oid funcOid)
 		if (!HeapTupleIsValid(tup))		/* should not happen */
 			elog(ERROR, "cache lookup failed for pg_aggregate tuple for function %u", funcOid);
 
-		simple_heap_delete(relation, &tup->t_self);
+		CatalogTupleDelete(relation, &tup->t_self);
 
 		ReleaseSysCache(tup);
 
@@ -2129,7 +2129,7 @@ DropCastById(Oid castOid)
 	tuple = systable_getnext(scan);
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "could not find tuple for cast %u", castOid);
-	simple_heap_delete(relation, &tuple->t_self);
+	CatalogTupleDelete(relation, &tuple->t_self);
 
 	systable_endscan(scan);
 	heap_close(relation, RowExclusiveLock);

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -1638,8 +1638,7 @@ AlterFunction(AlterFunctionStmt *stmt)
 							   procForm->proretset);
 
 	/* Do the update */
-	simple_heap_update(rel, &tup->t_self, tup);
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 	InvokeObjectPostAlterHook(ProcedureRelationId, funcOid, 0);
 
@@ -1689,9 +1688,7 @@ SetFunctionReturnType(Oid funcOid, Oid newRetType)
 	procForm->prorettype = newRetType;
 
 	/* update the catalog and its indexes */
-	simple_heap_update(pg_proc_rel, &tup->t_self, tup);
-
-	CatalogUpdateIndexes(pg_proc_rel, tup);
+	CatalogTupleUpdate(pg_proc_rel, &tup->t_self, tup);
 
 	heap_close(pg_proc_rel, RowExclusiveLock);
 
@@ -1740,9 +1737,7 @@ SetFunctionArgType(Oid funcOid, int argIndex, Oid newArgType)
 	procForm->proargtypes.values[argIndex] = newArgType;
 
 	/* update the catalog and its indexes */
-	simple_heap_update(pg_proc_rel, &tup->t_self, tup);
-
-	CatalogUpdateIndexes(pg_proc_rel, tup);
+	CatalogTupleUpdate(pg_proc_rel, &tup->t_self, tup);
 
 	heap_close(pg_proc_rel, RowExclusiveLock);
 
@@ -2040,9 +2035,7 @@ CreateCast(CreateCastStmt *stmt)
 
 	tuple = heap_form_tuple(RelationGetDescr(relation), values, nulls);
 
-	castid = simple_heap_insert(relation, tuple);
-
-	CatalogUpdateIndexes(relation, tuple);
+	castid = CatalogTupleInsert(relation, tuple);
 
 	/* make dependency entries */
 	myself.classId = CastRelationId;

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -170,8 +170,7 @@ cdb_sync_indcheckxmin_with_segments(Oid indexRelationId)
 		if (!indexForm->indcheckxmin)
 		{
 			indexForm->indcheckxmin = true;
-			simple_heap_update(pg_index, &indexTuple->t_self, indexTuple);
-			CatalogUpdateIndexes(pg_index, indexTuple);
+			CatalogTupleUpdate(pg_index, &indexTuple->t_self, indexTuple);
 		}
 
 		heap_freetuple(indexTuple);
@@ -2751,8 +2750,7 @@ IndexSetParentIndex(Relation partitionIdx, Oid parentOid)
 			tuple = heap_form_tuple(RelationGetDescr(pg_inherits),
 									values, isnull);
 
-			simple_heap_insert(pg_inherits, tuple);
-			CatalogUpdateIndexes(pg_inherits, tuple);
+			CatalogTupleInsert(pg_inherits, tuple);
 
 			fix_dependencies = true;
 		}

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -2764,7 +2764,7 @@ IndexSetParentIndex(Relation partitionIdx, Oid parentOid)
 			/*
 			 * There exists a pg_inherits row, which we want to clear; do so.
 			 */
-			simple_heap_delete(pg_inherits, &tuple->t_self);
+			CatalogTupleDelete(pg_inherits, &tuple->t_self);
 			fix_dependencies = true;
 		}
 		else

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -111,9 +111,7 @@ SetMatViewPopulatedState(Relation relation, bool newstate)
 
 	((Form_pg_class) GETSTRUCT(tuple))->relispopulated = newstate;
 
-	simple_heap_update(pgrel, &tuple->t_self, tuple);
-
-	CatalogUpdateIndexes(pgrel, tuple);
+	CatalogTupleUpdate(pgrel, &tuple->t_self, tuple);
 
 	heap_freetuple(tuple);
 	heap_close(pgrel, RowExclusiveLock);

--- a/src/backend/commands/opclasscmds.c
+++ b/src/backend/commands/opclasscmds.c
@@ -291,9 +291,7 @@ CreateOpFamily(char *amname, char *opfname, Oid namespaceoid, Oid amoid)
 
 	tup = heap_form_tuple(rel->rd_att, values, nulls);
 
-	opfamilyoid = simple_heap_insert(rel, tup);
-
-	CatalogUpdateIndexes(rel, tup);
+	opfamilyoid = CatalogTupleInsert(rel, tup);
 
 	heap_freetuple(tup);
 
@@ -661,9 +659,7 @@ DefineOpClass(CreateOpClassStmt *stmt)
 
 	tup = heap_form_tuple(rel->rd_att, values, nulls);
 
-	opclassoid = simple_heap_insert(rel, tup);
-
-	CatalogUpdateIndexes(rel, tup);
+	opclassoid = CatalogTupleInsert(rel, tup);
 
 	heap_freetuple(tup);
 
@@ -1368,9 +1364,7 @@ storeOperators(List *opfamilyname, Oid amoid,
 
 		tup = heap_form_tuple(rel->rd_att, values, nulls);
 
-		entryoid = simple_heap_insert(rel, tup);
-
-		CatalogUpdateIndexes(rel, tup);
+		entryoid = CatalogTupleInsert(rel, tup);
 
 		heap_freetuple(tup);
 
@@ -1479,9 +1473,7 @@ storeProcedures(List *opfamilyname, Oid amoid,
 
 		tup = heap_form_tuple(rel->rd_att, values, nulls);
 
-		entryoid = simple_heap_insert(rel, tup);
-
-		CatalogUpdateIndexes(rel, tup);
+		entryoid = CatalogTupleInsert(rel, tup);
 
 		heap_freetuple(tup);
 

--- a/src/backend/commands/opclasscmds.c
+++ b/src/backend/commands/opclasscmds.c
@@ -1612,7 +1612,7 @@ RemoveOpFamilyById(Oid opfamilyOid)
 	if (!HeapTupleIsValid(tup)) /* should not happen */
 		elog(ERROR, "cache lookup failed for opfamily %u", opfamilyOid);
 
-	simple_heap_delete(rel, &tup->t_self);
+	CatalogTupleDelete(rel, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -1631,7 +1631,7 @@ RemoveOpClassById(Oid opclassOid)
 	if (!HeapTupleIsValid(tup)) /* should not happen */
 		elog(ERROR, "cache lookup failed for opclass %u", opclassOid);
 
-	simple_heap_delete(rel, &tup->t_self);
+	CatalogTupleDelete(rel, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -1661,7 +1661,7 @@ RemoveAmOpEntryById(Oid entryOid)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "could not find tuple for amop entry %u", entryOid);
 
-	simple_heap_delete(rel, &tup->t_self);
+	CatalogTupleDelete(rel, &tup->t_self);
 
 	systable_endscan(scan);
 	heap_close(rel, RowExclusiveLock);
@@ -1690,7 +1690,7 @@ RemoveAmProcEntryById(Oid entryOid)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "could not find tuple for amproc entry %u", entryOid);
 
-	simple_heap_delete(rel, &tup->t_self);
+	CatalogTupleDelete(rel, &tup->t_self);
 
 	systable_endscan(scan);
 	heap_close(rel, RowExclusiveLock);

--- a/src/backend/commands/operatorcmds.c
+++ b/src/backend/commands/operatorcmds.c
@@ -347,7 +347,7 @@ RemoveOperatorById(Oid operOid)
 	if (!HeapTupleIsValid(tup)) /* should not happen */
 		elog(ERROR, "cache lookup failed for operator %u", operOid);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 

--- a/src/backend/commands/proclang.c
+++ b/src/backend/commands/proclang.c
@@ -562,7 +562,7 @@ DropProceduralLanguageById(Oid langOid)
 	if (!HeapTupleIsValid(langTup))		/* should not happen */
 		elog(ERROR, "cache lookup failed for language %u", langOid);
 
-	simple_heap_delete(rel, &langTup->t_self);
+	CatalogTupleDelete(rel, &langTup->t_self);
 
 	ReleaseSysCache(langTup);
 

--- a/src/backend/commands/proclang.c
+++ b/src/backend/commands/proclang.c
@@ -404,7 +404,7 @@ create_proc_lang(const char *languageName, bool replace,
 
 		/* Okay, do it... */
 		tup = heap_modify_tuple(oldtup, tupDesc, values, nulls, replaces);
-		simple_heap_update(rel, &tup->t_self, tup);
+		CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 		ReleaseSysCache(oldtup);
 		is_update = true;
@@ -413,12 +413,9 @@ create_proc_lang(const char *languageName, bool replace,
 	{
 		/* Creating a new language */
 		tup = heap_form_tuple(tupDesc, values, nulls);
-		simple_heap_insert(rel, tup);
+		CatalogTupleInsert(rel, tup);
 		is_update = false;
 	}
-
-	/* Need to update indexes for either the insert or update case */
-	CatalogUpdateIndexes(rel, tup);
 
 	/*
 	 * Create dependencies for the new language.  If we are updating an

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -258,15 +258,13 @@ AddUpdResqueueCapabilityEntryInternal(
 									  RelationGetDescr(resqueuecap_rel),
 									  values, isnull, new_record_repl);
 
-		simple_heap_update(resqueuecap_rel, &old_tuple->t_self, new_tuple);
-		CatalogUpdateIndexes(resqueuecap_rel, new_tuple);
+		CatalogTupleUpdate(resqueuecap_rel, &old_tuple->t_self, new_tuple);
 	}
 	else
 	{
 		new_tuple = heap_form_tuple(RelationGetDescr(resqueuecap_rel), values, isnull);
 
-		simple_heap_insert(resqueuecap_rel, new_tuple);
-		CatalogUpdateIndexes(resqueuecap_rel, new_tuple);
+		CatalogTupleInsert(resqueuecap_rel, new_tuple);
 	}
 
 	if (HeapTupleIsValid(old_tuple))
@@ -919,8 +917,7 @@ CreateQueue(CreateQueueStmt *stmt)
 	/*
 	 * Insert new record in the pg_resqueue table
 	 */
-	queueid = simple_heap_insert(pg_resqueue_rel, tuple);
-	CatalogUpdateIndexes(pg_resqueue_rel, tuple);
+	queueid = CatalogTupleInsert(pg_resqueue_rel, tuple);
 
 	/* process the remainder of the WITH (...) list items */
 	if (bWith)
@@ -1322,8 +1319,7 @@ AlterQueue(AlterQueueStmt *stmt)
 	new_tuple = heap_modify_tuple(tuple, pg_resqueue_dsc, new_record,
 									new_record_nulls, new_record_repl);
 
-	simple_heap_update(pg_resqueue_rel, &tuple->t_self, new_tuple);
-	CatalogUpdateIndexes(pg_resqueue_rel, new_tuple);
+	CatalogTupleUpdate(pg_resqueue_rel, &tuple->t_self, new_tuple);
 
 	systable_endscan(sscan);
 

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -190,8 +190,7 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 	/*
 	 * Insert new record in the pg_resgroup table
 	 */
-	groupid = simple_heap_insert(pg_resgroup_rel, tuple);
-	CatalogUpdateIndexes(pg_resgroup_rel, tuple);
+	groupid = CatalogTupleInsert(pg_resgroup_rel, tuple);
 
 	/* process the WITH (...) list items */
 	validateCapabilities(pg_resgroupcapability_rel, groupid, &caps, true);
@@ -1269,8 +1268,7 @@ updateResgroupCapabilityEntry(Relation rel,
 	newTuple = heap_modify_tuple(oldTuple, RelationGetDescr(rel),
 								 values, isnull, repl);
 
-	simple_heap_update(rel, &oldTuple->t_self, newTuple);
-	CatalogUpdateIndexes(rel, newTuple);
+	CatalogTupleUpdate(rel, &oldTuple->t_self, newTuple);
 
 	systable_endscan(sscan);
 }
@@ -1469,8 +1467,7 @@ insertResgroupCapabilityEntry(Relation rel,
 	new_record[Anum_pg_resgroupcapability_value - 1] = CStringGetTextDatum(value);
 
 	tuple = heap_form_tuple(tupleDesc, new_record, new_record_nulls);
-	simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	CatalogTupleInsert(rel, tuple);
 }
 
 /*

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -352,8 +352,7 @@ RenameSchema(const char *oldname, const char *newname)
 
 	/* rename */
 	namestrcpy(&(((Form_pg_namespace) GETSTRUCT(tup))->nspname), newname);
-	simple_heap_update(rel, &tup->t_self, tup);
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 	/* MPP-6929: metadata tracking */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -500,8 +499,7 @@ AlterSchemaOwner_internal(HeapTuple tup, Relation rel, Oid newOwnerId)
 
 		newtuple = heap_modify_tuple(tup, RelationGetDescr(rel), repl_val, repl_null, repl_repl);
 
-		simple_heap_update(rel, &newtuple->t_self, newtuple);
-		CatalogUpdateIndexes(rel, newtuple);
+		CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 
 		/* MPP-6929: metadata tracking */
 		if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -277,7 +277,7 @@ RemoveSchemaById(Oid schemaOid)
 	if (!HeapTupleIsValid(tup)) /* should not happen */
 		elog(ERROR, "cache lookup failed for namespace %u", schemaOid);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 

--- a/src/backend/commands/seclabel.c
+++ b/src/backend/commands/seclabel.c
@@ -290,7 +290,7 @@ SetSharedSecurityLabel(const ObjectAddress *object,
 	if (HeapTupleIsValid(oldtup))
 	{
 		if (label == NULL)
-			simple_heap_delete(pg_shseclabel, &oldtup->t_self);
+			CatalogTupleDelete(pg_shseclabel, &oldtup->t_self);
 		else
 		{
 			replaces[Anum_pg_shseclabel_label - 1] = true;
@@ -377,7 +377,7 @@ SetSecurityLabel(const ObjectAddress *object,
 	if (HeapTupleIsValid(oldtup))
 	{
 		if (label == NULL)
-			simple_heap_delete(pg_seclabel, &oldtup->t_self);
+			CatalogTupleDelete(pg_seclabel, &oldtup->t_self);
 		else
 		{
 			replaces[Anum_pg_seclabel_label - 1] = true;
@@ -429,7 +429,7 @@ DeleteSharedSecurityLabel(Oid objectId, Oid classId)
 	scan = systable_beginscan(pg_shseclabel, SharedSecLabelObjectIndexId, true,
 							  NULL, 2, skey);
 	while (HeapTupleIsValid(oldtup = systable_getnext(scan)))
-		simple_heap_delete(pg_shseclabel, &oldtup->t_self);
+		CatalogTupleDelete(pg_shseclabel, &oldtup->t_self);
 	systable_endscan(scan);
 
 	heap_close(pg_shseclabel, RowExclusiveLock);
@@ -480,7 +480,7 @@ DeleteSecurityLabel(const ObjectAddress *object)
 	scan = systable_beginscan(pg_seclabel, SecLabelObjectIndexId, true,
 							  NULL, nkeys, skey);
 	while (HeapTupleIsValid(oldtup = systable_getnext(scan)))
-		simple_heap_delete(pg_seclabel, &oldtup->t_self);
+		CatalogTupleDelete(pg_seclabel, &oldtup->t_self);
 	systable_endscan(scan);
 
 	heap_close(pg_seclabel, RowExclusiveLock);

--- a/src/backend/commands/seclabel.c
+++ b/src/backend/commands/seclabel.c
@@ -296,7 +296,7 @@ SetSharedSecurityLabel(const ObjectAddress *object,
 			replaces[Anum_pg_shseclabel_label - 1] = true;
 			newtup = heap_modify_tuple(oldtup, RelationGetDescr(pg_shseclabel),
 									   values, nulls, replaces);
-			simple_heap_update(pg_shseclabel, &oldtup->t_self, newtup);
+			CatalogTupleUpdate(pg_shseclabel, &oldtup->t_self, newtup);
 		}
 	}
 	systable_endscan(scan);
@@ -306,15 +306,11 @@ SetSharedSecurityLabel(const ObjectAddress *object,
 	{
 		newtup = heap_form_tuple(RelationGetDescr(pg_shseclabel),
 								 values, nulls);
-		simple_heap_insert(pg_shseclabel, newtup);
+		CatalogTupleInsert(pg_shseclabel, newtup);
 	}
 
-	/* Update indexes, if necessary */
 	if (newtup != NULL)
-	{
-		CatalogUpdateIndexes(pg_shseclabel, newtup);
 		heap_freetuple(newtup);
-	}
 
 	heap_close(pg_shseclabel, RowExclusiveLock);
 }
@@ -387,7 +383,7 @@ SetSecurityLabel(const ObjectAddress *object,
 			replaces[Anum_pg_seclabel_label - 1] = true;
 			newtup = heap_modify_tuple(oldtup, RelationGetDescr(pg_seclabel),
 									   values, nulls, replaces);
-			simple_heap_update(pg_seclabel, &oldtup->t_self, newtup);
+			CatalogTupleUpdate(pg_seclabel, &oldtup->t_self, newtup);
 		}
 	}
 	systable_endscan(scan);
@@ -397,15 +393,12 @@ SetSecurityLabel(const ObjectAddress *object,
 	{
 		newtup = heap_form_tuple(RelationGetDescr(pg_seclabel),
 								 values, nulls);
-		simple_heap_insert(pg_seclabel, newtup);
+		CatalogTupleInsert(pg_seclabel, newtup);
 	}
 
 	/* Update indexes, if necessary */
 	if (newtup != NULL)
-	{
-		CatalogUpdateIndexes(pg_seclabel, newtup);
 		heap_freetuple(newtup);
-	}
 
 	heap_close(pg_seclabel, RowExclusiveLock);
 }

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11519,7 +11519,7 @@ ATExecAlterColumnType(AlteredTableInfo *tab, Relation rel,
 			  foundDep->refobjid == attTup->attcollation))
 			elog(ERROR, "found unexpected dependency for column");
 
-		simple_heap_delete(depRel, &depTup->t_self);
+		CatalogTupleDelete(depRel, &depTup->t_self);
 	}
 
 	systable_endscan(scan);
@@ -14382,7 +14382,7 @@ drop_parent_dependency(Oid relid, Oid refclassid, Oid refobjid, bool is_partitio
 			((dep->deptype == DEPENDENCY_NORMAL && !is_partition) ||
 			 (dep->deptype == DEPENDENCY_AUTO && is_partition)))
 		{
-			simple_heap_delete(catalogRelation, &depTuple->t_self);
+			CatalogTupleDelete(catalogRelation, &depTuple->t_self);
 		}
 	}
 

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -381,9 +381,7 @@ CreateTableSpace(CreateTableSpaceStmt *stmt)
 
 	tuple = heap_form_tuple(rel->rd_att, values, nulls);
 
-	tablespaceoid = simple_heap_insert(rel, tuple);
-
-	CatalogUpdateIndexes(rel, tuple);
+	tablespaceoid = CatalogTupleInsert(rel, tuple);
 
 	heap_freetuple(tuple);
 
@@ -1282,8 +1280,7 @@ RenameTableSpace(const char *oldname, const char *newname)
 	/* OK, update the entry */
 	namestrcpy(&(newform->spcname), newname);
 
-	simple_heap_update(rel, &newtuple->t_self, newtuple);
-	CatalogUpdateIndexes(rel, newtuple);
+	CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 
 	/* MPP-6929: metadata tracking */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -1361,8 +1358,7 @@ AlterTableSpaceOptions(AlterTableSpaceOptionsStmt *stmt)
 								 repl_null, repl_repl);
 
 	/* Update system catalog. */
-	simple_heap_update(rel, &newtuple->t_self, newtuple);
-	CatalogUpdateIndexes(rel, newtuple);
+	CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 
 	InvokeObjectPostAlterHook(TableSpaceRelationId, HeapTupleGetOid(tup), 0);
 

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -626,7 +626,7 @@ DropTableSpace(DropTableSpaceStmt *stmt)
 	/*
 	 * Remove the pg_tablespace tuple (this will roll back if we fail below)
 	 */
-	simple_heap_delete(rel, &tuple->t_self);
+	CatalogTupleDelete(rel, &tuple->t_self);
 
 	heap_endscan(scandesc);
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1167,7 +1167,7 @@ RemoveTriggerById(Oid trigOid)
 	/*
 	 * Delete the pg_trigger tuple.
 	 */
-	simple_heap_delete(tgrel, &tup->t_self);
+	CatalogTupleDelete(tgrel, &tup->t_self);
 
 	systable_endscan(tgscan);
 	heap_close(tgrel, RowExclusiveLock);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -715,9 +715,7 @@ CreateTrigger(CreateTrigStmt *stmt, const char *queryString,
 	/*
 	 * Insert tuple into pg_trigger.
 	 */
-	simple_heap_insert(tgrel, tuple);
-
-	CatalogUpdateIndexes(tgrel, tuple);
+	CatalogTupleInsert(tgrel, tuple);
 
 	heap_freetuple(tuple);
 	heap_close(tgrel, RowExclusiveLock);
@@ -740,9 +738,7 @@ CreateTrigger(CreateTrigStmt *stmt, const char *queryString,
 
 	((Form_pg_class) GETSTRUCT(tuple))->relhastriggers = true;
 
-	simple_heap_update(pgrel, &tuple->t_self, tuple);
-
-	CatalogUpdateIndexes(pgrel, tuple);
+	CatalogTupleUpdate(pgrel, &tuple->t_self, tuple);
 
 	heap_freetuple(tuple);
 	heap_close(pgrel, RowExclusiveLock);
@@ -1371,10 +1367,7 @@ renametrig(RenameStmt *stmt)
 		namestrcpy(&((Form_pg_trigger) GETSTRUCT(tuple))->tgname,
 				   stmt->newname);
 
-		simple_heap_update(tgrel, &tuple->t_self, tuple);
-
-		/* keep system catalog indexes current */
-		CatalogUpdateIndexes(tgrel, tuple);
+		CatalogTupleUpdate(tgrel, &tuple->t_self, tuple);
 
 		InvokeObjectPostAlterHook(TriggerRelationId,
 								  HeapTupleGetOid(tuple), 0);
@@ -1485,10 +1478,7 @@ EnableDisableTrigger(Relation rel, const char *tgname,
 
 			newtrig->tgenabled = fires_when;
 
-			simple_heap_update(tgrel, &newtup->t_self, newtup);
-
-			/* Keep catalog indexes current */
-			CatalogUpdateIndexes(tgrel, newtup);
+			CatalogTupleUpdate(tgrel, &newtup->t_self, newtup);
 
 			heap_freetuple(newtup);
 

--- a/src/backend/commands/tsearchcmds.c
+++ b/src/backend/commands/tsearchcmds.c
@@ -316,7 +316,7 @@ RemoveTSParserById(Oid prsId)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "cache lookup failed for text search parser %u", prsId);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -537,7 +537,7 @@ RemoveTSDictionaryById(Oid dictId)
 		elog(ERROR, "cache lookup failed for text search dictionary %u",
 			 dictId);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -875,7 +875,7 @@ RemoveTSTemplateById(Oid tmplId)
 		elog(ERROR, "cache lookup failed for text search template %u",
 			 tmplId);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -1188,7 +1188,7 @@ RemoveTSConfigurationById(Oid cfgId)
 		elog(ERROR, "cache lookup failed for text search dictionary %u",
 			 cfgId);
 
-	simple_heap_delete(relCfg, &tup->t_self);
+	CatalogTupleDelete(relCfg, &tup->t_self);
 
 	ReleaseSysCache(tup);
 
@@ -1207,7 +1207,7 @@ RemoveTSConfigurationById(Oid cfgId)
 
 	while (HeapTupleIsValid((tup = systable_getnext(scan))))
 	{
-		simple_heap_delete(relMap, &tup->t_self);
+		CatalogTupleDelete(relMap, &tup->t_self);
 	}
 
 	systable_endscan(scan);
@@ -1371,7 +1371,7 @@ MakeConfigurationMapping(AlterTSConfigurationStmt *stmt,
 
 			while (HeapTupleIsValid((maptup = systable_getnext(scan))))
 			{
-				simple_heap_delete(relMap, &maptup->t_self);
+				CatalogTupleDelete(relMap, &maptup->t_self);
 			}
 
 			systable_endscan(scan);
@@ -1524,7 +1524,7 @@ DropConfigurationMapping(AlterTSConfigurationStmt *stmt,
 
 		while (HeapTupleIsValid((maptup = systable_getnext(scan))))
 		{
-			simple_heap_delete(relMap, &maptup->t_self);
+			CatalogTupleDelete(relMap, &maptup->t_self);
 			found = true;
 		}
 

--- a/src/backend/commands/tsearchcmds.c
+++ b/src/backend/commands/tsearchcmds.c
@@ -268,9 +268,7 @@ DefineTSParser(List *names, List *parameters)
 
 	tup = heap_form_tuple(prsRel->rd_att, values, nulls);
 
-	prsOid = simple_heap_insert(prsRel, tup);
-
-	CatalogUpdateIndexes(prsRel, tup);
+	prsOid = CatalogTupleInsert(prsRel, tup);
 
 	makeParserDependencies(tup);
 
@@ -492,9 +490,7 @@ DefineTSDictionary(List *names, List *parameters)
 
 	tup = heap_form_tuple(dictRel->rd_att, values, nulls);
 
-	dictOid = simple_heap_insert(dictRel, tup);
-
-	CatalogUpdateIndexes(dictRel, tup);
+	dictOid = CatalogTupleInsert(dictRel, tup);
 
 	makeDictionaryDependencies(tup);
 
@@ -645,9 +641,7 @@ AlterTSDictionary(AlterTSDictionaryStmt *stmt)
 	newtup = heap_modify_tuple(tup, RelationGetDescr(rel),
 							   repl_val, repl_null, repl_repl);
 
-	simple_heap_update(rel, &newtup->t_self, newtup);
-
-	CatalogUpdateIndexes(rel, newtup);
+	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
 
 	InvokeObjectPostAlterHook(TSDictionaryRelationId, dictId, 0);
 
@@ -834,9 +828,7 @@ DefineTSTemplate(List *names, List *parameters)
 
 	tup = heap_form_tuple(tmplRel->rd_att, values, nulls);
 
-	tmplOid = simple_heap_insert(tmplRel, tup);
-
-	CatalogUpdateIndexes(tmplRel, tup);
+	tmplOid = CatalogTupleInsert(tmplRel, tup);
 
 	makeTSTemplateDependencies(tup);
 
@@ -1099,9 +1091,7 @@ DefineTSConfiguration(List *names, List *parameters)
 
 	tup = heap_form_tuple(cfgRel->rd_att, values, nulls);
 
-	cfgOid = simple_heap_insert(cfgRel, tup);
-
-	CatalogUpdateIndexes(cfgRel, tup);
+	cfgOid = CatalogTupleInsert(cfgRel, tup);
 
 	if (OidIsValid(sourceOid))
 	{
@@ -1139,9 +1129,7 @@ DefineTSConfiguration(List *names, List *parameters)
 
 			newmaptup = heap_form_tuple(mapRel->rd_att, mapvalues, mapnulls);
 
-			simple_heap_insert(mapRel, newmaptup);
-
-			CatalogUpdateIndexes(mapRel, newmaptup);
+			CatalogTupleInsert(mapRel, newmaptup);
 
 			heap_freetuple(newmaptup);
 		}
@@ -1463,9 +1451,7 @@ MakeConfigurationMapping(AlterTSConfigurationStmt *stmt,
 				newtup = heap_modify_tuple(maptup,
 										   RelationGetDescr(relMap),
 										   repl_val, repl_null, repl_repl);
-				simple_heap_update(relMap, &newtup->t_self, newtup);
-
-				CatalogUpdateIndexes(relMap, newtup);
+				CatalogTupleUpdate(relMap, &newtup->t_self, newtup);
 			}
 		}
 
@@ -1490,8 +1476,7 @@ MakeConfigurationMapping(AlterTSConfigurationStmt *stmt,
 				values[Anum_pg_ts_config_map_mapdict - 1] = ObjectIdGetDatum(dictIds[j]);
 
 				tup = heap_form_tuple(relMap->rd_att, values, nulls);
-				simple_heap_insert(relMap, tup);
-				CatalogUpdateIndexes(relMap, tup);
+				CatalogTupleInsert(relMap, tup);
 
 				heap_freetuple(tup);
 			}

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -2335,9 +2335,7 @@ AlterDomainDefault(List *names, Node *defaultRaw)
 								 new_record, new_record_nulls,
 								 new_record_repl);
 
-	simple_heap_update(rel, &tup->t_self, newtuple);
-
-	CatalogUpdateIndexes(rel, newtuple);
+	CatalogTupleUpdate(rel, &tup->t_self, newtuple);
 
 	/* Must extract ACL for use of GenerateTypeDependencies */
 	aclDatum = heap_getattr(newtuple, Anum_pg_type_typacl,
@@ -2467,9 +2465,7 @@ AlterDomainNotNull(List *names, bool notNull)
 	 */
 	typTup->typnotnull = notNull;
 
-	simple_heap_update(typrel, &tup->t_self, tup);
-
-	CatalogUpdateIndexes(typrel, tup);
+	CatalogTupleUpdate(typrel, &tup->t_self, tup);
 
 	InvokeObjectPostAlterHook(TypeRelationId, domainoid, 0);
 
@@ -2758,8 +2754,7 @@ AlterDomainValidateConstraint(List *names, char *constrName)
 	copyTuple = heap_copytuple(tuple);
 	copy_con = (Form_pg_constraint) GETSTRUCT(copyTuple);
 	copy_con->convalidated = true;
-	simple_heap_update(conrel, &copyTuple->t_self, copyTuple);
-	CatalogUpdateIndexes(conrel, copyTuple);
+	CatalogTupleUpdate(conrel, &copyTuple->t_self, copyTuple);
 
 	InvokeObjectPostAlterHook(ConstraintRelationId,
 							  HeapTupleGetOid(copyTuple), 0);
@@ -3594,9 +3589,7 @@ AlterTypeOwnerInternal(Oid typeOid, Oid newOwnerId)
 	tup = heap_modify_tuple(tup, RelationGetDescr(rel), repl_val, repl_null,
 							repl_repl);
 
-	simple_heap_update(rel, &tup->t_self, tup);
-
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 	/* If it has an array type, update that too */
 	if (OidIsValid(typTup->typarray))
@@ -3742,8 +3735,7 @@ AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 	/* tup is a copy, so we can scribble directly on it */
 	typform->typnamespace = nspOid;
 
-	simple_heap_update(rel, &tup->t_self, tup);
-	CatalogUpdateIndexes(rel, tup);
+	CatalogTupleUpdate(rel, &tup->t_self, tup);
 
 	/*
 	 * Composite types have pg_class entries.
@@ -3821,8 +3813,7 @@ AlterTypeArray(Oid typeOid, Oid arrayOid)
 
 	typform->typarray = arrayOid;
 
-	simple_heap_update(typrel, &typtup->t_self, typtup);
-	CatalogUpdateIndexes(typrel, typtup);
+	CatalogTupleUpdate(typrel, &typtup->t_self, typtup);
 
 	InvokeObjectPostAlterHook(TypeRelationId, typeOid, 0);
 	heap_freetuple(typtup);

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -736,7 +736,7 @@ RemoveTypeById(Oid typeOid)
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "cache lookup failed for type %u", typeOid);
 
-	simple_heap_delete(relation, &tup->t_self);
+	CatalogTupleDelete(relation, &tup->t_self);
 
 	/*
 	 * If it is an enum, delete the pg_enum entries too; we don't bother with

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -1557,7 +1557,7 @@ DropRole(DropRoleStmt *stmt)
 		/*
 		 * Remove the role from the pg_authid table
 		 */
-		simple_heap_delete(pg_authid_rel, &tuple->t_self);
+		CatalogTupleDelete(pg_authid_rel, &tuple->t_self);
 
 		ReleaseSysCache(tuple);
 
@@ -1577,7 +1577,7 @@ DropRole(DropRoleStmt *stmt)
 
 		while (HeapTupleIsValid(tmp_tuple = systable_getnext(sscan)))
 		{
-			simple_heap_delete(pg_auth_members_rel, &tmp_tuple->t_self);
+			CatalogTupleDelete(pg_auth_members_rel, &tmp_tuple->t_self);
 		}
 
 		systable_endscan(sscan);
@@ -1592,7 +1592,7 @@ DropRole(DropRoleStmt *stmt)
 
 		while (HeapTupleIsValid(tmp_tuple = systable_getnext(sscan)))
 		{
-			simple_heap_delete(pg_auth_members_rel, &tmp_tuple->t_self);
+			CatalogTupleDelete(pg_auth_members_rel, &tmp_tuple->t_self);
 		}
 
 		systable_endscan(sscan);
@@ -2460,7 +2460,7 @@ DelRoleMems(const char *rolename, Oid roleid,
 		if (!admin_opt)
 		{
 			/* Remove the entry altogether */
-			simple_heap_delete(pg_authmem_rel, &authmem_tuple->t_self);
+			CatalogTupleDelete(pg_authmem_rel, &authmem_tuple->t_self);
 		}
 		else
 		{
@@ -2671,14 +2671,14 @@ DelRoleDenials(const char *rolename, Oid roleid, List *dropintervals)
 										DatumGetCString(DirectFunctionCall1(time_out, TimeADTGetDatum(existing->start.time))),
 										daysofweek[existing->end.day],
 										DatumGetCString(DirectFunctionCall1(time_out, TimeADTGetDatum(existing->end.time))))));
-					simple_heap_delete(pg_auth_time_rel, &tmp_tuple->t_self);
+					CatalogTupleDelete(pg_auth_time_rel, &tmp_tuple->t_self);
 					dropped_matching_interval = true;
 					break;
 				}
 			}
 		}
 		else
-			simple_heap_delete(pg_auth_time_rel, &tmp_tuple->t_self);
+			CatalogTupleDelete(pg_auth_time_rel, &tmp_tuple->t_self);
 	}
 
 	/* if intervals were specified and none was found, raise error */

--- a/src/backend/commands/user.c
+++ b/src/backend/commands/user.c
@@ -599,8 +599,7 @@ CreateRole(CreateRoleStmt *stmt)
 	/*
 	 * Insert new record in the pg_authid table
 	 */
-	roleid = simple_heap_insert(pg_authid_rel, tuple);
-	CatalogUpdateIndexes(pg_authid_rel, tuple);
+	roleid = CatalogTupleInsert(pg_authid_rel, tuple);
 
 	/*
 	 * Advance command counter so we can see new record; else tests in
@@ -1277,10 +1276,7 @@ AlterRole(AlterRoleStmt *stmt)
 
 	new_tuple = heap_modify_tuple(tuple, pg_authid_dsc, new_record,
 								  new_record_nulls, new_record_repl);
-	simple_heap_update(pg_authid_rel, &tuple->t_self, new_tuple);
-
-	/* Update indexes */
-	CatalogUpdateIndexes(pg_authid_rel, new_tuple);
+	CatalogTupleUpdate(pg_authid_rel, &tuple->t_self, new_tuple);
 
 	InvokeObjectPostAlterHook(AuthIdRelationId, roleid, 0);
 
@@ -1751,9 +1747,7 @@ RenameRole(const char *oldname, const char *newname)
 	}
 
 	newtuple = heap_modify_tuple(oldtuple, dsc, repl_val, repl_null, repl_repl);
-	simple_heap_update(rel, &oldtuple->t_self, newtuple);
-
-	CatalogUpdateIndexes(rel, newtuple);
+	CatalogTupleUpdate(rel, &oldtuple->t_self, newtuple);
 
 	InvokeObjectPostAlterHook(AuthIdRelationId, roleid, 0);
 
@@ -2081,16 +2075,14 @@ AddRoleMems(const char *rolename, Oid roleid,
 			tuple = heap_modify_tuple(authmem_tuple, pg_authmem_dsc,
 									  new_record,
 									  new_record_nulls, new_record_repl);
-			simple_heap_update(pg_authmem_rel, &tuple->t_self, tuple);
-			CatalogUpdateIndexes(pg_authmem_rel, tuple);
+			CatalogTupleUpdate(pg_authmem_rel, &tuple->t_self, tuple);
 			ReleaseSysCache(authmem_tuple);
 		}
 		else
 		{
 			tuple = heap_form_tuple(pg_authmem_dsc,
 									new_record, new_record_nulls);
-			simple_heap_insert(pg_authmem_rel, tuple);
-			CatalogUpdateIndexes(pg_authmem_rel, tuple);
+			CatalogTupleInsert(pg_authmem_rel, tuple);
 		}
 
 		/* CCI after each change, in case there are duplicates in list */
@@ -2489,8 +2481,7 @@ DelRoleMems(const char *rolename, Oid roleid,
 			tuple = heap_modify_tuple(authmem_tuple, pg_authmem_dsc,
 									  new_record,
 									  new_record_nulls, new_record_repl);
-			simple_heap_update(pg_authmem_rel, &tuple->t_self, tuple);
-			CatalogUpdateIndexes(pg_authmem_rel, tuple);
+			CatalogTupleUpdate(pg_authmem_rel, &tuple->t_self, tuple);
 		}
 
 		ReleaseSysCache(authmem_tuple);
@@ -2614,8 +2605,7 @@ AddRoleDenials(const char *rolename, Oid roleid, List *addintervals)
 		tuple = heap_form_tuple(pg_auth_time_dsc, new_record, new_record_nulls);
 
 		/* Insert tuple into the relation */
-		simple_heap_insert(pg_auth_time_rel, tuple);
-		CatalogUpdateIndexes(pg_auth_time_rel, tuple);
+		CatalogTupleInsert(pg_auth_time_rel, tuple);
 	}
 
 	CommandCounterIncrement();

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -225,8 +225,7 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 		histvals[Anum_gp_configuration_history_desc-1] =
 				CStringGetTextDatum(desc);
 		histtuple = heap_form_tuple(RelationGetDescr(histrel), histvals, histnulls);
-		simple_heap_insert(histrel, histtuple);
-		CatalogUpdateIndexes(histrel, histtuple);
+		CatalogTupleInsert(histrel, histtuple);
 
 		SIMPLE_FAULT_INJECTOR("fts_update_config");
 
@@ -282,8 +281,7 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 
 		newtuple = heap_modify_tuple(configtuple, RelationGetDescr(configrel),
 									 configvals, confignulls, repls);
-		simple_heap_update(configrel, &configtuple->t_self, newtuple);
-		CatalogUpdateIndexes(configrel, newtuple);
+		CatalogTupleUpdate(configrel, &configtuple->t_self, newtuple);
 
 		systable_endscan(sscan);
 		pfree(newtuple);

--- a/src/backend/rewrite/rewriteRemove.c
+++ b/src/backend/rewrite/rewriteRemove.c
@@ -76,7 +76,7 @@ RemoveRewriteRuleById(Oid ruleOid)
 	/*
 	 * Now delete the pg_rewrite tuple for the rule
 	 */
-	simple_heap_delete(RewriteRelation, &tuple->t_self);
+	CatalogTupleDelete(RewriteRelation, &tuple->t_self);
 
 	systable_endscan(rcscan);
 

--- a/src/backend/rewrite/rewriteSupport.c
+++ b/src/backend/rewrite/rewriteSupport.c
@@ -72,10 +72,7 @@ SetRelationRuleStatus(Oid relationId, bool relHasRules)
 		/* Do the update */
 		classForm->relhasrules = relHasRules;
 
-		simple_heap_update(relationRelation, &tuple->t_self, tuple);
-
-		/* Keep the catalog indexes up to date */
-		CatalogUpdateIndexes(relationRelation, tuple);
+		CatalogTupleUpdate(relationRelation, &tuple->t_self, tuple);
 	}
 	else
 	{

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -857,7 +857,7 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		if (olddata != NULL)
 		{
 			Assert(olddata->pageno > pageno);
-			simple_heap_delete(lo_heap_r, &oldtuple->t_self);
+			CatalogTupleDelete(lo_heap_r, &oldtuple->t_self);
 		}
 
 		/*
@@ -893,7 +893,7 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 	{
 		while ((oldtuple = systable_getnext_ordered(sd, ForwardScanDirection)) != NULL)
 		{
-			simple_heap_delete(lo_heap_r, &oldtuple->t_self);
+			CatalogTupleDelete(lo_heap_r, &oldtuple->t_self);
 		}
 	}
 

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -676,8 +676,7 @@ inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			replace[Anum_pg_largeobject_data - 1] = true;
 			newtup = heap_modify_tuple(oldtuple, RelationGetDescr(lo_heap_r),
 									   values, nulls, replace);
-			simple_heap_update(lo_heap_r, &newtup->t_self, newtup);
-			CatalogIndexInsert(indstate, newtup);
+			CatalogTupleUpdate(lo_heap_r, &newtup->t_self, newtup);
 			heap_freetuple(newtup);
 
 			/*
@@ -719,8 +718,7 @@ inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			values[Anum_pg_largeobject_pageno - 1] = Int32GetDatum(pageno);
 			values[Anum_pg_largeobject_data - 1] = PointerGetDatum(&workbuf);
 			newtup = heap_form_tuple(lo_heap_r->rd_att, values, nulls);
-			simple_heap_insert(lo_heap_r, newtup);
-			CatalogIndexInsert(indstate, newtup);
+			CatalogTupleInsert(lo_heap_r, newtup);
 			heap_freetuple(newtup);
 		}
 		pageno++;
@@ -846,8 +844,7 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		replace[Anum_pg_largeobject_data - 1] = true;
 		newtup = heap_modify_tuple(oldtuple, RelationGetDescr(lo_heap_r),
 								   values, nulls, replace);
-		simple_heap_update(lo_heap_r, &newtup->t_self, newtup);
-		CatalogIndexInsert(indstate, newtup);
+		CatalogTupleUpdate(lo_heap_r, &newtup->t_self, newtup);
 		heap_freetuple(newtup);
 	}
 	else
@@ -884,8 +881,7 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		values[Anum_pg_largeobject_pageno - 1] = Int32GetDatum(pageno);
 		values[Anum_pg_largeobject_data - 1] = PointerGetDatum(&workbuf);
 		newtup = heap_form_tuple(lo_heap_r->rd_att, values, nulls);
-		simple_heap_insert(lo_heap_r, newtup);
-		CatalogIndexInsert(indstate, newtup);
+		CatalogTupleInsert(lo_heap_r, newtup);
 		heap_freetuple(newtup);
 	}
 

--- a/src/backend/storage/large_object/inv_api.c
+++ b/src/backend/storage/large_object/inv_api.c
@@ -676,7 +676,8 @@ inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			replace[Anum_pg_largeobject_data - 1] = true;
 			newtup = heap_modify_tuple(oldtuple, RelationGetDescr(lo_heap_r),
 									   values, nulls, replace);
-			CatalogTupleUpdate(lo_heap_r, &newtup->t_self, newtup);
+			CatalogTupleUpdateWithInfo(lo_heap_r, &newtup->t_self, newtup,
+									   indstate);
 			heap_freetuple(newtup);
 
 			/*
@@ -718,7 +719,7 @@ inv_write(LargeObjectDesc *obj_desc, const char *buf, int nbytes)
 			values[Anum_pg_largeobject_pageno - 1] = Int32GetDatum(pageno);
 			values[Anum_pg_largeobject_data - 1] = PointerGetDatum(&workbuf);
 			newtup = heap_form_tuple(lo_heap_r->rd_att, values, nulls);
-			CatalogTupleInsert(lo_heap_r, newtup);
+			CatalogTupleInsertWithInfo(lo_heap_r, newtup, indstate);
 			heap_freetuple(newtup);
 		}
 		pageno++;
@@ -844,7 +845,8 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		replace[Anum_pg_largeobject_data - 1] = true;
 		newtup = heap_modify_tuple(oldtuple, RelationGetDescr(lo_heap_r),
 								   values, nulls, replace);
-		CatalogTupleUpdate(lo_heap_r, &newtup->t_self, newtup);
+		CatalogTupleUpdateWithInfo(lo_heap_r, &newtup->t_self, newtup,
+								   indstate);
 		heap_freetuple(newtup);
 	}
 	else
@@ -881,7 +883,7 @@ inv_truncate(LargeObjectDesc *obj_desc, int64 len)
 		values[Anum_pg_largeobject_pageno - 1] = Int32GetDatum(pageno);
 		values[Anum_pg_largeobject_data - 1] = PointerGetDatum(&workbuf);
 		newtup = heap_form_tuple(lo_heap_r->rd_att, values, nulls);
-		CatalogTupleInsert(lo_heap_r, newtup);
+		CatalogTupleInsertWithInfo(lo_heap_r, newtup, indstate);
 		heap_freetuple(newtup);
 	}
 

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3301,8 +3301,7 @@ RelationSetNewRelfilenode(Relation relation, TransactionId freezeXid,
 		}
 		classform->relminmxid = minmulti;
 
-		simple_heap_update(pg_class, &tuple->t_self, tuple);
-		CatalogUpdateIndexes(pg_class, tuple);
+		CatalogTupleUpdate(pg_class, &tuple->t_self, tuple);
 	}
 
 	heap_freetuple(tuple);

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -100,11 +100,9 @@
 	(Adding an index requires a catversion.h update, while simply
 	adding/deleting caches only requires a recompile.)
 
-	Finally, any place your relation gets heap_insert() or heap_update()
-	calls, make sure there is a CatalogTupleInsert() or CatalogTupleUpdate()
-	or similar call.  The heap_* calls do not update indexes.
-
-	bjm 1999/11/22
+	Finally, any place your relation gets heap_insert() or
+	heap_update() calls, use CatalogTupleInsert() or CatalogTupleUpdate()
+	instead, which also update indexes.  The heap_* calls do not do that.
 
 *---------------------------------------------------------------------------
 */

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -100,9 +100,9 @@
 	(Adding an index requires a catversion.h update, while simply
 	adding/deleting caches only requires a recompile.)
 
-	Finally, any place your relation gets heap_insert() or
-	heap_update() calls, make sure there is a CatalogUpdateIndexes() or
-	similar call.  The heap_* calls do not update indexes.
+	Finally, any place your relation gets heap_insert() or heap_update()
+	calls, make sure there is a CatalogTupleInsert() or CatalogTupleUpdate()
+	or similar call.  The heap_* calls do not update indexes.
 
 	bjm 1999/11/22
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -271,8 +271,7 @@ add_segment_config(GpSegConfigEntry *i)
 	tuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
 	/* insert a new tuple */
-	simple_heap_insert(rel, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	CatalogTupleInsert(rel, tuple);
 
 	heap_close(rel, NoLock);
 }
@@ -750,8 +749,7 @@ segment_config_activate_standby(int16 standby_dbid, int16 master_dbid)
 	((Form_gp_segment_configuration) GETSTRUCT(tuple))->role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 	((Form_gp_segment_configuration) GETSTRUCT(tuple))->preferred_role = GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY;
 
-	simple_heap_update(rel, &tuple->t_self, tuple);
-	CatalogUpdateIndexes(rel, tuple);
+	CatalogTupleUpdate(rel, &tuple->t_self, tuple);
 
 	systable_endscan(sscan);
 

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -309,7 +309,7 @@ remove_segment_config(int16 dbid)
 							   NULL, 1, &scankey);
 	while ((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 		numDel++;
 	}
 	systable_endscan(sscan);
@@ -723,7 +723,7 @@ segment_config_activate_standby(int16 standby_dbid, int16 master_dbid)
 							   NULL, 1, &scankey);
 	while ((tuple = systable_getnext(sscan)) != NULL)
 	{
-		simple_heap_delete(rel, &tuple->t_self);
+		CatalogTupleDelete(rel, &tuple->t_self);
 		numDel++;
 	}
 	systable_endscan(sscan);

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -37,6 +37,7 @@ extern void CatalogIndexInsert(CatalogIndexState indstate,
 extern Oid CatalogTupleInsert(Relation heapRel, HeapTuple tup);
 extern void CatalogTupleUpdate(Relation heapRel, ItemPointer otid,
 				   HeapTuple tup);
+extern void CatalogTupleDelete(Relation heapRel, ItemPointer tid);
 
 extern void CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup);
 

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -34,8 +34,11 @@ extern CatalogIndexState CatalogOpenIndexes(Relation heapRel);
 extern void CatalogCloseIndexes(CatalogIndexState indstate);
 extern void CatalogIndexInsert(CatalogIndexState indstate,
 				   HeapTuple heapTuple);
-extern void CatalogUpdateIndexes(Relation heapRel, HeapTuple heapTuple);
+extern Oid CatalogTupleInsert(Relation heapRel, HeapTuple tup);
+extern void CatalogTupleUpdate(Relation heapRel, ItemPointer otid,
+				   HeapTuple tup);
 
+extern void CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup);
 
 /*
  * These macros are just to keep the C compiler from spitting up on the

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -32,11 +32,14 @@ typedef struct ResultRelInfo *CatalogIndexState;
  */
 extern CatalogIndexState CatalogOpenIndexes(Relation heapRel);
 extern void CatalogCloseIndexes(CatalogIndexState indstate);
-extern void CatalogIndexInsert(CatalogIndexState indstate,
-				   HeapTuple heapTuple);
-extern Oid CatalogTupleInsert(Relation heapRel, HeapTuple tup);
+extern Oid	CatalogTupleInsert(Relation heapRel, HeapTuple tup);
+extern Oid CatalogTupleInsertWithInfo(Relation heapRel, HeapTuple tup,
+						   CatalogIndexState indstate);
 extern void CatalogTupleUpdate(Relation heapRel, ItemPointer otid,
 				   HeapTuple tup);
+extern void CatalogTupleUpdateWithInfo(Relation heapRel,
+						   ItemPointer otid, HeapTuple tup,
+						   CatalogIndexState indstate);
 extern void CatalogTupleDelete(Relation heapRel, ItemPointer tid);
 
 extern void CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup);


### PR DESCRIPTION
We need these patches to make easy https://github.com/arenadata/gpdb/pull/585.
These patches do not solve any problem, but make the code cleaner, more logical and closer to the upstream.
There is no way to repeat it or check it.
<details>
<summary>1) Tweak catalog indexing abstraction for upcoming WARM</summary>

Split the existing CatalogUpdateIndexes into two different routines,
CatalogTupleInsert and CatalogTupleUpdate, which do both the heap
insert/update plus the index update.  This removes over 300 lines of
boilerplate code all over src/backend/catalog/ and src/backend/commands.
The resulting code is much more pleasing to the eye.

Also, by encapsulating what happens in detail during an UPDATE, this
facilitates the upcoming WARM patch, which is going to add a few more
lines to the update case making the boilerplate even more boring.

The original CatalogUpdateIndexes is removed; there was only one use
left, and since it's just three lines, we can as well expand it in place
there.  We could keep it, but WARM is going to break all the UPDATE
out-of-core callsites anyway, so there seems to be no benefit in doing
so.

This is backport of 2f5c9d9c9cec436e55847ec580606d7e88067df6
CatalogTupleInsertFrozen is taken from 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4
This patch replaces simple_heap_insert and CatalogUpdateIndexes to CatalogTupleInsert,
and simple_heap_update and CatalogUpdateIndexes to CatalogTupleUpdate

Author: Pavan Deolasee
Discussion: https://www.postgr.es/m/CABOikdOcFYSZ4vA2gYfs=M2cdXzXX4qGHeEiW3fu9PCfkHLa2A@mail.gmail.com
</details>
<details>
<summary>2) Provide CatalogTupleDelete() as a wrapper around simple_heap_delete().</summary>

This extends the work done in commit 2f5c9d9c9cec436e55847ec580606d7e88067df6 to provide a more nearly
complete abstraction layer hiding the details of index updating for catalog
changes.  That commit only invented abstractions for catalog inserts and
updates, leaving nearby code for catalog deletes still calling the
heap-level routines directly.  That seems rather ugly from here, and it
does little to help if we ever want to shift to a storage system in which
indexing work is needed at delete time.

Hence, create a wrapper function CatalogTupleDelete(), and replace calls
of simple_heap_delete() on catalog tuples with it.  There are now very
few direct calls of [simple_]heap_delete remaining in the tree.

This is backport of ab02896510e26e46b830c87eef2c03dd3c52c09e
This patch replaces simple_heap_delete to CatalogTupleDelete

Discussion: https://postgr.es/m/462.1485902736@sss.pgh.pa.us
</details>
<details>
<summary>3) Fix CatalogTupleInsert/Update abstraction for case of shared indstate.</summary>

Add CatalogTupleInsertWithInfo and CatalogTupleUpdateWithInfo to let
callers use the CatalogTupleXXX abstraction layer even in cases where
we want to share the results of CatalogOpenIndexes across multiple
inserts/updates for efficiency.  This finishes the job begun in commit
2f5c9d9c9cec436e55847ec580606d7e88067df6, by allowing some remaining simple_heap_insert/update
calls to be replaced.  The abstraction layer is now complete enough
that we don't have to export CatalogIndexInsert at all anymore.

Also, this fixes several places in which 2f5c9d9c9cec436e55847ec580606d7e88067df6 introduced performance
regressions by using retail CatalogTupleInsert or CatalogTupleUpdate even
though the previous coding had been able to amortize CatalogOpenIndexes
work across multiple tuples.

A possible future improvement is to arrange for the indexing.c functions
to cache the CatalogIndexState somewhere, maybe in the relcache, in which
case we could get rid of CatalogTupleInsertWithInfo and
CatalogTupleUpdateWithInfo again.  But that's a task for another day.

This is backport of aedd554f84bb3cedb32e6e2a954a70537a4da6b9

Discussion: https://postgr.es/m/27502.1485981379@sss.pgh.pa.us
</details>
<details>
<summary>4) Update comments overlooked by 2f5c9d9c9cec436e55847ec580606d7e88067df6.</summary>

This is backport of fa42b2005f0cd825fe5a5fd4db93a7c30b5fe883
</details>
