### PR TITLE
ADBDEV-4902-6: Assert that `rel` is not null

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4552,6 +4552,9 @@ BeginCopyFrom(Relation rel,
 	MemoryContext oldcontext;
 	bool		volatile_defexprs;
 
+	/* rel will need be copied to cstate->rel and must not be NULL */
+	Assert(rel);
+
 	cstate = BeginCopy(true, rel, NULL, NULL, attnamelist, options, NULL);
 	oldcontext = MemoryContextSwitchTo(cstate->copycontext);
 
@@ -4560,8 +4563,7 @@ BeginCopyFrom(Relation rel,
 	 */
 	if (cstate->on_segment || data_source_cb)
 		cstate->dispatch_mode = COPY_DIRECT;
-	else if (Gp_role == GP_ROLE_DISPATCH &&
-			 cstate->rel && cstate->rel->rd_cdbpolicy)
+	else if (Gp_role == GP_ROLE_DISPATCH && cstate->rel->rd_cdbpolicy)
 		cstate->dispatch_mode = COPY_DISPATCH;
 	else if (Gp_role == GP_ROLE_EXECUTE)
 		cstate->dispatch_mode = COPY_EXECUTOR;


### PR DESCRIPTION
Assert that rel is not null

The warning was encountered in BeginCopyFrom().

All places where BeginCopyFrom() is called:
- In DoCopy(), rel is asserted to be non-NULL before the call.
- In external_beginscan(), which gets relation by range table index from
  ExecOpenScanExternalRelation(), that throws an error and does not return if an
  invalid relation id encountered.
- In fileBeginForeignScan(), RelationGetRelid(node->ss.ss_currentRelation)
  dereferences the pointer before the function call that in passed as rel.
- file_acquire_sample_rows() asserts that onerel (that is passed as rel) is not
  NULL.
- In fileReScanForeignScan(), which gets called by ExecRescan(). For foreign
  scan, rel is passed as scan->ss.ss_CurrentRelation. ss_CurrentRelation is only
  assigned in ExecInitForeignScan(), to a value returned from
  ExecOpenScanRelation(), which cannot return NULL.
