### PR TITLE
ADBDEV-4305 Develop a prototype of limiting temporary tables size

### DIFF
--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -36,6 +36,7 @@
 #include "cdb/cdbappendonlystorage.h"
 #include "cdb/cdbappendonlyxlog.h"
 #include "common/relpath.h"
+#include "storage/temp_tables_limit.h"
 #include "utils/guc.h"
 
 #define SEGNO_SUFFIX_LENGTH 12
@@ -179,6 +180,8 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 
 	Assert(fd > 0);
 	Assert(offset >= 0);
+
+	TruncateAOSegmentFilePreHook(rel, fd, offset);
 
 	/*
 	 * Call the 'fd' module with a 64-bit length since AO segment files

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -202,7 +202,7 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 		(*file_truncate_hook)(rnode);
 	}
 
-	TruncateAOSegmentFilePreHook(rel, offset);
+	TruncateAOSegmentFilePostHook(rel, offset);
 }
 
 struct mdunlink_ao_callback_ctx

--- a/src/backend/access/appendonly/aomd.c
+++ b/src/backend/access/appendonly/aomd.c
@@ -181,7 +181,7 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 	Assert(fd > 0);
 	Assert(offset >= 0);
 
-	TruncateAOSegmentFilePreHook(rel, fd, offset);
+	TruncateAOSegmentFilePreHook(rel, fd);
 
 	/*
 	 * Call the 'fd' module with a 64-bit length since AO segment files
@@ -201,6 +201,8 @@ TruncateAOSegmentFile(File fd, Relation rel, int32 segFileNum, int64 offset)
 		rnode.backend = rel->rd_backend;
 		(*file_truncate_hook)(rnode);
 	}
+
+	TruncateAOSegmentFilePreHook(rel, offset);
 }
 
 struct mdunlink_ao_callback_ctx
@@ -253,6 +255,8 @@ mdunlink_ao_perFile(const int segno, void *ctx)
 	char *segPathSuffixPosition = unlinkFiles->segpathSuffixPosition;
 
 	sprintf(segPathSuffixPosition, ".%u", segno);
+
+	mdunlink_ao_perFile_pre_hook(segPath);
 	if (unlink(segPath) != 0)
 	{
 		/* ENOENT is expected after the end of the extensions */
@@ -263,6 +267,8 @@ mdunlink_ao_perFile(const int segno, void *ctx)
 		else
 			return false;
 	}
+
+	mdunlink_ao_perFile_post_hook();
 
 	return true;
 }

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -21,6 +21,7 @@
 
 #include "cdb/cdbappendonlyxlog.h"
 #include "cdb/cdbbufferedappend.h"
+#include "storage/temp_tables_limit.h"
 #include "utils/guc.h"
 
 static void BufferedAppendWrite(
@@ -170,6 +171,8 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend, bool needsWAL)
 	Assert(bufferedAppend->largeWriteLen > 0);
 	largeWriteMemory = bufferedAppend->largeWriteMemory;
 
+	BufferedAppendWritePreHook(bufferedAppend);
+
 	bytestotal = 0;
 	bytesleft = bufferedAppend->largeWriteLen;
 	while (bytesleft > 0)
@@ -192,6 +195,8 @@ BufferedAppendWrite(BufferedAppend *bufferedAppend, bool needsWAL)
 		if (file_extend_hook)
 			(*file_extend_hook)(bufferedAppend->relFileNode);
 	}
+
+	BufferedAppendWritePostHook(bufferedAppend);
 
 	elogif(Debug_appendonly_print_append_block, LOG,
 		   "Append-Only storage write: table \"%s\", segment file \"%s\", write position " INT64_FORMAT ", bytes written %d",

--- a/src/backend/storage/ipc/Makefile
+++ b/src/backend/storage/ipc/Makefile
@@ -17,6 +17,6 @@ endif
 endif
 
 OBJS = dsm_impl.o dsm.o ipc.o ipci.o pmsignal.o procarray.o procsignal.o \
-	shmem.o shmqueue.o shm_mq.o shm_toc.o sinval.o sinvaladt.o standby.o
+	shmem.o shmqueue.o shm_mq.o shm_toc.o sinval.o sinvaladt.o standby.o temp_tables_limit.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -48,6 +48,7 @@
 #include "storage/procsignal.h"
 #include "storage/sinvaladt.h"
 #include "storage/spin.h"
+#include "storage/temp_tables_limit.h"
 #include "utils/backend_cancel.h"
 #include "utils/resource_manager.h"
 #include "utils/faultinjector.h"
@@ -210,6 +211,8 @@ CreateSharedMemoryAndSemaphores(int port)
 
 		/* size of parallel cursor count */
 		size = add_size(size, ParallelCursorCountSize());
+
+		size = add_size(size, TempTablesLimitSize());
 
 		elog(DEBUG3, "invoking IpcMemoryCreate(size=%zu)", size);
 
@@ -378,6 +381,9 @@ CreateSharedMemoryAndSemaphores(int port)
 	
 	if (Gp_role == GP_ROLE_DISPATCH)
 		ParallelCursorCountInit();
+
+	if (!IsUnderPostmaster)
+		TempTablesLimitShmemInit();
 
 	/*
 	 * Now give loadable modules a chance to set up their shmem allocations

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -190,7 +190,7 @@ mdunlinkforksegment_pre_hook(RelFileNodeBackend rnode, char *segpath)
 {
 	struct stat buf;
 	char fullPath[MAXPGPATH];
-	size_t strLen = strlen(data_directory) + strlen(segpath) + 1;
+	size_t strLen = strnlen(data_directory, MAXPGPATH) + strnlen(segpath, MAXPGPATH) + 1;
 
 	TempTablesLimitChecks();
 
@@ -223,15 +223,15 @@ void
 mdunlink_ao_perFile_pre_hook(char *segPath)
 {
 	struct stat buf;
-	char *segPathCopy = malloc(sizeof(char) * (strlen(segPath) + 1));
+	char *segPathCopy = malloc(sizeof(char) * (strnlen(segPath, MAXPGPATH) + 1));
 	char fullPath[MAXPGPATH];
 	char *name;
 	size_t strLen;
 
 	if (data_directory) // unit tests don't fill data_directory so we can get a segfault here
-		strLen = strlen(data_directory) + strlen(segPath) + 1;
+		strLen = strnlen(data_directory, MAXPGPATH) + strnlen(segPath, MAXPGPATH) + 1;
 	else
-		strLen = strlen(segPath) + 1;
+		strLen = strnlen(segPath, MAXPGPATH) + 1;
 
 	TempTablesLimitChecks();
 

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -190,10 +190,11 @@ mdunlinkforksegment_pre_hook(RelFileNodeBackend rnode, char *segpath)
 {
 	struct stat buf;
 	char fullPath[MAXPGPATH];
+	size_t strLen = strlen(data_directory) + strlen(segpath) + 1;
 
 	TempTablesLimitChecks();
 
-	sprintf(fullPath, "%s/%s", data_directory, segpath);
+	snprintf(fullPath, strLen, "%s/%s", data_directory, segpath);
 
 	if (RelFileNodeBackendIsTemp(rnode))
 		if (stat(fullPath, &buf) == 0)
@@ -222,14 +223,15 @@ void
 mdunlink_ao_perFile_pre_hook(char *segPath)
 {
 	struct stat buf;
-	char *segPathCopy = malloc(sizeof(char) * strlen(segPath));
+	char *segPathCopy = malloc(sizeof(char) * (strlen(segPath) + 1));
 	char fullPath[MAXPGPATH];
 	char *name;
+	size_t strLen = strlen(data_directory) + strlen(segPathCopy) + 1;
 
 	TempTablesLimitChecks();
 
 	strcpy(segPathCopy, segPath);
-	sprintf(fullPath, "%s/%s", data_directory, segPathCopy);
+	snprintf(fullPath, strLen, "%s/%s", data_directory, segPathCopy);
 
 	name = basename(segPathCopy);
 	if (name[0] == 't')

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -6,6 +6,7 @@
 #include "c.h"
 #include "cdb/cdbbufferedappend.h"
 #include "cdb/cdbvars.h"
+#include "pg_config_manual.h"
 #include "port/atomics.h"
 #include "storage/fd.h"
 #include "storage/relfilenode.h"
@@ -188,7 +189,7 @@ void
 mdunlinkforksegment_pre_hook(RelFileNodeBackend rnode, char *segpath)
 {
 	struct stat buf;
-	char fullPath[1024];
+	char fullPath[MAXPGPATH];
 
 	TempTablesLimitChecks();
 
@@ -221,8 +222,8 @@ void
 mdunlink_ao_perFile_pre_hook(char *segPath)
 {
 	struct stat buf;
-	char segPathCopy[20];
-	char fullPath[1024];
+	char *segPathCopy = malloc(sizeof(char) * strlen(segPath));
+	char fullPath[MAXPGPATH];
 	char *name;
 
 	TempTablesLimitChecks();
@@ -238,6 +239,8 @@ mdunlink_ao_perFile_pre_hook(char *segPath)
 			segFileSkip = true;
 	else
 		segFileSkip = true;
+
+	free(segPathCopy);
 }
 
 void

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -235,7 +235,7 @@ mdunlink_ao_perFile_pre_hook(char *segPath)
 
 	TempTablesLimitChecks();
 
-	strcpy(segPathCopy, segPath);
+	strncat(segPathCopy, segPath, strnlen(segPathCopy, MAXPGPATH));
 	snprintf(fullPath, strLen, "%s/%s", data_directory, segPathCopy);
 
 	name = basename(segPathCopy);

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -226,7 +226,12 @@ mdunlink_ao_perFile_pre_hook(char *segPath)
 	char *segPathCopy = malloc(sizeof(char) * (strlen(segPath) + 1));
 	char fullPath[MAXPGPATH];
 	char *name;
-	size_t strLen = strlen(data_directory) + strlen(segPath) + 1;
+	size_t strLen;
+
+	if (data_directory) // unit tests don't fill data_directory so we can get a segfault here
+		strLen = strlen(data_directory) + strlen(segPath) + 1;
+	else
+		strLen = strlen(segPath) + 1;
 
 	TempTablesLimitChecks();
 

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -68,7 +68,7 @@ BufferedAppendWritePreHook(BufferedAppend *bufferedAppend)
 
 		prevFileLen = bufferedAppend->fileLen;
 
-		if (bytesToWrite > 0 && temp_tables_limit_value->value + bytesToWrite > temp_tables_limit * 1024)
+		if (bytesToWrite > 0 && temp_tables_limit_value->value + bytesToWrite > TempTablesLimitToBytes())
 			elog(ERROR, "Temp tables quota exceeded");
 	}
 }
@@ -117,7 +117,7 @@ mdextend_pre_hook(SMgrRelation reln, ForkNumber forknum, int64 size)
 	TempTablesLimitChecks();
 
 	if (SmgrIsTemp(reln))
-		if (temp_tables_limit_value->value + size > temp_tables_limit * 1024
+		if (temp_tables_limit_value->value + size > TempTablesLimitToBytes()
 			&& forknum == MAIN_FORKNUM) /* visibility map can be extended during vacuum */
 			elog(ERROR, "Temp tables quota exceeded");
 }

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -223,31 +223,20 @@ void
 mdunlink_ao_perFile_pre_hook(char *segPath)
 {
 	struct stat buf;
-	char *segPathCopy = malloc(sizeof(char) * (strnlen(segPath, MAXPGPATH) + 1));
-	char fullPath[MAXPGPATH];
+	char segPathCopy[MAXPGPATH];
 	char *name;
-	size_t strLen;
 
-	if (data_directory) // unit tests don't fill data_directory so we can get a segfault here
-		strLen = strnlen(data_directory, MAXPGPATH) + strnlen(segPath, MAXPGPATH) + 1;
-	else
-		strLen = strnlen(segPath, MAXPGPATH) + 1;
-
-	TempTablesLimitChecks();
-
-	strncat(segPathCopy, segPath, strnlen(segPathCopy, MAXPGPATH));
-	snprintf(fullPath, strLen, "%s/%s", data_directory, segPathCopy);
+	segPathCopy[0] = '\0';
+	strncpy(segPathCopy, segPath, strnlen(segPathCopy, MAXPGPATH)); // basename may modify incoming string so we better make a copy
 
 	name = basename(segPathCopy);
 	if (name[0] == 't')
-		if (stat(fullPath, &buf) == 0)
+		if (stat(segPath, &buf) == 0)
 			prevSegFileLen = buf.st_size;
 		else
 			segFileSkip = true;
 	else
 		segFileSkip = true;
-
-	free(segPathCopy);
 }
 
 void

--- a/src/backend/storage/ipc/temp_tables_limit.c
+++ b/src/backend/storage/ipc/temp_tables_limit.c
@@ -63,12 +63,12 @@ BufferedAppendWritePreHook(BufferedAppend *bufferedAppend)
 
 	if (RelFileNodeBackendIsTemp(bufferedAppend->relFileNode))
 	{
+		prevFileLen = FileDiskSize(bufferedAppend->file);
+
 		bytesToWrite = bufferedAppend->largeWriteLen -
-			(FileDiskSize(bufferedAppend->file) - FileSeek(bufferedAppend->file, 0, SEEK_CUR));
+			(prevFileLen - FileSeek(bufferedAppend->file, 0, SEEK_CUR));
 
 		bytes = bytesToWrite > 0 ? bytesToWrite : 0; // for testing purposes
-
-		prevFileLen = FileDiskSize(bufferedAppend->file);
 
 		if (bytesToWrite > 0 && temp_tables_limit_value->value + bytesToWrite > TempTablesLimitToBytes())
 			elog(ERROR, "Temp tables quota exceeded");
@@ -226,7 +226,7 @@ mdunlink_ao_perFile_pre_hook(char *segPath)
 	char *segPathCopy = malloc(sizeof(char) * (strlen(segPath) + 1));
 	char fullPath[MAXPGPATH];
 	char *name;
-	size_t strLen = strlen(data_directory) + strlen(segPathCopy) + 1;
+	size_t strLen = strlen(data_directory) + strlen(segPath) + 1;
 
 	TempTablesLimitChecks();
 

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1047,6 +1047,8 @@ mdtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks)
 												 * segment */
 			FileClose(ov->mdfd_vfd);
 			pfree(ov);
+
+			mdtruncate_post_hook(reln, 0);
 		}
 		else if (priorblocks + ((BlockNumber) RELSEG_SIZE) > nblocks)
 		{
@@ -1072,6 +1074,8 @@ mdtruncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks)
 				register_dirty_segment(reln, forknum, v);
 			v = v->mdfd_chain;
 			ov->mdfd_chain = NULL;
+
+			mdtruncate_post_hook(reln, lastsegblocks);
 		}
 		else
 		{

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -569,6 +569,8 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char rel
 		{
 			sprintf(segpath, "%s.%u", path, segno);
 
+			mdunlinkforksegment_pre_hook(rnode, segpath);
+
 			if (!RelFileNodeBackendIsTemp(rnode))
 			{
 				/*
@@ -586,8 +588,12 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char rel
 					ereport(WARNING,
 							(errcode_for_file_access(),
 							 errmsg("could not remove file \"%s\": %m", segpath)));
+
+				mdunlinkforksegment_post_hook(rnode);
 				break;
 			}
+
+			mdunlinkforksegment_post_hook(rnode);
 		}
 		pfree(segpath);
 	}

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -555,6 +555,7 @@ mdunlinkfork(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo, char rel
 		{
 			mdunlink_ao(path, forkNum);
 			pfree(path);
+			mdunlinkfork_post_hook(rnode);
 			return;
 		}
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -471,6 +471,8 @@ bool		gp_log_endpoints = false;
 /* optional reject to  parse ambigous 5-digits date in YYYMMDD format */
 bool		gp_allow_date_field_width_5digits = false;
 
+int			temp_tables_limit = 1024;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -3335,6 +3337,17 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_KB | GUC_NOT_IN_SAMPLE
 		},
 		&writable_external_table_bufsize,
+		1024, 32, 131072,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"temp_tables_limit", PGC_SUSET, RESOURCES_MEM,
+			gettext_noop("Maximum amount of memory per segment that temporary tables can occupy on disk. "),
+			gettext_noop("Valid value is between 32K and 128M: [32, 131072]."),
+			GUC_UNIT_MB | GUC_NOT_IN_SAMPLE
+		},
+		&temp_tables_limit,
 		1024, 32, 131072,
 		NULL, NULL, NULL
 	},

--- a/src/include/storage/temp_tables_limit.h
+++ b/src/include/storage/temp_tables_limit.h
@@ -1,0 +1,34 @@
+#include "access/aocssegfiles.h"
+#include "cdb/cdbbufferedappend.h"
+#include "c.h"
+
+#ifndef TEMP_TABLES_LIMIT_H
+#define TEMP_TABLES_LIMIT_H
+
+/* init */
+
+Size TempTablesLimitSize(void);
+
+void TempTablesLimitShmemInit(void);
+
+/* ao */
+
+void BufferedAppendWritePreHook(BufferedAppend *bufferedAppend);
+
+void BufferedAppendWritePostHook(BufferedAppend *bufferedAppend);
+
+void TruncateAOSegmentFilePreHook(Relation rel, File fd, int64 offset);
+
+/* heap */
+
+void mdextend_pre_hook(SMgrRelation reln, ForkNumber forknum, int64 size);
+
+void mdextend_post_hook(SMgrRelation reln, int64 size);
+
+void mdunlinkfork_pre_hook(RelFileNodeBackend rnode, ForkNumber forkNum);
+
+void mdunlinkfork_post_hook(RelFileNodeBackend rnode);
+
+void mdtruncate_pre_hook(SMgrRelation reln, File vfd, BlockNumber blockNum);
+
+#endif

--- a/src/include/storage/temp_tables_limit.h
+++ b/src/include/storage/temp_tables_limit.h
@@ -31,4 +31,6 @@ void mdunlinkfork_post_hook(RelFileNodeBackend rnode);
 
 void mdtruncate_pre_hook(SMgrRelation reln, File vfd, BlockNumber blockNum);
 
+void mdtruncate_post_hook(SMgrRelation reln, BlockNumber blockNum);
+
 #endif

--- a/src/include/storage/temp_tables_limit.h
+++ b/src/include/storage/temp_tables_limit.h
@@ -17,7 +17,9 @@ void BufferedAppendWritePreHook(BufferedAppend *bufferedAppend);
 
 void BufferedAppendWritePostHook(BufferedAppend *bufferedAppend);
 
-void TruncateAOSegmentFilePreHook(Relation rel, File fd, int64 offset);
+void TruncateAOSegmentFilePreHook(Relation rel, File fd);
+
+void TruncateAOSegmentFilePostHook(Relation rel, int64 offset);
 
 /* heap */
 
@@ -28,6 +30,14 @@ void mdextend_post_hook(SMgrRelation reln, int64 size);
 void mdunlinkfork_pre_hook(RelFileNodeBackend rnode, ForkNumber forkNum);
 
 void mdunlinkfork_post_hook(RelFileNodeBackend rnode);
+
+void mdunlinkforksegment_pre_hook(RelFileNodeBackend rnode, char *segpath);
+
+void mdunlinkforksegment_post_hook(RelFileNodeBackend rnode);
+
+void mdunlink_ao_perFile_pre_hook(char *segPath);
+
+void mdunlink_ao_perFile_post_hook(void);
 
 void mdtruncate_pre_hook(SMgrRelation reln, File vfd, BlockNumber blockNum);
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -594,6 +594,8 @@ extern bool gp_log_endpoints;
 
 extern bool gp_allow_date_field_width_5digits;
 
+extern int temp_tables_limit;
+
 typedef enum
 {
 	INDEX_CHECK_NONE,

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -114,6 +114,7 @@
 		"statement_timeout",
 		"synchronize_seqscans",
 		"temp_buffers",
+		"temp_tables_limit",
 		"test_copy_qd_qe_split",
 		"test_print_prefetch_joinqual",
 		"TimeZone",


### PR DESCRIPTION
This PR implements hard size limit for temporary tables. The implementation is based on atomic operations, so if there are several processes which operate with temp tables, the quota can be exceeded. 

Temp tables are handled with a set of hooks which are different for head and ao tables. While heap tables have a rather simple driver which fits in a single file, functions which handle ao tables are implemented across several files and don't have such a unified way to handle tables as heap functions do