### PR TITLE
ADBDEV-4902-5: Add a null check for `port->hba`

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -282,7 +282,6 @@ auth_failed(Port *port, int status, char *logdetail)
 	{
 		errstr = gettext_noop("authentication failed for user \"%s\": "
 							  "invalid authentication method");
-		cdetail = NULL;
 	}
 	else
 	{
@@ -330,15 +329,16 @@ auth_failed(Port *port, int status, char *logdetail)
 			errstr = gettext_noop("authentication failed for user \"%s\": invalid authentication method");
 			break;
 	  }
-	  cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
-						   port->hba->linenumber, port->hba->rawline);
 	}
+
+	cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
+					   port->hba->linenumber, port->hba->rawline);
 
     /*
      * Avoid leak user infomations when failed to connect database using LDAP,
      * and we need hide failed details return by LDAP.
      * */
-    if (port->hba && port->hba->auth_method == uaLDAP)
+    if (port->hba->auth_method == uaLDAP)
     {
         pfree(cdetail);
         cdetail = NULL;

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -329,9 +329,8 @@ auth_failed(Port *port, int status, char *logdetail)
 			errstr = gettext_noop("authentication failed for user \"%s\": invalid authentication method");
 			break;
 	  }
-
-		cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
-							 port->hba->linenumber, port->hba->rawline);
+	  cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
+						   port->hba->linenumber, port->hba->rawline);
 	}
 
     /*

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -329,8 +329,9 @@ auth_failed(Port *port, int status, char *logdetail)
 			errstr = gettext_noop("authentication failed for user \"%s\": invalid authentication method");
 			break;
 	  }
-	  cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
-						   port->hba->linenumber, port->hba->rawline);
+
+		cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
+							 port->hba->linenumber, port->hba->rawline);
 	}
 
     /*

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -282,6 +282,7 @@ auth_failed(Port *port, int status, char *logdetail)
 	{
 		errstr = gettext_noop("authentication failed for user \"%s\": "
 							  "invalid authentication method");
+		cdetail = NULL;
 	}
 	else
 	{
@@ -329,16 +330,15 @@ auth_failed(Port *port, int status, char *logdetail)
 			errstr = gettext_noop("authentication failed for user \"%s\": invalid authentication method");
 			break;
 	  }
+	  cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
+						   port->hba->linenumber, port->hba->rawline);
 	}
-
-	cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
-					   port->hba->linenumber, port->hba->rawline);
 
     /*
      * Avoid leak user infomations when failed to connect database using LDAP,
      * and we need hide failed details return by LDAP.
      * */
-    if (port->hba->auth_method == uaLDAP)
+    if (port->hba && port->hba->auth_method == uaLDAP)
     {
         pfree(cdetail);
         cdetail = NULL;

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -261,7 +261,7 @@ static void
 auth_failed(Port *port, int status, char *logdetail)
 {
 	const char *errstr;
-	char	   *cdetail;
+	char	   *cdetail = NULL;
 	int			errcode_return = ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION;
 
 	/*
@@ -282,7 +282,6 @@ auth_failed(Port *port, int status, char *logdetail)
 	{
 		errstr = gettext_noop("authentication failed for user \"%s\": "
 							  "invalid authentication method");
-		cdetail = NULL;
 	}
 	else
 	{

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -261,7 +261,7 @@ static void
 auth_failed(Port *port, int status, char *logdetail)
 {
 	const char *errstr;
-	char	   *cdetail;
+	char	   *cdetail = NULL;
 	int			errcode_return = ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION;
 
 	/*
@@ -329,8 +329,8 @@ auth_failed(Port *port, int status, char *logdetail)
 			errstr = gettext_noop("authentication failed for user \"%s\": invalid authentication method");
 			break;
 	  }
-	}
 
+	/* FIXME: indent this */
 	cdetail = psprintf(_("Connection matched pg_hba.conf line %d: \"%s\""),
 					   port->hba->linenumber, port->hba->rawline);
 
@@ -344,6 +344,7 @@ auth_failed(Port *port, int status, char *logdetail)
         cdetail = NULL;
         logdetail = NULL;
     }
+	}
 
 	if (logdetail)
 		logdetail = psprintf("%s\n%s", logdetail, cdetail);

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -261,7 +261,7 @@ static void
 auth_failed(Port *port, int status, char *logdetail)
 {
 	const char *errstr;
-	char	   *cdetail = NULL;
+	char	   *cdetail;
 	int			errcode_return = ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION;
 
 	/*
@@ -282,6 +282,7 @@ auth_failed(Port *port, int status, char *logdetail)
 	{
 		errstr = gettext_noop("authentication failed for user \"%s\": "
 							  "invalid authentication method");
+		cdetail = NULL;
 	}
 	else
 	{


### PR DESCRIPTION
Add a null check for port->hba

port->hba may be NULL on internal communication failure.

Move if condition under a null check to avoid dereferencing port->hba if it's
NULL.