### PR TITLE
ADBDEV-4799: Fix the environment for running test suite for gpdb7

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -3,9 +3,9 @@ FROM centos:centos7 as base
 # Install some basic utilities and build tools
 RUN yum makecache && yum update -y ca-certificates && \
     rpm --import https://mirror.yandex.ru/centos/RPM-GPG-KEY-CentOS-7 && \
-    yum -y install epel-release java-1.8.0-openjdk-devel && \
+    yum -y install epel-release java-11-openjdk-devel && \
     yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
-                   ant-junit autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
+                   autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
                    krb5-server krb5-workstation xerces-c-devel file && \
     yum clean all
 
@@ -15,7 +15,7 @@ RUN yum makecache && \
     yum -y install apr-devel bzip2-devel expat-devel libcurl-devel && \
     yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
     yum -y install openssl-devel pam-devel readline-devel snappy-devel libuv-devel && \
-    yum -y install apache-ivy libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
+    yum -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     yum -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
     yum clean all
 

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,45 +1,49 @@
-FROM centos:centos7 as base
+FROM rockylinux:8.8 as base
 
 # Install some basic utilities and build tools
-RUN yum makecache && yum update -y ca-certificates && \
-    rpm --import https://mirror.yandex.ru/centos/RPM-GPG-KEY-CentOS-7 && \
-    yum -y install epel-release java-11-openjdk-devel && \
-    yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
-                   autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
-                   krb5-server krb5-workstation xerces-c-devel file && \
-    yum clean all
+RUN dnf -y install 'dnf-command(config-manager)' && dnf config-manager --set-enabled devel && dnf makecache && dnf update -y ca-certificates && \
+    rpm --import https://mirror.yandex.ru/rockylinux/RPM-GPG-KEY-Rocky-8 && \
+    dnf -y install epel-release java-11-openjdk-devel && \
+    dnf -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
+                   autoconf bison cmake3 flex gperftools indent jq libtool \
+                   krb5-server krb5-workstation xerces-c-devel file netcat passwd lsof xz && \
+    dnf clean all
 
 # install all software we need
-RUN yum makecache && \
-    yum -y install python3-devel && \
-    yum -y install apr-devel bzip2-devel expat-devel libcurl-devel && \
-    yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
-    yum -y install openssl-devel pam-devel readline-devel snappy-devel libuv-devel && \
-    yum -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
-    yum -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
-    yum clean all
+RUN dnf makecache && \
+    dnf -y install python39-devel && \
+    dnf -y install apr-devel bzip2 bzip2-devel expat-devel libcurl-devel && \
+    dnf -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
+    dnf -y install openssl-devel pam-devel readline-devel snappy-devel libuv-devel && \
+    dnf -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
+    dnf -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
+    dnf -y install python39-psycopg2 python39-psutil python39-pyyaml python39-lxml && \
+    dnf clean all && \
+    #we install pytest from pypi since the version from the repository does not contain an executable file
+    #the rest of the packages are not available in the repository.
+    pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave
+
+RUN dnf -y install \
+                --repofrompath=devel_external,https://dl.rockylinux.org/vault/rocky/8.8/devel/x86_64/os \
+                llvm-libs-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                llvm-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                llvm-test-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                llvm-static-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                llvm-devel-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                clang-resource-filesystem-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                clang-libs-15.0.7-1.module+el8.8.0+1144+0a4e73bd \
+                clang-15.0.7-1.module+el8.8.0+1144+0a4e73bd && \
+    dnf clean all
 
 # setup ssh configuration
-RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
-    cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && \
-    chmod 0600 /root/.ssh/authorized_keys && \
-    echo -e "password\npassword" | passwd 2> /dev/null && \
-    { ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /root/.ssh/known_hosts && \
-    #
-    ssh-keygen -f /etc/ssh/ssh_host_key -N '' -t rsa1 && \
-    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \
+RUN ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \
     ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa && \
     sed -i -e 's|Defaults    requiretty|#Defaults    requiretty|' /etc/sudoers && \
     sed -ri 's/UsePAM yes/UsePAM no/g;s/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
     sed -ri 's@^HostKey /etc/ssh/ssh_host_ecdsa_key$@#&@;s@^HostKey /etc/ssh/ssh_host_ed25519_key$@#&@' /etc/ssh/sshd_config
 
-# newer version of gcc and run environment for gpdb
-RUN yum -y install centos-release-scl && \
-    yum -y install --nogpgcheck devtoolset-7-gcc devtoolset-7-gcc-c++ \
-    llvm-toolset-7 llvm-toolset-7-llvm-devel && yum clean all && \
-    ln -s /usr/bin/cmake3 /usr/bin/cmake && \
-    ln -s /usr/bin/ctest3 /usr/bin/ctest && \
-    echo -e 'source /opt/rh/devtoolset-7/enable' >> /opt/gcc_env.sh && \
+# run environment for gpdb
+RUN \
     echo -e '#!/bin/sh' >> /etc/profile.d/jdk_home.sh && \
     echo -e 'export JAVA_HOME=/etc/alternatives/java_sdk' >> /etc/profile.d/jdk_home.sh && \
     echo -e 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
@@ -52,8 +56,8 @@ COPY . gpdb_src
 
 RUN mkdir /home/gpadmin/bin_gpdb
 
-ENV TARGET_OS_VERSION=7
-ENV TARGET_OS=centos
+ENV TARGET_OS_VERSION=8
+ENV TARGET_OS=rocky8
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
 ENV SKIP_UNITTESTS=
 # To set default locale for unittests
@@ -61,8 +65,7 @@ ENV LANG=en_US.UTF-8
 ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
 
 # Compile with running mocking tests
-RUN scl enable devtoolset-7 llvm-toolset-7 'bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash'
-
+RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash
 FROM base as code
 COPY . gpdb_src
 RUN rm -rf gpdb_src/.git/
@@ -70,5 +73,3 @@ RUN rm -rf gpdb_src/.git/
 FROM base as test
 COPY --from=code /home/gpadmin/gpdb_src gpdb_src
 COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
-
-RUN echo -e '/opt/rh/llvm-toolset-7/root/usr/lib64/\n' >> /etc/ld.so.conf && ldconfig

--- a/arenadata/docker-compose.yaml
+++ b/arenadata/docker-compose.yaml
@@ -2,12 +2,12 @@
 
 version: "3"
 services:
-  #image can be either hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}-x86-64 or
-  #hub.adsw.io/library/gpdb6_regress:${BRANCH_NAME}-ppc64le depending on the arch
-  mdw:
+  #image can be either hub.adsw.io/library/gpdb7_regress:${BRANCH_NAME}-x86-64 or
+  #hub.adsw.io/library/gpdb7_regress:${BRANCH_NAME}-ppc64le depending on the arch
+  cdw:
     image: "${IMAGE}"
     working_dir: /home/gpadmin
-    hostname: mdw
+    hostname: cdw
     volumes:
       - "$PWD/ssh_keys/id_rsa:/home/gpadmin/.ssh/id_rsa"
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
@@ -15,8 +15,9 @@ services:
     privileged: true
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw1:
     image: "${IMAGE}"
     privileged: true
@@ -26,8 +27,9 @@ services:
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw2:
     image: "${IMAGE}"
     privileged: true
@@ -37,8 +39,9 @@ services:
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw3:
     image: "${IMAGE}"
     privileged: true
@@ -48,5 +51,6 @@ services:
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity

--- a/arenadata/readme.md
+++ b/arenadata/readme.md
@@ -22,16 +22,15 @@ We need to execute [../concourse/scripts/ic_gpdb.bash](../concourse/scripts/ic_g
 
 ```bash
  docker run --name gpdb7_opt_on --rm -it -e TEST_OS=centos \
-  -e MAKE_TEST_COMMAND=-k PGOPTIONS='-c optimizer=on' installcheck-world \
-  --sysctl kernel.sem=500 1024000 200 4096 gpdb7_regress:latest \
-  scl enable devtoolset-7 llvm-toolset-7 \
+  -e MAKE_TEST_COMMAND="-k PGOPTIONS='-c optimizer=on' installcheck-world" \
+  --sysctl "kernel.sem=500 1024000 200 4096" gpdb7_regress:latest \
   /home/gpadmin/gpdb_src/concourse/scripts/ic_gpdb.bash
 ```
 
 * we need to modify `MAKE_TEST_COMMAND` environment variable to run different suite. e.g. we may run test againt Postgres optimizer or ORCA with altering `PGOPTIONS` environment variable;
-* we need to run container as `--privileged` to run debugger inside it
 * we need to increase semaphore amount to be able to run demo cluster
-* we need running ssh server to be able to run demo cluster
+
+To use gdb inside the container, add the `--privileged` flag to the run command.
 
 ## ORCA linter
 
@@ -54,7 +53,7 @@ docker run --rm -it gpdb7_regress:latest bash -c "gpdb_src/concourse/scripts/uni
 1. Start container with
    ```bash
    docker run --name gpdb7_demo --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpdb7_regress:latest \
-     scl enable devtoolset-7 llvm-toolset-7 bash
+     bash
    ```
 1. Run the next commands in container
    ```bash
@@ -89,15 +88,10 @@ bash arenadata/scripts/run_behave_tests.bash gpstart gpstop
 ```
 
 
-Tests use `allure-behave` package and store allure output files in `allure-results` folder
-**NOTE** that `allure-behave` has too old a version because it is compatible with `python2`.
-Also, the allure report for each failed test has gpdb logs attached files. See `gpMgmt/test/behave_utils/arenadata/formatter.py`
-It required to add `gpMgmt/tests` directory to `PYTHONPATH`.
+Tests use `allure-behave` package and store allure output files in `allure-results` folder.
 
 Greenplum cluster in Docker containers has its own peculiarities in preparing a cluster for tests.
 All tests are run in one way or another on the demo cluster, wherever possible.
 For example, cross_subnet tests or tests with tag `concourse_cluster` currently not worked because of too complex cluster preconditions.
 
 Tests in a docker-compose cluster use the same ssh keys for `gpadmin` user and pre-add the cluster hosts to `.ssh/know_hosts` and `/etc/hosts`.
-
-Docker containers have installed `sigar` libraries. It is required only for `gpperfmon` tests.

--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -57,11 +57,9 @@ run_feature() {
   wait
   docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
     -e FEATURE="$feature" -e BEHAVE_FLAGS="--tags $feature --tags=$cluster \
-      -f behave_utils.arenadata.formatter:CustomFormatter \
-      -o non-existed-output \
       -f allure_behave.formatter:AllureFormatter \
       -o /tmp/allure-results"  \
-    mdw gpdb_src/arenadata/scripts/behave_gpdb.bash
+    cdw gpdb_src/arenadata/scripts/behave_gpdb.bash
   status=$?
 
   docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env down -v

--- a/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_old_ssl.source
@@ -1,3 +1,30 @@
+--
+-- GPFDISTS test cases
+--
+
+-- start_ignore
+drop external table if exists gpfdist_ssl_start;
+drop external table if exists gpfdist_ssl_stop;
+-- end_ignore
+
+-- --------------------------------------
+-- 'gpfdists' protocol
+-- --------------------------------------
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 6`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
+execute E'(ps -A -o pid,comm |grep [g]pfdist |grep -v postgres: |awk \'{print $1;}\' |xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+select * from gpfdist_ssl_start;
+-- end_ignore
+
 CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
@@ -24,3 +51,7 @@ select * from curl_with_tls10;
 select * from curl_with_tls11;
 drop external table if exists curl_with_tls10;
 drop external table if exists curl_with_tls11;
+
+-- start_ignore
+select * from gpfdist_ssl_stop;
+-- end_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist_old_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_old_ssl.source
@@ -1,3 +1,37 @@
+--
+-- GPFDISTS test cases
+--
+-- start_ignore
+drop external table if exists gpfdist_ssl_start;
+NOTICE:  table "gpfdist_ssl_start" does not exist, skipping
+drop external table if exists gpfdist_ssl_stop;
+NOTICE:  table "gpfdist_ssl_stop" does not exist, skipping
+-- end_ignore
+-- --------------------------------------
+-- 'gpfdists' protocol
+-- --------------------------------------
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --ssl @abs_srcdir@/data/gpfdist_ssl/certs_matching </dev/null >/dev/null 2>&1 &); for i in `seq 1 6`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; ps -A -o pid,comm |grep [g]pfdist |grep -v postgres:) '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE gpfdist_ssl_stop (x text)
+execute E'(ps -A -o pid,comm |grep [g]pfdist |grep -v postgres: |awk \'{print $1;}\' |xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist_ssl_start;
+       x       
+---------------
+ 26034 gpfdist
+(1 row)
+
+-- end_ignore
 CREATE EXTERNAL WEB TABLE curl_with_tls10 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.0";fi;
@@ -34,3 +68,11 @@ select * from curl_with_tls11;
 
 drop external table if exists curl_with_tls10;
 drop external table if exists curl_with_tls11;
+-- start_ignore
+select * from gpfdist_ssl_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore


### PR DESCRIPTION
Fix the environment for running test suite for gpdb7

The container base has been changed from CentOS 7 to Rocky 8.8.
Dnf is now used instead of yum as a package manager.
Devtoolset-7 was removed since the necessary tools are available in the base
repository.
RSA1 key generation was removed since it's deprecated.
In docker-compose, the coordinator's name has been changed from mdw to cdw.
Containers also now use the init process to prevent zombie processes from
appearing.
Packages for llvm and clang are taken from the vault, since only clang-16 is
available in the main repository, and the build gpdb with llvm 16+ is not
supported.
Cherry-picked commit c24d7e60d7f8569522b2716b77e0905c91ad3d4f to fix gpfdist
tests with TLS 1.0 and TLS 1.1.
The attachment of gpdb logs to the allure report will be added as a separate patch.