### PR TITLE
ADBDEV-4907-41: Add NULL check in transformSetOperationStmt function

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2090,7 +2090,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 		leftmostSelect = leftmostSelect->larg;
 	Assert(leftmostSelect && IsA(leftmostSelect, SelectStmt) &&
 		   leftmostSelect->larg == NULL);
-	if (leftmostSelect->intoClause)
+	if (leftmostSelect && leftmostSelect->intoClause)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("SELECT ... INTO is not allowed here"),


### PR DESCRIPTION
Add NULL check in transformSetOperationStmt function

In the transformSetOperationStmt function, the leftmostSelect
pointer can be NULL on release builds, so to avoid a
null-pointer reference, I added an additional check.