### PR TITLE
ADBDEV-4607: Revert "temporary change test order to mute checkcat test"

### DIFF
--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -15,6 +15,8 @@ test: select_dropped_table
 test: update_hash_col_utilitymode execute_on_utilitymode
 
 # Tests for crash recovery
+test: uao_crash_compaction_column
+test: uao_crash_compaction_row
 test: crash_recovery
 test: crash_recovery_redundant_dtx
 test: crash_recovery_dtm
@@ -24,8 +26,6 @@ test: udf_exception_blocks_panic_scenarios
 test: ao_same_trans_truncate_crash
 test: frozen_insert_crash
 test: ao_fsync_panic
-test: uao_crash_compaction_column
-test: uao_crash_compaction_row
 
 test: prevent_ao_wal
 


### PR DESCRIPTION
This patch reverts the 7e8eb2dd2c375622b1a2087e0243d659a43efdae commit.
Since there was the https://github.com/greenplum-db/gpdb/issues/14837 problem in
GPDB, the order of tests was changed to avoid it. The problem has now been fixed
with the https://github.com/arenadata/gpdb/pull/585 patch. Therefore, we can now
restore the previous order of tests.