### PR TITLE
ADBDEV-4548: Implement vacuum/analyze ordering functions for arenadata_toolkit

### DIFF
--- a/gpcontrib/arenadata_toolkit/Makefile
+++ b/gpcontrib/arenadata_toolkit/Makefile
@@ -3,11 +3,12 @@
 MODULES = arenadata_toolkit
 
 EXTENSION = arenadata_toolkit
-EXTENSION_VERSION = 1.2
+EXTENSION_VERSION = 1.3
 DATA = \
        arenadata_toolkit--1.0.sql \
        arenadata_toolkit--1.0--1.1.sql \
-       arenadata_toolkit--1.1--1.2.sql
+       arenadata_toolkit--1.1--1.2.sql \
+       arenadata_toolkit--1.2--1.3.sql
 
 DATA_built = $(EXTENSION)--$(EXTENSION_VERSION).sql
 
@@ -15,7 +16,7 @@ $(DATA_built): $(DATA)
 	cat $(DATA) > $(DATA_built)
 
 REGRESS = arenadata_toolkit_test arenadata_toolkit_skew_test adb_get_relfilenodes_test \
-          adb_collect_table_stats_test
+          adb_collect_table_stats_test adb_vacuum_strategy_test
 REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
 
 ifdef USE_PGXS

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -14,7 +14,7 @@ BEGIN
 	SELECT nspname, relname
 	FROM pg_catalog.pg_class c
 	JOIN pg_catalog.pg_namespace n ON relnamespace = n.oid
-		LEFT JOIN pg_catalog.pg_stat_last_operation ON classid = 'pg_class'::regclass::oid
+		LEFT JOIN pg_catalog.pg_stat_last_operation ON classid = 'pg_catalog.pg_class'::pg_catalog.regclass
 			AND objid = c.oid AND staactionname = UPPER(%L)
 		LEFT JOIN pg_catalog.pg_partition_rule ON parchildrelid = c.oid
 	WHERE relkind = 'r'

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -1,7 +1,33 @@
 /* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql */
 
 /*
- * Returns pairs of columns (table_schema, table_name) ordered by increasing vacuum time.
+ * Returns the columns (table_schema, table_name, statime) unordered.
+ */
+CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_unordered(actionname TEXT)
+RETURNS TABLE (table_schema NAME, table_name NAME, statime TIMESTAMPTZ) AS
+$$
+BEGIN
+	RETURN query
+	SELECT n.nspname AS table_schema, c.relname AS table_name, o.statime
+	FROM pg_class c
+	JOIN pg_namespace n ON c.relnamespace = n.oid
+	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid
+		AND o.objid = c.oid AND o.staactionname = UPPER(actionname)
+	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
+	WHERE c.relkind = 'r'
+		AND c.relstorage != 'x'
+		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
+		AND p.parchildrelid IS NULL;
+END;
+$$ LANGUAGE plpgsql EXECUTE ON MASTER;
+
+/*
+ * Only for admin usage.
+ */
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_unordered(actionname TEXT) FROM public;
+
+/*
+ * Returns columns (table_schema, table_name) ordered by increasing vacuum time.
  * In this list, tables that are not yet vacuumed are located first,
  * and already vacuumed - at the end (default strategy).
  */
@@ -10,16 +36,9 @@ RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $$
 BEGIN
 	RETURN query
-	SELECT n.nspname AS table_schema, c.relname AS table_name
-	FROM pg_class c
-	JOIN pg_namespace n ON c.relnamespace = n.oid
-	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = UPPER(actionname)
-	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
-	WHERE c.relkind = 'r'
-		AND c.relstorage != 'x'
-		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
-		AND p.parchildrelid IS NULL
-	ORDER BY o.statime ASC NULLS FIRST;
+	SELECT u.table_schema, u.table_name
+	FROM arenadata_toolkit.adb_vacuum_strategy_unordered(actionname) u
+	ORDER BY u.statime ASC NULLS FIRST;
 END;
 $$ LANGUAGE plpgsql EXECUTE ON MASTER;
 
@@ -29,7 +48,7 @@ $$ LANGUAGE plpgsql EXECUTE ON MASTER;
 REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT) FROM public;
 
 /*
- * Returns pairs of columns (table_schema, table_name) ordered by increasing vacuum time.
+ * Returns columns (table_schema, table_name) ordered by increasing vacuum time.
  * In this list, tables that are already vacuumed are located first,
  * and tables that are not yet vacuumed are located at the end.
  */
@@ -38,16 +57,9 @@ RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $$
 BEGIN
 	RETURN query
-	SELECT n.nspname AS table_schema, c.relname AS table_name
-	FROM pg_class c
-	JOIN pg_namespace n ON c.relnamespace = n.oid
-	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = UPPER(actionname)
-	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
-	WHERE c.relkind = 'r'
-		AND c.relstorage != 'x'
-		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
-		AND p.parchildrelid IS NULL
-	ORDER BY o.statime ASC NULLS LAST;
+	SELECT u.table_schema, u.table_name
+	FROM arenadata_toolkit.adb_vacuum_strategy_unordered(actionname) u
+	ORDER BY u.statime ASC NULLS LAST;
 END;
 $$ LANGUAGE plpgsql EXECUTE ON MASTER;
 

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -13,14 +13,12 @@ BEGIN
 	RETURN query EXECUTE format($$
 	SELECT nspname, relname
 	FROM pg_catalog.pg_class c
-	JOIN pg_catalog.pg_namespace n ON relnamespace = n.oid
-		LEFT JOIN pg_catalog.pg_stat_last_operation ON classid = 'pg_catalog.pg_class'::pg_catalog.regclass
-			AND objid = c.oid AND staactionname = UPPER(%L)
+		JOIN pg_catalog.pg_namespace n ON relnamespace = n.oid
 		LEFT JOIN pg_catalog.pg_partition_rule ON parchildrelid = c.oid
-	WHERE relkind = 'r'
-		AND relstorage != 'x'
+		LEFT JOIN pg_catalog.pg_stat_last_operation ON staactionname = UPPER(%L)
+			AND objid = c.oid AND classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+	WHERE relkind = 'r' AND relstorage != 'x' AND parchildrelid IS NULL
 		AND nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
-		AND parchildrelid IS NULL
 	ORDER BY statime ASC NULLS %s
 	$$, actionname, CASE WHEN newest_first THEN 'FIRST' ELSE 'LAST' END);
 END;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -1,9 +1,9 @@
 /* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql */
 
 /*
- * Returns columns (table_schema, table_name) ordered by increasing vacuum time.
- * In this list, if first is true, then tables that are not yet vacuumed are located first,
- * and already vacuumed - at the end, else (arg is false) tables that are already
+ * Returns columns (table_schema, table_name) ordered by increasing vacuum time. In this
+ * list, if newest_first is true, then tables that are not yet vacuumed are located first,
+ * and already vacuumed - at the end, else (newest_first is false) tables that are already
  * vacuumed are located first, and tables that are not yet vacuumed are located at the end.
  */
 CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy(actionname TEXT, newest_first BOOLEAN)
@@ -22,12 +22,12 @@ BEGIN
 	ORDER BY statime ASC NULLS %s
 	$$, actionname, CASE WHEN newest_first THEN 'FIRST' ELSE 'LAST' END);
 END;
-$func$ LANGUAGE plpgsql IMMUTABLE EXECUTE ON MASTER;
+$func$ LANGUAGE plpgsql STABLE EXECUTE ON MASTER;
 
 /*
  * Only for admin usage.
  */
-REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy(actionname TEXT, newest_first BOOLEAN) FROM public;
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy(TEXT, BOOLEAN) FROM public;
 
 /*
  * Returns columns (table_schema, table_name) ordered by increasing vacuum time.
@@ -38,12 +38,12 @@ CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TE
 RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $$
 	SELECT arenadata_toolkit.adb_vacuum_strategy(actionname, true);
-$$ LANGUAGE sql IMMUTABLE EXECUTE ON MASTER;
+$$ LANGUAGE sql STABLE EXECUTE ON MASTER;
 
 /*
  * Only for admin usage.
  */
-REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT) FROM public;
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(TEXT) FROM public;
 
 /*
  * Returns columns (table_schema, table_name) ordered by increasing vacuum time.
@@ -54,9 +54,9 @@ CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(actionname TEX
 RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $$
 	SELECT arenadata_toolkit.adb_vacuum_strategy(actionname, false);
-$$ LANGUAGE sql IMMUTABLE EXECUTE ON MASTER;
+$$ LANGUAGE sql STABLE EXECUTE ON MASTER;
 
 /*
  * Only for admin usage.
  */
-REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(actionname TEXT) FROM public;
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(TEXT) FROM public;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -36,7 +36,7 @@ RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $$
 BEGIN
 	RETURN query
-    SELECT n.nspname AS table_schema, c.relname AS table_name
+	SELECT n.nspname AS table_schema, c.relname AS table_name
 	FROM pg_class c
 	JOIN pg_namespace n ON c.relnamespace = n.oid
 	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = actionname

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -12,7 +12,7 @@ BEGIN
 	SELECT n.nspname AS table_schema, c.relname AS table_name
 	FROM pg_class c
 	JOIN pg_namespace n ON c.relnamespace = n.oid
-	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = actionname
+	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = UPPER(actionname)
 	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
 	WHERE c.relkind = 'r'
 		AND c.relstorage != 'x'
@@ -39,7 +39,7 @@ BEGIN
 	SELECT n.nspname AS table_schema, c.relname AS table_name
 	FROM pg_class c
 	JOIN pg_namespace n ON c.relnamespace = n.oid
-	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = actionname
+	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = UPPER(actionname)
 	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
 	WHERE c.relkind = 'r'
 		AND c.relstorage != 'x'

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -11,16 +11,16 @@ RETURNS TABLE (table_schema NAME, table_name NAME) AS
 $func$
 BEGIN
 	RETURN query EXECUTE format($$
-	SELECT n.nspname, c.relname
-	FROM pg_class c
-	JOIN pg_namespace n ON c.relnamespace = n.oid
-		LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid
-			AND o.objid = c.oid AND o.staactionname = UPPER(%L)
-		LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
-	WHERE c.relkind = 'r'
-		AND c.relstorage != 'x'
-		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
-		AND p.parchildrelid IS NULL
+	SELECT nspname, relname
+	FROM pg_catalog.pg_class c
+	JOIN pg_catalog.pg_namespace n ON relnamespace = n.oid
+		LEFT JOIN pg_catalog.pg_stat_last_operation ON classid = 'pg_class'::regclass::oid
+			AND objid = c.oid AND staactionname = UPPER(%L)
+		LEFT JOIN pg_catalog.pg_partition_rule ON parchildrelid = c.oid
+	WHERE relkind = 'r'
+		AND relstorage != 'x'
+		AND nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
+		AND parchildrelid IS NULL
 	ORDER BY statime ASC NULLS %s
 	$$, actionname, CASE WHEN newest_first THEN 'FIRST' ELSE 'LAST' END);
 END;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -1,0 +1,55 @@
+/* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql */
+
+/*
+ * Returns column pair (table_schema, table_name) ordered by haven't been vacuumed
+ * before at the head of the list and vacuumed before by ascending order (default strategy)
+ */
+CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT)
+RETURNS TABLE (table_schema NAME, table_name NAME) AS
+$$
+BEGIN
+	RETURN query
+	SELECT n.nspname AS table_schema, c.relname AS table_name
+	FROM pg_class c
+	JOIN pg_namespace n ON c.relnamespace = n.oid
+	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = actionname
+	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
+	WHERE c.relkind = 'r'
+		AND c.relstorage != 'x'
+		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
+		AND p.parchildrelid IS NULL
+	ORDER BY o.statime ASC NULLS FIRST;
+END;
+$$ LANGUAGE plpgsql EXECUTE ON MASTER;
+
+/*
+ * Only for admin usage.
+ */
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT) FROM public;
+
+/*
+ * Returns column pair (table_schema, table_name) ordered by haven't been vacuumed
+ * before at the end of the list and vacuumed before by ascending order
+ */
+CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(actionname TEXT)
+RETURNS TABLE (table_schema NAME, table_name NAME) AS
+$$
+BEGIN
+	RETURN query
+    SELECT n.nspname AS table_schema, c.relname AS table_name
+	FROM pg_class c
+	JOIN pg_namespace n ON c.relnamespace = n.oid
+	LEFT JOIN pg_stat_last_operation o ON o.classid = 'pg_class'::regclass::oid AND o.objid = c.oid AND o.staactionname = actionname
+	LEFT JOIN pg_partition_rule p ON p.parchildrelid = c.oid
+	WHERE c.relkind = 'r'
+		AND c.relstorage != 'x'
+		AND n.nspname NOT IN (SELECT schema_name FROM arenadata_toolkit.operation_exclude)
+		AND p.parchildrelid IS NULL
+	ORDER BY o.statime ASC NULLS LAST;
+END;
+$$ LANGUAGE plpgsql EXECUTE ON MASTER;
+
+/*
+ * Only for admin usage.
+ */
+REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(actionname TEXT) FROM public;

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql
@@ -1,8 +1,9 @@
 /* gpcontrib/arenadata_toolkit/arenadata_toolkit--1.2--1.3.sql */
 
 /*
- * Returns column pair (table_schema, table_name) ordered by haven't been vacuumed
- * before at the head of the list and vacuumed before by ascending order (default strategy)
+ * Returns pairs of columns (table_schema, table_name) ordered by increasing vacuum time.
+ * In this list, tables that are not yet vacuumed are located first,
+ * and already vacuumed - at the end (default strategy).
  */
 CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT)
 RETURNS TABLE (table_schema NAME, table_name NAME) AS
@@ -28,8 +29,9 @@ $$ LANGUAGE plpgsql EXECUTE ON MASTER;
 REVOKE ALL ON FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_first(actionname TEXT) FROM public;
 
 /*
- * Returns column pair (table_schema, table_name) ordered by haven't been vacuumed
- * before at the end of the list and vacuumed before by ascending order
+ * Returns pairs of columns (table_schema, table_name) ordered by increasing vacuum time.
+ * In this list, tables that are already vacuumed are located first,
+ * and tables that are not yet vacuumed are located at the end.
  */
 CREATE FUNCTION arenadata_toolkit.adb_vacuum_strategy_newest_last(actionname TEXT)
 RETURNS TABLE (table_schema NAME, table_name NAME) AS

--- a/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
+++ b/gpcontrib/arenadata_toolkit/arenadata_toolkit.control
@@ -1,5 +1,5 @@
 # arenadata_toolkit extension
 comment = 'extension is used for manipulation of objects created by adb-bundle'
-default_version = '1.2'
+default_version = '1.3'
 module_pathname = '$libdir/arenadata_toolkit'
 relocatable = false

--- a/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
@@ -29,41 +29,7 @@ INSERT INTO test_vacuum.not_vacuumed SELECT generate_series(1, 10);
 DELETE FROM test_vacuum.vacuumed WHERE a >= 5;
 DELETE FROM test_vacuum.not_vacuumed WHERE a >= 5;
 VACUUM test_vacuum.vacuumed;
--- original query from operation.py
-SELECT table_schema, table_name from (
-SELECT n.nspname AS table_schema,
-       c.relname AS table_name,
-       a.statime AS statime
-FROM pg_class c
-LEFT JOIN pg_namespace n
-    ON c.relnamespace = n.oid
-LEFT JOIN pg_stat_operations o
-    ON o.objname = c.relname AND o.schemaname = n.nspname
-LEFT JOIN (SELECT *
-           FROM pg_stat_operations
-           WHERE actionname = 'VACUUM'
-) a
-    ON a.objname = c.relname AND a.schemaname = n.nspname
-LEFT JOIN pg_partition_rule p
-    ON p.parchildrelid = c.oid
-LEFT JOIN arenadata_toolkit.operation_exclude exc
-    ON exc.schema_name = n.nspname
-WHERE c.relkind = 'r'
-    AND c.relstorage <> 'x'
-    AND (a.actionname IS NULL or o.actionname = 'VACUUM')
-    AND p.parchildrelid IS NULL
-    AND exc.schema_name IS NULL
-GROUP BY n.nspname, c.relname, a.statime) q
-WHERE table_schema = 'test_vacuum'
-ORDER BY q.statime asc nulls first;
- table_schema |  table_name  
---------------+--------------
- test_vacuum  | part_table
- test_vacuum  | not_vacuumed
- test_vacuum  | vacuumed
-(3 rows)
-
--- default strategy is same as original query
+-- default strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE table_schema = 'test_vacuum';
  table_schema |  table_name  
 --------------+--------------

--- a/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
@@ -1,0 +1,89 @@
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+ adb_create_tables 
+-------------------
+ 
+(1 row)
+
+CREATE SCHEMA test_vacuum;
+CREATE TABLE test_vacuum.vacuumed (a int) DISTRIBUTED BY (a);
+CREATE TABLE test_vacuum.not_vacuumed (a int) DISTRIBUTED BY (a);
+SET client_min_messages=WARNING;
+CREATE TABLE test_vacuum.part_table (id INT, a INT, b INT, c INT, d INT, str TEXT)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (a)
+	SUBPARTITION BY RANGE (b)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY RANGE (c)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY RANGE (d)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY LIST (str)
+		SUBPARTITION TEMPLATE (
+			SUBPARTITION sub_prt1 VALUES ('sub_prt1'),
+			SUBPARTITION sub_prt2 VALUES ('sub_prt2'))
+	(START (1) END (3) EVERY (1));
+RESET client_min_messages;
+INSERT INTO test_vacuum.vacuumed SELECT generate_series(1, 10);
+INSERT INTO test_vacuum.not_vacuumed SELECT generate_series(1, 10);
+DELETE FROM test_vacuum.vacuumed WHERE a >= 5;
+DELETE FROM test_vacuum.not_vacuumed WHERE a >= 5;
+VACUUM test_vacuum.vacuumed;
+-- original query from operation.py
+SELECT table_schema, table_name from (
+SELECT n.nspname AS table_schema,
+       c.relname AS table_name,
+       a.statime AS statime
+FROM pg_class c
+LEFT JOIN pg_namespace n
+    ON c.relnamespace = n.oid
+LEFT JOIN pg_stat_operations o
+    ON o.objname = c.relname AND o.schemaname = n.nspname
+LEFT JOIN (SELECT *
+           FROM pg_stat_operations
+           WHERE actionname = 'VACUUM'
+) a
+    ON a.objname = c.relname AND a.schemaname = n.nspname
+LEFT JOIN pg_partition_rule p
+    ON p.parchildrelid = c.oid
+LEFT JOIN arenadata_toolkit.operation_exclude exc
+    ON exc.schema_name = n.nspname
+WHERE c.relkind = 'r'
+    AND c.relstorage <> 'x'
+    AND (a.actionname IS NULL or o.actionname = 'VACUUM')
+    AND p.parchildrelid IS NULL
+    AND exc.schema_name IS NULL
+GROUP BY n.nspname, c.relname, a.statime) q
+WHERE table_schema = 'test_vacuum'
+ORDER BY q.statime asc nulls first;
+ table_schema |  table_name  
+--------------+--------------
+ test_vacuum  | part_table
+ test_vacuum  | not_vacuumed
+ test_vacuum  | vacuumed
+(3 rows)
+
+-- default strategy is same as original query
+SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE table_schema = 'test_vacuum';
+ table_schema |  table_name  
+--------------+--------------
+ test_vacuum  | part_table
+ test_vacuum  | not_vacuumed
+ test_vacuum  | vacuumed
+(3 rows)
+
+-- revert strategy
+SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_last('VACUUM') WHERE table_schema = 'test_vacuum';
+ table_schema |  table_name  
+--------------+--------------
+ test_vacuum  | vacuumed
+ test_vacuum  | not_vacuumed
+ test_vacuum  | part_table
+(3 rows)
+
+DROP SCHEMA test_vacuum CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table test_vacuum.vacuumed
+drop cascades to table test_vacuum.not_vacuumed
+drop cascades to table test_vacuum.part_table
+DROP EXTENSION arenadata_toolkit;

--- a/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
@@ -38,7 +38,7 @@ SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE
  test_vacuum  | vacuumed
 (3 rows)
 
--- revert strategy
+-- reversed strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_last('VACUUM') WHERE table_schema = 'test_vacuum';
  table_schema |  table_name  
 --------------+--------------

--- a/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/adb_vacuum_strategy_test.out
@@ -8,6 +8,7 @@ SELECT arenadata_toolkit.adb_create_tables();
 CREATE SCHEMA test_vacuum;
 CREATE TABLE test_vacuum.vacuumed (a int) DISTRIBUTED BY (a);
 CREATE TABLE test_vacuum.not_vacuumed (a int) DISTRIBUTED BY (a);
+-- Disable multiple notifications about the creation of multiple subpartitions.
 SET client_min_messages=WARNING;
 CREATE TABLE test_vacuum.part_table (id INT, a INT, b INT, c INT, d INT, str TEXT)
 DISTRIBUTED BY (id)

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -96,6 +96,8 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
+ adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | 
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -103,7 +105,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part   | table   | a          | 
  db_files_history_1_prt_pYYYYMM        | table   | a          | 
  operation_exclude                     | table   | a          | 
-(16 rows)
+(18 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
@@ -121,7 +123,9 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
-(9 rows)
+ adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
+ adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
+(11 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;
@@ -149,6 +153,8 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
+ adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | {owner=arwdDxt/owner}
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -156,7 +162,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part   | table   | a          | {owner=arwdDxt/owner}
  db_files_history_1_prt_pYYYYMM        | table   | a          | {owner=arwdDxt/owner}
  operation_exclude                     | table   | a          | {owner=arwdDxt/owner}
-(16 rows)
+(18 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
@@ -174,7 +180,9 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
-(9 rows)
+ adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
+ adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
+(11 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -96,7 +96,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
- adb_vacuum_strategy_arg               | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy                   | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
@@ -124,7 +124,7 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
- adb_vacuum_strategy_arg               | proc    | arenadata_toolkit | e
+ adb_vacuum_strategy                   | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
 (12 rows)
@@ -155,7 +155,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
- adb_vacuum_strategy_arg               | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy                   | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
@@ -183,7 +183,7 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
- adb_vacuum_strategy_arg               | proc    | arenadata_toolkit | e
+ adb_vacuum_strategy                   | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
 (12 rows)

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -96,9 +96,9 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
+ adb_vacuum_strategy_arg               | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
- adb_vacuum_strategy_unordered         | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | 
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -124,9 +124,9 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
+ adb_vacuum_strategy_arg               | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
- adb_vacuum_strategy_unordered         | proc    | arenadata_toolkit | e
 (12 rows)
 
 DROP EXTENSION arenadata_toolkit;
@@ -155,9 +155,9 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_relation_storage_size             | proc    | -          | {=X/owner,owner=X/owner}
  adb_relation_storage_size_on_segments | proc    | -          | {=X/owner,owner=X/owner}
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
+ adb_vacuum_strategy_arg               | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
- adb_vacuum_strategy_unordered         | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | {owner=arwdDxt/owner}
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -183,9 +183,9 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_relation_storage_size             | proc    | arenadata_toolkit | e
  adb_relation_storage_size_on_segments | proc    | arenadata_toolkit | e
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
+ adb_vacuum_strategy_arg               | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
- adb_vacuum_strategy_unordered         | proc    | arenadata_toolkit | e
 (12 rows)
 
 DROP EXTENSION arenadata_toolkit;

--- a/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
+++ b/gpcontrib/arenadata_toolkit/expected/arenadata_toolkit_test.out
@@ -98,6 +98,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy_unordered         | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | 
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -105,7 +106,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part   | table   | a          | 
  db_files_history_1_prt_pYYYYMM        | table   | a          | 
  operation_exclude                     | table   | a          | 
-(18 rows)
+(19 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
@@ -125,7 +126,8 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
-(11 rows)
+ adb_vacuum_strategy_unordered         | proc    | arenadata_toolkit | e
+(12 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;
@@ -155,6 +157,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  adb_skew_coefficients                 | table   | v          | {owner=arwdDxt/owner,=r/owner}
  adb_vacuum_strategy_newest_first      | proc    | -          | {owner=X/owner}
  adb_vacuum_strategy_newest_last       | proc    | -          | {owner=X/owner}
+ adb_vacuum_strategy_unordered         | proc    | -          | {owner=X/owner}
  arenadata_toolkit                     | schema  | -          | {owner=UC/owner,=U/owner}
  daily_operation                       | table   | a          | {owner=arwdDxt/owner}
  db_files_current                      | table   | h          | {owner=arwdDxt/owner,=r/owner}
@@ -162,7 +165,7 @@ SELECT objname, objtype, objstorage, objacl FROM toolkit_objects_info ORDER BY o
  db_files_history_1_prt_default_part   | table   | a          | {owner=arwdDxt/owner}
  db_files_history_1_prt_pYYYYMM        | table   | a          | {owner=arwdDxt/owner}
  operation_exclude                     | table   | a          | {owner=arwdDxt/owner}
-(18 rows)
+(19 rows)
 
 -- check that toolkit objects now depends on extension
 SELECT objname, objtype, extname, deptype FROM pg_depend d JOIN
@@ -182,7 +185,8 @@ WHERE d.deptype = 'e' AND e.extname = 'arenadata_toolkit' ORDER BY objname;
  adb_skew_coefficients                 | table   | arenadata_toolkit | e
  adb_vacuum_strategy_newest_first      | proc    | arenadata_toolkit | e
  adb_vacuum_strategy_newest_last       | proc    | arenadata_toolkit | e
-(11 rows)
+ adb_vacuum_strategy_unordered         | proc    | arenadata_toolkit | e
+(12 rows)
 
 DROP EXTENSION arenadata_toolkit;
 DROP SCHEMA arenadata_toolkit cascade;

--- a/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
@@ -1,0 +1,67 @@
+CREATE EXTENSION arenadata_toolkit;
+SELECT arenadata_toolkit.adb_create_tables();
+
+CREATE SCHEMA test_vacuum;
+
+CREATE TABLE test_vacuum.vacuumed (a int) DISTRIBUTED BY (a);
+CREATE TABLE test_vacuum.not_vacuumed (a int) DISTRIBUTED BY (a);
+SET client_min_messages=WARNING;
+CREATE TABLE test_vacuum.part_table (id INT, a INT, b INT, c INT, d INT, str TEXT)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (a)
+	SUBPARTITION BY RANGE (b)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY RANGE (c)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY RANGE (d)
+		SUBPARTITION TEMPLATE (START (1) END (3) EVERY (1))
+	SUBPARTITION BY LIST (str)
+		SUBPARTITION TEMPLATE (
+			SUBPARTITION sub_prt1 VALUES ('sub_prt1'),
+			SUBPARTITION sub_prt2 VALUES ('sub_prt2'))
+	(START (1) END (3) EVERY (1));
+RESET client_min_messages;
+
+INSERT INTO test_vacuum.vacuumed SELECT generate_series(1, 10);
+INSERT INTO test_vacuum.not_vacuumed SELECT generate_series(1, 10);
+
+DELETE FROM test_vacuum.vacuumed WHERE a >= 5;
+DELETE FROM test_vacuum.not_vacuumed WHERE a >= 5;
+
+VACUUM test_vacuum.vacuumed;
+
+-- original query from operation.py
+SELECT table_schema, table_name from (
+SELECT n.nspname AS table_schema,
+       c.relname AS table_name,
+       a.statime AS statime
+FROM pg_class c
+LEFT JOIN pg_namespace n
+    ON c.relnamespace = n.oid
+LEFT JOIN pg_stat_operations o
+    ON o.objname = c.relname AND o.schemaname = n.nspname
+LEFT JOIN (SELECT *
+           FROM pg_stat_operations
+           WHERE actionname = 'VACUUM'
+) a
+    ON a.objname = c.relname AND a.schemaname = n.nspname
+LEFT JOIN pg_partition_rule p
+    ON p.parchildrelid = c.oid
+LEFT JOIN arenadata_toolkit.operation_exclude exc
+    ON exc.schema_name = n.nspname
+WHERE c.relkind = 'r'
+    AND c.relstorage <> 'x'
+    AND (a.actionname IS NULL or o.actionname = 'VACUUM')
+    AND p.parchildrelid IS NULL
+    AND exc.schema_name IS NULL
+GROUP BY n.nspname, c.relname, a.statime) q
+WHERE table_schema = 'test_vacuum'
+ORDER BY q.statime asc nulls first;
+
+-- default strategy is same as original query
+SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE table_schema = 'test_vacuum';
+-- revert strategy
+SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_last('VACUUM') WHERE table_schema = 'test_vacuum';
+
+DROP SCHEMA test_vacuum CASCADE;
+DROP EXTENSION arenadata_toolkit;

--- a/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
@@ -33,7 +33,7 @@ VACUUM test_vacuum.vacuumed;
 
 -- default strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE table_schema = 'test_vacuum';
--- revert strategy
+-- reversed strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_last('VACUUM') WHERE table_schema = 'test_vacuum';
 
 DROP SCHEMA test_vacuum CASCADE;

--- a/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
@@ -31,35 +31,7 @@ DELETE FROM test_vacuum.not_vacuumed WHERE a >= 5;
 
 VACUUM test_vacuum.vacuumed;
 
--- original query from operation.py
-SELECT table_schema, table_name from (
-SELECT n.nspname AS table_schema,
-       c.relname AS table_name,
-       a.statime AS statime
-FROM pg_class c
-LEFT JOIN pg_namespace n
-    ON c.relnamespace = n.oid
-LEFT JOIN pg_stat_operations o
-    ON o.objname = c.relname AND o.schemaname = n.nspname
-LEFT JOIN (SELECT *
-           FROM pg_stat_operations
-           WHERE actionname = 'VACUUM'
-) a
-    ON a.objname = c.relname AND a.schemaname = n.nspname
-LEFT JOIN pg_partition_rule p
-    ON p.parchildrelid = c.oid
-LEFT JOIN arenadata_toolkit.operation_exclude exc
-    ON exc.schema_name = n.nspname
-WHERE c.relkind = 'r'
-    AND c.relstorage <> 'x'
-    AND (a.actionname IS NULL or o.actionname = 'VACUUM')
-    AND p.parchildrelid IS NULL
-    AND exc.schema_name IS NULL
-GROUP BY n.nspname, c.relname, a.statime) q
-WHERE table_schema = 'test_vacuum'
-ORDER BY q.statime asc nulls first;
-
--- default strategy is same as original query
+-- default strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_first('VACUUM') WHERE table_schema = 'test_vacuum';
 -- revert strategy
 SELECT * FROM arenadata_toolkit.adb_vacuum_strategy_newest_last('VACUUM') WHERE table_schema = 'test_vacuum';

--- a/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
+++ b/gpcontrib/arenadata_toolkit/sql/adb_vacuum_strategy_test.sql
@@ -5,6 +5,7 @@ CREATE SCHEMA test_vacuum;
 
 CREATE TABLE test_vacuum.vacuumed (a int) DISTRIBUTED BY (a);
 CREATE TABLE test_vacuum.not_vacuumed (a int) DISTRIBUTED BY (a);
+-- Disable multiple notifications about the creation of multiple subpartitions.
 SET client_min_messages=WARNING;
 CREATE TABLE test_vacuum.part_table (id INT, a INT, b INT, c INT, d INT, str TEXT)
 DISTRIBUTED BY (id)


### PR DESCRIPTION
Implement vacuum/analyze ordering functions for arenadata_toolkit

This patch extends the functionality of the arenadata_toolkit extension
by adding two functions to obtain different table orders for vacuum/analyze.
These two functions are planned to be used in the vacuum command in
the operation.py script. By default, the bundle will use the current approach,
in which new tables are placed at the beginning of the list. But users will
be able to reconfigure it to use a second function that places new tables
at the end of the list, or even use a custom query to determine the order.