### PR TITLE
Fix potential lock by shared SegmentGeneral CTE

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2280,3 +2280,92 @@ WITH cte AS (
 
 RESET optimizer;
 DROP TABLE d;
+-- Check if sharing is disabled for a SegmentGeneral CTE to avoid deadlock if CTE is
+-- executed with 1-gang and joined with Hashed
+SET optimizer = off;
+SET gp_cte_sharing = on;
+--start_ignore
+DROP TABLE IF EXISTS d;
+NOTICE:  table "d" does not exist, skipping
+DROP TABLE IF EXISTS r;
+NOTICE:  table "r" does not exist, skipping
+--end_ignore
+CREATE TABLE d (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO d VALUES (1,2),(2,3);
+CREATE TABLE r (a int, b int) DISTRIBUTED REPLICATED;
+INSERT INTO r VALUES (1,2),(3,4);
+EXPLAIN (COSTS off)
+with cte as (
+    select count(*) a from r
+) select * from cte join (select * from d join cte using(a) limit 1) d_join_cte using(a);
+                          QUERY PLAN
+---------------------------------------------------------------
+ Hash Join
+   Hash Cond: (d_join_cte.a = (count(*)))
+   ->  Subquery Scan on d_join_cte
+         ->  Limit
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Limit
+                           ->  Hash Join
+                                 Hash Cond: (d.a = (count(*)))
+                                 ->  Seq Scan on d
+                                 ->  Hash
+                                       ->  Aggregate
+                                             ->  Seq Scan on r
+   ->  Hash
+         ->  Gather Motion 1:1  (slice2; segments: 1)
+               ->  Aggregate
+                     ->  Seq Scan on r r_1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+with cte as (
+    select count(*) a from r
+) select * from cte join (select * from d join cte using(a) limit 1) d_join_cte using(a);
+ a | b 
+---+---
+ 2 | 3
+(1 row)
+
+-- Check if sharing is still enabled for other cases
+ALTER TABLE r SET DISTRIBUTED BY (a);
+EXPLAIN (COSTS off)
+with cte as (
+    select count(*) a from r
+) select * from cte join (select * from d join cte using(a) limit 1) d_join_cte using(a);
+                                    QUERY PLAN
+----------------------------------------------------------------------------------
+ Hash Join
+   Hash Cond: (d_join_cte.a = share0_ref1.a)
+   ->  Subquery Scan on d_join_cte
+         ->  Limit
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     ->  Limit
+                           ->  Hash Join
+                                 Hash Cond: (d.a = share0_ref2.a)
+                                 ->  Seq Scan on d
+                                 ->  Hash
+                                       ->  Redistribute Motion 1:3  (slice1)
+                                             Hash Key: share0_ref2.a
+                                             ->  Shared Scan (share slice:id 1:0)
+   ->  Hash
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Materialize
+                     ->  Aggregate
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Aggregate
+                                       ->  Seq Scan on r
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+with cte as (
+    select count(*) a from r
+) select * from cte join (select * from d join cte using(a) limit 1) d_join_cte using(a);
+ a | b 
+---+---
+ 2 | 3
+(1 row)
+
+RESET optimizer;
+DROP TABLE d;
+DROP TABLE r;


### PR DESCRIPTION
Depending on the usage of the shared CTE with SegmentGeneral subplan, the number of segments the CTE are executed on may be single for joins with Singleton nodes, and multiple for hashed nodes. In the current implementation this may lead to deadlock if the CTE is used for both join targets: the Join with the Singleton node results in the Share Input Scan producer being executed on a single segment, while the Join with the Hashed node creates Share Input Scan reader on multiple segments, so the plan execution hangs. If we force execution of CTE on multiple segments as well, it will cause redundant motions in case of joining the CTE with another SegmentGeneral. At the moment of constructing and sharing the CTE we don't know the rest of the plan, so we can't predict the correct CTE locus. Because replicated tables are considered small, the most universal and optimal way to fix deadlock would be to inline CTE scans with SegmentGeneral locus.

This patch fixes the deadlock by disabling sharing CTE if the subplan has SegmentGeneral locus.
