### PR TITLE
ADBDEV-4871: Implement MVP to move temp files to a separate table space

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -9809,7 +9809,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
       <p>When setting <codeph>temp_file_tablespaces</codeph> interactively, avoid specifying a
         nonexistent tablespace, or a tablespace for which the user does have <codeph>CREATE</codeph>
         privileges. For non-superusers, a superuser must <codeph>GRANT</codeph> them the
-          <codeph>CREATE</codeph> privilege on the temp tablespace.. When using a previously set
+          <codeph>CREATE</codeph> privilege on the temp tablespace. When using a previously set
         value (for example a value in <codeph>postgresql.conf</codeph>), nonexistent tablespaces are
         ignored, as are tablespaces for which the user lacks <codeph>CREATE</codeph> privilege. </p>
       <p>The default value is an empty string, which results in all temporary files being created

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -638,6 +638,9 @@
             <li><xref href="#topic_k52_fqm_f3b" format="dita"/>
             </li>
             <li>
+              <xref href="#temp_file_tablespaces" format="dita"/>
+            </li>
+            <li>
               <xref href="#TimeZone"/>
             </li>
             <li>
@@ -9747,7 +9750,8 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
     <body>
       <p>Specifies tablespaces in which to create temporary objects (temp tables and indexes on temp
         tables) when a <codeph>CREATE</codeph> command does not explicitly specify a tablespace.
-        These tablespaces can also include temporary files for purposes such as large data set sorting. </p>
+        If <codeph>temp_file_tablespaces</codeph> is not set, these tablespaces can also include
+        temporary files for purposes such as large data set sorting. </p>
       
       <p>The value is a comma-separated list of tablespace names. When the list contains more than
         one tablespace name, Greenplum chooses a random list member each time it creates a temporary
@@ -9764,6 +9768,54 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
         ignored, as are tablespaces for which the user lacks <codeph>CREATE</codeph> privilege. </p>
       <p>The default value is an empty string, which results in all temporary objects being created
         in the default tablespace of the current database.</p>
+      <p>See also <xref href="#default_tablespace" format="dita"/>.</p>
+      <table id="table_l52_fqm_f3b">
+        <tgroup cols="3">
+          <colspec colnum="1" colname="col1" colwidth="1*"/>
+          <colspec colnum="2" colname="col2" colwidth="1*"/>
+          <colspec colnum="3" colname="col3" colwidth="1*"/>
+          <thead>
+            <row>
+              <entry colname="col1">Value Range</entry>
+              <entry colname="col2">Default</entry>
+              <entry colname="col3">Set Classifications</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry colname="col1">one or more tablespace names</entry>
+              <entry colname="col2">unset</entry>
+              <entry colname="col3">master<p>session</p><p>reload</p></entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </body>
+  </topic>
+  <topic id="temp_file_tablespaces">
+    <title>temp_file_tablespaces</title>
+    <body>
+      <p>Specifies tablespaces in which to create temporary files for purposes such as large data
+        set sorting. This setting takes precedence over `temp_tablespaces` for temporary files.</p>
+
+      <p>The value is a comma-separated list of tablespace names. When the list contains more than
+        one tablespace name, Greenplum chooses a random list member each time it creates a temporary
+        file. An exception applies within a transaction, where successively created temporary files
+        are placed in successive tablespaces from the list. If the selected element of the list is
+        an empty string, Greenplum automatically falls back to tablespaces specified
+        <codeph>temp_tablespaces<codeph>. If <codeph>temp_tablespaces<codeph> is empty, Greenplum
+        uses the default tablespace of the current database instead.</p>
+
+      <p>When setting <codeph>temp_file_tablespaces</codeph> interactively, avoid specifying a
+        nonexistent tablespace, or a tablespace for which the user does have <codeph>CREATE</codeph>
+        privileges. For non-superusers, a superuser must <codeph>GRANT</codeph> them the
+          <codeph>CREATE</codeph> privilege on the temp tablespace.. When using a previously set
+        value (for example a value in <codeph>postgresql.conf</codeph>), nonexistent tablespaces are
+        ignored, as are tablespaces for which the user lacks <codeph>CREATE</codeph> privilege. </p>
+      <p>The default value is an empty string, which results in all temporary files being created
+        in tablespaces specified in <codeph>temp_tablespaces<codeph>. If
+          <codeph>temp_tablespaces<codeph> is also empty, default tablespace of the current database
+        will be used.</p>
       <p>See also <xref href="#default_tablespace" format="dita"/>.</p>
       <table id="table_l52_fqm_f3b">
         <tgroup cols="3">

--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -9802,7 +9802,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
         one tablespace name, Greenplum chooses a random list member each time it creates a temporary
         file. An exception applies within a transaction, where successively created temporary files
         are placed in successive tablespaces from the list. If the selected element of the list is
-        an empty string, Greenplum automatically falls back to tablespaces specified
+        an empty string, Greenplum automatically falls back to tablespaces specified in
         <codeph>temp_tablespaces<codeph>. If <codeph>temp_tablespaces<codeph> is empty, Greenplum
         uses the default tablespace of the current database instead.</p>
 
@@ -9817,7 +9817,7 @@ statement_mem = rg_perseg_mem / max_expected_concurrent_queries</codeblock></li>
           <codeph>temp_tablespaces<codeph> is also empty, default tablespace of the current database
         will be used.</p>
       <p>See also <xref href="#default_tablespace" format="dita"/>.</p>
-      <table id="table_l52_fqm_f3b">
+      <table id="temp_file_tablespaces_table">
         <tgroup cols="3">
           <colspec colnum="1" colname="col1" colwidth="1*"/>
           <colspec colnum="2" colname="col2" colwidth="1*"/>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1028,10 +1028,8 @@
                 <xref href="guc-list.xml#search_path" type="section">search_path</xref>
               </p><p>
                 <xref href="guc-list.xml#statement_timeout" type="section">statement_timeout</xref>
-              </p><p><xref href="guc-list.xml#topic_k52_fqm_f3b"/></p>
-              <p>
-                <xref href="guc-list.xml#temp_file_tablespaces" type="section"
-                  >temp_file_tablespaces</xref>
+              </p><p><xref href="guc-list.xml#topic_k52_fqm_f3b"/>
+              </p><p><xref href="guc-list.xml#temp_file_tablespaces"/></xref>
               </p>
               <p>
                 <xref href="guc-list.xml#vacuum_freeze_min_age" type="section"

--- a/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_category-list.xml
@@ -1028,7 +1028,12 @@
                 <xref href="guc-list.xml#search_path" type="section">search_path</xref>
               </p><p>
                 <xref href="guc-list.xml#statement_timeout" type="section">statement_timeout</xref>
-              </p><p><xref href="guc-list.xml#topic_k52_fqm_f3b"/></p><p>
+              </p><p><xref href="guc-list.xml#topic_k52_fqm_f3b"/></p>
+              <p>
+                <xref href="guc-list.xml#temp_file_tablespaces" type="section"
+                  >temp_file_tablespaces</xref>
+              </p>
+              <p>
                 <xref href="guc-list.xml#vacuum_freeze_min_age" type="section"
                   >vacuum_freeze_min_age</xref>
               </p></stentry>

--- a/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
+++ b/gpdb-doc/dita/ref_guide/config_params/guc_config.ditamap
@@ -300,6 +300,7 @@
             <topicref href="guc-list.xml#tcp_keepalives_interval"/>
             <topicref href="guc-list.xml#temp_buffers"/>
             <topicref href="guc-list.xml#topic_k52_fqm_f3b"/>
+            <topicref href="guc-list.xml#temp_file_tablespaces"/>
             <topicref href="guc-list.xml#TimeZone"/>
             <topicref href="guc-list.xml#timezone_abbreviations"/>
             <topicref href="guc-list.xml#track_activities"/>

--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
@@ -54,7 +54,7 @@ CREATE TABLE foo(i int);
 
 There is also the `temp_tablespaces` configuration parameter, which determines the placement of temporary tables and indexes, as well as temporary files that are used for purposes such as sorting large data sets. This can be a comma-separate list of tablespace names, rather than only one, so that the load associated with temporary objects can be spread over multiple tablespaces. A random member of the list is picked each time a temporary object is to be created.
 
-If you need to separate temporary tables from temporary files, `temp_files_tablespaces` configuration parameter allows to change their placement. If this parameter is empty, temporary files are created according to `temp_tablespaces`.
+If you need to separate temporary files from temporary tables, `temp_files_tablespaces` configuration parameter allows to change their placement. If this parameter is empty, temporary files are created according to `temp_tablespaces`.
 
 The tablespace associated with a database stores that database's system catalogs, temporary files created by server processes using that database, and is the default tablespace selected for tables and indexes created within the database, if no `TABLESPACE` is specified when the objects are created. If you do not specify a tablespace when you create a database, the database uses the same tablespace used by its template database.
 

--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
@@ -54,6 +54,8 @@ CREATE TABLE foo(i int);
 
 There is also the `temp_tablespaces` configuration parameter, which determines the placement of temporary tables and indexes, as well as temporary files that are used for purposes such as sorting large data sets. This can be a comma-separate list of tablespace names, rather than only one, so that the load associated with temporary objects can be spread over multiple tablespaces. A random member of the list is picked each time a temporary object is to be created.
 
+If you need to separate temporary tables from temporary files, `temp_files_tablespaces` configuration parameter allows to change their placement. If this parameter is empty, temporary files are created according to `temp_tablespaces`.
+
 The tablespace associated with a database stores that database's system catalogs, temporary files created by server processes using that database, and is the default tablespace selected for tables and indexes created within the database, if no `TABLESPACE` is specified when the objects are created. If you do not specify a tablespace when you create a database, the database uses the same tablespace used by its template database.
 
 You can use a tablespace from any database in the Greenplum Database system if you have appropriate privileges.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -3029,7 +3029,7 @@ When setting `temp_tablespaces` interactively, avoid specifying a nonexistent ta
 
 The default value is an empty string, which results in all temporary objects being created in the default tablespace of the current database.
 
-See also [temp_file_tablespaces](#temp_file_tablespaces), [default\_tablespace](#default_tablespace).
+See also [temp\_file\_tablespaces](#temp_file_tablespaces), [default\_tablespace](#default_tablespace).
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -3029,7 +3029,17 @@ When setting `temp_tablespaces` interactively, avoid specifying a nonexistent ta
 
 The default value is an empty string, which results in all temporary objects being created in the default tablespace of the current database.
 
-See also [default\_tablespace](#default_tablespace).
+See also [temp_file_tablespaces](#temp_file_tablespaces), [default\_tablespace](#default_tablespace).
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|one or more tablespace names|unset|master, session, reload|
+
+## <a id="temp_file_tablespaces"></a>temp\_file\_tablespaces
+
+Specifies tablespaces in which to create temporary files for purposes such as large data set sorting. This setting takes precedence over `temp_tablespaces` for temporary files.
+
+The value is a comma-separated list of tablespace names. When the list contains more than one tablespace name, Greenplum chooses a random list member each time it creates a temporary file. An exception applies within a transaction, where successively created temporary files are placed in successive tablespaces from the list. If the selected element of the list is an empty string, Greenplum automatically falls back to tablespaces specified `temp_tablespaces`. If `temp_tablespaces` is empty, Greenplum uses the default tablespace of the current database instead.</p>
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -3039,7 +3039,7 @@ See also [temp\_file\_tablespaces](#temp_file_tablespaces), [default\_tablespace
 
 Specifies tablespaces in which to create temporary files for purposes such as large data set sorting. This setting takes precedence over `temp_tablespaces` for temporary files.
 
-The value is a comma-separated list of tablespace names. When the list contains more than one tablespace name, Greenplum chooses a random list member each time it creates a temporary file. An exception applies within a transaction, where successively created temporary files are placed in successive tablespaces from the list. If the selected element of the list is an empty string, Greenplum automatically falls back to tablespaces specified `temp_tablespaces`. If `temp_tablespaces` is empty, Greenplum uses the default tablespace of the current database instead.</p>
+The value is a comma-separated list of tablespace names. When the list contains more than one tablespace name, Greenplum chooses a random list member each time it creates a temporary file. An exception applies within a transaction, where successively created temporary files are placed in successive tablespaces from the list. If the selected element of the list is an empty string, Greenplum automatically falls back to tablespaces specified in `temp_tablespaces`. If `temp_tablespaces` is empty, Greenplum uses the default tablespace of the current database instead.</p>
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -340,6 +340,7 @@ These configuration parameters set defaults that are used for client connections
 - [search_path](guc-list.html#search_path)
 - [statement_timeout](guc-list.html#statement_timeout)
 - [temp_tablespaces](guc-list.html#temp_tablespaces)
+- [temp_file_tablespaces](guc-list.html#temp_file_tablespaces)
 - [vacuum_freeze_min_age](guc-list.html#vacuum_freeze_min_age)
 
 ### <a id="topic41"></a>Locale and Formatting Parameters 

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1669,7 +1669,8 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
  * temp_tablespaces GUC variable and tell fd.c which tablespace(s) to use
  * for temporary files or tables.
  */
-static void PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
+static void
+PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1674,10 +1674,9 @@ PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
+	Oid		   *tblSpcs;
+	int			numSpcs;
 	ListCell   *l;
-
-	Oid *tblSpcs;
-	int numSpcs;
 
 	/*
 	 * Can't do catalog access unless within a transaction.  This is just a

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1760,17 +1760,20 @@ static void PrepareTablespacesImpl(char *str, Oid **tblSpcs, int *numSpcs)
 void
 PrepareTempTablespaces(void)
 {
-	Oid		   *tblSpcs;
-	int			numSpcs;
-
 	if (!TempTablespacesAreSet())
 	{
+		Oid		   *tblSpcs = NULL;
+		int			numSpcs = 0;
+
 		PrepareTablespacesImpl(temp_tablespaces, &tblSpcs, &numSpcs);
 		SetTempTablespaces(tblSpcs, numSpcs);
 	}
 
 	if (!FileTempTablespacesAreSet())
 	{
+		Oid		   *tblSpcs = NULL;
+		int			numSpcs = 0;
+
 		PrepareTablespacesImpl(temp_file_tablespaces, &tblSpcs, &numSpcs);
 		SetFileTempTablespaces(tblSpcs, numSpcs);
 	}

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1631,33 +1631,38 @@ check_temp_tablespaces(char **newval, void **extra, GucSource source)
 	return true;
 }
 
-/*
- * assign_temp_tablespaces & assign_file_temp_tablespaces
- *
- * assign_hook: do extra actions as needed
- *
- * If check_temp_tablespaces was executed inside a transaction, then pass
- * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
- * still outside a transaction, or else restoring during transaction exit,
- * and in either case we can just let the next PrepareTempTablespaces call
- * make things sane.
- */
+/* assign_hook: do extra actions as needed */
 void
 assign_temp_tablespaces(const char *newval, void *extra)
 {
 	temp_tablespaces_extra *myextra = (temp_tablespaces_extra *) extra;
 
+	/*
+	 * If check_temp_tablespaces was executed inside a transaction, then pass
+	 * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
+	 * still outside a transaction, or else restoring during transaction exit,
+	 * and in either case we can just let the next PrepareTempTablespaces call
+	 * make things sane.
+	 */
 	if (myextra)
 		SetTempTablespaces(myextra->tblSpcs, myextra->numSpcs);
 	else
 		SetTempTablespaces(NULL, 0);
 }
 
+/* assign_hook: do extra actions as needed */
 void
 assign_file_temp_tablespaces(const char *newval, void *extra)
 {
 	temp_tablespaces_extra *myextra = (temp_tablespaces_extra *) extra;
 
+	/*
+	 * If check_temp_tablespaces was executed inside a transaction, then pass
+	 * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
+	 * still outside a transaction, or else restoring during transaction exit,
+	 * and in either case we can just let the next PrepareTempTablespaces call
+	 * make things sane.
+	 */
 	if (myextra)
 		SetFileTempTablespaces(myextra->tblSpcs, myextra->numSpcs);
 	else

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1675,7 +1675,7 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
  * for temporary files or tables.
  */
 static void
-PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
+PrepareTablespacesImpl(char *str, void (*setTablespacesFunc)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
@@ -1700,7 +1700,7 @@ PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
 	if (!SplitIdentifierString(rawname, ',', &namelist))
 	{
 		/* syntax error in name list */
-		set(NULL, 0);
+		setTablespacesFunc(NULL, 0);
 		pfree(rawname);
 		list_free(namelist);
 		return;
@@ -1750,7 +1750,7 @@ PrepareTablespacesImpl(char *str, void (*set)(Oid *, int))
 		tblSpcs[numSpcs++] = curoid;
 	}
 
-	set(tblSpcs, numSpcs);
+	setTablespacesFunc(tblSpcs, numSpcs);
 
 	pfree(rawname);
 	list_free(namelist);

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1675,7 +1675,7 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
  * for temporary files or tables.
  */
 static void
-PrepareTablespacesImpl(char *str, void (*setTablespacesFunc)(Oid *, int))
+PrepareTablespacesImpl(char *gucStr, void (*setTablespacesFunc)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
@@ -1694,7 +1694,7 @@ PrepareTablespacesImpl(char *str, void (*setTablespacesFunc)(Oid *, int))
 		return;
 
 	/* Need a modifiable copy of string */
-	rawname = pstrdup(str);
+	rawname = pstrdup(gucStr);
 
 	/* Parse string into list of identifiers */
 	if (!SplitIdentifierString(rawname, ',', &namelist))

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1704,7 +1704,7 @@ static void PrepareTablespacesImpl(char *str, Oid **tblSpcs, int *numSpcs)
 
 	/* Store tablespace OIDs in an array in TopTransactionContext */
 	iTblSpcs = (Oid *) MemoryContextAlloc(TopTransactionContext,
-										 list_length(namelist) * sizeof(Oid));
+										  list_length(namelist) * sizeof(Oid));
 	iNumSpcs = 0;
 	foreach(l, namelist)
 	{

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1639,15 +1639,13 @@ assign_temp_tablespaces(const char *newval, void *extra)
 
 	/*
 	 * If check_temp_tablespaces was executed inside a transaction, then pass
-	 * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
-	 * still outside a transaction, or else restoring during transaction exit,
-	 * and in either case we can just let the next PrepareTempTablespaces call
-	 * make things sane.
+	 * the list it made to fd.c.  Otherwise, just let the next
+	 * PrepareTempTablespaces call make things sane.
 	 */
 	if (myextra)
 		SetTempTablespaces(myextra->tblSpcs, myextra->numSpcs);
 	else
-		SetTempTablespaces(NULL, 0);
+		SetTempTablespaces(NULL, -1);
 }
 
 /* assign_hook: do extra actions as needed */
@@ -1658,15 +1656,13 @@ assign_temp_file_tablespaces(const char *newval, void *extra)
 
 	/*
 	 * If check_temp_tablespaces was executed inside a transaction, then pass
-	 * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
-	 * still outside a transaction, or else restoring during transaction exit,
-	 * and in either case we can just let the next PrepareTempTablespaces call
-	 * make things sane.
+	 * the list it made to fd.c.  Otherwise, just let the next
+	 * PrepareTempTablespaces call make things sane.
 	 */
 	if (myextra)
 		SetTempFileTablespaces(myextra->tblSpcs, myextra->numSpcs);
 	else
-		SetTempFileTablespaces(NULL, 0);
+		SetTempFileTablespaces(NULL, -1);
 }
 
 /*

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1652,7 +1652,7 @@ assign_temp_tablespaces(const char *newval, void *extra)
 
 /* assign_hook: do extra actions as needed */
 void
-assign_file_temp_tablespaces(const char *newval, void *extra)
+assign_temp_file_tablespaces(const char *newval, void *extra)
 {
 	temp_tablespaces_extra *myextra = (temp_tablespaces_extra *) extra;
 
@@ -1664,9 +1664,9 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
 	 * make things sane.
 	 */
 	if (myextra)
-		SetFileTempTablespaces(myextra->tblSpcs, myextra->numSpcs);
+		SetTempFileTablespaces(myextra->tblSpcs, myextra->numSpcs);
 	else
-		SetFileTempTablespaces(NULL, 0);
+		SetTempFileTablespaces(NULL, 0);
 }
 
 /*
@@ -1675,7 +1675,7 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
  * for temporary files or tables.
  */
 static void
-PrepareTablespacesImpl(char *gucstr, void (*setTablespacesFunc)(Oid *, int))
+PrepareTempTablespacesImpl(char *gucstr, void (*setTablespacesFunc)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
@@ -1757,17 +1757,17 @@ PrepareTablespacesImpl(char *gucstr, void (*setTablespacesFunc)(Oid *, int))
 }
 
 /*
- * PrepareTempTablespaces -- prepare to use temp tablespaces for tables and
- * files.  No work if already done in current transaction.
+ * PrepareTempTablespaces -- prepare to use tablespaces set in temp_tablespaces
+ * and temp_file_tablespaces.  No work if already done in current transaction.
  */
 void
 PrepareTempTablespaces(void)
 {
 	if (!TempTablespacesAreSet())
-		PrepareTablespacesImpl(temp_tablespaces, SetTempTablespaces);
+		PrepareTempTablespacesImpl(temp_tablespaces, SetTempTablespaces);
 
-	if (!FileTempTablespacesAreSet())
-		PrepareTablespacesImpl(temp_file_tablespaces, SetFileTempTablespaces);
+	if (!TempFileTablespacesAreSet())
+		PrepareTempTablespacesImpl(temp_file_tablespaces, SetTempFileTablespaces);
 }
 
 /*

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1675,7 +1675,7 @@ assign_file_temp_tablespaces(const char *newval, void *extra)
  * for temporary files or tables.
  */
 static void
-PrepareTablespacesImpl(char *gucStr, void (*setTablespacesFunc)(Oid *, int))
+PrepareTablespacesImpl(char *gucstr, void (*setTablespacesFunc)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
@@ -1694,7 +1694,7 @@ PrepareTablespacesImpl(char *gucStr, void (*setTablespacesFunc)(Oid *, int))
 		return;
 
 	/* Need a modifiable copy of string */
-	rawname = pstrdup(gucStr);
+	rawname = pstrdup(gucstr);
 
 	/* Parse string into list of identifiers */
 	if (!SplitIdentifierString(rawname, ',', &namelist))

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -1767,7 +1767,7 @@ PrepareTempTablespaces(void)
 		PrepareTablespacesImpl(temp_tablespaces, SetTempTablespaces);
 
 	if (!FileTempTablespacesAreSet())
-		PrepareTablespacesImpl(temp_file_tablespaces, SetTempTablespaces);
+		PrepareTablespacesImpl(temp_file_tablespaces, SetFileTempTablespaces);
 }
 
 /*

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2774,6 +2774,7 @@ Oid
 GetNextFileTempTableSpace(void)
 {
 	Oid		tablespace = GetSessionFileTempTableSpace();
+
 	if (OidIsValid(tablespace))
 		return tablespace;
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1244,8 +1244,9 @@ PathNameOpenFile(FileName fileName, int fileFlags, int fileMode)
  * a file, and another process reads it.
  *
  * NOTE: this always uses the session temp tablespace from
- * `temp_file_tablespaces`.  Otherwise picking randomly from list would be hard
- * for the reader process to find the file created by the writer process.
+ * `temp_file_tablespaces` or `temp_tablespaces`, if first is not set.
+ * Otherwise picking randomly from list would be hard for the reader process to
+ * find the file created by the writer process.
  */
 File
 OpenNamedTemporaryFile(const char *fileName,

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2628,13 +2628,6 @@ closeAllVfds(void)
  * unless this function is called again before then.  It is caller's
  * responsibility that the passed-in array has adequate lifespan (typically
  * it'd be allocated in TopTransactionContext).
- *
- * We select a random starting point in the list.  This is to minimize
- * conflicts between backends that are most likely sharing the same list
- * of temp tablespaces.  Note that if we create multiple temp files in the
- * same transaction, we'll advance circularly through the list --- this
- * ensures that large temporary sort files are nicely spread across all
- * available tablespaces.
  */
 void
 SetTempTablespaces(Oid *tableSpaces, int numSpaces)
@@ -2643,6 +2636,14 @@ SetTempTablespaces(Oid *tableSpaces, int numSpaces)
 	tempTableSpaces = tableSpaces;
 	numTempTableSpaces = numSpaces;
 
+	/*
+	 * We select a random starting point in the list.  This is to minimize
+	 * conflicts between backends that are most likely sharing the same list
+	 * of temp tablespaces.  Note that if we create multiple temp files in the
+	 * same transaction, we'll advance circularly through the list --- this
+	 * ensures that large temporary sort files are nicely spread across all
+	 * available tablespaces.
+	 */
 	if (numSpaces > 1)
 		nextTempTableSpace = random() % numSpaces;
 	else
@@ -2657,13 +2658,6 @@ SetTempTablespaces(Oid *tableSpaces, int numSpaces)
  * unless this function is called again before then.  It is caller's
  * responsibility that the passed-in array has adequate lifespan (typically
  * it'd be allocated in TopTransactionContext).
- *
- * We select a random starting point in the list.  This is to minimize
- * conflicts between backends that are most likely sharing the same list
- * of temp tablespaces.  Note that if we create multiple temp files in the
- * same transaction, we'll advance circularly through the list --- this
- * ensures that large temporary sort files are nicely spread across all
- * available tablespaces.
  */
 void
 SetFileTempTablespaces(Oid *tableSpaces, int numSpaces)
@@ -2672,6 +2666,14 @@ SetFileTempTablespaces(Oid *tableSpaces, int numSpaces)
 	fileTempTableSpaces = tableSpaces;
 	fileNumTempTableSpaces = numSpaces;
 
+	/*
+	 * We select a random starting point in the list.  This is to minimize
+	 * conflicts between backends that are most likely sharing the same list
+	 * of temp tablespaces.  Note that if we create multiple temp files in the
+	 * same transaction, we'll advance circularly through the list --- this
+	 * ensures that large temporary sort files are nicely spread across all
+	 * available tablespaces.
+	 */
 	if (numSpaces > 1)
 		fileNextTempTableSpace = random() % numSpaces;
 	else

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -267,6 +267,10 @@ static Oid *tempTableSpaces = NULL;
 static int	numTempTableSpaces = -1;
 static int	nextTempTableSpace = 0;
 
+/*
+ * Array of OIDs of temp file tablespaces.  When fileNumTempTableSpaces is -1,
+ * this has not been set in the current transaction.
+ */
 static Oid *fileTempTableSpaces = NULL;
 static int	fileNumTempTableSpaces = -1;
 static int	fileNextTempTableSpace = 0;

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1270,7 +1270,7 @@ OpenNamedTemporaryFile(const char *fileName,
 
 		/*
 		 * If we got an InvalidOid, this may mean we couldn't not retrieve
-		 * tablespaces from GUCS. The caller must ensure that
+		 * tablespaces from GUCs.  The caller must ensure that
 		 * PrepareTempTablespaces() was called before opening temporary files.
 		 */
 		if (OidIsValid(tblspcOid))
@@ -2637,7 +2637,7 @@ SetTempTablespaces(Oid *tableSpaces, int numSpaces)
 	numTempTableSpaces = numSpaces;
 
 	/*
-	 * We select a random starting point in the list.  This is to minimize
+	 * Select a random starting point in the list.  This is to minimize
 	 * conflicts between backends that are most likely sharing the same list
 	 * of temp tablespaces.  Note that if we create multiple temp files in the
 	 * same transaction, we'll advance circularly through the list --- this
@@ -2667,7 +2667,7 @@ SetFileTempTablespaces(Oid *tableSpaces, int numSpaces)
 	fileNumTempTableSpaces = numSpaces;
 
 	/*
-	 * We select a random starting point in the list.  This is to minimize
+	 * Select a random starting point in the list.  This is to minimize
 	 * conflicts between backends that are most likely sharing the same list
 	 * of temp tablespaces.  Note that if we create multiple temp files in the
 	 * same transaction, we'll advance circularly through the list --- this

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1270,7 +1270,7 @@ OpenNamedTemporaryFile(const char *fileName,
 		Oid            tblspcOid = GetNextFileTempTableSpace();
 
 		/*
-		 * If we got an InvalidOid, this may mean we couldn't not retrieve
+		 * If we got an InvalidOid, this may mean we couldn't retrieve
 		 * tablespaces from GUCs.  The caller must ensure that
 		 * PrepareTempTablespaces() was called before opening temporary files.
 		 */
@@ -1360,7 +1360,7 @@ OpenTemporaryFile(bool interXact, const char *filePrefix)
 		Oid			tblspcOid = GetNextFileTempTableSpace();
 
 		/*
-		 * If we got an InvalidOid, this may mean we couldn't not retrieve
+		 * If we got an InvalidOid, this may mean we couldn't retrieve
 		 * tablespaces from GUCS. The caller must ensure that
 		 * PrepareTempTablespaces() was called before opening temporary files.
 		 */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2633,7 +2633,9 @@ closeAllVfds(void)
 void
 SetTempTablespaces(Oid *tableSpaces, int numSpaces)
 {
-	Assert(numSpaces >= 0);
+	AssertImply(tableSpaces == NULL, numSpaces == -1 || numSpaces == 0);
+	AssertImply(tableSpaces != NULL, numSpaces >= 0);
+
 	tempTableSpaces = tableSpaces;
 	numTempTableSpaces = numSpaces;
 
@@ -2663,7 +2665,9 @@ SetTempTablespaces(Oid *tableSpaces, int numSpaces)
 void
 SetTempFileTablespaces(Oid *tableSpaces, int numSpaces)
 {
-	Assert(numSpaces >= 0);
+	AssertImply(tableSpaces == NULL, numSpaces == -1 || numSpaces == 0);
+	AssertImply(tableSpaces != NULL, numSpaces >= 0);
+
 	tempFileTableSpaces = tableSpaces;
 	numTempFileTableSpaces = numSpaces;
 

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1264,6 +1264,11 @@ OpenNamedTemporaryFile(const char *fileName,
 	{
 		Oid            tblspcOid = GetNextFileTempTableSpace();
 
+		/*
+		 * If we got an InvalidOid, this may mean we couldn't not retrieve
+		 * tablespaces from GUCS. The caller must ensure that
+		 * PrepareTempTablespaces() was called before opening temporary files.
+		 */
 		if (OidIsValid(tblspcOid))
 			file = OpenTemporaryFileInTablespace(tblspcOid,
 												 false, /* rejectError */
@@ -1349,6 +1354,11 @@ OpenTemporaryFile(bool interXact, const char *filePrefix)
 	{
 		Oid			tblspcOid = GetNextFileTempTableSpace();
 
+		/*
+		 * If we got an InvalidOid, this may mean we couldn't not retrieve
+		 * tablespaces from GUCS. The caller must ensure that
+		 * PrepareTempTablespaces() was called before opening temporary files.
+		 */
 		if (OidIsValid(tblspcOid))
 			file = OpenTemporaryFileInTablespace(tblspcOid,
 												 false, /* rejectError */

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2675,8 +2675,6 @@ FileTempTablespacesAreSet(void)
  * tablespace in all QD/QE processes in the same session.
  * A result of InvalidOid means to use the current database's
  * default tablespace.
- *
- * If this session is not MPP, use the implementation from upstream.
  */
 static inline Oid
 GetSessionTempTableSpace(void)
@@ -2687,6 +2685,7 @@ GetSessionTempTableSpace(void)
 	if (gp_session_id >= 0)
 		return tempTableSpaces[gp_session_id % numTempTableSpaces];
 
+	/* If this session is not MPP, uses the implementation from upstream */
 	if (++nextTempTableSpace >= numTempTableSpaces)
 		nextTempTableSpace = 0;
 	return tempTableSpaces[nextTempTableSpace];
@@ -2701,6 +2700,7 @@ GetSessionFileTempTableSpace(void)
 	if (gp_session_id >= 0)
 		return fileTempTableSpaces[gp_session_id % fileNumTempTableSpaces];
 
+	/* If this session is not MPP, uses the implementation from upstream */
 	if (++fileNextTempTableSpace >= fileNumTempTableSpaces)
 		fileNextTempTableSpace = 0;
 	return fileTempTableSpaces[fileNextTempTableSpace];

--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -2652,7 +2652,7 @@ SetTempTablespaces(Oid *tableSpaces, int numSpaces)
 }
 
 /*
- * SetFileTempTablespaces
+ * SetTempFileTablespaces
  *
  * Define a list (actually an array) of OIDs of tablespaces to use for
  * temporary files.  This list will be used until end of transaction,
@@ -2695,7 +2695,7 @@ TempTablespacesAreSet(void)
 }
 
 /*
- * FileTempTablespacesAreSet
+ * TempFileTablespacesAreSet
  *
  * Returns TRUE if SetFileTempTablespaces has been called in current
  * transaction.  (This is just so that tablespaces.c doesn't need its own
@@ -2732,7 +2732,7 @@ GetSessionTempTableSpace(void)
 }
 
 /*
- * GetSessionFileTempTableSpace
+ * GetSessionTempFileTableSpace
  *
  * Select temp tablespace for current session to use. It's like
  * GetNextTempTableSpace in upstream, but it gets the same temp
@@ -2768,7 +2768,7 @@ GetNextTempTableSpace(void)
 }
 
 /*
- * GetNextFileTempTableSpace
+ * GetNextTempFileTableSpace
  *
  * Select the next temp tablespace to use for temporary files.  A result of
  * InvalidOid means to use the current database's default tablespace.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2866,7 +2866,7 @@ static struct config_string ConfigureNamesString[] =
 
 	{
 		{"temp_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
-			gettext_noop("Sets the tablespace(s) to use for temporary tables."),
+			gettext_noop("Sets the tablespace(s) to use for temporary tables and sort files."),
 			NULL,
 			GUC_LIST_INPUT | GUC_LIST_QUOTE
 		},
@@ -2878,7 +2878,8 @@ static struct config_string ConfigureNamesString[] =
 	{
 		{"temp_file_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the tablespace(s) to use for temporary files."),
-			NULL,
+			gettext_noop("This setting takes precedence over temp_tablespaces "
+						 "for temporary files."),
 			GUC_LIST_INPUT | GUC_LIST_QUOTE
 		},
 		&temp_file_tablespaces,

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -136,6 +136,7 @@ extern int	CommitDelay;
 extern int	CommitSiblings;
 extern char *default_tablespace;
 extern char *temp_tablespaces;
+extern char *temp_file_tablespaces;
 extern bool ignore_checksum_failure;
 extern bool synchronize_seqscans;
 extern char *SSLCipherSuites;
@@ -2865,13 +2866,24 @@ static struct config_string ConfigureNamesString[] =
 
 	{
 		{"temp_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
-			gettext_noop("Sets the tablespace(s) to use for temporary tables and sort files."),
+			gettext_noop("Sets the tablespace(s) to use for temporary tables."),
 			NULL,
 			GUC_LIST_INPUT | GUC_LIST_QUOTE
 		},
 		&temp_tablespaces,
 		"",
 		check_temp_tablespaces, assign_temp_tablespaces, NULL
+	},
+
+	{
+		{"temp_file_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
+			gettext_noop("Sets the tablespace(s) to use for temporary files."),
+			NULL,
+			GUC_LIST_INPUT | GUC_LIST_QUOTE
+		},
+		&temp_file_tablespaces,
+		"",
+		check_temp_tablespaces, assign_file_temp_tablespaces, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2884,7 +2884,7 @@ static struct config_string ConfigureNamesString[] =
 		},
 		&temp_file_tablespaces,
 		"",
-		check_temp_tablespaces, assign_file_temp_tablespaces, NULL
+		check_temp_tablespaces, assign_temp_file_tablespaces, NULL
 	},
 
 	{

--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -1663,6 +1663,7 @@ bool
 variable_is_guc_list_quote(const char *name)
 {
 	if (pg_strcasecmp(name, "temp_tablespaces") == 0 ||
+		pg_strcasecmp(name, "temp_file_tablespaces") == 0 ||
 		pg_strcasecmp(name, "session_preload_libraries") == 0 ||
 		pg_strcasecmp(name, "shared_preload_libraries") == 0 ||
 		pg_strcasecmp(name, "local_preload_libraries") == 0 ||

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -113,8 +113,11 @@ extern void InitFileAccess(void);
 extern void set_max_safe_fds(void);
 extern void closeAllVfds(void);
 extern void SetTempTablespaces(Oid *tableSpaces, int numSpaces);
+extern void SetFileTempTablespaces(Oid *tableSpaces, int numSpaces);
 extern bool TempTablespacesAreSet(void);
+extern bool FileTempTablespacesAreSet(void);
 extern Oid	GetNextTempTableSpace(void);
+extern Oid	GetNextFileTempTableSpace(void);
 extern void AtEOXact_Files(void);
 extern void AtEOSubXact_Files(bool isCommit, SubTransactionId mySubid,
 				  SubTransactionId parentSubid);

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -113,11 +113,11 @@ extern void InitFileAccess(void);
 extern void set_max_safe_fds(void);
 extern void closeAllVfds(void);
 extern void SetTempTablespaces(Oid *tableSpaces, int numSpaces);
-extern void SetFileTempTablespaces(Oid *tableSpaces, int numSpaces);
+extern void SetTempFileTablespaces(Oid *tableSpaces, int numSpaces);
 extern bool TempTablespacesAreSet(void);
-extern bool FileTempTablespacesAreSet(void);
+extern bool TempFileTablespacesAreSet(void);
 extern Oid	GetNextTempTableSpace(void);
-extern Oid	GetNextFileTempTableSpace(void);
+extern Oid	GetNextTempFileTableSpace(void);
 extern void AtEOXact_Files(void);
 extern void AtEOSubXact_Files(bool isCommit, SubTransactionId mySubid,
 				  SubTransactionId parentSubid);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -778,6 +778,7 @@ extern void GUC_check_errcode(int sqlerrcode);
 extern bool check_default_tablespace(char **newval, void **extra, GucSource source);
 extern bool check_temp_tablespaces(char **newval, void **extra, GucSource source);
 extern void assign_temp_tablespaces(const char *newval, void *extra);
+extern void assign_file_temp_tablespaces(const char *newval, void *extra);
 
 /* in catalog/namespace.c */
 extern bool check_search_path(char **newval, void **extra, GucSource source);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -778,7 +778,7 @@ extern void GUC_check_errcode(int sqlerrcode);
 extern bool check_default_tablespace(char **newval, void **extra, GucSource source);
 extern bool check_temp_tablespaces(char **newval, void **extra, GucSource source);
 extern void assign_temp_tablespaces(const char *newval, void *extra);
-extern void assign_file_temp_tablespaces(const char *newval, void *extra);
+extern void assign_temp_file_tablespaces(const char *newval, void *extra);
 
 /* in catalog/namespace.c */
 extern bool check_search_path(char **newval, void **extra, GucSource source);

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -124,6 +124,7 @@
 		"vmem_process_interrupt",
 		"work_mem",
 		"temp_tablespaces",
+		"temp_file_tablespaces",
 		"gp_add_column_inherits_table_setting",
 		"gp_resgroup_debug_wait_queue",
 		"gp_log_resqueue_priority_sleep_time",

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -185,7 +185,10 @@ tablespace-setup:
 	./testtablespace_space_12871 \
 	./testtablespace_database_tablespace \
 	./testtablespace_temp_tables \
-	./testtablespace_temp_files
+	./testtablespace_temp_files0 \
+	./testtablespace_temp_files1 \
+	./testtablespace_temp_files2 \
+	./testtablespace_temp_files3
 
 .PHONY: hooktest
 hooktest:

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -183,7 +183,9 @@ tablespace-setup:
 	./testtablespace_mytempsp3 \
 	./testtablespace_mytempsp4 \
 	./testtablespace_space_12871 \
-	./testtablespace_database_tablespace
+	./testtablespace_database_tablespace \
+	./testtablespace_temp_tables \
+	./testtablespace_temp_files
 
 .PHONY: hooktest
 hooktest:

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -364,8 +364,8 @@ SELECT gp_tablespace_watch_stop();
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
 
--- If temp_tablespaces is not empty, temporary tables should be stored in
--- temp_tablespaces, while files should be stored in temp_file_tablespaces.
+-- If temp_file_tablespaces is empty, temporary tables should be stored in
+-- temp_tablespaces.
 RESET temp_file_tablespaces;
 
 -- This query should create the temporary directory

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -304,9 +304,6 @@ drop tablespace space_12871;
 --
 -- temp_file_tablespaces:
 --
-SET optimizer = off;
-SET statement_mem = '2MB';
-
 CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
 CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
@@ -319,38 +316,68 @@ ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
 
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
 CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
+CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 
-SET temp_file_tablespaces = temp_files;
+SET optimizer = off;
+SET statement_mem = '2MB';
 
--- Should be in default tablespace.
-CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
-
-SELECT count(*)
-    FROM pg_class
-    WHERE pg_class.reltablespace = 0 AND relname = 'tts_baz';
-
-DROP TABLE tts_baz;
-RESET temp_file_tablespaces;
-
+-- Creates a temporary table returns the tablespace it was created in. Runs a
+-- query that creates some temporary files, calculates the tablespace for
+-- temporary files that will be used for current session, and checks if any
+-- files were created in that tablespace.
+--
+-- 'n_temp_file_tablespaces' is the count of tablespaces specified in
+-- 'temp_file_tablespaces'. Multiple tablespaces in 'temp_file_tablespaces' need
+-- to be specified in increasing order.
 CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
     temp_tablespaces text,
-    temp_file_tablespaces text
-) RETURNS TABLE (in_default boolean, in_temp_tables boolean, in_temp_files boolean) AS $$
+    temp_file_tablespaces text,
+    n_temp_file_tablespaces int
+) RETURNS TABLE (
+        temp_table_in text,
+        files_in_default boolean,
+        files_in_temp_tables boolean,
+        files_in_temp_files_n boolean
+    ) AS $$
 DECLARE
     owo int;
+    session_ts_n int;
+    session_file_ts_name text;
+    temp_table_ts_name text;
 BEGIN
     RESET temp_tablespaces;
     RESET temp_file_tablespaces;
 
     IF temp_tablespaces IS NOT NULL THEN
-        EXECUTE 'SET temp_tablespaces = ' || quote_literal(temp_tablespaces);
+        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
     END IF;
 
     IF temp_file_tablespaces IS NOT NULL THEN
-        EXECUTE 'SET temp_file_tablespaces = ' || quote_literal(temp_file_tablespaces);
+        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
     END IF;
+
+    CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+    -- See the tablespace where temporary table was created. If there is no
+    -- tablespace for this table, it's in default tablespace.
+    SELECT ts.spcname
+        FROM pg_tablespace ts
+        JOIN pg_class c ON ts.oid = c.reltablespace AND c.relname = 'tts_baz'
+        LIMIT 1
+        INTO temp_table_ts_name;
+
+    DROP TABLE tts_baz;
+
+    -- Find out the tablespace that will be used for files.
+    -- N = gp_session_id % number of tablespaces in GUC.
+    SELECT id.setting::int % n_temp_file_tablespaces
+        FROM (SELECT setting FROM pg_settings WHERE name = 'gp_session_id') id
+        INTO session_ts_n;
+    SELECT 'temp_files' || session_ts_n INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (
@@ -364,9 +391,9 @@ BEGIN
     SELECT count(*) FROM out11 INTO owo;
 
     -- Start monitoring temporary tablespace usage.
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
 
     -- Run the query again to create temporary hashjoin files in the tablespaces.
     WITH out11 AS (
@@ -383,24 +410,47 @@ BEGIN
 
     -- Check the existence of temporary hashjoin files.
     RETURN QUERY SELECT
+        coalesce(temp_table_ts_name, 'default'),
         gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0,
         gp_tablespace_watch_match(gp_execution_dbid(), 'temp_tables', '_HashJoin') > 0,
-        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_files', '_HashJoin') > 0;
+        gp_tablespace_watch_match(gp_execution_dbid(), session_file_ts_name, '_HashJoin') > 0;
 END;
 $$ LANGUAGE plpgsql;
 
--- Files should be in default tablespace
-SELECT * FROM gp_tablespace_file_report(NULL, NULL);
--- Files should be in temp_tables
-SELECT * FROM gp_tablespace_file_report('temp_tables', NULL);
--- Files should be in temp_files
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files');
--- Files should be in temp_files
-SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files');
+-- Show directories of the tablespaces that will be used.
+-- start_ignore
+SELECT gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1));
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1));
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files0' LIMIT 1));
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files1' LIMIT 1));
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files2' LIMIT 1));
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files3' LIMIT 1));
+-- end_ignore
+
+-- Both files and the table should be in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, NULL, 1);
+-- Both files and the table should be in temp_tables.
+SELECT * FROM gp_tablespace_file_report('temp_tables', NULL, 1);
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
+--end_ignore
+-- Files should be in temp_files0, table should be in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0', 1);
+-- Files should be in temp_files0, table should be in temp_tables.
+SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files0', 1);
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
+--end_ignore
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3', 4);
 
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;
 DROP TABLE tts_jazz;
 
 DROP TABLESPACE temp_tables;
-DROP TABLESPACE temp_files;
+DROP TABLESPACE temp_files0;
+DROP TABLESPACE temp_files1;
+DROP TABLESPACE temp_files2;
+DROP TABLESPACE temp_files3;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -301,3 +301,105 @@ $$;
 drop table tmp_table_12871;
 drop tablespace space_12871;
 
+-- temp_file_tablespaces:
+
+-- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
+-- only temporary files will be saved in the specified table spaces. Temporary
+-- table files will still be stored in the system tablespace.
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+
+SET optimizer = off;
+SET statement_mem = '2MB';
+
+SET temp_tablespaces = temp_tables;
+SET temp_file_tablespaces = temp_files;
+
+CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+SELECT pg_tablespace.spcname
+    FROM pg_class
+    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
+        WHERE relname = 'tts_baz';
+
+CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
+CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
+
+INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
+INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
+
+ANALYZE tts_foo;
+ANALYZE tts_bar;
+ANALYZE tts_jazz;
+
+-- This query should create the temporary directory
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+
+-- Run this this query again to create temporary hashjoin files in temp_files
+-- tablespace
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_stop();
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
+
+-- If temp_tablespaces is not empty, temporary tables should be stored in
+-- temp_tablespaces, while files should be stored in temp_file_tablespaces.
+RESET temp_file_tablespaces;
+
+-- This query should create the temporary directory
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+
+-- Run this this query again to create temporary hashjoin files in temp_
+-- tablespace
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_stop();
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
+
+DROP TABLE tts_baz;
+DROP TABLE tts_foo;
+DROP TABLE tts_bar;
+DROP TABLE tts_jazz;
+
+DROP TABLESPACE temp_tables;
+DROP TABLESPACE temp_files;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -325,8 +325,8 @@ CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 SET optimizer = off;
 SET statement_mem = '2MB';
 
--- Creates a temporary table returns the tablespace it was created in. Runs a
--- query that creates some temporary files, calculates the tablespace for
+-- Creates a temporary table and remembers the tablespace it was created in.
+-- Runs a query that creates some temporary files, calculates the tablespace for
 -- temporary files that will be used for current session, and checks if any
 -- files were created in that tablespace.
 --
@@ -345,7 +345,7 @@ CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
     ) AS $$
 DECLARE
     owo int;
-    session_ts_n int;
+    session_file_ts_n int;
     session_file_ts_name text;
     temp_table_ts_name text;
 BEGIN
@@ -376,8 +376,8 @@ BEGIN
     -- N = gp_session_id % number of tablespaces in GUC.
     SELECT id.setting::int % n_temp_file_tablespaces
         FROM (SELECT setting FROM pg_settings WHERE name = 'gp_session_id') id
-        INTO session_ts_n;
-    SELECT 'temp_files' || session_ts_n INTO session_file_ts_name;
+        INTO session_file_ts_n;
+    SELECT 'temp_files' || session_file_ts_n INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -304,6 +304,18 @@ drop tablespace space_12871;
 --
 -- temp_file_tablespaces:
 --
+
+-- start_ignore
+DROP TABLE IF EXISTS tts_foo;
+DROP TABLE IF EXISTS tts_bar;
+DROP TABLE IF EXISTS tts_jazz;
+DROP TABLESPACE IF EXISTS temp_tables;
+DROP TABLESPACE IF EXISTS temp_files0;
+DROP TABLESPACE IF EXISTS temp_files1;
+DROP TABLESPACE IF EXISTS temp_files2;
+DROP TABLESPACE IF EXISTS temp_files3;
+-- end_ignore
+
 CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
 CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
@@ -322,20 +334,43 @@ CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
 CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
 CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 
+RESET temp_tablespaces;
+RESET temp_file_tablespaces;
+
 SET optimizer = off;
 SET statement_mem = '2MB';
+
+-- Multiple tablespaces in 'temp_file_tablespaces' and 'g_temp_file_tablespaces'
+-- need to be specified in increasing order.
+CREATE OR REPLACE FUNCTION gp_tablespace_set_gucs(
+    temp_tablespaces text,
+    temp_file_tablespaces text
+) RETURNS void AS $$
+BEGIN
+    RESET temp_tablespaces;
+    RESET temp_file_tablespaces;
+
+    IF temp_tablespaces IS NOT NULL THEN
+        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
+    END IF;
+
+    IF temp_file_tablespaces IS NOT NULL THEN
+        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
 
 -- Creates a temporary table and remembers the tablespace it was created in.
 -- Runs a query that creates some temporary files, calculates the tablespace for
 -- temporary files that will be used for current session, and checks if any
 -- files were created in that tablespace.
 --
+-- We set GUCs and perform the report in two separate function calls
+-- (transactions). Otherwise, global configuration will not be reloaded.
+--
 -- 'n_temp_file_tablespaces' is the count of tablespaces specified in
--- 'temp_file_tablespaces'. Multiple tablespaces in 'temp_file_tablespaces' need
--- to be specified in increasing order.
+-- 'temp_file_tablespaces', either global or session-wide.
 CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
-    temp_tablespaces text,
-    temp_file_tablespaces text,
     n_temp_file_tablespaces int
 ) RETURNS TABLE (
         temp_table_in text,
@@ -349,17 +384,6 @@ DECLARE
     session_file_ts_name text;
     temp_table_ts_name text;
 BEGIN
-    RESET temp_tablespaces;
-    RESET temp_file_tablespaces;
-
-    IF temp_tablespaces IS NOT NULL THEN
-        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
-    END IF;
-
-    IF temp_file_tablespaces IS NOT NULL THEN
-        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
-    END IF;
-
     CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
 
     -- See the tablespace where temporary table was created. If there is no
@@ -427,23 +451,92 @@ SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'te
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files3' LIMIT 1));
 -- end_ignore
 
+--
+-- Global GUC value tests:
+--
+
 -- Both files and the table should be in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, NULL, 1);
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
 -- Both files and the table should be in temp_tables.
-SELECT * FROM gp_tablespace_file_report('temp_tables', NULL, 1);
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v temp_tables
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
+
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_file_tablespaces -v temp_files0
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v temp_tables
+\! gpconfig -c temp_file_tablespaces -v temp_files0
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
+
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_file_tablespaces -v temp_files0,temp_files1,temp_files2,temp_files3
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(4);
+
+-- Reset the global config before testing session-only values.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+
+--
+-- Session-only GUC value tests:
+--
+
+-- Both files and the table should be in the default tablespace.
+SELECT * FROM gp_tablespace_set_gucs(NULL, NULL);
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Both files and the table should be in temp_tables.
+SELECT * FROM gp_tablespace_set_gucs('temp_tables', NULL);
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in the default tablespace.
 --start_ignore
 SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
 --end_ignore
--- Files should be in temp_files0, table should be in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0', 1);
+SELECT * FROM gp_tablespace_set_gucs(NULL, 'temp_files0');
+SELECT * FROM gp_tablespace_file_report(1);
+
 -- Files should be in temp_files0, table should be in temp_tables.
-SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files0', 1);
+SELECT * FROM gp_tablespace_set_gucs('temp_tables', 'temp_files0');
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
 --start_ignore
 SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
 --end_ignore
--- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
--- in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3', 4);
+SELECT * FROM gp_tablespace_set_gucs(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3');
+SELECT * FROM gp_tablespace_file_report(4);
 
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -319,9 +319,8 @@ ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
 
--- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
--- only temporary files will be saved in the specified table spaces.
 CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
 
 SET temp_file_tablespaces = temp_files;
 
@@ -333,120 +332,71 @@ SELECT count(*)
     WHERE pg_class.reltablespace = 0 AND relname = 'tts_baz';
 
 DROP TABLE tts_baz;
-
--- This query should create the temporary directory.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
-
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
-
--- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
-
-SELECT gp_tablespace_watch_stop();
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0 as "exist";
-
-DROP TABLESPACE temp_files;
 RESET temp_file_tablespaces;
 
--- If both temp_tablespaces and temp_file_tablespaces is not empty, only
--- temporary files should be saved in temp_file_tablespaces. Temporary tables
--- shoud still be stored in temp_tablespaces.
-CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
+    temp_tablespaces text,
+    temp_file_tablespaces text
+) RETURNS TABLE (in_default boolean, in_temp_tables boolean, in_temp_files boolean) AS $$
+DECLARE
+    owo int;
+BEGIN
+    RESET temp_tablespaces;
+    RESET temp_file_tablespaces;
 
-SET temp_tablespaces = temp_tables;
-SET temp_file_tablespaces = temp_files;
+    IF temp_tablespaces IS NOT NULL THEN
+        EXECUTE 'SET temp_tablespaces = ' || quote_literal(temp_tablespaces);
+    END IF;
 
--- Should be in temp_tables tablespace.
-CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+    IF temp_file_tablespaces IS NOT NULL THEN
+        EXECUTE 'SET temp_file_tablespaces = ' || quote_literal(temp_file_tablespaces);
+    END IF;
 
-SELECT pg_tablespace.spcname
-    FROM pg_class
-    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
-        WHERE relname = 'tts_baz';
+    -- Create the temporary directory.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
 
-DROP TABLE tts_baz;
+    -- Start monitoring temporary tablespace usage.
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
 
--- This query should create the temporary directory.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
+    -- Run the query again to create temporary hashjoin files in the tablespaces.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
 
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+    PERFORM gp_tablespace_watch_stop();
 
--- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
+    -- Check the existence of temporary hashjoin files.
+    RETURN QUERY SELECT
+        gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0,
+        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_tables', '_HashJoin') > 0,
+        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_files', '_HashJoin') > 0;
+END;
+$$ LANGUAGE plpgsql;
 
-SELECT gp_tablespace_watch_stop();
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
-
--- If temp_file_tablespaces is empty, temporary tables should be stored in
--- temp_tablespaces.
-RESET temp_file_tablespaces;
-
--- This query should create the temporary directory
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
-
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-
--- Run this this query again to create temporary hashjoin files in temp_tables
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
-
-SELECT gp_tablespace_watch_stop();
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
+-- Files should be in default tablespace
+SELECT * FROM gp_tablespace_file_report(NULL, NULL);
+-- Files should be in temp_tables
+SELECT * FROM gp_tablespace_file_report('temp_tables', NULL);
+-- Files should be in temp_files
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files');
+-- Files should be in temp_files
+SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files');
 
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -301,26 +301,11 @@ $$;
 drop table tmp_table_12871;
 drop tablespace space_12871;
 
+--
 -- temp_file_tablespaces:
-
--- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
--- only temporary files will be saved in the specified table spaces. Temporary
--- table files will still be stored in the system tablespace.
-CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
-
+--
 SET optimizer = off;
 SET statement_mem = '2MB';
-
-SET temp_tablespaces = temp_tables;
-SET temp_file_tablespaces = temp_files;
-
-CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
-
-SELECT pg_tablespace.spcname
-    FROM pg_class
-    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
-        WHERE relname = 'tts_baz';
 
 CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
@@ -334,7 +319,74 @@ ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
 
--- This query should create the temporary directory
+-- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
+-- only temporary files will be saved in the specified table spaces.
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+
+SET temp_file_tablespaces = temp_files;
+
+-- Should be in default tablespace.
+CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+SELECT count(*)
+    FROM pg_class
+    WHERE pg_class.reltablespace = 0 AND relname = 'tts_baz';
+
+DROP TABLE tts_baz;
+
+-- This query should create the temporary directory.
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+
+-- Run this this query again to create temporary hashjoin files in temp_files
+-- tablespace.
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+
+SELECT gp_tablespace_watch_stop();
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0 as "exist";
+
+DROP TABLESPACE temp_files;
+RESET temp_file_tablespaces;
+
+-- If both temp_tablespaces and temp_file_tablespaces is not empty, only
+-- temporary files should be saved in temp_file_tablespaces. Temporary tables
+-- shoud still be stored in temp_tablespaces.
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+
+SET temp_tablespaces = temp_tables;
+SET temp_file_tablespaces = temp_files;
+
+-- Should be in temp_tables tablespace.
+CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+SELECT pg_tablespace.spcname
+    FROM pg_class
+    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
+        WHERE relname = 'tts_baz';
+
+DROP TABLE tts_baz;
+
+-- This query should create the temporary directory.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -349,7 +401,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespac
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
 
 -- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace
+-- tablespace.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -382,7 +434,7 @@ select count(*) from out11;
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
 
 -- Run this this query again to create temporary hashjoin files in temp_tables
--- tablespace
+-- tablespace.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -396,7 +448,6 @@ select count(*) from out11;
 SELECT gp_tablespace_watch_stop();
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
 
-DROP TABLE tts_baz;
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;
 DROP TABLE tts_jazz;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -381,7 +381,7 @@ select count(*) from out11;
 
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
 
--- Run this this query again to create temporary hashjoin files in temp_
+-- Run this this query again to create temporary hashjoin files in temp_tables
 -- tablespace
 with out11 as (
     SELECT * FROM (

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -313,7 +313,7 @@ CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
 
 INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
 INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
-INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
 
 ANALYZE tts_foo;
 ANALYZE tts_bar;
@@ -335,7 +335,7 @@ SELECT count(*)
 DROP TABLE tts_baz;
 
 -- This query should create the temporary directory.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -343,14 +343,14 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
 
 -- Run this this query again to create temporary hashjoin files in temp_files
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -358,7 +358,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_stop();
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
@@ -387,7 +387,7 @@ SELECT pg_tablespace.spcname
 DROP TABLE tts_baz;
 
 -- This query should create the temporary directory.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -395,14 +395,14 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
 
 -- Run this this query again to create temporary hashjoin files in temp_files
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -410,7 +410,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_stop();
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
@@ -421,7 +421,7 @@ SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 
 RESET temp_file_tablespaces;
 
 -- This query should create the temporary directory
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -429,13 +429,13 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
 
 -- Run this this query again to create temporary hashjoin files in temp_tables
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -443,7 +443,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
 
 SELECT gp_tablespace_watch_stop();
 SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -504,7 +504,7 @@ CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
 CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
 INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
 INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
-INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
 ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
@@ -524,7 +524,7 @@ SELECT count(*)
 
 DROP TABLE tts_baz;
 -- This query should create the temporary directory.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -532,7 +532,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002
@@ -556,7 +556,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespa
 
 -- Run this this query again to create temporary hashjoin files in temp_files
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -564,7 +564,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002
@@ -616,7 +616,7 @@ SELECT pg_tablespace.spcname
 
 DROP TABLE tts_baz;
 -- This query should create the temporary directory.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -624,7 +624,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002
@@ -648,7 +648,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace
 
 -- Run this this query again to create temporary hashjoin files in temp_files
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -656,7 +656,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002
@@ -690,7 +690,7 @@ SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 
 -- temp_tablespaces.
 RESET temp_file_tablespaces;
 -- This query should create the temporary directory
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -698,7 +698,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002
@@ -714,7 +714,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespac
 
 -- Run this this query again to create temporary hashjoin files in temp_tables
 -- tablespace.
-with out11 as (
+WITH out11 AS (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
       SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
@@ -722,7 +722,7 @@ with out11 as (
     ) AS XY
     JOIN tts_jazz on c = e AND b = f
 )
-select count(*) from out11;
+SELECT count(*) FROM out11;
  count  
 --------
  228002

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -594,8 +594,8 @@ SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 
  t
 (3 rows)
 
--- If temp_tablespaces is not empty, temporary tables should be stored in
--- temp_tablespaces, while files should be stored in temp_file_tablespaces.
+-- If temp_file_tablespaces is empty, temporary tables should be stored in
+-- temp_tablespaces.
 RESET temp_file_tablespaces;
 -- This query should create the temporary directory
 with out11 as (

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -494,3 +494,167 @@ NOTICE:  ok
 NOTICE:  ok
 drop table tmp_table_12871;
 drop tablespace space_12871;
+-- temp_file_tablespaces:
+-- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
+-- only temporary files will be saved in the specified table spaces. Temporary
+-- table files will still be stored in the system tablespace.
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+SET optimizer = off;
+SET statement_mem = '2MB';
+SET temp_tablespaces = temp_tables;
+SET temp_file_tablespaces = temp_files;
+CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+SELECT pg_tablespace.spcname
+    FROM pg_class
+    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
+        WHERE relname = 'tts_baz';
+   spcname   
+-------------
+ temp_tables
+(1 row)
+
+CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
+CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
+INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
+INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
+ANALYZE tts_foo;
+ANALYZE tts_bar;
+ANALYZE tts_jazz;
+-- This query should create the temporary directory
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+ gp_tablespace_watch_start 
+---------------------------
+ 
+ 
+ 
+(3 rows)
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+ gp_tablespace_watch_start 
+---------------------------
+ 
+ 
+ 
+(3 rows)
+
+-- Run this this query again to create temporary hashjoin files in temp_files
+-- tablespace
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_stop();
+ gp_tablespace_watch_stop 
+--------------------------
+ 
+ 
+ 
+(3 rows)
+
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
+ exist 
+-------
+ f
+ f
+ f
+(3 rows)
+
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
+ exist 
+-------
+ t
+ t
+ t
+(3 rows)
+
+-- If temp_tablespaces is not empty, temporary tables should be stored in
+-- temp_tablespaces, while files should be stored in temp_file_tablespaces.
+RESET temp_file_tablespaces;
+-- This query should create the temporary directory
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+ gp_tablespace_watch_start 
+---------------------------
+ 
+ 
+ 
+(3 rows)
+
+-- Run this this query again to create temporary hashjoin files in temp_
+-- tablespace
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_stop();
+ gp_tablespace_watch_stop 
+--------------------------
+ 
+ 
+ 
+(3 rows)
+
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
+ exist 
+-------
+ t
+ t
+ t
+(3 rows)
+
+DROP TABLE tts_baz;
+DROP TABLE tts_foo;
+DROP TABLE tts_bar;
+DROP TABLE tts_jazz;
+DROP TABLESPACE temp_tables;
+DROP TABLESPACE temp_files;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -497,8 +497,6 @@ drop tablespace space_12871;
 --
 -- temp_file_tablespaces:
 --
-SET optimizer = off;
-SET statement_mem = '2MB';
 CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
 CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
@@ -508,38 +506,66 @@ INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
 ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
 CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
-SET temp_file_tablespaces = temp_files;
--- Should be in default tablespace.
-CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
-SELECT count(*)
-    FROM pg_class
-    WHERE pg_class.reltablespace = 0 AND relname = 'tts_baz';
- count 
--------
-     1
-(1 row)
-
-DROP TABLE tts_baz;
-RESET temp_file_tablespaces;
+CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
+CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
+SET optimizer = off;
+SET statement_mem = '2MB';
+-- Creates a temporary table returns the tablespace it was created in. Runs a
+-- query that creates some temporary files, calculates the tablespace for
+-- temporary files that will be used for current session, and checks if any
+-- files were created in that tablespace.
+--
+-- 'n_temp_file_tablespaces' is the count of tablespaces specified in
+-- 'temp_file_tablespaces'. Multiple tablespaces in 'temp_file_tablespaces' need
+-- to be specified in increasing order.
 CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
     temp_tablespaces text,
-    temp_file_tablespaces text
-) RETURNS TABLE (in_default boolean, in_temp_tables boolean, in_temp_files boolean) AS $$
+    temp_file_tablespaces text,
+    n_temp_file_tablespaces int
+) RETURNS TABLE (
+        temp_table_in text,
+        files_in_default boolean,
+        files_in_temp_tables boolean,
+        files_in_temp_files_n boolean
+    ) AS $$
 DECLARE
     owo int;
+    session_ts_n int;
+    session_file_ts_name text;
+    temp_table_ts_name text;
 BEGIN
     RESET temp_tablespaces;
     RESET temp_file_tablespaces;
 
     IF temp_tablespaces IS NOT NULL THEN
-        EXECUTE 'SET temp_tablespaces = ' || quote_literal(temp_tablespaces);
+        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
     END IF;
 
     IF temp_file_tablespaces IS NOT NULL THEN
-        EXECUTE 'SET temp_file_tablespaces = ' || quote_literal(temp_file_tablespaces);
+        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
     END IF;
+
+    CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+    -- See the tablespace where temporary table was created. If there is no
+    -- tablespace for this table, it's in default tablespace.
+    SELECT ts.spcname
+        FROM pg_tablespace ts
+        JOIN pg_class c ON ts.oid = c.reltablespace AND c.relname = 'tts_baz'
+        LIMIT 1
+        INTO temp_table_ts_name;
+
+    DROP TABLE tts_baz;
+
+    -- Find out the tablespace that will be used for files.
+    -- N = gp_session_id % number of tablespaces in GUC.
+    SELECT id.setting::int % n_temp_file_tablespaces
+        FROM (SELECT setting FROM pg_settings WHERE name = 'gp_session_id') id
+        INTO session_ts_n;
+    SELECT 'temp_files' || session_ts_n INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (
@@ -553,9 +579,9 @@ BEGIN
     SELECT count(*) FROM out11 INTO owo;
 
     -- Start monitoring temporary tablespace usage.
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
 
     -- Run the query again to create temporary hashjoin files in the tablespaces.
     WITH out11 AS (
@@ -572,49 +598,130 @@ BEGIN
 
     -- Check the existence of temporary hashjoin files.
     RETURN QUERY SELECT
+        coalesce(temp_table_ts_name, 'default'),
         gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0,
         gp_tablespace_watch_match(gp_execution_dbid(), 'temp_tables', '_HashJoin') > 0,
-        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_files', '_HashJoin') > 0;
+        gp_tablespace_watch_match(gp_execution_dbid(), session_file_ts_name, '_HashJoin') > 0;
 END;
 $$ LANGUAGE plpgsql;
--- Files should be in default tablespace
-SELECT * FROM gp_tablespace_file_report(NULL, NULL);
- in_default | in_temp_tables | in_temp_files 
-------------+----------------+---------------
- t          | f              | f
- t          | f              | f
- t          | f              | f
+-- Show directories of the tablespaces that will be used.
+-- start_ignore
+SELECT gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1));
+ gp_temptablespace_path 
+------------------------
+ base/pgsql_tmp
+ base/pgsql_tmp
+ base/pgsql_tmp
 (3 rows)
 
--- Files should be in temp_tables
-SELECT * FROM gp_tablespace_file_report('temp_tables', NULL);
- in_default | in_temp_tables | in_temp_files 
-------------+----------------+---------------
- f          | t              | f
- f          | t              | f
- f          | t              | f
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1));
+           gp_temptablespace_path            
+---------------------------------------------
+ pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
--- Files should be in temp_files
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files');
- in_default | in_temp_tables | in_temp_files 
-------------+----------------+---------------
- f          | f              | t
- f          | f              | t
- f          | f              | t
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files0' LIMIT 1));
+           gp_temptablespace_path            
+---------------------------------------------
+ pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
--- Files should be in temp_files
-SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files');
- in_default | in_temp_tables | in_temp_files 
-------------+----------------+---------------
- f          | f              | t
- f          | f              | t
- f          | f              | t
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files1' LIMIT 1));
+           gp_temptablespace_path            
+---------------------------------------------
+ pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
+(3 rows)
+
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files2' LIMIT 1));
+           gp_temptablespace_path            
+---------------------------------------------
+ pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
+(3 rows)
+
+SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files3' LIMIT 1));
+           gp_temptablespace_path            
+---------------------------------------------
+ pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
+(3 rows)
+
+-- end_ignore
+-- Both files and the table should be in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, NULL, 1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | t                | f                    | f
+ default       | t                | f                    | f
+ default       | t                | f                    | f
+(3 rows)
+
+-- Both files and the table should be in temp_tables.
+SELECT * FROM gp_tablespace_file_report('temp_tables', NULL, 1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ temp_tables   | f                | t                    | f
+ temp_tables   | f                | t                    | f
+ temp_tables   | f                | t                    | f
+(3 rows)
+
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
+ gp_session_id | n 
+---------------+---
+ 649           | 0
+(1 row)
+
+--end_ignore
+-- Files should be in temp_files0, table should be in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0', 1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+(3 rows)
+
+-- Files should be in temp_files0, table should be in temp_tables.
+SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files0', 1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ temp_tables   | f                | f                    | t
+ temp_tables   | f                | f                    | t
+ temp_tables   | f                | f                    | t
+(3 rows)
+
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
+ gp_session_id | n 
+---------------+---
+ 649           | 1
+(1 row)
+
+--end_ignore
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3', 4);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+ default       | f                | f                    | t
 (3 rows)
 
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;
 DROP TABLE tts_jazz;
 DROP TABLESPACE temp_tables;
-DROP TABLESPACE temp_files;
+DROP TABLESPACE temp_files0;
+DROP TABLESPACE temp_files1;
+DROP TABLESPACE temp_files2;
+DROP TABLESPACE temp_files3;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -494,16 +494,116 @@ NOTICE:  ok
 NOTICE:  ok
 drop table tmp_table_12871;
 drop tablespace space_12871;
+--
 -- temp_file_tablespaces:
--- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
--- only temporary files will be saved in the specified table spaces. Temporary
--- table files will still be stored in the system tablespace.
-CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+--
 SET optimizer = off;
 SET statement_mem = '2MB';
+CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
+CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
+INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
+INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
+ANALYZE tts_foo;
+ANALYZE tts_bar;
+ANALYZE tts_jazz;
+-- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
+-- only temporary files will be saved in the specified table spaces.
+CREATE TABLESPACE temp_files LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_files';
+SET temp_file_tablespaces = temp_files;
+-- Should be in default tablespace.
+CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+SELECT count(*)
+    FROM pg_class
+    WHERE pg_class.reltablespace = 0 AND relname = 'tts_baz';
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE tts_baz;
+-- This query should create the temporary directory.
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+ gp_tablespace_watch_start 
+---------------------------
+ 
+ 
+ 
+(3 rows)
+
+SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+ gp_tablespace_watch_start 
+---------------------------
+ 
+ 
+ 
+(3 rows)
+
+-- Run this this query again to create temporary hashjoin files in temp_files
+-- tablespace.
+with out11 as (
+    SELECT * FROM (
+      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+      UNION ALL SELECT *, 1, 2 FROM cte
+    ) AS XY
+    JOIN tts_jazz on c = e AND b = f
+)
+select count(*) from out11;
+ count  
+--------
+ 228002
+(1 row)
+
+SELECT gp_tablespace_watch_stop();
+ gp_tablespace_watch_stop 
+--------------------------
+ 
+ 
+ 
+(3 rows)
+
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
+ exist 
+-------
+ t
+ t
+ t
+(3 rows)
+
+SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0 as "exist";
+ exist 
+-------
+ f
+ f
+ f
+(3 rows)
+
+DROP TABLESPACE temp_files;
+RESET temp_file_tablespaces;
+-- If both temp_tablespaces and temp_file_tablespaces is not empty, only
+-- temporary files should be saved in temp_file_tablespaces. Temporary tables
+-- shoud still be stored in temp_tablespaces.
+CREATE TABLESPACE temp_tables LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_tables';
+CREATE TABLESPACE temp_files LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_files';
 SET temp_tablespaces = temp_tables;
 SET temp_file_tablespaces = temp_files;
+-- Should be in temp_tables tablespace.
 CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
 SELECT pg_tablespace.spcname
     FROM pg_class
@@ -514,16 +614,8 @@ SELECT pg_tablespace.spcname
  temp_tables
 (1 row)
 
-CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
-CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
-CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
-INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
-INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
-INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000,150000) i;
-ANALYZE tts_foo;
-ANALYZE tts_bar;
-ANALYZE tts_jazz;
--- This query should create the temporary directory
+DROP TABLE tts_baz;
+-- This query should create the temporary directory.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -555,7 +647,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace
 (3 rows)
 
 -- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace
+-- tablespace.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -621,7 +713,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespac
 (3 rows)
 
 -- Run this this query again to create temporary hashjoin files in temp_tables
--- tablespace
+-- tablespace.
 with out11 as (
     SELECT * FROM (
       WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
@@ -652,7 +744,6 @@ SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0
  t
 (3 rows)
 
-DROP TABLE tts_baz;
 DROP TABLE tts_foo;
 DROP TABLE tts_bar;
 DROP TABLE tts_jazz;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -513,8 +513,8 @@ CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
 CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 SET optimizer = off;
 SET statement_mem = '2MB';
--- Creates a temporary table returns the tablespace it was created in. Runs a
--- query that creates some temporary files, calculates the tablespace for
+-- Creates a temporary table and remembers the tablespace it was created in.
+-- Runs a query that creates some temporary files, calculates the tablespace for
 -- temporary files that will be used for current session, and checks if any
 -- files were created in that tablespace.
 --
@@ -533,7 +533,7 @@ CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
     ) AS $$
 DECLARE
     owo int;
-    session_ts_n int;
+    session_file_ts_n int;
     session_file_ts_name text;
     temp_table_ts_name text;
 BEGIN
@@ -564,8 +564,8 @@ BEGIN
     -- N = gp_session_id % number of tablespaces in GUC.
     SELECT id.setting::int % n_temp_file_tablespaces
         FROM (SELECT setting FROM pg_settings WHERE name = 'gp_session_id') id
-        INTO session_ts_n;
-    SELECT 'temp_files' || session_ts_n INTO session_file_ts_name;
+        INTO session_file_ts_n;
+    SELECT 'temp_files' || session_file_ts_n INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -508,9 +508,8 @@ INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
 ANALYZE tts_foo;
 ANALYZE tts_bar;
 ANALYZE tts_jazz;
--- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
--- only temporary files will be saved in the specified table spaces.
 CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
 SET temp_file_tablespaces = temp_files;
 -- Should be in default tablespace.
 CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
@@ -523,225 +522,95 @@ SELECT count(*)
 (1 row)
 
 DROP TABLE tts_baz;
--- This query should create the temporary directory.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
-
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
- gp_tablespace_watch_start 
----------------------------
- 
- 
- 
-(3 rows)
-
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
- gp_tablespace_watch_start 
----------------------------
- 
- 
- 
-(3 rows)
-
--- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
-
-SELECT gp_tablespace_watch_stop();
- gp_tablespace_watch_stop 
---------------------------
- 
- 
- 
-(3 rows)
-
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
- exist 
--------
- t
- t
- t
-(3 rows)
-
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0 as "exist";
- exist 
--------
- f
- f
- f
-(3 rows)
-
-DROP TABLESPACE temp_files;
 RESET temp_file_tablespaces;
--- If both temp_tablespaces and temp_file_tablespaces is not empty, only
--- temporary files should be saved in temp_file_tablespaces. Temporary tables
--- shoud still be stored in temp_tablespaces.
-CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
-CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
-SET temp_tablespaces = temp_tables;
-SET temp_file_tablespaces = temp_files;
--- Should be in temp_tables tablespace.
-CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
-SELECT pg_tablespace.spcname
-    FROM pg_class
-    INNER JOIN pg_tablespace ON pg_class.reltablespace = pg_tablespace.oid
-        WHERE relname = 'tts_baz';
-   spcname   
--------------
- temp_tables
-(1 row)
+CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
+    temp_tablespaces text,
+    temp_file_tablespaces text
+) RETURNS TABLE (in_default boolean, in_temp_tables boolean, in_temp_files boolean) AS $$
+DECLARE
+    owo int;
+BEGIN
+    RESET temp_tablespaces;
+    RESET temp_file_tablespaces;
 
-DROP TABLE tts_baz;
--- This query should create the temporary directory.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
+    IF temp_tablespaces IS NOT NULL THEN
+        EXECUTE 'SET temp_tablespaces = ' || quote_literal(temp_tablespaces);
+    END IF;
 
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
- gp_tablespace_watch_start 
----------------------------
- 
- 
- 
+    IF temp_file_tablespaces IS NOT NULL THEN
+        EXECUTE 'SET temp_file_tablespaces = ' || quote_literal(temp_file_tablespaces);
+    END IF;
+
+    -- Create the temporary directory.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    -- Start monitoring temporary tablespace usage.
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((select dattablespace from pg_database where datname=current_database() limit 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
+
+    -- Run the query again to create temporary hashjoin files in the tablespaces.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    PERFORM gp_tablespace_watch_stop();
+
+    -- Check the existence of temporary hashjoin files.
+    RETURN QUERY SELECT
+        gp_tablespace_watch_match(gp_execution_dbid(), 'default', '_HashJoin') > 0,
+        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_tables', '_HashJoin') > 0,
+        gp_tablespace_watch_match(gp_execution_dbid(), 'temp_files', '_HashJoin') > 0;
+END;
+$$ LANGUAGE plpgsql;
+-- Files should be in default tablespace
+SELECT * FROM gp_tablespace_file_report(NULL, NULL);
+ in_default | in_temp_tables | in_temp_files 
+------------+----------------+---------------
+ t          | f              | f
+ t          | f              | f
+ t          | f              | f
 (3 rows)
 
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'files', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files' LIMIT 1)));
- gp_tablespace_watch_start 
----------------------------
- 
- 
- 
+-- Files should be in temp_tables
+SELECT * FROM gp_tablespace_file_report('temp_tables', NULL);
+ in_default | in_temp_tables | in_temp_files 
+------------+----------------+---------------
+ f          | t              | f
+ f          | t              | f
+ f          | t              | f
 (3 rows)
 
--- Run this this query again to create temporary hashjoin files in temp_files
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
-
-SELECT gp_tablespace_watch_stop();
- gp_tablespace_watch_stop 
---------------------------
- 
- 
- 
+-- Files should be in temp_files
+SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files');
+ in_default | in_temp_tables | in_temp_files 
+------------+----------------+---------------
+ f          | f              | t
+ f          | f              | t
+ f          | f              | t
 (3 rows)
 
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
- exist 
--------
- f
- f
- f
-(3 rows)
-
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'files', '_HashJoin') > 0 as "exist";
- exist 
--------
- t
- t
- t
-(3 rows)
-
--- If temp_file_tablespaces is empty, temporary tables should be stored in
--- temp_tablespaces.
-RESET temp_file_tablespaces;
--- This query should create the temporary directory
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
-
-SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
- gp_tablespace_watch_start 
----------------------------
- 
- 
- 
-(3 rows)
-
--- Run this this query again to create temporary hashjoin files in temp_tables
--- tablespace.
-WITH out11 AS (
-    SELECT * FROM (
-      WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
-      SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
-      UNION ALL SELECT *, 1, 2 FROM cte
-    ) AS XY
-    JOIN tts_jazz on c = e AND b = f
-)
-SELECT count(*) FROM out11;
- count  
---------
- 228002
-(1 row)
-
-SELECT gp_tablespace_watch_stop();
- gp_tablespace_watch_stop 
---------------------------
- 
- 
- 
-(3 rows)
-
-SELECT gp_tablespace_watch_match(gp_execution_dbid(), 'tables', '_HashJoin') > 0 as "exist";
- exist 
--------
- t
- t
- t
+-- Files should be in temp_files
+SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files');
+ in_default | in_temp_tables | in_temp_files 
+------------+----------------+---------------
+ f          | f              | t
+ f          | f              | t
+ f          | f              | t
 (3 rows)
 
 DROP TABLE tts_foo;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -510,7 +510,7 @@ ANALYZE tts_bar;
 ANALYZE tts_jazz;
 -- If the temp_file_tablespaces is not empty, but temp_tablespaces is empty,
 -- only temporary files will be saved in the specified table spaces.
-CREATE TABLESPACE temp_files LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_files';
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
 SET temp_file_tablespaces = temp_files;
 -- Should be in default tablespace.
 CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
@@ -599,8 +599,8 @@ RESET temp_file_tablespaces;
 -- If both temp_tablespaces and temp_file_tablespaces is not empty, only
 -- temporary files should be saved in temp_file_tablespaces. Temporary tables
 -- shoud still be stored in temp_tablespaces.
-CREATE TABLESPACE temp_tables LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_tables';
-CREATE TABLESPACE temp_files LOCATION '/home/sd/Work/Actual/gpdb/src/test/regress/testtablespace_temp_files';
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files LOCATION '@testtablespace@_temp_files';
 SET temp_tablespaces = temp_tables;
 SET temp_file_tablespaces = temp_files;
 -- Should be in temp_tables tablespace.

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -497,6 +497,16 @@ drop tablespace space_12871;
 --
 -- temp_file_tablespaces:
 --
+-- start_ignore
+DROP TABLE IF EXISTS tts_foo;
+DROP TABLE IF EXISTS tts_bar;
+DROP TABLE IF EXISTS tts_jazz;
+DROP TABLESPACE IF EXISTS temp_tables;
+DROP TABLESPACE IF EXISTS temp_files0;
+DROP TABLESPACE IF EXISTS temp_files1;
+DROP TABLESPACE IF EXISTS temp_files2;
+DROP TABLESPACE IF EXISTS temp_files3;
+-- end_ignore
 CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
 CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
@@ -511,19 +521,40 @@ CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
 CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
 CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
 CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
+RESET temp_tablespaces;
+RESET temp_file_tablespaces;
 SET optimizer = off;
 SET statement_mem = '2MB';
+-- Multiple tablespaces in 'temp_file_tablespaces' and 'g_temp_file_tablespaces'
+-- need to be specified in increasing order.
+CREATE OR REPLACE FUNCTION gp_tablespace_set_gucs(
+    temp_tablespaces text,
+    temp_file_tablespaces text
+) RETURNS void AS $$
+BEGIN
+    RESET temp_tablespaces;
+    RESET temp_file_tablespaces;
+
+    IF temp_tablespaces IS NOT NULL THEN
+        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
+    END IF;
+
+    IF temp_file_tablespaces IS NOT NULL THEN
+        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
 -- Creates a temporary table and remembers the tablespace it was created in.
 -- Runs a query that creates some temporary files, calculates the tablespace for
 -- temporary files that will be used for current session, and checks if any
 -- files were created in that tablespace.
 --
+-- We set GUCs and perform the report in two separate function calls
+-- (transactions). Otherwise, global configuration will not be reloaded.
+--
 -- 'n_temp_file_tablespaces' is the count of tablespaces specified in
--- 'temp_file_tablespaces'. Multiple tablespaces in 'temp_file_tablespaces' need
--- to be specified in increasing order.
+-- 'temp_file_tablespaces', either global or session-wide.
 CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
-    temp_tablespaces text,
-    temp_file_tablespaces text,
     n_temp_file_tablespaces int
 ) RETURNS TABLE (
         temp_table_in text,
@@ -537,17 +568,6 @@ DECLARE
     session_file_ts_name text;
     temp_table_ts_name text;
 BEGIN
-    RESET temp_tablespaces;
-    RESET temp_file_tablespaces;
-
-    IF temp_tablespaces IS NOT NULL THEN
-        EXECUTE format('SET temp_tablespaces = %s', temp_tablespaces);
-    END IF;
-
-    IF temp_file_tablespaces IS NOT NULL THEN
-        EXECUTE format('SET temp_file_tablespaces = %s', temp_file_tablespaces);
-    END IF;
-
     CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
 
     -- See the tablespace where temporary table was created. If there is no
@@ -615,48 +635,56 @@ SELECT gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datna
 (3 rows)
 
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1));
-           gp_temptablespace_path            
----------------------------------------------
- pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147681/GPDB_6_301908232/pgsql_tmp
+           gp_temptablespace_path           
+--------------------------------------------
+ pg_tblspc/16544/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16544/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16544/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files0' LIMIT 1));
-           gp_temptablespace_path            
----------------------------------------------
- pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147682/GPDB_6_301908232/pgsql_tmp
+           gp_temptablespace_path           
+--------------------------------------------
+ pg_tblspc/16545/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16545/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16545/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files1' LIMIT 1));
-           gp_temptablespace_path            
----------------------------------------------
- pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147683/GPDB_6_301908232/pgsql_tmp
+           gp_temptablespace_path           
+--------------------------------------------
+ pg_tblspc/16546/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16546/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16546/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files2' LIMIT 1));
-           gp_temptablespace_path            
----------------------------------------------
- pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147684/GPDB_6_301908232/pgsql_tmp
+           gp_temptablespace_path           
+--------------------------------------------
+ pg_tblspc/16547/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16547/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16547/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
 SELECT gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_files3' LIMIT 1));
-           gp_temptablespace_path            
----------------------------------------------
- pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
- pg_tblspc/147685/GPDB_6_301908232/pgsql_tmp
+           gp_temptablespace_path           
+--------------------------------------------
+ pg_tblspc/16548/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16548/GPDB_6_301908232/pgsql_tmp
+ pg_tblspc/16548/GPDB_6_301908232/pgsql_tmp
 (3 rows)
 
 -- end_ignore
+--
+-- Global GUC value tests:
+--
 -- Both files and the table should be in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, NULL, 1);
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
  temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
 ---------------+------------------+----------------------+-----------------------
  default       | t                | f                    | f
@@ -665,7 +693,12 @@ SELECT * FROM gp_tablespace_file_report(NULL, NULL, 1);
 (3 rows)
 
 -- Both files and the table should be in temp_tables.
-SELECT * FROM gp_tablespace_file_report('temp_tables', NULL, 1);
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v temp_tables
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
  temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
 ---------------+------------------+----------------------+-----------------------
  temp_tables   | f                | t                    | f
@@ -673,16 +706,19 @@ SELECT * FROM gp_tablespace_file_report('temp_tables', NULL, 1);
  temp_tables   | f                | t                    | f
 (3 rows)
 
+-- Files should be in temp_files0, table should be in the default tablespace.
 --start_ignore
 SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
  gp_session_id | n 
 ---------------+---
- 649           | 0
+ 97            | 0
 (1 row)
 
---end_ignore
--- Files should be in temp_files0, table should be in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0', 1);
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_file_tablespaces -v temp_files0
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
  temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
 ---------------+------------------+----------------------+-----------------------
  default       | f                | f                    | t
@@ -691,7 +727,12 @@ SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0', 1);
 (3 rows)
 
 -- Files should be in temp_files0, table should be in temp_tables.
-SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files0', 1);
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v temp_tables
+\! gpconfig -c temp_file_tablespaces -v temp_files0
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
  temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
 ---------------+------------------+----------------------+-----------------------
  temp_tables   | f                | f                    | t
@@ -699,17 +740,121 @@ SELECT * FROM gp_tablespace_file_report('temp_tables', 'temp_files0', 1);
  temp_tables   | f                | f                    | t
 (3 rows)
 
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
 --start_ignore
 SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
  gp_session_id | n 
 ---------------+---
- 649           | 1
+ 97            | 1
+(1 row)
+
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_file_tablespaces -v temp_files0,temp_files1,temp_files2,temp_files3
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(4);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+(3 rows)
+
+-- Reset the global config before testing session-only values.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_file_tablespaces
+\! gpstop -u
+-- end_ignore
+--
+-- Session-only GUC value tests:
+--
+-- Both files and the table should be in the default tablespace.
+SELECT * FROM gp_tablespace_set_gucs(NULL, NULL);
+ gp_tablespace_set_gucs 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | t                | f                    | f
+ default       | t                | f                    | f
+ default       | t                | f                    | f
+(3 rows)
+
+-- Both files and the table should be in temp_tables.
+SELECT * FROM gp_tablespace_set_gucs('temp_tables', NULL);
+ gp_tablespace_set_gucs 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ temp_tables   | f                | t                    | f
+ temp_tables   | f                | t                    | f
+ temp_tables   | f                | t                    | f
+(3 rows)
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 1 as n FROM pg_settings WHERE name = 'gp_session_id';
+ gp_session_id | n 
+---------------+---
+ 97            | 0
 (1 row)
 
 --end_ignore
+SELECT * FROM gp_tablespace_set_gucs(NULL, 'temp_files0');
+ gp_tablespace_set_gucs 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+ default       | f                | f                    | t
+(3 rows)
+
+-- Files should be in temp_files0, table should be in temp_tables.
+SELECT * FROM gp_tablespace_set_gucs('temp_tables', 'temp_files0');
+ gp_tablespace_set_gucs 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
+---------------+------------------+----------------------+-----------------------
+ temp_tables   | f                | f                    | t
+ temp_tables   | f                | f                    | t
+ temp_tables   | f                | f                    | t
+(3 rows)
+
 -- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
 -- in the default tablespace.
-SELECT * FROM gp_tablespace_file_report(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3', 4);
+--start_ignore
+SELECT setting as gp_session_id, setting::int % 4 as n FROM pg_settings WHERE name = 'gp_session_id';
+ gp_session_id | n 
+---------------+---
+ 97            | 1
+(1 row)
+
+--end_ignore
+SELECT * FROM gp_tablespace_set_gucs(NULL, 'temp_files0,temp_files1,temp_files2,temp_files3');
+ gp_tablespace_set_gucs 
+------------------------
+ 
+(1 row)
+
+SELECT * FROM gp_tablespace_file_report(4);
  temp_table_in | files_in_default | files_in_temp_tables | files_in_temp_files_n 
 ---------------+------------------+----------------------+-----------------------
  default       | f                | f                    | t

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -620,7 +620,7 @@ SELECT gp_tablespace_watch_start(gp_execution_dbid(), 'tables', gp_temptablespac
  
 (3 rows)
 
--- Run this this query again to create temporary hashjoin files in temp_
+-- Run this this query again to create temporary hashjoin files in temp_tables
 -- tablespace
 with out11 as (
     SELECT * FROM (


### PR DESCRIPTION
Implement MVP to move temp files to a separate table space

Some operations create temporary files on disk. The growth of temporary files in
conjunction with temporary tables can lead to 100% usage of the data directory
and an emergency stop of the DBMS.

Implement `temp_file_tablespaces` GUC that controls tablespaces where temporary
files are stored. Temporary tables will still be stored in `temp_tablespaces`.

In case `temp_file_tablespaces` is empty: the behavior will remain the same, and
both files and tables will be stored in the specified table spaces according to
the list in `temp_tablespaces`, or if it's also empty, in system table spaces. 

If the `temp_file_tablespaces` is not empty, but `temp_tablespaces` is empty,
only temporary files will be saved in the specified table spaces. Temporary
table files will still be stored in the system tablespace.
