### PR TITLE
ADBDEV-4207 Fix partition selection during DML execution when dropped columns are present

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4697,12 +4697,11 @@ slot_get_partition(TupleTableSlot *slot, EState *estate)
 							 true);
 
 	/* Free up if we allocated mapped attributes. */
-	if (values != slot_get_values(slot) &&
-		nulls != slot_get_isnull(slot))
-	{
+	if (values != slot_get_values(slot))
 		pfree(values);
+
+	if (nulls != slot_get_isnull(slot))
 		pfree(nulls);
-	}
 
 	return resultRelInfo;
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4686,7 +4686,7 @@ slot_get_partition(TupleTableSlot *slot, EState *estate)
 		/* Now we have values/nulls in parent's view. */
 		values = parent_values;
 		nulls = parent_nulls;
-		tupdesc = RelationGetDescr(parentRel);
+		tupdesc = parentTupdesc;
 	}
 	else
 	{

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -85,6 +85,39 @@ ExecDML(DMLState *node)
 	/* remove 'junk' columns from tuple */
 	node->cleanedUpSlot = ExecFilterJunk(node->junkfilter, projectedSlot);
 
+	/*
+	 * If we are modifying a leaf partition we have to ensure that partition
+	 * selection operation will consider leaf partition's attributes as
+	 * coherent with root partition's attribute numbers, because partition
+	 * selection is performed using root's attribute numbers (all partition
+	 * rules are based on the parent relation's tuple descriptor). In case
+	 * when child partition has different attribute numbers from root's due to
+	 * dropped columns, the partition selection may go wrong without extra
+	 * validation.
+	 */
+	if (node->ps.state->es_result_partitions)
+	{
+		ResultRelInfo *relInfo = node->ps.state->es_result_relations;
+
+		/*
+		 * The DML is done on a leaf partition. In order to reuse the map,
+		 * it will be allocated at es_result_relations.
+		 */
+		if (RelationGetRelid(relInfo->ri_RelationDesc) !=
+			node->ps.state->es_result_partitions->part->parrelid)
+			makePartitionCheckMap(node->ps.state,
+								  relInfo);
+
+		/*
+		 * DML node always performs partition selection, and if we want to
+		 * reuse the map built in makePartitionCheckMap, we are allowed to
+		 * reassign es_result_relation_info, because ExecInsert, ExecDelete
+		 * changes it with target partition anyway. Moreover, without
+		 * inheritance plan (ORCA never builds such plans) the
+		 * es_result_relations will contain the only relation.
+		 */
+		node->ps.state->es_result_relation_info = relInfo;
+	}
 	/* GPDB_91_MERGE_FIXME:
 	 * This kind of node is used by ORCA only. If in the future ORCA still uses
 	 * DML node, canSetTag should be saved in DML plan node and init-ed by

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -105,8 +105,7 @@ ExecDML(DMLState *node)
 		 */
 		if (RelationGetRelid(relInfo->ri_RelationDesc) !=
 			node->ps.state->es_result_partitions->part->parrelid)
-			makePartitionCheckMap(node->ps.state,
-								  relInfo);
+			makePartitionCheckMap(node->ps.state, relInfo);
 
 		/*
 		 * DML node always performs partition selection, and if we want to

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1132,7 +1132,6 @@ checkPartitionUpdate(EState *estate, TupleTableSlot *partslot,
 	Datum	   *values = NULL;
 	bool	   *nulls = NULL;
 	TupleDesc	tupdesc = NULL;
-	Oid			parentRelid;
 	Oid			targetid;
 
 	Assert(estate->es_partition_state != NULL &&
@@ -1144,81 +1143,11 @@ checkPartitionUpdate(EState *estate, TupleTableSlot *partslot,
 	Assert(PointerIsValid(estate->es_result_partitions));
 
 	/*
-	 * As opposed to INSERT, resultRelation here is the same child part
-	 * as scan origin.  However, the partition selection is done with the
-	 * parent partition's attribute numbers, so if this result (child) part
-	 * has physically-different attribute numbers due to dropped columns,
-	 * we should map the child attribute numbers to the parent's attribute
-	 * numbers to perform the partition selection.
-	 * EState doesn't have the parent relation information at the moment,
-	 * so we have to do a hard job here by opening it and compare the
-	 * tuple descriptors.  If we find we need to map attribute numbers,
-	 * max_partition_attr could also be bogus for this child part,
-	 * so we end up materializing the whole columns using slot_getallattrs().
-	 * The purpose of this code is just to prevent the tuple from
-	 * incorrectly staying in default partition that has no constraint
-	 * (parts with constraint will throw an error if the tuple is changing
-	 * partition keys to out of part value anyway.)  It's a bit overkill
-	 * to do this complicated logic just for this purpose, which is necessary
-	 * with our current partitioning design, but I hope some day we can
-	 * change this so that we disallow phyisically-different tuple descriptor
-	 * across partition.
+	 * If we find we need to map attribute numbers (in case if child part has
+	 * physically-different attribute numbers from parent's)
+	 * max_partition_attr could also be bogus for this child part, so we end
+	 * up materializing the whole columns using slot_getallattrs().
 	 */
-	parentRelid = estate->es_result_partitions->part->parrelid;
-
-	/*
-	 * I don't believe this is the case currently, but we check the parent relid
-	 * in case the updating partition has changed since the last time we opened it.
-	 */
-	if (resultRelInfo->ri_PartitionParent &&
-		parentRelid != RelationGetRelid(resultRelInfo->ri_PartitionParent))
-	{
-		resultRelInfo->ri_PartCheckTupDescMatch = 0;
-		if (resultRelInfo->ri_PartCheckMap != NULL)
-			pfree(resultRelInfo->ri_PartCheckMap);
-		if (resultRelInfo->ri_PartitionParent)
-			relation_close(resultRelInfo->ri_PartitionParent, AccessShareLock);
-	}
-
-	/*
-	 * Check this at the first pass only to avoid repeated catalog access.
-	 */
-	if (resultRelInfo->ri_PartCheckTupDescMatch == 0 &&
-		parentRelid != RelationGetRelid(resultRelInfo->ri_RelationDesc))
-	{
-		Relation	parentRel;
-		TupleDesc	resultTupdesc, parentTupdesc;
-
-		/*
-		 * We are on a child part, let's see the tuple descriptor looks like
-		 * the parent's one.  Probably this won't cause deadlock because
-		 * DML should have opened the parent table with appropriate lock.
-		 */
-		parentRel = relation_open(parentRelid, AccessShareLock);
-		resultTupdesc = RelationGetDescr(resultRelationDesc);
-		parentTupdesc = RelationGetDescr(parentRel);
-		if (!equalTupleDescs(resultTupdesc, parentTupdesc, false))
-		{
-			AttrMap		   *map;
-			MemoryContext	oldcontext;
-
-			/* Tuple looks different.  Construct attribute mapping. */
-			oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
-			map_part_attrs(resultRelationDesc, parentRel, &map, true);
-			MemoryContextSwitchTo(oldcontext);
-
-			/* And save it for later use. */
-			resultRelInfo->ri_PartCheckMap = map;
-
-			resultRelInfo->ri_PartCheckTupDescMatch = -1;
-		}
-		else
-			resultRelInfo->ri_PartCheckTupDescMatch = 1;
-
-		resultRelInfo->ri_PartitionParent = parentRel;
-		/* parentRel will be closed as part of ResultRelInfo cleanup */
-	}
-
 	if (resultRelInfo->ri_PartCheckMap != NULL)
 	{
 		Datum	   *parent_values;
@@ -1927,6 +1856,19 @@ ExecModifyTable(ModifyTableState *node)
 				slot = ExecFilterJunk(junkfilter, slot);
 		}
 
+		/*
+		 * We have to ensure that partition selection in INSERT or UPDATE will
+		 * consider leaf partition's attributes as coherent with root
+		 * partition's attribute numbers, because partition selection is
+		 * performed using root's attribute numbers (all partition rules are
+		 * based on the parent relation's tuple descriptor). In case when
+		 * child partition has different attribute numbers from parent's
+		 * due to dropped columns, the partition selection may go wrong without
+		 * extra validation.
+		 */
+		if (operation != CMD_DELETE && estate->es_result_partitions)
+			makePartitionCheckMap(estate, estate->es_result_relation_info);
+
 		switch (operation)
 		{
 			case CMD_INSERT:
@@ -2504,5 +2446,81 @@ ExecSquelchModifyTable(ModifyTableState *node)
 		result = ExecModifyTable(node);
 		if (!result)
 			break;
+	}
+}
+
+/*
+ * Build a attribute mapping between child partition and the root partition in
+ * case if child partition has physically-different attribute numbers from
+ * root's due to dropped columns.
+ */
+void
+makePartitionCheckMap(EState *estate, ResultRelInfo *resultRelInfo)
+{
+	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
+	Oid			parentRelid;
+
+	Assert(PointerIsValid(estate->es_result_partitions));
+
+	/*
+	 * The partition selection operation is done with the parent partition's
+	 * attribute numbers, so if child partition has physically-different
+	 * attribute numbers due to dropped columns, we should map the child
+	 * attribute numbers to the parent's attribute numbers to perform the
+	 * partition selection. EState may not have the parent relation
+	 * information at the moment, so we have to do a hard job here by opening
+	 * it and compare the tuple descriptors. The purpose of this code is to
+	 * prevent the tuple from being incorrectly interpreted during partition
+	 * selection, that can be performed in ExecInsert, ExecDelete and
+	 * checkPartitionUpdate functions when we work with the leaf partition as
+	 * result relation.
+	 */
+	parentRelid = estate->es_result_partitions->part->parrelid;
+
+	if (resultRelInfo->ri_PartitionParent &&
+		parentRelid != RelationGetRelid(resultRelInfo->ri_PartitionParent))
+	{
+		resultRelInfo->ri_PartCheckTupDescMatch = 0;
+		if (resultRelInfo->ri_PartCheckMap != NULL)
+			pfree(resultRelInfo->ri_PartCheckMap);
+		if (resultRelInfo->ri_PartitionParent)
+			relation_close(resultRelInfo->ri_PartitionParent, AccessShareLock);
+	}
+
+	if (resultRelInfo->ri_PartCheckTupDescMatch == 0 &&
+		parentRelid != RelationGetRelid(resultRelInfo->ri_RelationDesc))
+	{
+		Relation	parentRel;
+		TupleDesc	resultTupdesc,
+					parentTupdesc;
+
+		/*
+		 * We are on a child part, let's see the tuple descriptor looks like
+		 * the parent's one.  Probably this won't cause deadlock because DML
+		 * should have opened the parent table with appropriate lock.
+		 */
+		parentRel = relation_open(parentRelid, AccessShareLock);
+		resultTupdesc = RelationGetDescr(resultRelationDesc);
+		parentTupdesc = RelationGetDescr(parentRel);
+		if (!equalTupleDescs(resultTupdesc, parentTupdesc, false))
+		{
+			AttrMap    *map;
+			MemoryContext oldcontext;
+
+			/* Tuple looks different. Construct attribute mapping. */
+			oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+			map_part_attrs(resultRelationDesc, parentRel, &map, true);
+			MemoryContextSwitchTo(oldcontext);
+
+			/* And save it for later use. */
+			resultRelInfo->ri_PartCheckMap = map;
+
+			resultRelInfo->ri_PartCheckTupDescMatch = -1;
+		}
+		else
+			resultRelInfo->ri_PartCheckTupDescMatch = 1;
+
+		resultRelInfo->ri_PartitionParent = parentRel;
+		/* parentRel will be closed as part of ResultRelInfo cleanup */
 	}
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2477,16 +2477,6 @@ makePartitionCheckMap(EState *estate, ResultRelInfo *resultRelInfo)
 	 */
 	parentRelid = estate->es_result_partitions->part->parrelid;
 
-	if (resultRelInfo->ri_PartitionParent &&
-		parentRelid != RelationGetRelid(resultRelInfo->ri_PartitionParent))
-	{
-		resultRelInfo->ri_PartCheckTupDescMatch = 0;
-		if (resultRelInfo->ri_PartCheckMap != NULL)
-			pfree(resultRelInfo->ri_PartCheckMap);
-		if (resultRelInfo->ri_PartitionParent)
-			relation_close(resultRelInfo->ri_PartitionParent, AccessShareLock);
-	}
-
 	if (resultRelInfo->ri_PartCheckTupDescMatch == 0 &&
 		parentRelid != RelationGetRelid(resultRelInfo->ri_RelationDesc))
 	{

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2479,8 +2479,9 @@ makePartitionCheckMap(EState *estate, ResultRelInfo *resultRelInfo)
 	parentRelid = estate->es_result_partitions->part->parrelid;
 
 	/*
-	 * I don't believe this is the case currently, but we check the parent relid
-	 * in case the updating partition has changed since the last time we opened it.
+	 * I don't believe this is the case currently, but we check the parent
+	 * relid in case the updating partition has changed since the last time we
+	 * opened it.
 	 */
 	if (resultRelInfo->ri_PartitionParent &&
 		parentRelid != RelationGetRelid(resultRelInfo->ri_PartitionParent))

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -24,6 +24,9 @@ reconstructTupleValues(AttrMap *map,
 extern TupleTableSlot *
 reconstructMatchingTupleSlot(TupleTableSlot *slot, ResultRelInfo *resultRelInfo);
 
+extern void
+makePartitionCheckMap(EState *estate, ResultRelInfo *resultRelInfo);
+
 /*
  * In PostgreSQL, ExecInsert, ExecDelete and ExecUpdate are static in nodeModifyTable.c.
  * In GPDB, they're exported.

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -382,11 +382,11 @@ typedef struct ResultRelInfo
 	uint64		ri_aoprocessed; /* tuples added/deleted for AO */
 	struct AttrMap *ri_partInsertMap;
 	TupleTableSlot *ri_resultSlot;
-	/* Parent relation in checkPartitionUpdate */
+	/* Parent relation in makePartitionCheckMap */
 	Relation	ri_PartitionParent;
-	/* tupdesc_match for checkPartitionUpdate */
+	/* tupdesc_match for makePartitionCheckMap */
 	int			ri_PartCheckTupDescMatch;
-	/* Attribute map in checkPartitionUpdate */
+	/* Attribute map in makePartitionCheckMap */
 	struct AttrMap *ri_PartCheckMap;
 
 	/*

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16360,3 +16360,115 @@ DELETE FROM dist_key_dropped_pt WHERE b=6;
 -- the tables, or the pg_upgrade test fails.
 set client_min_messages='warning';
 drop schema qp_dropped_cols cascade;
+-- Test modifying DML on leaf partition when parent has dropped columns and
+-- the partition has not. Ensure that DML commands pass without execution
+-- errors and produce valid results.
+RESET search_path;
+-- start_ignore
+DROP TABLE IF EXISTS t_part_dropped;
+-- end_ignore
+CREATE TABLE t_part_dropped (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+ALTER TABLE t_part_dropped DROP c2;
+ALTER TABLE t_part_dropped ADD PARTITION p2 VALUES (2);
+-- Partition selection should go smoothly when inserting into leaf
+-- partition with different attribute structure.
+INSERT INTO t_part_dropped VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+UPDATE t_part_dropped SET c1 = 3;
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+ count 
+-------
+     4
+(1 row)
+
+-- Split update on root relation should choose the correct partition
+-- at insert (legacy planner doesn't put the tuple to wrong partition).
+UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+ count 
+-------
+     4
+(1 row)
+
+SELECT * FROM t_part_dropped_1_prt_p0;
+ c1 | c3 | c4 
+----+----+----
+(0 rows)
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_dropped_1_prt_p2;
+DROP TABLE t_part_dropped;
+-- Test modifying DML on leaf partition after it was exchanged with a relation,
+-- that contained dropped columns. Ensure that DML commands pass without
+-- execution errors and produce valid results.
+-- start_ignore
+DROP TABLE IF EXISTS t_part;
+DROP TABLE IF EXISTS t_new_part;
+-- end_ignore
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part DROP c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part;
+INSERT INTO t_part VALUES (1, 5, 2, 5);
+INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_1_prt_p2 SET c1 = 2;
+UPDATE t_part SET c1 = 3;
+INSERT INTO t_part VALUES (1, 0, 2, 0);
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+SELECT count(*) FROM t_part_1_prt_p2;
+ count 
+-------
+     3
+(1 row)
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_1_prt_p2;
+DROP TABLE t_part;
+DROP TABLE t_new_part;
+-- Test split update execution of a plan from legacy planner in case
+-- when parent relation has several partitions, and one of them has
+-- physically-different attribute structure from parent's due to
+-- dropped columns. Ensure that split update does not reconstruct tuple
+-- of correct (without dropped attributes) partition.
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+-- This one is not compatible with the parent due to dropped columns
+CREATE TABLE t_new_part0 (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part0 drop c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (0) WITH TABLE t_new_part0;
+-- This partition is compatible with the parent.
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part2 (c1 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
+-- Insert into correct partition, and perform split update on root,
+-- that will execute split update on each subplan in case of inheritance
+-- plan (legacy planner). Ensure that split update does not reconstruct the
+-- tuple at insert.
+INSERT INTO t_part VALUES (1, 4, 2, 2);
+UPDATE t_part SET c1=3;
+SELECT * FROM t_part_1_prt_p2;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  3 |  4 |  2 |  2
+(1 row)
+
+DROP TABLE t_part;
+DROP TABLE t_new_part0;
+DROP TABLE t_new_part2;

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16373,12 +16373,69 @@ ALTER TABLE t_part_dropped DROP c2;
 ALTER TABLE t_part_dropped ADD PARTITION p2 VALUES (2);
 -- Partition selection should go smoothly when inserting into leaf
 -- partition with different attribute structure.
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_dropped VALUES (1, 2, 4);
+               QUERY PLAN               
+----------------------------------------
+ Insert on public.t_part_dropped
+   ->  Result
+         Output: 1, NULL::integer, 2, 4
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 INSERT INTO t_part_dropped VALUES (1, 2, 4);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
+                QUERY PLAN                
+------------------------------------------
+ Insert on public.t_part_dropped_1_prt_p2
+   ->  Result
+         Output: 1, 2, 4
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
 INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
 -- Ensure that split update on leaf and root partitions does not
 -- throw partition selection error in both planners.
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Update on public.t_part_dropped_1_prt_p2
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 2, c3, c4, c1, ctid, gp_segment_id, (DMLAction)
+         Hash Key: c1
+         ->  Split
+               Output: 2, c3, c4, c1, ctid, gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_dropped_1_prt_p2
+                     Output: 2, c3, c4, c1, ctid, gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(10 rows)
+
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped SET c1 = 3;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.t_part_dropped_1_prt_p0
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_dropped_1_prt_p0
+                     Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_dropped_1_prt_p2
+                     Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(17 rows)
+
 UPDATE t_part_dropped SET c1 = 3;
 -- Ensure that split update on leaf partition does not throw constraint error
 -- (executor does not choose the wrong partition at insert stage of update).
@@ -16393,6 +16450,30 @@ SELECT count(*) FROM t_part_dropped_1_prt_p2;
 -- Split update on root relation should choose the correct partition
 -- at insert (executor doesn't put the tuple to wrong partition for legacy
 -- planner case).
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.t_part_dropped_1_prt_p0
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_dropped_1_prt_p0
+                     Output: 3, NULL::integer, t_part_dropped_1_prt_p0.c3, t_part_dropped_1_prt_p0.c4, t_part_dropped_1_prt_p0.c1, t_part_dropped_1_prt_p0.ctid, t_part_dropped_1_prt_p0.gp_segment_id
+                     Filter: (t_part_dropped_1_prt_p0.c4 = 0)
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_dropped_1_prt_p2
+                     Output: 3, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+                     Filter: (t_part_dropped_1_prt_p2.c4 = 0)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(19 rows)
+
 UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16406,6 +16487,16 @@ SELECT * FROM t_part_dropped_1_prt_p0;
 (0 rows)
 
 -- For ORCA the partition selection error should not occur.
+EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_dropped_1_prt_p2;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Delete on public.t_part_dropped_1_prt_p2
+   ->  Seq Scan on public.t_part_dropped_1_prt_p2
+         Output: ctid, gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 DELETE FROM t_part_dropped_1_prt_p2;
 DROP TABLE t_part_dropped;
 -- Test modifying DML on leaf partition after it was exchanged with a relation,
@@ -16421,11 +16512,68 @@ ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
 CREATE TABLE t_new_part (c1 int, c11 int, c2 int, c3 int, c4 int);
 ALTER TABLE t_new_part DROP c11;
 ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part;
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part VALUES (1, 5, 2, 5);
+             QUERY PLAN              
+-------------------------------------
+ Insert on public.t_part
+   ->  Result
+         Output: 1, 5, 2, 5
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 INSERT INTO t_part VALUES (1, 5, 2, 5);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
+                QUERY PLAN                 
+-------------------------------------------
+ Insert on public.t_part_1_prt_p2
+   ->  Result
+         Output: 1, NULL::integer, 5, 2, 5
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
 -- Ensure that split update on leaf and root partitions does not
 -- throw partition selection error in both planners.
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_1_prt_p2 SET c1 = 2;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Update on public.t_part_1_prt_p2
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 2, NULL::integer, c2, c3, c4, c1, ctid, gp_segment_id, (DMLAction)
+         Hash Key: c1
+         ->  Split
+               Output: 2, NULL::integer, c2, c3, c4, c1, ctid, gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_1_prt_p2
+                     Output: 2, NULL::integer, c2, c3, c4, c1, ctid, gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(10 rows)
+
 UPDATE t_part_1_prt_p2 SET c1 = 2;
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part SET c1 = 3;
+                                                                                       QUERY PLAN                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.t_part_1_prt_p0
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 3, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_1_prt_p0
+                     Output: 3, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: 3, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_1_prt_p2
+                     Output: 3, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(17 rows)
+
 UPDATE t_part SET c1 = 3;
 -- Ensure that split update on leaf partition does not throw constraint error
 -- (executor does not choose the wrong partition at insert stage of update).
@@ -16438,6 +16586,16 @@ SELECT count(*) FROM t_part_1_prt_p2;
 (1 row)
 
 -- For ORCA the partition selection error should not occur.
+EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_1_prt_p2;
+                QUERY PLAN                
+------------------------------------------
+ Delete on public.t_part_1_prt_p2
+   ->  Seq Scan on public.t_part_1_prt_p2
+         Output: ctid, gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(5 rows)
+
 DELETE FROM t_part_1_prt_p2;
 DROP TABLE t_part;
 DROP TABLE t_new_part;
@@ -16448,7 +16606,15 @@ DROP TABLE t_new_part;
 -- of correct (without dropped attributes) partition.
 CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
 PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
--- This one is not compatible with the parent due to dropped columns
+-- Legacy planner UPDATE's plan consists of several subplans (partitioned
+-- relations are considered in inheritance planner), and their execution
+-- order varies depending on the order the partitions have been added.
+-- Therefore, we add each partition through EXCHANGE to get UPDATE's
+-- test plan in a form such that the t_new_part0 update comes first, and the
+-- t_new_part2 comes second. This aspect is crucial because executor's
+-- partitions related logic depended on that fact, what led to the
+-- issue this test demonstrates.
+-- This paritition is not compatible with the parent due to dropped columns
 CREATE TABLE t_new_part0 (c1 int, c11 int, c2 int, c3 int, c4 int);
 ALTER TABLE t_new_part0 drop c11;
 ALTER TABLE t_part EXCHANGE PARTITION FOR (0) WITH TABLE t_new_part0;
@@ -16461,6 +16627,28 @@ ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
 -- plan (legacy planner). Ensure that split update does not reconstruct the
 -- tuple at insert.
 INSERT INTO t_part VALUES (1, 4, 2, 2);
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part SET c1 = 3;
+                                                                                       QUERY PLAN                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.t_part_1_prt_p0
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: 3, NULL::integer, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, NULL::integer, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_1_prt_p0
+                     Output: 3, NULL::integer, t_part_1_prt_p0.c2, t_part_1_prt_p0.c3, t_part_1_prt_p0.c4, t_part_1_prt_p0.c1, t_part_1_prt_p0.ctid, t_part_1_prt_p0.gp_segment_id
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)
+         Output: 3, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: "outer".c1
+         ->  Split
+               Output: 3, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, DMLAction
+               ->  Seq Scan on public.t_part_1_prt_p2
+                     Output: 3, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.c1, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(17 rows)
+
 UPDATE t_part SET c1 = 3;
 SELECT * FROM t_part_1_prt_p2;
  c1 | c2 | c3 | c4 

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16380,10 +16380,9 @@ INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
 -- throw partition selection error in both planners.
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
 UPDATE t_part_dropped SET c1 = 3;
-INSERT INTO t_part_dropped VALUES (1, 2, 0);
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16392,7 +16391,8 @@ SELECT count(*) FROM t_part_dropped_1_prt_p2;
 (1 row)
 
 -- Split update on root relation should choose the correct partition
--- at insert (legacy planner doesn't put the tuple to wrong partition).
+-- at insert (executor doesn't put the tuple to wrong partition for legacy
+-- planner case).
 UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16427,10 +16427,9 @@ INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
 -- throw partition selection error in both planners.
 UPDATE t_part_1_prt_p2 SET c1 = 2;
 UPDATE t_part SET c1 = 3;
-INSERT INTO t_part VALUES (1, 0, 2, 0);
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part VALUES (1, 0, 2, 0);
 UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
 SELECT count(*) FROM t_part_1_prt_p2;
  count 
@@ -16462,7 +16461,7 @@ ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
 -- plan (legacy planner). Ensure that split update does not reconstruct the
 -- tuple at insert.
 INSERT INTO t_part VALUES (1, 4, 2, 2);
-UPDATE t_part SET c1=3;
+UPDATE t_part SET c1 = 3;
 SELECT * FROM t_part_1_prt_p2;
  c1 | c2 | c3 | c4 
 ----+----+----+----

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16273,3 +16273,115 @@ DELETE FROM dist_key_dropped_pt WHERE b=6;
 -- the tables, or the pg_upgrade test fails.
 set client_min_messages='warning';
 drop schema qp_dropped_cols cascade;
+-- Test modifying DML on leaf partition when parent has dropped columns and
+-- the partition has not. Ensure that DML commands pass without execution
+-- errors and produce valid results.
+RESET search_path;
+-- start_ignore
+DROP TABLE IF EXISTS t_part_dropped;
+-- end_ignore
+CREATE TABLE t_part_dropped (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+ALTER TABLE t_part_dropped DROP c2;
+ALTER TABLE t_part_dropped ADD PARTITION p2 VALUES (2);
+-- Partition selection should go smoothly when inserting into leaf
+-- partition with different attribute structure.
+INSERT INTO t_part_dropped VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+UPDATE t_part_dropped SET c1 = 3;
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+ count 
+-------
+     4
+(1 row)
+
+-- Split update on root relation should choose the correct partition
+-- at insert (legacy planner doesn't put the tuple to wrong partition).
+UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+ count 
+-------
+     4
+(1 row)
+
+SELECT * FROM t_part_dropped_1_prt_p0;
+ c1 | c3 | c4 
+----+----+----
+(0 rows)
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_dropped_1_prt_p2;
+DROP TABLE t_part_dropped;
+-- Test modifying DML on leaf partition after it was exchanged with a relation,
+-- that contained dropped columns. Ensure that DML commands pass without
+-- execution errors and produce valid results.
+-- start_ignore
+DROP TABLE IF EXISTS t_part;
+DROP TABLE IF EXISTS t_new_part;
+-- end_ignore
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part DROP c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part;
+INSERT INTO t_part VALUES (1, 5, 2, 5);
+INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_1_prt_p2 SET c1 = 2;
+UPDATE t_part SET c1 = 3;
+INSERT INTO t_part VALUES (1, 0, 2, 0);
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+SELECT count(*) FROM t_part_1_prt_p2;
+ count 
+-------
+     3
+(1 row)
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_1_prt_p2;
+DROP TABLE t_part;
+DROP TABLE t_new_part;
+-- Test split update execution of a plan from legacy planner in case
+-- when parent relation has several partitions, and one of them has
+-- physically-different attribute structure from parent's due to
+-- dropped columns. Ensure that split update does not reconstruct tuple
+-- of correct (without dropped attributes) partition.
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+-- This one is not compatible with the parent due to dropped columns
+CREATE TABLE t_new_part0 (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part0 drop c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (0) WITH TABLE t_new_part0;
+-- This partition is compatible with the parent.
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part2 (c1 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
+-- Insert into correct partition, and perform split update on root,
+-- that will execute split update on each subplan in case of inheritance
+-- plan (legacy planner). Ensure that split update does not reconstruct the
+-- tuple at insert.
+INSERT INTO t_part VALUES (1, 4, 2, 2);
+UPDATE t_part SET c1=3;
+SELECT * FROM t_part_1_prt_p2;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  3 |  4 |  2 |  2
+(1 row)
+
+DROP TABLE t_part;
+DROP TABLE t_new_part0;
+DROP TABLE t_new_part2;

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16293,10 +16293,9 @@ INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
 -- throw partition selection error in both planners.
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
 UPDATE t_part_dropped SET c1 = 3;
-INSERT INTO t_part_dropped VALUES (1, 2, 0);
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16305,7 +16304,8 @@ SELECT count(*) FROM t_part_dropped_1_prt_p2;
 (1 row)
 
 -- Split update on root relation should choose the correct partition
--- at insert (legacy planner doesn't put the tuple to wrong partition).
+-- at insert (executor doesn't put the tuple to wrong partition for legacy
+-- planner case).
 UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16340,10 +16340,9 @@ INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
 -- throw partition selection error in both planners.
 UPDATE t_part_1_prt_p2 SET c1 = 2;
 UPDATE t_part SET c1 = 3;
-INSERT INTO t_part VALUES (1, 0, 2, 0);
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part VALUES (1, 0, 2, 0);
 UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
 SELECT count(*) FROM t_part_1_prt_p2;
  count 
@@ -16375,7 +16374,7 @@ ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
 -- plan (legacy planner). Ensure that split update does not reconstruct the
 -- tuple at insert.
 INSERT INTO t_part VALUES (1, 4, 2, 2);
-UPDATE t_part SET c1=3;
+UPDATE t_part SET c1 = 3;
 SELECT * FROM t_part_1_prt_p2;
  c1 | c2 | c3 | c4 
 ----+----+----+----

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16286,12 +16286,82 @@ ALTER TABLE t_part_dropped DROP c2;
 ALTER TABLE t_part_dropped ADD PARTITION p2 VALUES (2);
 -- Partition selection should go smoothly when inserting into leaf
 -- partition with different attribute structure.
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_dropped VALUES (1, 2, 4);
+                    QUERY PLAN                    
+--------------------------------------------------
+ Insert
+   Output: c1, NULL::integer, c3, c4, ColRef_0004
+   ->  Result
+         Output: c1, c3, c4, 1
+         ->  Result
+               Output: c1, c3, c4
+               ->  Result
+                     Output: 1, 2, 4
+                     ->  Result
+                           Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 INSERT INTO t_part_dropped VALUES (1, 2, 4);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
+               QUERY PLAN               
+----------------------------------------
+ Insert
+   Output: c1, c3, c4, ColRef_0004
+   ->  Result
+         Output: c1, c3, c4, 1
+         ->  Result
+               Output: c1, c3, c4
+               ->  Result
+                     Output: 1, 2, 4
+                     ->  Result
+                           Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
 INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
 -- Ensure that split update on leaf and root partitions does not
 -- throw partition selection error in both planners.
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, (DMLAction), t_part_dropped_1_prt_p2.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: t_part_dropped_1_prt_p2.c1
+         ->  Split
+               Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, 2, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+                     ->  Seq Scan on public.t_part_dropped_1_prt_p2
+                           Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped SET c1 = 3;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part_dropped.c1, NULL::integer, t_part_dropped.c3, t_part_dropped.c4, (DMLAction), t_part_dropped.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id, (DMLAction)
+         Hash Key: t_part_dropped.c1
+         ->  Split
+               Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, 3, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+                     ->  Sequence
+                           Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+                           ->  Partition Selector for t_part_dropped (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on public.t_part_dropped (dynamic scan id: 1)
+                                 Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
 UPDATE t_part_dropped SET c1 = 3;
 -- Ensure that split update on leaf partition does not throw constraint error
 -- (executor does not choose the wrong partition at insert stage of update).
@@ -16306,6 +16376,28 @@ SELECT count(*) FROM t_part_dropped_1_prt_p2;
 -- Split update on root relation should choose the correct partition
 -- at insert (executor doesn't put the tuple to wrong partition for legacy
 -- planner case).
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part_dropped.c1, NULL::integer, t_part_dropped.c3, t_part_dropped.c4, (DMLAction), t_part_dropped.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id, (DMLAction)
+         Hash Key: t_part_dropped.c1
+         ->  Split
+               Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, 3, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+                     ->  Sequence
+                           Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+                           ->  Partition Selector for t_part_dropped (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on public.t_part_dropped (dynamic scan id: 1)
+                                 Output: t_part_dropped.c1, t_part_dropped.c3, t_part_dropped.c4, t_part_dropped.ctid, t_part_dropped.gp_segment_id
+                                 Filter: (t_part_dropped.c4 = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
 UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
  count 
@@ -16319,6 +16411,18 @@ SELECT * FROM t_part_dropped_1_prt_p0;
 (0 rows)
 
 -- For ORCA the partition selection error should not occur.
+EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_dropped_1_prt_p2;
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete
+   Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, "outer".ColRef_0010, t_part_dropped_1_prt_p2.ctid
+   ->  Result
+         Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, 0
+         ->  Seq Scan on public.t_part_dropped_1_prt_p2
+               Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
 DELETE FROM t_part_dropped_1_prt_p2;
 DROP TABLE t_part_dropped;
 -- Test modifying DML on leaf partition after it was exchanged with a relation,
@@ -16334,11 +16438,81 @@ ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
 CREATE TABLE t_new_part (c1 int, c11 int, c2 int, c3 int, c4 int);
 ALTER TABLE t_new_part DROP c11;
 ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part;
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part VALUES (1, 5, 2, 5);
+               QUERY PLAN               
+----------------------------------------
+ Insert
+   Output: c1, c2, c3, c4, ColRef_0005
+   ->  Result
+         Output: c1, c2, c3, c4, 1
+         ->  Result
+               Output: c1, c2, c3, c4
+               ->  Result
+                     Output: 1, 5, 2, 5
+                     ->  Result
+                           Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 INSERT INTO t_part VALUES (1, 5, 2, 5);
+EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
+                      QUERY PLAN                      
+------------------------------------------------------
+ Insert
+   Output: c1, NULL::integer, c2, c3, c4, ColRef_0005
+   ->  Result
+         Output: c1, c2, c3, c4, 1
+         ->  Result
+               Output: c1, c2, c3, c4
+               ->  Result
+                     Output: 1, 5, 2, 5
+                     ->  Result
+                           Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
 -- Ensure that split update on leaf and root partitions does not
 -- throw partition selection error in both planners.
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part_1_prt_p2 SET c1 = 2;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part_1_prt_p2.c1, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, (DMLAction), t_part_1_prt_p2.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, (DMLAction)
+         Hash Key: t_part_1_prt_p2.c1
+         ->  Split
+               Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, 2, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+                     ->  Seq Scan on public.t_part_1_prt_p2
+                           Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
 UPDATE t_part_1_prt_p2 SET c1 = 2;
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part SET c1 = 3;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, (DMLAction), t_part.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id, (DMLAction)
+         Hash Key: t_part.c1
+         ->  Split
+               Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, 3, t_part.ctid, t_part.gp_segment_id
+                     ->  Sequence
+                           Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id
+                           ->  Partition Selector for t_part (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on public.t_part (dynamic scan id: 1)
+                                 Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
 UPDATE t_part SET c1 = 3;
 -- Ensure that split update on leaf partition does not throw constraint error
 -- (executor does not choose the wrong partition at insert stage of update).
@@ -16351,6 +16525,18 @@ SELECT count(*) FROM t_part_1_prt_p2;
 (1 row)
 
 -- For ORCA the partition selection error should not occur.
+EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_1_prt_p2;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete
+   Output: t_part_1_prt_p2.c1, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, "outer".ColRef_0011, t_part_1_prt_p2.ctid
+   ->  Result
+         Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, 0
+         ->  Seq Scan on public.t_part_1_prt_p2
+               Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
 DELETE FROM t_part_1_prt_p2;
 DROP TABLE t_part;
 DROP TABLE t_new_part;
@@ -16361,7 +16547,15 @@ DROP TABLE t_new_part;
 -- of correct (without dropped attributes) partition.
 CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
 PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
--- This one is not compatible with the parent due to dropped columns
+-- Legacy planner UPDATE's plan consists of several subplans (partitioned
+-- relations are considered in inheritance planner), and their execution
+-- order varies depending on the order the partitions have been added.
+-- Therefore, we add each partition through EXCHANGE to get UPDATE's
+-- test plan in a form such that the t_new_part0 update comes first, and the
+-- t_new_part2 comes second. This aspect is crucial because executor's
+-- partitions related logic depended on that fact, what led to the
+-- issue this test demonstrates.
+-- This paritition is not compatible with the parent due to dropped columns
 CREATE TABLE t_new_part0 (c1 int, c11 int, c2 int, c3 int, c4 int);
 ALTER TABLE t_new_part0 drop c11;
 ALTER TABLE t_part EXCHANGE PARTITION FOR (0) WITH TABLE t_new_part0;
@@ -16374,6 +16568,27 @@ ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
 -- plan (legacy planner). Ensure that split update does not reconstruct the
 -- tuple at insert.
 INSERT INTO t_part VALUES (1, 4, 2, 2);
+EXPLAIN (COSTS OFF, VERBOSE) UPDATE t_part SET c1 = 3;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, (DMLAction), t_part.ctid
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)
+         Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id, (DMLAction)
+         Hash Key: t_part.c1
+         ->  Split
+               Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id, DMLAction
+               ->  Result
+                     Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, 3, t_part.ctid, t_part.gp_segment_id
+                     ->  Sequence
+                           Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id
+                           ->  Partition Selector for t_part (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on public.t_part (dynamic scan id: 1)
+                                 Output: t_part.c1, t_part.c2, t_part.c3, t_part.c4, t_part.ctid, t_part.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
 UPDATE t_part SET c1 = 3;
 SELECT * FROM t_part_1_prt_p2;
  c1 | c2 | c3 | c4 

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8712,16 +8712,16 @@ INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
 UPDATE t_part_dropped SET c1 = 3;
 
-INSERT INTO t_part_dropped VALUES (1, 2, 0);
-
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
 UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
 
 -- Split update on root relation should choose the correct partition
--- at insert (legacy planner doesn't put the tuple to wrong partition).
+-- at insert (executor doesn't put the tuple to wrong partition for legacy
+-- planner case).
 UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
 SELECT count(*) FROM t_part_dropped_1_prt_p2;
 SELECT * FROM t_part_dropped_1_prt_p0;
@@ -8754,11 +8754,9 @@ INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
 UPDATE t_part_1_prt_p2 SET c1 = 2;
 UPDATE t_part SET c1 = 3;
 
-INSERT INTO t_part VALUES (1, 0, 2, 0);
-
 -- Ensure that split update on leaf partition does not throw constraint error
--- (legacy planner does not choose the wrong partition at insert) and does not
--- throw partition selection error (ORCA).
+-- (executor does not choose the wrong partition at insert stage of update).
+INSERT INTO t_part VALUES (1, 0, 2, 0);
 UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
 
 SELECT count(*) FROM t_part_1_prt_p2;
@@ -8792,7 +8790,7 @@ ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
 -- plan (legacy planner). Ensure that split update does not reconstruct the
 -- tuple at insert.
 INSERT INTO t_part VALUES (1, 4, 2, 2);
-UPDATE t_part SET c1=3;
+UPDATE t_part SET c1 = 3;
 SELECT * FROM t_part_1_prt_p2;
 
 DROP TABLE t_part;

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8687,3 +8687,114 @@ DELETE FROM dist_key_dropped_pt WHERE b=6;
 -- the tables, or the pg_upgrade test fails.
 set client_min_messages='warning';
 drop schema qp_dropped_cols cascade;
+
+-- Test modifying DML on leaf partition when parent has dropped columns and
+-- the partition has not. Ensure that DML commands pass without execution
+-- errors and produce valid results.
+RESET search_path;
+-- start_ignore
+DROP TABLE IF EXISTS t_part_dropped;
+-- end_ignore
+CREATE TABLE t_part_dropped (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+
+ALTER TABLE t_part_dropped DROP c2;
+ALTER TABLE t_part_dropped ADD PARTITION p2 VALUES (2);
+
+-- Partition selection should go smoothly when inserting into leaf
+-- partition with different attribute structure.
+INSERT INTO t_part_dropped VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 4);
+INSERT INTO t_part_dropped_1_prt_p2 VALUES (1, 2, 0);
+
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2;
+UPDATE t_part_dropped SET c1 = 3;
+
+INSERT INTO t_part_dropped VALUES (1, 2, 0);
+
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_dropped_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+
+-- Split update on root relation should choose the correct partition
+-- at insert (legacy planner doesn't put the tuple to wrong partition).
+UPDATE t_part_dropped SET c1 = 3 WHERE c4 = 0;
+SELECT count(*) FROM t_part_dropped_1_prt_p2;
+SELECT * FROM t_part_dropped_1_prt_p0;
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_dropped_1_prt_p2;
+
+DROP TABLE t_part_dropped;
+
+-- Test modifying DML on leaf partition after it was exchanged with a relation,
+-- that contained dropped columns. Ensure that DML commands pass without
+-- execution errors and produce valid results.
+-- start_ignore
+DROP TABLE IF EXISTS t_part;
+DROP TABLE IF EXISTS t_new_part;
+-- end_ignore
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part DROP c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part;
+
+INSERT INTO t_part VALUES (1, 5, 2, 5);
+INSERT INTO t_part_1_prt_p2 VALUES (1, 5, 2, 5);
+
+-- Ensure that split update on leaf and root partitions does not
+-- throw partition selection error in both planners.
+UPDATE t_part_1_prt_p2 SET c1 = 2;
+UPDATE t_part SET c1 = 3;
+
+INSERT INTO t_part VALUES (1, 0, 2, 0);
+
+-- Ensure that split update on leaf partition does not throw constraint error
+-- (legacy planner does not choose the wrong partition at insert) and does not
+-- throw partition selection error (ORCA).
+UPDATE t_part_1_prt_p2 SET c1 = 2 WHERE c4 = 0;
+
+SELECT count(*) FROM t_part_1_prt_p2;
+
+-- For ORCA the partition selection error should not occur.
+DELETE FROM t_part_1_prt_p2;
+
+DROP TABLE t_part;
+DROP TABLE t_new_part;
+
+-- Test split update execution of a plan from legacy planner in case
+-- when parent relation has several partitions, and one of them has
+-- physically-different attribute structure from parent's due to
+-- dropped columns. Ensure that split update does not reconstruct tuple
+-- of correct (without dropped attributes) partition.
+CREATE TABLE t_part (c1 int, c2 int, c3 int, c4 int) DISTRIBUTED BY (c1)
+PARTITION BY LIST (c3) (PARTITION p0 VALUES (0));
+
+-- This one is not compatible with the parent due to dropped columns
+CREATE TABLE t_new_part0 (c1 int, c11 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_new_part0 drop c11;
+ALTER TABLE t_part EXCHANGE PARTITION FOR (0) WITH TABLE t_new_part0;
+
+-- This partition is compatible with the parent.
+ALTER TABLE t_part ADD PARTITION p2 VALUES (2);
+CREATE TABLE t_new_part2 (c1 int, c2 int, c3 int, c4 int);
+ALTER TABLE t_part EXCHANGE PARTITION FOR (2) WITH TABLE t_new_part2;
+
+-- Insert into correct partition, and perform split update on root,
+-- that will execute split update on each subplan in case of inheritance
+-- plan (legacy planner). Ensure that split update does not reconstruct the
+-- tuple at insert.
+INSERT INTO t_part VALUES (1, 4, 2, 2);
+UPDATE t_part SET c1=3;
+SELECT * FROM t_part_1_prt_p2;
+
+DROP TABLE t_part;
+DROP TABLE t_new_part0;
+DROP TABLE t_new_part2;


### PR DESCRIPTION
Fix partition selection during DML execution when dropped columns are present

Current partitioning design faced a problem, which is connected with the
differences in physical attribute layouts of the child partition and the parent
relation in case when the parent relation has dropped columns and the newly
added child partition has not, and vice versa.

When executing modifying DML operations on a leaf partition of a partitioned
table, the executor anyway performs the partition selection in case of INSERT,
UPDATE for legacy planner and in case of INSERT, UPDATE, DELETE for ORCA
optimizer. This is done in `selectPartition` function, which is called from
`slot_get_partition` function (in case of modifying DML commands). This procedure 
is done based on 1) attribute values of the tuple, which have been retrieved
from the respective subplan of ModifyTable (DML) node and whose attribute
structure corresponds the leaf partition's. 2) the root partition's attribute
numbers and partition rules, which are based on the parent (root) relation's
tuple descriptor. Thus, **if the parent relation's tuple descriptor contained
dropped columns and leaf partition's did not** (or visa versa, the leaf partition
had dropped columns and parent had not), the partition selection could go wrong
and lead to various execution errors.

Let's consider the following case. The partitioned table was created, and at
one moment it was decided to drop several irrelevant columns from it. After that
some new partitions were added or some were exchanged with new relations. In
this situation these newly added (exchanged) partitions don't have dropped
columns in it's structure, but the original parent relation has such dropped
attributes. Then the INSERT command into the new leaf partition is executed. In
this case for both planners the `ExecInsert` function is called, which then calls
`slot_get_partition` function in order to validate that the tuple values
correspond to specified leaf partition. And here the tuple descriptor does not
have dropped attributes, but the **partition selection is performed from parent's
view**, which have those attributes, and the parent's partitioning attribute
numbers are used to validate the tuple. Because of that the partition selection
procedure could either select wrong target partition (the wrong attribute was
taken from the slot values to check the partition rule) or fail to find the
partition at all, becasue none of the partition rules were satisfied. The same
issue occured when we didn't drop anything from parent relation, however we
exhanged a partition to the one with dropped columns. When inserting into
exchanged leaf partition the partition selection could also go wrong by the same
reasons (selection is performed from parent's view).

Similar issue occured for both planners in other commands, when partition
selection was performed. And in order to prevent the potentially wrong partition
selection, when modifying the leaf partition, this patch proposes the
following solution.

The legacy planner have `checkPartitionUpdate` function, which is called in UPDATE
cases and which checks that the tuple does not switch its partition at
update. And to our astonishment this function is able to handle the case when
the partition being modified has **physically-different attribute numbers from
root partition's due to dropped columns**. In this case the function creates the
`ri_PartCheckMap` map in target (child) `ResultRelInfo`, which stores correspondance
between target partition attributes and parent's. And because of that map, the
partition selection goes smoothly inside the function.

The proposed solution is to build `ri_PartCheckMap` for all the cases when the
leaf partition is modified and parent relation has dropped columns (or child
has and parent doesn't), and when the partition selection is expected. The
logic, which checks the matching of leaf's and parent's relation descriptors and
builds the `ri_PartCheckMap` is moved to a separate function
`makePartitionCheckMap`. This new function is called inside the `ExecModifyTable`
and `ExecDML` functions under different conditions.

For legacy planner this function is called for any command, except DELETE, no
matter which relation is initially specified as target (can be either root or
leaf). For example, when executing UPDATE (either split or common update) on
root relation, the planner builds the plan via `inheritance_planner`, and,
therefore, the each subplan of ModifyTable node will return the tuple slot with
attributes structure of the specific partition (some subplans will contain
dropped attributes in targetList, some won't). Here call of
`makePartitionCheckMap` is also required. For INSERT command it will be always
called as well, because `makePartitionCheckMap` validates whether oid of result
relation is equal to parent't partition oid, and this check allows us to call
the function on root relation too (if it's true, the map is not built, because
it's safe to perform operation through the root relation).

For ORCA optimizer the `makePartitionCheckMap` is called inside the `ExecDML`
function only in the case if the leaf partition is being modified. Otherwise, if
the command is called on root relation, the tuple will always have the
parent's structure, which does not break the partition selection procedure.

This patch also changes the `slot_get_partition` function, which performs the
partition selection. This function is extended with the alternative variant of
the attribute values extraction from the given slot. When the
`makePartitionCheckMap` function have created the `ri_PartCheckMap` of the child
ResultRelInfo, the attributes values array is built via that map
(inside `reconstructTupleValues`), what allows to perform the partition selection
from parent's view.

Finally, this patch additionally solves one more issue, that is not directly
related partition selection problem described above. Let's consider the
case when the parent relation has two partitions, and one of them has
incompatible attribute structure with parent's due to dropped columns. The
issue occured when the split UPDATE on parent partition was executed, and its
plan is built by legacy planner. That means that ModifyTable node contains
several sublans and several result relations inside the
`estate->es_result_relations` (inheritance planner creates them and the update is
executed for each of them). And during execution of this plan, when update is
executed on the partition, which has the same relation descriptor with parent's,
the invalid behaviour could occur when preparing the tuple for insertion (see
the last test case in tests section). In this case the partition selection at
insert stage works correct, because the partition does not differ from parent
relation. However, inside the `get_part` function, after the partition was
selected correctly from `selectPartition` function, the `targetid_get_partition`
function could wrongly form the final ResultRelInfo by creating unnecessary
`ri_partInsertMap` map, which is used in `reconstructMatchingTupleSlot` function
(inside the ExecInsert) to adjust the tuple to the selected partition descriptor
if the tuple does not fit. `targetid_get_partition` function makes the desicion on
building that map based on check, that compares two relation's descriptors:
one, which is considered to be parent's
(`parentInfo = estate->es_result_relations`), and one, which corresponds to
selected child partition (`childInfo`). But in case when UPDATE is formed by
inheritance planner, the parentInfo does not correspond the true parent
relation. It corresponds to one of other partitions. And in the case, when
selected partition is valid (it has the same relation descriptor with parent's),
and parentInfo corresponds to invalid partition (it does not match with parent
descriptor), the `ri_partInsertMap` could be built by mistake, what led to
unnecessary tuple reformatting and invalid results.

This patch solves this last issue by adding a check inside the
`targetid_get_partition` function, which ensures that the
`estate->es_result_relations` corresponds to the true root relation. That
would be true for all the cases when the DML is executed on parent relation,
except the UPDATE by legacy planner.  And if the check is passed, the
`ri_partInsertMap` is built, otherwise it's not. Moreover, during such UPDATE
there is completely no need to reconstruct the tuple, because each ModifyTable's
subplan will give already valid tuple.