### PR TITLE
ADBDEV-4722: Fix ABI test pipeline

### DIFF
--- a/.abi-check/6.26.0/postgres.symbols.ignore
+++ b/.abi-check/6.26.0/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get Greenplum version variables
         id: vars
         run: |
-          remote_repo='https://github.com/greenplum-db/gpdb.git'
+          remote_repo='https://github.com/arenadata/gpdb.git'
           git ls-remote --tags --refs --sort='v:refname' $remote_repo '6.*' | tail -n 1  > baseline_version_ref
           baseline_ref=$(cat baseline_version_ref | awk '{print $1}')
           baseline_version=$(cat baseline_version_ref | awk '{print $2}')
@@ -53,7 +53,7 @@ jobs:
   abi-dump:
     needs: abi-dump-setup
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb6-rocky8-build
+    container: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
     strategy:
       matrix:
         name:
@@ -61,7 +61,7 @@ jobs:
           - build-latest
         include:
           - name: build-baseline
-            repo: greenplum-db/gpdb
+            repo: arenadata/gpdb
             ref: ${{ needs.abi-dump-setup.outputs.BASELINE_VERSION }}
           - name: build-latest
             repo: ${{ github.repository }}
@@ -76,6 +76,8 @@ jobs:
           tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
           cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
           which ctags
+          yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+          yum install -y git
 
       - name: Download Greenplum source code
         uses: actions/checkout@v3
@@ -90,6 +92,7 @@ jobs:
         run: |
           yum install -y epel-release
           yum install -y abi-dumper
+          yum install -y libzstd-static
 
       - name: Build Greenplum
         run: |
@@ -122,7 +125,7 @@ jobs:
       - abi-dump-setup
       - abi-dump
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb6-rocky8-build
+    container: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v3
@@ -145,7 +148,7 @@ jobs:
         run: |
           yum install -y epel-release
           yum install -y abi-compliance-checker
-          yum install -y --enablerepo=powertools lynx
+          yum install -y lynx
 
       - name: Compare ABI
         run: |

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -28,6 +28,7 @@ jobs:
       BASELINE_VERSION: ${{ steps.vars.outputs.BASELINE_VERSION }}
       ABI_LIBS: ${{ steps.vars.outputs.ABI_LIBS }}
       ABI_HEADERS: ${{ steps.vars.outputs.ABI_HEADERS }}
+      EXCEPTION_LISTS_COUNT: ${{ steps.check_exception_lists.outputs.EXCEPTION_LISTS_COUNT }}
     steps:
       - name: Fetch source
         uses: actions/checkout@v3
@@ -44,7 +45,14 @@ jobs:
           echo "ABI_LIBS=postgres" | tee -a $GITHUB_OUTPUT
           echo "ABI_HEADERS=." | tee -a $GITHUB_OUTPUT
 
+      - name: Check if exception list exists
+        id: check_exception_lists
+        run: |
+          exception_lists_count=$(ls .abi-check/${{ steps.vars.outputs.BASELINE_VERSION }}/ 2> /dev/null | wc -l)
+          echo "EXCEPTION_LISTS_COUNT=${exception_lists_count}" | tee -a $GITHUB_OUTPUT
+
       - name: Upload symbol/type checking exception list
+        if: steps.check_exception_lists.outputs.EXCEPTION_LISTS_COUNT != '0'
         uses: actions/upload-artifact@v3
         with:
           name: exception_lists
@@ -139,6 +147,7 @@ jobs:
           path: build-latest/
 
       - name: Download exception lists
+        if: needs.abi-dump-setup.outputs.EXCEPTION_LISTS_COUNT != '0'
         uses: actions/download-artifact@v3
         with:
           name: exception_lists


### PR DESCRIPTION
The container image is changed from Rocky 8 to CentOS 7 to install zstd-static.
The repository to compate with is changed to Arenadata fork.
Git is installed from the endpointdev repository to clone with submodules.
Lynx is now installed from the main repository, because it is located in the
CentOS 7 main repository and there is no powertools repository in CentOS 7. 

Also cherry-picked a commit which fixes the tests failure if there is no file
with a list of ignored symbols.