### PR TITLE
Upgrade Java 1.8 to Java 11 in arenadata/Dockerfile

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -12,9 +12,9 @@ RUN sed -i 's/\(override_install_langs*\)/# \1/' /etc/yum.conf && \
 # Install some basic utilities and build tools
 RUN yum makecache && yum update -y ca-certificates && \
     rpm --import https://mirror.yandex.ru/centos/RPM-GPG-KEY-CentOS-7 && \
-    yum -y install epel-release java-1.8.0-openjdk-devel && \
+    yum -y install epel-release java-11-openjdk-devel && \
     yum -y install git iproute net-tools openssh-server rsync sudo time vim wget unzip \
-                   ant-junit autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
+                   autoconf bison cmake3 flex gperf indent jq libtool gcc-c++ \
                    krb5-server krb5-workstation xerces-c-devel && \
     yum clean all
 
@@ -25,7 +25,7 @@ RUN yum makecache && \
     yum -y install apr-devel apr-util-devel bzip2-devel expat-devel libcurl-devel && \
     yum -y install libevent-devel libuuid-devel libxml2-devel libyaml-devel libzstd-devel && \
     yum -y install openssl-devel pam-devel readline-devel snappy-devel libuv-devel && \
-    yum -y install apache-ivy libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
+    yum -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     yum -y install perl-IPC-Run perl-Test-Base libxslt-devel && \
     yum -y install libzstd-static && \
     # The last python 2.7 pip


### PR DESCRIPTION
We are going to move our programs to be running on Java 11. All these programs use the docker image (arenadata/Dockerfile) to run a lot of different kind of tests. So, we need Java 11 to test these programs. This PR replaces Java 1.8 with Java 11.   