### PR TITLE
Filter excessive attrs from ORCA's DML delete node

### DIFF
--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -281,17 +281,29 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 			dmlstate->cleanedUpSlot);
 
 	/*
-	 * We don't maintain typmod in the targetlist, so we should fixup the
-	 * junkfilter to use the same tuple descriptor as the result relation.
-	 * Otherwise the mismatch of tuple descriptor will cause a break in
-	 * ExecInsert()->reconstructMatchingTupleSlot().
+	 * The comment below is related to ExecInsert() and ExecUpdate(). The code
+	 * works correctly, because insert and update operations always translate
+	 * full set of attrs to targetlist. So, resulting tupledesc has the same
+	 * number of attrs after replacing. ExecDelete() doesn't have such
+	 * machinery, and more, can work with subset of table attrs. So, the code
+	 * below can add attrs, which doesn't exist in original targetlist. This
+	 * may cause execution errors.
 	 */
-	TupleDesc cleanTupType = CreateTupleDescCopy(dmlstate->ps.state->es_result_relation_info->ri_RelationDesc->rd_att);
+	if (estate->es_plannedstmt->commandType != CMD_DELETE)
+	{
+		/*
+		 * We don't maintain typmod in the targetlist, so we should fixup the
+		 * junkfilter to use the same tuple descriptor as the result relation.
+		 * Otherwise the mismatch of tuple descriptor will cause a break in
+		 * ExecInsert()->reconstructMatchingTupleSlot().
+		 */
+		TupleDesc	cleanTupType = CreateTupleDescCopy(dmlstate->ps.state->es_result_relation_info->ri_RelationDesc->rd_att);
 
-	ExecSetSlotDescriptor(dmlstate->junkfilter->jf_resultSlot, cleanTupType);
+		ExecSetSlotDescriptor(dmlstate->junkfilter->jf_resultSlot, cleanTupType);
 
-	ReleaseTupleDesc(dmlstate->junkfilter->jf_cleanTupType);
-	dmlstate->junkfilter->jf_cleanTupType = cleanTupType;
+		ReleaseTupleDesc(dmlstate->junkfilter->jf_cleanTupType);
+		dmlstate->junkfilter->jf_cleanTupType = cleanTupType;
+	}
 
 	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
 	{

--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -281,13 +281,12 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 			dmlstate->cleanedUpSlot);
 
 	/*
-	 * The comment below is related to ExecInsert() and ExecUpdate(). The code
-	 * works correctly, because insert and update operations always translate
-	 * full set of attrs to targetlist. So, resulting tupledesc has the same
-	 * number of attrs after replacing. ExecDelete() doesn't have such
-	 * machinery, and more, can work with subset of table attrs. So, the code
-	 * below can add attrs, which doesn't exist in original targetlist. This
-	 * may cause execution errors.
+	 * The comment below is related to ExecInsert(). The code works correctly,
+	 * because insert operations always translate full set of attrs to
+	 * targetlist. So, tupledesc below has the same number of attrs after
+	 * replacing. ExecDelete() doesn't reconstruct a slot, and more, can work
+	 * with subset of table attrs. In order to avoid unnecessary job and
+	 * execution error, the code below is not executed for DELETE.
 	 */
 	if (estate->es_plannedstmt->commandType != CMD_DELETE)
 	{

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4177,7 +4177,11 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 							 NULL,	// translate context for the base table
 							 child_contexts, output_context);
 
-	if (md_rel->HasDroppedColumns())
+	// Create target list with nulls if rel has dropped cols. DELETE may has
+	// empty target list if there no after trigger present. Skip creating in
+	// such case.
+	if (md_rel->HasDroppedColumns() &&
+		(m_cmd_type != CMD_DELETE || dml_target_list != NIL))
 	{
 		// pad DML target list with NULLs for dropped columns for all DML operator types
 		List *target_list_with_dropped_cols =

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4177,7 +4177,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 							 NULL,	// translate context for the base table
 							 child_contexts, output_context);
 
-	// Create target list with nulls if rel has dropped cols. DELETE may has
+	// Create target list with nulls if rel has dropped cols. DELETE may have
 	// empty target list if there no after trigger present. Skip creating in
 	// such case.
 	if (md_rel->HasDroppedColumns() &&

--- a/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-HJ-And-UniversalChild.mdp
@@ -712,16 +712,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="156">
-      <dxl:DMLDelete Columns="0" ActionCol="23" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="23" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.570616" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.557257" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
             <dxl:Column ColId="24" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -736,12 +732,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.547178" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.539027" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -756,12 +749,9 @@
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.547172" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.539023" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>
@@ -775,12 +765,9 @@
             </dxl:JoinFilter>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="10"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="ctid">
                   <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DML-With-MasterOnlyTable-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DML-With-MasterOnlyTable-1.mdp
@@ -367,16 +367,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="42">
-      <dxl:DMLDelete Columns="0" ActionCol="29" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="29" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.712669" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.699310" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49152.1.0" TableName="x">
           <dxl:Columns>
             <dxl:Column ColId="30" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -391,12 +387,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.689232" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.681081" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -411,12 +404,9 @@
           <dxl:OneTimeFilter/>
           <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.689226" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.681076" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>
@@ -430,12 +420,9 @@
             </dxl:JoinFilter>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="10"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="ctid">
                   <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -722,16 +722,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="238">
-      <dxl:DMLDelete Columns="0" ActionCol="21" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="21" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.965580" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.960365" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.49433.1.0" TableName="test2">
           <dxl:Columns>
             <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -746,12 +742,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.942142" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.942136" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -766,12 +759,9 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.942136" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.942132" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -338,22 +338,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="40">
-      <dxl:DMLDelete Columns="0,1,2" ActionCol="24" CtidCol="3" SegmentIdCol="9">
+      <dxl:DMLDelete Columns="" ActionCol="24" CtidCol="3" SegmentIdCol="9">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.025894" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.014131" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="i">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="j">
-            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="k">
-            <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
           <dxl:Columns>
             <dxl:Column ColId="25" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -370,18 +360,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000503" Rows="1.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000459" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="i">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="j">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="k">
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="ctid">
               <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -396,18 +377,9 @@
           <dxl:OneTimeFilter/>
           <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000497" Rows="1.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000455" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="j">
-                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="k">
-                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="3" Alias="ctid">
                 <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>
@@ -419,18 +391,9 @@
             <dxl:SortingColumnList/>
             <dxl:HashJoin JoinType="In">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000480" Rows="1.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000448" Rows="1.000000" Width="10"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="j">
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="k">
-                  <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="ctid">
                   <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
@@ -448,17 +411,11 @@
               </dxl:HashCondList>
               <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="14"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="j">
-                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="k">
-                    <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="ctid">
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -476,17 +433,11 @@
                 </dxl:HashExprList>
                 <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
                       <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="j">
-                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="k">
-                      <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="3" Alias="ctid">
                       <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -518,17 +469,11 @@
                   </dxl:PartitionSelector>
                   <dxl:DynamicTableScan PartIndexId="1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="i">
                         <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="j">
-                        <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="k">
-                        <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="3" Alias="ctid">
                         <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomDistr.mdp
@@ -203,19 +203,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="0,1" ActionCol="9" CtidCol="2" SegmentIdCol="8">
+      <dxl:DMLDelete Columns="" ActionCol="9" CtidCol="2" SegmentIdCol="8">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.043023" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.027391" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.17027.1.1" TableName="rr">
           <dxl:Columns>
             <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -231,15 +224,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="ctid">
               <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -254,15 +241,9 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="1.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="ctid">
                 <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTable.mdp
@@ -196,16 +196,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="0" ActionCol="8" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="8" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023458" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.018246" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1" LockMode="3">
           <dxl:Columns>
             <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -220,12 +216,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -240,12 +233,9 @@
           <dxl:OneTimeFilter/>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp
@@ -278,16 +278,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="17">
-      <dxl:DMLDelete Columns="0" ActionCol="16" CtidCol="1" SegmentIdCol="7">
+      <dxl:DMLDelete Columns="" ActionCol="16" CtidCol="1" SegmentIdCol="7">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.023911" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.018692" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16414.1.0" TableName="foo" LockMode="3">
           <dxl:Columns>
             <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -302,12 +298,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000473" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000463" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="ctid">
               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -322,12 +315,9 @@
           <dxl:OneTimeFilter/>
           <dxl:RoutedDistributeMotion SegmentIdCol="7" InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000467" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000458" Rows="1.000000" Width="10"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="ctid">
                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
               </dxl:ProjElem>
@@ -339,12 +329,9 @@
             <dxl:SortingColumnList/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000453" Rows="1.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000448" Rows="1.000000" Width="10"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="ctid">
                   <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>

--- a/src/backend/gporca/data/dxl/minidump/DeleteWithAfterTriggerDroppedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteWithAfterTriggerDroppedCol.mdp
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table t(i int, j int);
+insert into t values(1,2);
+alter table t drop column j;
+create function func_trigger() returns trigger as
+$$begin
+    raise notice '%', old.i;
+    return old;
+end;$$ language 'plpgsql';
+create trigger trg_t_after_delete after delete on t
+for each row execute procedure func_trigger();
+set optimizer_enable_dml_triggers to on;
+explain verbose delete from t where i = 1;
+
+delete from t where i = 1;
+
+drop table t;
+drop function func_trigger();
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBFunc Mdid="0.97548.1.0" Name="func_trigger" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.2279.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBTrigger Mdid="0.97549.1.0" Name="trg_t_after_delete" RelationMdid="6.97545.1.0" FuncId="0.97548.1.0" IsRow="true" IsBefore="false" IsInsert="false" IsDelete="true" IsUpdate="false" IsEnabled="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.97545.1.0" Name="t" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.97545.1.0" Name="t" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="........pg.dropped.2........" Attno="2" Mdid="0.0.0.0" Nullable="true" ColWidth="8" IsDropped="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers>
+          <dxl:Trigger Mdid="0.97549.1.0"/>
+        </dxl:Triggers>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.97545.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="6.97545.1.0" TableName="t">
+          <dxl:Columns>
+            <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalSelect>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.97545.1.0" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.023504" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:ProjList/>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:RowTrigger RelationMdid="6.97545.1.0" Type="9" OldColumns="0">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.023504" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:DMLDelete Columns="0" ActionCol="8" CtidCol="1" SegmentIdCol="7">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.023504" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:DirectDispatchInfo/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:TableDescriptor Mdid="6.97545.1.0" TableName="t">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="18"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="ctid">
+                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="ColRef_0008">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="14"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="i">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="ctid">
+                    <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                    <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="6.97545.1.0" TableName="t">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:Result>
+          </dxl:DMLDelete>
+        </dxl:RowTrigger>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
@@ -234,19 +234,12 @@
       </dxl:LogicalDelete>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLDelete Columns="0,1" ActionCol="9" CtidCol="2" OidCol="7" SegmentIdCol="8">
+      <dxl:DMLDelete Columns="" ActionCol="9" CtidCol="2" OidCol="7" SegmentIdCol="8">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.033894" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023473" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="i">
-            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="j">
-            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
+        <dxl:ProjList/>
         <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
           <dxl:Columns>
             <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -262,15 +255,9 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="i">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="j">
-              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="ctid">
               <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
             </dxl:ProjElem>
@@ -288,12 +275,9 @@
           <dxl:OneTimeFilter/>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="i">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="j">
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
@@ -335,12 +319,9 @@
             </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="18"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="i">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="j">
                   <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -61,6 +61,7 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/DML-Replicated-Input.mdp",
 	"../data/dxl/minidump/InsertWithTriggers.mdp",
 	"../data/dxl/minidump/DeleteWithTriggers.mdp",
+	"../data/dxl/minidump/DeleteWithAfterTriggerDroppedCol.mdp",
 	"../data/dxl/minidump/UpdateWithTriggers.mdp",
 	"../data/dxl/minidump/InsertNotNullCols.mdp",
 	"../data/dxl/minidump/InsertCheckConstraint.mdp",

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3492,11 +3492,11 @@ explain (verbose, costs off) delete from test_1_prt_extra where j = 2;
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
  Delete
-   Output: test_1_prt_extra.i, test_1_prt_extra.j, "outer".ColRef_0009, test_1_prt_extra.ctid
+   Output: "outer".ColRef_0009, test_1_prt_extra.ctid
    ->  Result
-         Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, 0
+         Output: test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, 0
          ->  Seq Scan on partition_pruning.test_1_prt_extra
-               Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id
+               Output: test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id
                Filter: (test_1_prt_extra.j = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
@@ -3558,11 +3558,11 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Delete
-   Output: test.i, test.j, "outer".ColRef_0025, test.ctid, test.tableoid
+   Output: "outer".ColRef_0025, test.ctid, test.tableoid
    ->  Result
-         Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id, 0
+         Output: test.ctid, test.tableoid, test.gp_segment_id, 0
          ->  Hash Anti Join
-               Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id
+               Output: test.ctid, test.tableoid, test.gp_segment_id
                Hash Cond: ((test.i = test_in_predicate.i) AND (test.j = test_in_predicate.j))
                ->  Sequence
                      Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16415,11 +16415,11 @@ EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_dropped_1_prt_p2;
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Delete
-   Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, "outer".ColRef_0010, t_part_dropped_1_prt_p2.ctid
+   Output: "outer".ColRef_0010, t_part_dropped_1_prt_p2.ctid
    ->  Result
-         Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, 0
+         Output: t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id, 0
          ->  Seq Scan on public.t_part_dropped_1_prt_p2
-               Output: t_part_dropped_1_prt_p2.c1, t_part_dropped_1_prt_p2.c3, t_part_dropped_1_prt_p2.c4, t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
+               Output: t_part_dropped_1_prt_p2.ctid, t_part_dropped_1_prt_p2.gp_segment_id
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -16529,11 +16529,11 @@ EXPLAIN (COSTS OFF, VERBOSE) DELETE FROM t_part_1_prt_p2;
                                                                         QUERY PLAN                                                                         
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
  Delete
-   Output: t_part_1_prt_p2.c1, NULL::integer, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, "outer".ColRef_0011, t_part_1_prt_p2.ctid
+   Output: "outer".ColRef_0011, t_part_1_prt_p2.ctid
    ->  Result
-         Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, 0
+         Output: t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id, 0
          ->  Seq Scan on public.t_part_1_prt_p2
-               Output: t_part_1_prt_p2.c1, t_part_1_prt_p2.c2, t_part_1_prt_p2.c3, t_part_1_prt_p2.c4, t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
+               Output: t_part_1_prt_p2.ctid, t_part_1_prt_p2.gp_segment_id
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 


### PR DESCRIPTION
Currently, ORCA passes all attributes to DML node regardless of the type of
operation. Passing all user-defined attrs to delete operation causes
unnecessary scans of these attrs. This may lead to performance decreasing,
especially for column-oriented tables. In the most of cases, such attrs may be
omitted. The only exception is the "after" trigger, which needs all attrs to
work.
The goal of this patch is to change the behavior of delete operation and remove
not used attrs from DML node's targetlist. To achieve that, pdrgpcrSource,
stored in CPhysicalDML, is cleared if possible. To use it, execution part of DML
node was also changed. From now, it can work with subset of attrs in target
list, which is close to how postgres works (ModifyTable in [7x](https://github.com/greenplum-db/gpdb/blob/fb5eb8dd6afb1f0acfc0c6a29514a8f671ea2e23/src/backend/executor/nodeModifyTable.c#L3261), [6x](https://github.com/greenplum-db/gpdb/blob/f451b4d1fe84a6d45aaa4d61ffb35c9b14831fa8/src/backend/executor/nodeModifyTable.c#L2398)).
It was decided that ORCA has enough tests for DELETE operation, including one
with triggers. But there is one uncovered case with after trigger on table with
dropped column. The new mdp test file was added for this case. It's suitable for
ORCA unit tests, but a real execution of a script inside gives an error. This
bug is not related to our patch. New ticket was created internally to fix it.
________
Another solution was to separate source and output arrays and pass them to [LogicalDML](https://github.com/greenplum-db/gpdb/blob/f451b4d1fe84a6d45aaa4d61ffb35c9b14831fa8/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp#L1359) node and [PhysicalDML](https://github.com/greenplum-db/gpdb/blob/f451b4d1fe84a6d45aaa4d61ffb35c9b14831fa8/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp#L101) node. I preferred as small and as simple solution as possible. It seems that it not adds inconsistency to code and architecture.
________
I may call a historical the reason that ORCA uses all attrs for delete. The code of DML operations is unified and thus, simpler.
Another reason is that delete operations are not a typical workload for GP.
Anyway, the performance of delete queries for ORCA may be changed dramatically.

Here is the example of improved performance.
```
create table test_col(
i1 int, i2 int, i3 int, i4 int,
i5 int, i6 int, i7 int, i8 int,
i9 int, i10 int, i11 int, i12 int,
i13 int, i14 int, i15 int, i16 int
) with (appendonly=true, orientation=column);

insert into test_col select i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,i from generate_series(1,3000000) i;
explain analyze verbose delete from test_col;
```
Before patch:
```
                                                                                                                                    QUERY PLAN                                                                    
                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------
 Delete  (cost=0.00..305377.04 rows=1000000 width=1) (actual time=10510.392..14877.302 rows=1001733 loops=1)
   Output: test_col.i1, test_col.i2, test_col.i3, test_col.i4, test_col.i5, test_col.i6, test_col.i7, test_col.i8, test_col.i9, test_col.i10, test_col.i11, test_col.i12, test_col.i13, test_col.i14, test_col.i15,
 test_col.i16, "outer".ColRef_0019, test_col.ctid
   Executor Memory: 1kB  Segments: 3  Max: 1kB (segment 0)
   ->  Result  (cost=0.00..689.54 rows=1000000 width=78) (actual time=10510.183..13969.730 rows=1001733 loops=1)
         Output: test_col.i1, test_col.i2, test_col.i3, test_col.i4, test_col.i5, test_col.i6, test_col.i7, test_col.i8, test_col.i9, test_col.i10, test_col.i11, test_col.i12, test_col.i13, test_col.i14, test_co
l.i15, test_col.i16, test_col.ctid, test_col.gp_segment_id, 0
         ->  Seq Scan on public.test_col  (cost=0.00..473.90 rows=1000000 width=74) (actual time=10510.180..13387.157 rows=1001733 loops=1)
               Output: test_col.i1, test_col.i2, test_col.i3, test_col.i4, test_col.i5, test_col.i6, test_col.i7, test_col.i8, test_col.i9, test_col.i10, test_col.i11, test_col.i12, test_col.i13, test_col.i14, t
est_col.i15, test_col.i16, test_col.ctid, test_col.gp_segment_id
 Planning time: 16.792 ms
   (slice0)    Executor memory: 1786K bytes avg x 3 workers, 1786K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 18862.796 ms
(12 rows)
```
After patch:
```
                                                              QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
 Delete  (cost=0.00..55194.00 rows=1000000 width=1) (actual time=0.206..1811.698 rows=1001733 loops=1)
   Output: "outer".ColRef_0019, test_col.ctid
   Executor Memory: 1kB  Segments: 3  Max: 1kB (segment 0)
   ->  Result  (cost=0.00..506.50 rows=1000000 width=14) (actual time=0.099..1264.342 rows=1001733 loops=1)
         Output: test_col.ctid, test_col.gp_segment_id, 0
         ->  Seq Scan on public.test_col  (cost=0.00..473.90 rows=1000000 width=10) (actual time=0.098..891.939 rows=1001733 loops=1)
               Output: test_col.ctid, test_col.gp_segment_id
 Planning time: 58.020 ms
   (slice0)    Executor memory: 265K bytes avg x 3 workers, 265K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 3003.620 ms
(12 rows)
```
The real performance depends on storage, number of cols and other obvious things. The test above is from my poor storage.
_____
The final commit message should be copied from last commit.
