### PR TITLE
gpmapreduce: add return after assert to parser_add_file

### DIFF
--- a/gpcontrib/gpmapreduce/src/parse.c
+++ b/gpcontrib/gpmapreduce/src/parse.c
@@ -1366,6 +1366,12 @@ void parser_add_file(mapred_parser_t *parser, char *value)
 				return;
 			default:
 				XASSERT(false);
+				/*
+				 * If function is executed out of XTRY block, function will
+				 * continue to work, using incorrect "value".
+				 * Let's do return to avoid this.
+				 */
+				return;
 		}
 	}
 	/* Todo: improved regex checking on files */


### PR DESCRIPTION
Macro "XASSERT" uses "XRAISE", which uses "longjmp" to process errors.
"setjmp" is done at macro "XTRY". If function "parser_add_file" will be
executed out of macro "XTRY", than after checking value of argument "value"
function will continue it's work, even if "value" is incorrect (because
"longjmp" was not executed: "global_exception_frame" is NULL).

To avoid this, "return" was added after "XASSERT" to exit the function.
