### PR TITLE
ADBDEV-4907-44: Avoid passing nulls to memcpy

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -148,7 +148,7 @@ initscan(AppendOnlyScanDesc scan, ScanKey key)
 	/*
 	 * copy the scan key, if appropriate
 	 */
-	if (key != NULL)
+	if (key != NULL && scan->aos_key != NULL && scan->aos_nkeys > 0)
 		memcpy(scan->aos_key, key, scan->aos_nkeys * sizeof(ScanKeyData));
 
 	scan->aos_filenamepath[0] = '\0';


### PR DESCRIPTION
Avoid passing nulls to memcpy

The appendonly_beginrangescan_internal function can set the
scan->aos_key pointer to NULL, which can then be passed to
memcpy as a destination in the initscan function.

I added two checks to avoid passing a null destination or
a zero length to the memcpy function.