### PR TITLE
ADBDEV-4599: Handle external protocols for DROP OWNED BY statement

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1580,6 +1580,9 @@ RemoveRoleFromObjectACL(Oid roleid, Oid classid, Oid objid)
 			case ForeignDataWrapperRelationId:
 				istmt.objtype = ACL_OBJECT_FDW;
 				break;
+			case ExtprotocolRelationId:
+				istmt.objtype = ACL_OBJECT_EXTPROTOCOL;
+				break;
 			default:
 				elog(ERROR, "unexpected object class %u", classid);
 				break;

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -293,6 +293,16 @@ SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist:/
 DROP EXTERNAL TABLE issue_9727;
 RESET client_encoding;
 
+-- Test "DROP OWNED BY" when everything of the protocol is granted to some user.
+-- GitHub Issue #12748: https://github.com/greenplum-db/gpdb/issues/12748
+CREATE TRUSTED PROTOCOL dummy_protocol_issue_12748 (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE ROLE test_role_issue_12748;
+GRANT ALL ON PROTOCOL dummy_protocol_issue_12748 TO test_role_issue_12748;
+DROP OWNED BY test_role_issue_12748;
+-- Clean up.
+DROP ROLE test_role_issue_12748;
+DROP PROTOCOL dummy_protocol_issue_12748;
+
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -394,6 +394,16 @@ SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist:/
 
 DROP EXTERNAL TABLE issue_9727;
 RESET client_encoding;
+-- Test "DROP OWNED BY" when everything of the protocol is granted to some user.
+-- GitHub Issue #12748: https://github.com/greenplum-db/gpdb/issues/12748
+CREATE TRUSTED PROTOCOL dummy_protocol_issue_12748 (readfunc = 'read_from_file', writefunc = 'write_to_file');
+CREATE ROLE test_role_issue_12748;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+GRANT ALL ON PROTOCOL dummy_protocol_issue_12748 TO test_role_issue_12748;
+DROP OWNED BY test_role_issue_12748;
+-- Clean up.
+DROP ROLE test_role_issue_12748;
+DROP PROTOCOL dummy_protocol_issue_12748;
 --
 -- WET tests
 --


### PR DESCRIPTION
When attempting to execute `DROP OWNED BY` statement with a role that is
granted access to or owns external protocols, the query will fail with the
following error:

```sql
ERROR:  unexpected object class 7175 (aclchk.c:1579) 
```

This was due to missing case in the switch statement, which is needed to set
object type when revoking privileges.

This patch fixes this by adding the missing case statement to the privilege
revoking function.