### PR TITLE
ADBDEV-4488: Fix inconsistency between the format of queries_now.dat and the queries_now_fast external table

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1479,23 +1479,25 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
 	snprintf(qfname, qfname_size, GPMON_DIR "q%d-%d-%d.txt", qdnode->qlog.key.tmid,
             qdnode->qlog.key.ssid, qdnode->qlog.key.ccnt);
 
+	/* query hash */
+	fputs("|0", fp);
+	bytes_written += 2;
+
 	qfptr = fopen(qfname, "r");
     if (!qfptr)
     {
-	    /* 0 it's query hash */
-	    fputs("|0|||||\n", fp);
-	    bytes_written += 8;
+	    fprintf(fp, "|||||\n");
+	    bytes_written += 6;
 	    return bytes_written;
     }
 
-    // 0 add query hash
-    // 1 add query text
-    // 2 add query plan
-    // 3 add application name
-    // 4 add rsqname
-    // 5 add priority
+    // 0 add query text
+    // 1 add query plan
+    // 2 add application name
+    // 3 add rsqname
+    // 4 add priority
 
-    int total_iterations = 6;
+    int total_iterations = 5;
     int all_good = 1;
     int iter;
     int retCode = APR_SUCCESS;
@@ -1504,15 +1506,7 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
 	    fprintf(fp, "|");
         bytes_written++;
 
-        if (iter == 0)
-        {
-            fputc('0', fp);
-            bytes_written++;
-            continue;
-        }
-
-        if (!all_good || iter == 2)
-        {
+        if (!all_good || iter == 1){
             // we have no data for query plan
             // if we failed once already don't bother trying to parse query file
             continue;

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1482,8 +1482,7 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
     if (!qfptr)
     {
 	    /* 0 it's query hash */
-	    fprintf(fp, "|0|||||\n");
-	    bytes_written += 8;
+	    bytes_written += fprintf(fp, "|0|||||\n");
 	    return bytes_written;
     }
 
@@ -1505,7 +1504,7 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
 
         if (iter == 0)
         {
-            fprintf(fp, "0");
+            fputc('0', fp);
             bytes_written++;
             continue;
         }

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1482,7 +1482,8 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
     if (!qfptr)
     {
 	    /* 0 it's query hash */
-	    bytes_written += fprintf(fp, "|0|||||\n");
+	    fputs("|0|||||\n", fp);
+	    bytes_written += 8;
 	    return bytes_written;
     }
 

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1503,13 +1503,15 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
 	    fprintf(fp, "|");
         bytes_written++;
 
-        if(iter == 0){
+        if (iter == 0)
+        {
             fprintf(fp, "0");
             bytes_written++;
             continue;
         }
 
-        if (!all_good || iter == 2){
+        if (!all_good || iter == 2)
+        {
             // we have no data for query plan
             // if we failed once already don't bother trying to parse query file
             continue;

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1375,7 +1375,8 @@ static apr_uint32_t write_qlog(FILE* fp, qdnode_t *qdnode, const char* nowstr, a
 	}
 	else
 	{
-		fprintf(fp, "%s\n", line);
+		fputs(line, fp);
+		fputc('\n', fp);
 		return bytes_written;
 	}
 }

--- a/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_agg.c
@@ -1474,14 +1474,12 @@ static apr_uint32_t write_qlog_full(FILE* fp, qdnode_t *qdnode, const char* nows
 		return 0;
 	}
 
-	fprintf(fp, "%s", line);
+	/* The query hash column is always 0 */
+	fprintf(fp, "%s|0", line);
+	bytes_written += 2;
 
 	snprintf(qfname, qfname_size, GPMON_DIR "q%d-%d-%d.txt", qdnode->qlog.key.tmid,
             qdnode->qlog.key.ssid, qdnode->qlog.key.ccnt);
-
-	/* query hash */
-	fputs("|0", fp);
-	bytes_written += 2;
 
 	qfptr = fopen(qfname, "r");
     if (!qfptr)

--- a/gpAux/gpperfmon/src/gpmon/gpmon_catqrynow.py
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_catqrynow.py
@@ -11,11 +11,9 @@ GPMONDIR = 'gpperfmon/data'
 for line in open(os.path.join(GPMONDIR, "queries_now.dat")):
     line = line.strip().split('|')
     line.append('0') # query hash
-    line.append('') # qrytxt
-    line.append('') # query plan
-    line.append('') # appname
-    line.append('') # rsqname
-    line.append('') # priority
+    # allocate space for qrytxt, query plan, appname, rsqname and priority
+    line.extend(['']*5)
+
     (tmid, xid, cid) = line[1:4]
     qrytxt = ''
     appname = ''

--- a/gpAux/gpperfmon/src/gpmon/gpmon_catqrynow.py
+++ b/gpAux/gpperfmon/src/gpmon/gpmon_catqrynow.py
@@ -9,7 +9,13 @@ GPMONDIR = 'gpperfmon/data'
 #	print the line
 
 for line in open(os.path.join(GPMONDIR, "queries_now.dat")):
-    line = line.split('|')
+    line = line.strip().split('|')
+    line.append('0') # query hash
+    line.append('') # qrytxt
+    line.append('') # query plan
+    line.append('') # appname
+    line.append('') # rsqname
+    line.append('') # priority
     (tmid, xid, cid) = line[1:4]
     qrytxt = ''
     appname = ''

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -29,6 +29,13 @@ Feature: gpperfmon
         Given the database "gpperfmon" does not exist
         Then gpperfmon is configured and running in qamode
 
+    @gpperfmon_query_now
+    Scenario: get info about current queries
+        Given gpperfmon is configured and running in qamode
+        Then run query for 20 seconds
+        And wait until the results from boolean sql "select count(*) > 0 from queries_now" is "true"
+        And wait until the results from boolean sql "select count(*) > 0 from queries_now_fast" is "true"
+
     @gpperfmon_database_history
     Scenario: gpperfmon adds to database_history table
         Given gpperfmon is configured and running in qamode
@@ -175,10 +182,3 @@ Feature: gpperfmon
         And wait until the process "gpsmon" is up
         # Note that the code considers partition_age + 1 as the number of partitions to keep
         Then wait until the results from boolean sql "SELECT count(*) = 6 FROM pg_namespace n INNER JOIN pg_class cl ON cl.relnamespace = n.oid INNER JOIN pg_partition pp ON pp.parrelid = cl.oid INNER JOIN pg_partition_rule ppr ON ppr.paroid = pp.oid WHERE n.nspname = 'public' AND cl.relname = 'diskspace_history'" is "true"
-
-        @gpperfmon_query_now
-        Scenario: get info about current queries
-            Given gpperfmon is configured and running in qamode
-            Then run query for 30 seconds
-            And wait until the results from boolean sql "select count(*) > 0 from queries_now" is "true"
-            And wait until the results from boolean sql "select count(*) > 0 from queries_now_fast" is "true"

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -175,3 +175,10 @@ Feature: gpperfmon
         And wait until the process "gpsmon" is up
         # Note that the code considers partition_age + 1 as the number of partitions to keep
         Then wait until the results from boolean sql "SELECT count(*) = 6 FROM pg_namespace n INNER JOIN pg_class cl ON cl.relnamespace = n.oid INNER JOIN pg_partition pp ON pp.parrelid = cl.oid INNER JOIN pg_partition_rule ppr ON ppr.paroid = pp.oid WHERE n.nspname = 'public' AND cl.relname = 'diskspace_history'" is "true"
+
+        @gpperfmon_query_now
+        Scenario: get info about current queries
+            Given gpperfmon is configured and running in qamode
+            Then run query for 30 seconds
+            And wait until the results from boolean sql "select count(*) > 0 from queries_now" is "true"
+            And wait until the results from boolean sql "select count(*) > 0 from queries_now_fast" is "true"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4302,5 +4302,5 @@ def impl(context):
 
 @then('run query for {second} seconds')
 def impl(context, second):
-	cmd = Command(name='psql', cmdStr="-c 'create table bla as SELECT * from generate_series(1, %s) test_adcc where pg_sleep(1) is not null; drop table bla;'" % second)
+	cmd = Command(name='psql', cmdStr="-c 'SELECT * from generate_series(1, %s) a where pg_sleep(1) is not null;'" % second)
 	cmd.runNoWait()

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4299,3 +4299,8 @@ def impl(context):
 		os.environ['LC_ALL'] = default_locale
 	else:
 		del os.environ['LC_ALL']
+
+@then('run query for {second} seconds')
+def impl(context, second):
+	cmd = Command(name='psql', cmdStr="-c 'create table bla as SELECT * from generate_series(1, %s) test_adcc where pg_sleep(1) is not null; drop table bla;'" % second)
+	cmd.runNoWait()


### PR DESCRIPTION
gpperfmon writes a string to queries_now.dat in the expectation that it will be
processed by gpmon_catqrynow.py, but the queries_now_fast external table reads
from the file directly. This leads to an error, because queries_now.dat contains
the query_hash column that is not declared in the queries_now_fast table. Also
queries_now.dat contains empty columns at the end that should be filled by
python script. These columns are not declared in the table too. 

This patch fixes this issue by removing extra columns from queries_now.dat and
adding them directly in the python script and in the write_qlog_full (write into
queries_tail.dat) function.