### PR TITLE
ADBDEV-4728: Fix the check for address availability when setting up UDP sockets in IPv6 disabled environments

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1197,6 +1197,16 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
 	hints.ai_protocol = 0;		/* Any protocol */
 
+	/*
+	 * Use AI_ADDRCONFIG to avoid returning IPv6 addresses if IPv6 is disabled.
+	 * We cannot really detect IPv6 availability only with a bind(), because
+	 * bind() to an IPv6 wildcard (::) will result in a special behavior on
+	 * Linux, binding to both IPv6 and IPv4. In case IPv6 is disabled, only
+	 * IPv4 will be bound, but bind() will not fail. We may cache the address,
+	 * and any connect() or sendto() to this cached address will cause errors.
+	 */
+	hints.ai_flags = AI_ADDRCONFIG;
+
 #ifdef USE_ASSERT_CHECKING
 	if (gp_udpic_network_disable_ipv6)
 		hints.ai_family = AF_INET;

--- a/src/backend/cdb/motion/test/Makefile
+++ b/src/backend/cdb/motion/test/Makefile
@@ -1,0 +1,9 @@
+subdir=src/backend/cdb/motion
+top_builddir=../../../../..
+include $(top_builddir)/src/Makefile.global
+
+TARGETS=cdbsenddummypacket
+
+include $(top_builddir)/src/backend/mock.mk
+
+cdbsenddummypacket.t: EXCL_OBJS += src/backend/cdb/motion/ic_udpifc.o

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -1,0 +1,331 @@
+#include <unistd.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../../motion/ic_udpifc.c"
+
+bool break_loop = false;
+
+/*
+ * PROTOTYPES
+ */
+
+extern ssize_t __real_sendto(int sockfd, const void *buf, size_t len, int flags,
+							 const struct sockaddr *dest_addr, socklen_t addrlen);
+int __wrap_errcode(int sqlerrcode);
+int __wrap_errdetail(const char *fmt,...);
+int __wrap_errmsg(const char *fmt,...);
+ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags,
+					  const struct sockaddr *dest_addr, socklen_t addrlen);
+void __wrap_elog_finish(int elevel, const char *fmt,...);
+void __wrap_elog_start(const char *filename, int lineno, const char *funcname);
+void __wrap_errfinish(int dummy __attribute__((unused)),...);
+void __wrap_errstart(int elevel, const char *filename, int lineno, const char *funcname, const char *domain);
+void __wrap_write_log(const char *fmt,...);
+
+/*
+ * WRAPPERS
+ */
+
+int __wrap_errcode(int sqlerrcode)  {return 0;}
+int __wrap_errdetail(const char *fmt,...) { return 0; }
+int __wrap_errmsg(const char *fmt,...) { return 0; }
+void __wrap_elog_start(const char *filename, int lineno, const char *funcname) {}
+void __wrap_errfinish(int dummy __attribute__((unused)),...) {}
+void __wrap_errstart(int elevel, const char *filename, int lineno, const char *funcname, const char *domain){}
+
+void __wrap_write_log(const char *fmt,...)
+{
+	/* check if we actually receive the message that sends the error */
+	if (strcmp("Interconnect error: short conn receive (\%d)", fmt) == 0)
+		break_loop = true;
+}
+
+void __wrap_elog_finish(int elevel, const char *fmt,...)
+{
+	assert_true(elevel <= LOG);
+}
+
+ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+	assert_true(sockfd != PGINVALID_SOCKET);
+#if defined(__darwin__)
+	/* check to see if we converted the wildcard value to something routeable */
+	if (udp_dummy_packet_sockaddr.ss_family == AF_INET6)
+	{
+		const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) dest_addr;
+		char address[INET6_ADDRSTRLEN];
+		inet_ntop(AF_INET6, &in6->sin6_addr, address, sizeof(address));
+		/* '::' and '::1' should always be '::1' */
+		assert_true(strcmp("::1", address) == 0);
+	}
+#endif
+
+	return	__real_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+/*
+ * HELPER FUNCTIONS
+ */
+
+static void wait_for_receiver(bool should_fail)
+{
+	int counter = 0;
+	/* break_loop should be reset at the beginning of each test
+	 * The while loop will end early once __wrap_write_log is called;
+	 * this should happen when the receiver polls the message that
+	 * SendDummyPacket sends.
+	 */
+	while(!break_loop)
+	{
+		/* we are sleeping for a generous amount of time; we should never
+		 * need this much time. There is something wrong if it takes this long.
+		 *
+		 * expect to fail if the communication is invalid, i.e,. IPv4 to IPv6
+		 */
+		if (counter > 2)
+			break;
+		sleep(1);
+		counter++;
+	}
+
+	if (should_fail)
+		assert_true(counter > 2);
+	else
+		assert_true(counter < 2);
+}
+
+static void
+start_receiver()
+{
+	pthread_attr_t	t_atts;
+	sigset_t		pthread_sigs;
+	int				pthread_err;
+
+	pthread_attr_init(&t_atts);
+	pthread_attr_setstacksize(&t_atts, Max(PTHREAD_STACK_MIN, (128 * 1024)));
+	ic_set_pthread_sigmasks(&pthread_sigs);
+	pthread_err = pthread_create(&ic_control_info.threadHandle, &t_atts, rxThreadFunc, NULL);
+	ic_reset_pthread_sigmasks(&pthread_sigs);
+
+	pthread_attr_destroy(&t_atts);
+	if (pthread_err != 0)
+	{
+		ic_control_info.threadCreated = false;
+		printf("failed to create thread");
+		fail();
+	}
+
+	ic_control_info.threadCreated = true;
+}
+
+static sa_family_t
+create_sender_socket(sa_family_t af)
+{
+	int sockfd = socket(af,
+						SOCK_DGRAM,
+						0);
+	if (sockfd < 0)
+	{
+		printf("send dummy packet failed, create socket failed: %m\n");
+		fail();
+		return PGINVALID_SOCKET;
+	}
+
+	if (!pg_set_noblock(sockfd))
+	{
+		if (sockfd >= 0)
+		{
+			closesocket(sockfd);
+		}
+		printf("send dummy packet failed, setting socket with noblock failed: %m\n");
+		fail();
+		return PGINVALID_SOCKET;
+	}
+
+	return sockfd;
+}
+
+/*
+ * START UNIT TEST
+ */
+
+static void
+test_send_dummy_packet_ipv4_to_ipv4(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "0.0.0.0";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET);
+	ICSenderFamily = AF_INET;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in *in = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET);
+	assert_true(in->sin_family == AF_INET);
+	assert_true(listenerPort == ntohs(in->sin_port));
+	assert_true(strcmp("0.0.0.0", inet_ntoa(in->sin_addr)) == 0);
+
+	wait_for_receiver(false);
+}
+
+/* Sending from IPv4 to receiving on IPv6 is currently not supported.
+ * The size of AF_INET6 is bigger than the side of IPv4, so converting from
+ * IPv6 to IPv4 may potentially not work.
+ */
+static void
+test_send_dummy_packet_ipv4_to_ipv6_should_fail(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET);
+	ICSenderFamily = AF_INET;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(true);
+}
+
+static void
+test_send_dummy_packet_ipv6_to_ipv6(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::1";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(false);
+}
+
+static void
+test_send_dummy_packet_ipv6_to_ipv4(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "0.0.0.0";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in *in = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET);
+	assert_true(in->sin_family == AF_INET);
+	assert_true(listenerPort == ntohs(in->sin_port));
+	assert_true(strcmp("0.0.0.0", inet_ntoa(in->sin_addr)) == 0);
+
+	wait_for_receiver(false);
+}
+
+
+static void
+test_send_dummy_packet_ipv6_to_ipv6_wildcard(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = "::";
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET6);
+	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET6);
+	assert_true(in6->sin6_family == AF_INET6);
+	assert_true(listenerPort == ntohs(in6->sin6_port));
+
+	wait_for_receiver(false);
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	int is_ipv6_supported = true;
+	int sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (sockfd < 0 && errno == EAFNOSUPPORT)
+		is_ipv6_supported = false;
+
+	log_min_messages = DEBUG1;
+
+	start_receiver();
+
+	if (is_ipv6_supported)
+	{
+		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
+			unit_test(test_send_dummy_packet_ipv4_to_ipv6_should_fail),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv6),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv4),
+			unit_test(test_send_dummy_packet_ipv6_to_ipv6_wildcard),
+		};
+		return run_tests(tests);
+	}
+	else
+	{
+		printf("WARNING: IPv6 is not supported, skipping unittest\n");
+		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
+		};
+		return run_tests(tests);
+	}
+	return 0;
+}

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -1,3 +1,5 @@
+#include <netinet/in.h>
+#include <ifaddrs.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -7,6 +9,7 @@
 #include "../../motion/ic_udpifc.c"
 
 bool break_loop = false;
+static bool is_ipv6_supported = true;
 
 /*
  * PROTOTYPES
@@ -148,9 +151,92 @@ create_sender_socket(sa_family_t af)
 	return sockfd;
 }
 
+static bool
+check_for_ipv6(void)
+{
+	struct ifaddrs *ifaddr_first;
+
+	if (getifaddrs(&ifaddr_first) == -1)
+	{
+		printf("send dummy packet failed, getifaddrs failed: %m");
+		fail();
+	}
+
+	for (struct ifaddrs *ifaddr = ifaddr_first; ifaddr != NULL; ifaddr = ifaddr->ifa_next)
+	{
+		/*
+		 * getaddrinfo() with AI_ADDRCONFIG skips loopback addresses, so we
+		 * skip them too.
+		 */
+		if (ifaddr->ifa_addr != NULL &&
+			ifaddr->ifa_addr->sa_family == AF_INET6 &&
+			!IN6_IS_ADDR_LOOPBACK(&((struct sockaddr_in6 *) ifaddr->ifa_addr)->sin6_addr))
+		{
+			freeifaddrs(ifaddr_first);
+			return true;
+		}
+	}
+
+	if (ifaddr_first)
+		freeifaddrs(ifaddr_first);
+
+	return false;
+}
+
 /*
  * START UNIT TEST
  */
+
+/*
+ * On Linux, bind() to an IPv6 wildcard will result in binding to both IPv6 and
+ * IPv4 and wont fail even if IPv6 is not available. We should not cache an
+ * AF_INET6 address when IPv6 is not available, since it will be impossible to
+ * connect to it. Address family should be correctly decided by AI_ADDRCONFIG
+ * flag for getaddrinfo() from setupUDPListeningSocket().
+ */
+static void
+test_send_dummy_packet_default_wildcard(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	char *saveICAddress = interconnect_address;
+	int saveICType = Gp_interconnect_address_type;
+
+	interconnect_address = NULL;
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_WILDCARD;
+
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+	setupUDPListeningSocket(&ICSenderSocket, &ICSenderPort, &ICSenderFamily, NULL);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	SendDummyPacket();
+
+	if (is_ipv6_supported)
+	{
+		const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *) &udp_dummy_packet_sockaddr;
+		assert_true(txFamily == AF_INET6);
+		assert_true(in6->sin6_family == AF_INET6);
+		assert_true(listenerPort == ntohs(in6->sin6_port));
+	}
+	else
+	{
+		const struct sockaddr_in *in4 = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+		assert_true(txFamily == AF_INET);
+		assert_true(in4->sin_family == AF_INET);
+		assert_true(listenerPort == ntohs(in4->sin_port));
+		assert_true(strcmp("0.0.0.0", inet_ntoa(in4->sin_addr)) == 0);
+	}
+
+	Gp_interconnect_address_type = saveICType;
+	interconnect_address = saveICAddress;
+
+	wait_for_receiver(false);
+}
 
 static void
 test_send_dummy_packet_ipv4_to_ipv4(void **state)
@@ -299,11 +385,7 @@ main(int argc, char* argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	int is_ipv6_supported = true;
-	int sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
-	if (sockfd < 0 && errno == EAFNOSUPPORT)
-		is_ipv6_supported = false;
-
+	is_ipv6_supported = check_for_ipv6();
 	log_min_messages = DEBUG1;
 
 	start_receiver();
@@ -311,6 +393,7 @@ main(int argc, char* argv[])
 	if (is_ipv6_supported)
 	{
 		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_default_wildcard),
 			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
 			unit_test(test_send_dummy_packet_ipv4_to_ipv6_should_fail),
 			unit_test(test_send_dummy_packet_ipv6_to_ipv6),
@@ -323,6 +406,7 @@ main(int argc, char* argv[])
 	{
 		printf("WARNING: IPv6 is not supported, skipping unittest\n");
 		const UnitTest tests[] = {
+			unit_test(test_send_dummy_packet_default_wildcard),
 			unit_test(test_send_dummy_packet_ipv4_to_ipv4),
 		};
 		return run_tests(tests);


### PR DESCRIPTION
Fix the check for address availability when setting up UDP sockets in IPv6
disabled environments

This patch brings changes introduced in 7f3c91f (which backported 70306db,
1ee34a4) and fixes them by correctly handling IPv6 addresses.

In these patches, a fix was created for `UDPIFC` that reworked
`SendDummyPacket()` by removing the unnecessary call to `getaddrinfo()` to avoid
using `malloc()` in a signal handler, making `setupUDPListeningSocket` cache the
address of the socket used for the `UDPIFC` interconnect when it was first
created.

In IPv6 disabled environments, `bind()` with address of an IPv6 wildcard will
result in binding to both IPv6 and IPv4 (since IPv6 is disabled, only IPv4 will
be bound) on all interfaces, and it won’t fail even if IPv6 is disabled. This
mistakenly passed the check and cached address with IPv6 address family. In IPv6
disabled environments, any `connect()` or `sendto()` that reuse this address
would fail. This fail occured when we wanted to send a dummy packet with
`SendDummyPacket()` using the cached address.

Add `AI_ADDRCONFIG` flag to `getaddrinfo()` hints to force it to check for
availability of the address families. This flag will prevent `getaddrinfo()`
from returning addresses that belong to the IPv6 family when IPv6 is not
available on the host machine.

This problem is present only when `INTERCONNECT_ADDRESS_TYPE_WILDCARD` is used
as the interconnect address type. It does not affect 7.X, because the default
setting for interconnect address type was changed to
`INTERCONNECT_ADDRESS_TYPE_UNICAST`.

This is a rework of cherry-picked commit 7f3c91f.

Co-authored-by: Marbin Tan <tmarbin@vmware.com>