### PR TITLE
ADBDEV-4599: Handle external protocols for DROP OWNED BY statement

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1580,6 +1580,9 @@ RemoveRoleFromObjectACL(Oid roleid, Oid classid, Oid objid)
 			case ForeignDataWrapperRelationId:
 				istmt.objtype = ACL_OBJECT_FDW;
 				break;
+			case ExtprotocolRelationId:
+				istmt.objtype = ACL_OBJECT_EXTPROTOCOL;
+				break;
 			default:
 				elog(ERROR, "unexpected object class %u", classid);
 				break;

--- a/src/test/regress/expected/drop_owned_by_external.out
+++ b/src/test/regress/expected/drop_owned_by_external.out
@@ -1,0 +1,28 @@
+--
+-- DROP OWNED BY for external protocols
+--
+-- Set up mock external protocol
+CREATE OR REPLACE FUNCTION write_to_file()
+    RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE NO SQL;
+CREATE OR REPLACE FUNCTION read_from_file()
+    RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
+CREATE TRUSTED PROTOCOL demo_prot_dob(readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE ROLE demo_role_dob RESOURCE QUEUE pg_default;
+-- Should do nothing, as demo role owns nothing
+DROP OWNED BY demo_role_dob;
+-- Should drop protocol successfully, since it's not dropped by previous query
+DROP PROTOCOL demo_prot_dob;
+CREATE TRUSTED PROTOCOL demo_prot_dob(readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE WRITABLE EXTERNAL TABLE demo_dob_table(a int)
+    location('demo_prot_dob://demo_dob_file.txt') format 'text';
+-- Make demo role own both protocol and table
+ALTER EXTERNAL TABLE demo_dob_table OWNER TO demo_role_dob;
+ALTER PROTOCOL demo_prot_dob OWNER TO demo_role_dob;
+-- Should drop both table and protocol
+DROP OWNED BY demo_role_dob;
+-- Both should fail, since they've been dropped with DROP OWNED BY
+DROP PROTOCOL demo_prot_dob;
+ERROR:  protocol "demo_prot_dob" does not exist
+DROP TABLE demo_dob_table;
+ERROR:  table "demo_dob_table" does not exist
+DROP ROLE demo_role_dob;

--- a/src/test/regress/sql/drop_owned_by_external.sql
+++ b/src/test/regress/sql/drop_owned_by_external.sql
@@ -1,0 +1,37 @@
+--
+-- DROP OWNED BY for external protocols
+--
+
+-- Set up mock external protocol
+CREATE OR REPLACE FUNCTION write_to_file()
+    RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_export' LANGUAGE C STABLE NO SQL;
+CREATE OR REPLACE FUNCTION read_from_file()
+    RETURNS integer as '$libdir/gpextprotocol.so', 'demoprot_import' LANGUAGE C STABLE NO SQL;
+
+CREATE TRUSTED PROTOCOL demo_prot_dob(readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+CREATE ROLE demo_role_dob RESOURCE QUEUE pg_default;
+
+-- Should do nothing, as demo role owns nothing
+DROP OWNED BY demo_role_dob;
+
+-- Should drop protocol successfully, since it's not dropped by previous query
+DROP PROTOCOL demo_prot_dob;
+
+CREATE TRUSTED PROTOCOL demo_prot_dob(readfunc = 'read_from_file', writefunc = 'write_to_file');
+
+CREATE WRITABLE EXTERNAL TABLE demo_dob_table(a int)
+    location('demo_prot_dob://demo_dob_file.txt') format 'text';
+
+-- Make demo role own both protocol and table
+ALTER EXTERNAL TABLE demo_dob_table OWNER TO demo_role_dob;
+ALTER PROTOCOL demo_prot_dob OWNER TO demo_role_dob;
+
+-- Should drop both table and protocol
+DROP OWNED BY demo_role_dob;
+
+-- Both should fail, since they've been dropped with DROP OWNED BY
+DROP PROTOCOL demo_prot_dob;
+DROP TABLE demo_dob_table;
+
+DROP ROLE demo_role_dob;


### PR DESCRIPTION
When attempting to execute `DROP OWNED BY` statement with a role that is
granted access to or owns external protocols, the query will fail with the
following error:

```sql
ERROR:  unexpected object class 7175 (aclchk.c:1579) 
```

This was due to missing case in the switch statement, which is needed to set
object type when revoking privileges.

This patch fixes this by adding the missing case statement to the privilege
revoking function. 
