### PR TITLE
ADBDEV-4321: Fix planning failure in the case of a Shared Scan over node with General locus

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2121,6 +2121,11 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		subplan = share_prepared_plan(cteroot, cteplaninfo->shared_plan);
 		subroot = cteplaninfo->subroot;
 
+		/*
+		 * If SharedScan is set to General, the planner might place the producer and
+		 * consumer on different segments, that leading to a deadlock. so in this
+		 * case we perform SharedScan on single segment.
+		 */
 		if (subplan->flow->locustype == CdbLocusType_General)
 		{
 			subplan->flow->locustype = CdbLocusType_SingleQE;

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2122,9 +2122,10 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		subroot = cteplaninfo->subroot;
 
 		/*
-		 * If SharedScan is set to General, the planner might place the producer and
-		 * consumer on different segments, that leading to a deadlock. so in this
-		 * case we perform SharedScan on single segment.
+		 * If Shared Scan has General locus the planner can place producer slice on
+		 * coordinator and consumer slice on segments. That lead to deadlock.
+		 * To avoid it we ensuring that the shared scan for a node with general
+		 * locus is always performed on a single segment.
 		 */
 		if (subplan->flow->locustype == CdbLocusType_General)
 		{

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2123,9 +2123,9 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 		/*
 		 * If Shared Scan has General locus the planner can place producer and
-		 * consumer slices different on segments. That lead to deadlock. To avoid it
-		 * we change locus and flow type to CdbLocusType_SingleQE and FLOW_SINGLETON
-		 * respectively for performing Shared Scan on a single segment.
+		 * consumer slices on different segments. That lead to deadlock. To avoid it
+		 * we change locus and flow type for performing Shared Scan on a single
+		 * segment.
 		 */
 		if (subplan->flow->locustype == CdbLocusType_General)
 		{

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2120,6 +2120,12 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		 */
 		subplan = share_prepared_plan(cteroot, cteplaninfo->shared_plan);
 		subroot = cteplaninfo->subroot;
+
+		if (subplan->flow->locustype == CdbLocusType_General)
+		{
+			subplan->flow->locustype = CdbLocusType_SingleQE;
+			subplan->flow->flotype = FLOW_SINGLETON;
+		}
 	}
 
 	pathkeys = subroot->query_pathkeys;

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2122,10 +2122,10 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		subroot = cteplaninfo->subroot;
 
 		/*
-		 * If Shared Scan has General locus the planner can place producer slice on
-		 * coordinator and consumer slice on segments. That lead to deadlock.
-		 * To avoid it we ensuring that the shared scan for a node with general
-		 * locus is always performed on a single segment.
+		 * If Shared Scan has General locus the planner can place producer and
+		 * consumer slices different on segments. That lead to deadlock. To avoid it
+		 * we change locus and flow type to CdbLocusType_SingleQE and FLOW_SINGLETON
+		 * respectively for performing Shared Scan on a single segment.
 		 */
 		if (subplan->flow->locustype == CdbLocusType_General)
 		{

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -322,11 +322,13 @@ typedef struct PlannerInfo
 typedef struct CtePlanInfo
 {
 	/*
-	 * A subplan, prepared for sharing among many CTE references by
-	 * prepare_plan_for_sharing(), that implements the CTE. NULL if the
-	 * CTE is not shared among references.
+	 * A subplan, that implements the CTE and which is prepared either for
+	 * sharing among many CTE references by prepare_plan_for_sharing() or
+	 * for inlining in cases, when sharing produces invalid plans. NULL if
+	 * the CTE is not shared among references (gp_cte_sharing is off), or to
+	 * be planned or inlined and has not been planned yet.
 	 */
-	Plan *shared_plan;
+	Plan *subplan;
 
 	/*
 	 * The subroot corresponding to the subplan.

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2269,7 +2269,6 @@ SET optimizer = off;
 DROP TABLE IF EXISTS d;
 --end_ignore
 CREATE TABLE d (c1 int, c2 int) DISTRIBUTED BY (c1);
-
 INSERT INTO d VALUES ( 2, 0 ),( 2, 0 );
 WITH cte AS (
 	SELECT count(*) c1 FROM d
@@ -2286,28 +2285,34 @@ WITH cte AS (
 	SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v
 )
 SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Hash Join
-   Hash Cond: (b.c1 = share0_ref1.c1)
+   Hash Cond: (b.c1 = (count(*)))
    ->  Subquery Scan on b
          ->  Limit
-               ->  Gather Motion 3:1  (slice2; segments: 3)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
                      ->  Limit
                            ->  Hash Join
-                                 Hash Cond: (d.c1 = share0_ref2.c1)
+                                 Hash Cond: (d.c1 = (count(*)))
                                  ->  Seq Scan on d
                                  ->  Hash
-                                       ->  Redistribute Motion 1:3  (slice1)
-                                             Hash Key: share0_ref2.c1
-                                             ->  Shared Scan (share slice:id 1:0)
+                                       ->  Aggregate
+                                             ->  Values Scan on "*VALUES*"
    ->  Hash
-         ->  Shared Scan (share slice:id 0:0)
-               ->  Materialize
-                     ->  Aggregate
-                           ->  Values Scan on "*VALUES*"
+         ->  Aggregate
+               ->  Values Scan on "*VALUES*_1"
  Optimizer: Postgres query optimizer
-(19 rows)
+(16 rows)
+
+WITH cte AS (
+    SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+ c1 | c2 
+----+----
+  2 |  0
+(1 row)
 
 RESET optimizer;
 DROP TABLE d;

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2279,7 +2279,8 @@ WITH cte AS (
   2 |  0
 (1 row)
 
--- Test shared scan over values with singleQE join
+-- Test that conusmer and producer slices are on single segment in case when
+-- Shared Scan is generated over a node with a General locus
 EXPLAIN (COSTS OFF)
 WITH cte AS (
 	SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2269,6 +2269,7 @@ SET optimizer = off;
 DROP TABLE IF EXISTS d;
 --end_ignore
 CREATE TABLE d (c1 int, c2 int) DISTRIBUTED BY (c1);
+
 INSERT INTO d VALUES ( 2, 0 ),( 2, 0 );
 WITH cte AS (
 	SELECT count(*) c1 FROM d
@@ -2277,6 +2278,35 @@ WITH cte AS (
 ----+----
   2 |  0
 (1 row)
+
+-- Test shared scan over values with singleQE join
+EXPLAIN (COSTS OFF)
+WITH cte AS (
+	SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Hash Join
+   Hash Cond: (b.c1 = share0_ref1.c1)
+   ->  Subquery Scan on b
+         ->  Limit
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     ->  Limit
+                           ->  Hash Join
+                                 Hash Cond: (d.c1 = share0_ref2.c1)
+                                 ->  Seq Scan on d
+                                 ->  Hash
+                                       ->  Redistribute Motion 1:3  (slice1)
+                                             Hash Key: share0_ref2.c1
+                                             ->  Shared Scan (share slice:id 1:0)
+   ->  Hash
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Materialize
+                     ->  Aggregate
+                           ->  Values Scan on "*VALUES*"
+ Optimizer: Postgres query optimizer
+(19 rows)
 
 RESET optimizer;
 DROP TABLE d;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1081,5 +1081,12 @@ WITH cte AS (
 	SELECT count(*) c1 FROM d
 ) SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
 
+-- Test shared scan over values with singleQE join
+EXPLAIN (COSTS OFF)
+WITH cte AS (
+	SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+
 RESET optimizer;
 DROP TABLE d;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1066,9 +1066,14 @@ SELECT * FROM cte1 a JOIN cte1 b USING (c1);
 
 DROP TABLE t1;
 
+<<<<<<< HEAD
 -- Ensure that prefetch is not disabled for HashJoin in case of join at single segment.
 -- Test Shared Scan producer is executed under inner part of join first and the
 -- deadlock between Shared Scans does not occur
+=======
+-- Test that conusmer and producer slices are on single segment in case when
+-- Shared Scan is generated over a node with a General locus
+>>>>>>> f7e6fe018d (change comment)
 SET optimizer = off;
 --start_ignore
 DROP TABLE IF EXISTS d;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1089,5 +1089,10 @@ WITH cte AS (
 )
 SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
 
+WITH cte AS (
+    SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+
 RESET optimizer;
 DROP TABLE d;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1066,14 +1066,9 @@ SELECT * FROM cte1 a JOIN cte1 b USING (c1);
 
 DROP TABLE t1;
 
-<<<<<<< HEAD
 -- Ensure that prefetch is not disabled for HashJoin in case of join at single segment.
 -- Test Shared Scan producer is executed under inner part of join first and the
 -- deadlock between Shared Scans does not occur
-=======
--- Test that conusmer and producer slices are on single segment in case when
--- Shared Scan is generated over a node with a General locus
->>>>>>> f7e6fe018d (change comment)
 SET optimizer = off;
 --start_ignore
 DROP TABLE IF EXISTS d;
@@ -1086,7 +1081,8 @@ WITH cte AS (
 	SELECT count(*) c1 FROM d
 ) SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
 
--- Test shared scan over values with singleQE join
+-- Test that conusmer and producer slices are on single segment in case when
+-- Shared Scan is generated over a node with a General locus
 EXPLAIN (COSTS OFF)
 WITH cte AS (
 	SELECT count(*) c1 FROM (VALUES ( 1, 2 ),( 3, 4 )) v


### PR DESCRIPTION
When Shared Scan was created above plan with General locus, the planner could
place producer slice at coordinator and consumer slice at segments. That led to
invalid Shared Scan processing during planning and assertion errors inside
several shareinput_mutator_xslice functions, these errors indicated that current
Shared Scan node is marked as available at all segments, however other scan with
the same id was previously considered to be executed at single segment. Without
asserts the plan became invalid, and deadlock occured during execution. Deadlock
happened because Shared Scan's producer and consumer slices couldn't communicate

This patch prevents such situations by making the Shared Scan in case of CTEs
plans with General locus be always performed on a single segment. In case of
General locus the Shared Scan's locus and flow type are changed to
CdbLocusType_SingleQE and FLOW_SINGLETON respectively inside the
set_cte_pathlist function. These changes may lead to suboptimal
plans if both slices (producer and consumer) are on the same segment, however
CTE's subplans can be planned independently from the main plan and we won't be
able to rebuild the prepared subplans if we find out that writer and reader
slices are on different segments.