### PR TITLE
alter precedence in favor of ipv4 during resolving

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -57,7 +57,8 @@ RUN yum -y install centos-release-scl && \
     echo -e 'source /opt/rh/devtoolset-7/enable' >> /opt/gcc_env.sh && \
     echo -e '#!/bin/sh' >> /etc/profile.d/jdk_home.sh && \
     echo -e 'export JAVA_HOME=/etc/alternatives/java_sdk' >> /etc/profile.d/jdk_home.sh && \
-    echo -e 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
+    echo -e 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh && \
+    echo -e 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
 
 RUN rpm -i $sigar && rpm -i $sigar_headers
 


### PR DESCRIPTION
gpdb test suite requires enabled ipv6 since 7f3c91f. But there is at least one src/test/ssl test that expects resolving to ipv4 address and fails in the ipv6 environment with:

```
psql: FATAL:  no pg_hba.conf entry for host "2001:db8:1::242:ac11:2",
user "ssltestuser", database "postgres", SSL on
pg_regress: cannot read the result
(using postmaster on 9f17c91f4c76, port 6000)
```

so we at least temporary try to change precedence of name resolution in favor of ipv4
