### PR TITLE
ADBDEV-4902-1: Move `for_each_cell` under a null check

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7042,7 +7042,7 @@ atpxPartAddList(Relation rel,
 				skipTableRelid = RangeVarGetRelid(t->relation, NoLock, true);
 			}
 
-		/* FIXME: indent this or remove condition above if it is not needed */
+		/* FIXME: indent this */
 		for_each_cell(lc, lnext(lc))
 		{
 			Node	   *q = lfirst(lc);

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7100,7 +7100,6 @@ atpxPartAddList(Relation rel,
 						List	   *l2 = spec->partElem;
 						PartitionElem *pel;
 
-
 						if (l2 && list_length(l2))
 						{
 							pel = (PartitionElem *) linitial(l2);


### PR DESCRIPTION
Move for_each_cell under a null check

This block of code is executed when ALTER TABLE ADD PARTITION is issued in a
query. The first element of the list will be the parent table of that partition,
and next elements will be the CREATE/ALTER TABLE queries for partitions.

If this list does not have any statements other than the first one, or lc is
NULL (there is no statements to CREATE/ALTER partitions), further logic is
useless, since statements are needed to correctly process utility statements for
the partitions.