### PR TITLE
Fix ORCA's triggers on debug build

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalRowTrigger.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalRowTrigger.cpp
@@ -33,7 +33,8 @@ CLogicalRowTrigger::CLogicalRowTrigger(CMemoryPool *mp)
 	  m_rel_mdid(NULL),
 	  m_type(0),
 	  m_pdrgpcrOld(NULL),
-	  m_pdrgpcrNew(NULL)
+	  m_pdrgpcrNew(NULL),
+	  m_efs(IMDFunction::EfsImmutable)
 {
 	m_fPattern = true;
 }
@@ -53,7 +54,8 @@ CLogicalRowTrigger::CLogicalRowTrigger(CMemoryPool *mp, IMDId *rel_mdid,
 	  m_rel_mdid(rel_mdid),
 	  m_type(type),
 	  m_pdrgpcrOld(pdrgpcrOld),
-	  m_pdrgpcrNew(pdrgpcrNew)
+	  m_pdrgpcrNew(pdrgpcrNew),
+	  m_efs(IMDFunction::EfsImmutable)
 {
 	GPOS_ASSERT(rel_mdid->IsValid());
 	GPOS_ASSERT(0 != type);


### PR DESCRIPTION
An attempt to call DML over a table with trigger may give an assertion error in
`CFunctionProp` constructor. `func_stability` passed to the constructor may be
more than max value (`IMDFunction::EfsSentinel`). This happens, because
`CLogicalRowTrigger` class has no default value for `m_efs` in its constructor.
This means that `m_efs` may contain any value (for example 2139062143). Later,
when `InitFunctionProperties()` tries to calculate less strict
stability level, `m_efs` is not overwritten, because it already has greater
value. The patch fixes the error by adding default `m_efs` value to constructor.
The planing may fall on any type of trigger on any DML operaion, so you may
test it with any trigger and `optimizer_enable_dml_triggers` set to enabled.

_______

During a work on another patch, I found that the following snippet causing an error
```
create table t_trig(t1 int, t2 int, t3 int) distributed by (t1);

create or replace function trig_proc() returns trigger
as $$
begin
  raise notice 'Values: (%, %, %)', old.t1, old.t2, old.t3;
  return new;
end;
$$ language plpgsql;

create trigger t_upd_del before update or delete on t_trig for each row
execute procedure trig_proc();

set client_min_messages = log;
set optimizer_enable_dml_triggers = true;

explain analyze verbose insert into t_trig values (1,1,1);
explain analyze verbose update t_trig set t2 = 2 where t1 = 1;
```
```
1    0x0000561c424568b2 gpos::CErrorContext::Record + 188
2    0x0000561c424579c6 gpos::CException::Raise + 278
3    0x0000561c425c4deb gpopt::CFunctionProp::CFunctionProp + 151
4    0x0000561c426755ed gpopt::COperator::PfpDeriveFromChildren + 151
5    0x0000561c42667d8c gpopt::CLogicalRowTrigger::DeriveFunctionProperties + 58
6    0x0000561c425c0b47 gpopt::CDrvdPropRelational::DeriveFunctionProperties + 113
7    0x0000561c425bf1bd gpopt::CDrvdPropRelational::Derive + 235
8    0x0000561c4262501b gpopt::CExpression::PdpDerive + 703
9    0x0000561c426fac72 gpopt::CMemo::PgroupInsert + 512
10   0x0000561c425fb6b0 gpopt::CEngine::PgroupInsert + 632
11   0x0000561c425fb415 gpopt::CEngine::InsertExpressionChildren + 503
12   0x0000561c425fb61d gpopt::CEngine::PgroupInsert + 485
13   0x0000561c425fba18 gpopt::CEngine::InsertXformResult + 722
14   0x0000561c426f8690 gpopt::CJobTransformation::EevtTransform + 320
15   0x0000561c426f8c2a gpopt::CJobStateMachine + 370
16   0x0000561c426f876e gpopt::CJobTransformation::FExecute + 120
17   0x0000561c426ff9ef gpopt::CScheduler::FExecute + 81
18   0x0000561c426ff37c gpopt::CScheduler::ExecuteJobs + 164
19   0x0000561c426ff2d0 gpopt::CScheduler::Run + 54
20   0x0000561c426004af gpopt::CEngine::Optimize + 981
```
User-defined triggers are not [supported](https://docs.vmware.com/en/VMware-Greenplum/7/greenplum-database/ref_guide-sql_commands-CREATE_TRIGGER.html) in Greenplum Database. And they are especially hidden from ORCA, which doesn't plan them if `optimizer_enable_dml_triggers` GUC is disabled (default).
Anyway, we want to somehow test already existed functionality, so the bug should be fixed.

After the voice chat debates we decided to not add additional tests. ORCA already has unit tests for triggers. Bug is related more to build environment.