### PR TITLE
ADBDEV-4902-2: Add a null check to `mapred_obj_error()`

### DIFF
--- a/gpcontrib/gpmapreduce/src/mapred.c
+++ b/gpcontrib/gpmapreduce/src/mapred.c
@@ -153,7 +153,7 @@ int mapred_obj_error(mapred_object_t *obj, char *fmt, ...)
 	va_start(arg, fmt);
 	vfprintf(stderr, fmt, arg);
 	va_end(arg);
-	if (obj->line > 0)
+	if (obj && obj->line > 0)
 		fprintf(stderr, ", at line %d\n", obj->line);
 	else
 		fprintf(stderr, "\n");


### PR DESCRIPTION
Add a null check to mapred_obj_error()

Every place that uses mapred_obj_error() either does XASSERT(obj), or begins
with a switch (obj->kind). There are no calls to mapred_obj_error() with obj
explicitly set to NULL, and every other check inside mapred_obj_error() checks
for obj to not be NULL.

Add a check for obj != NULL before trying to find out its line. Adding an assert
would defeat the purpose of other checks there (if (obj && ...)).
