### PR TITLE
ADBDEV-4907-45: Avoid passing NULL pointer to the strlen function

### DIFF
--- a/src/backend/libpq/ip.c
+++ b/src/backend/libpq/ip.c
@@ -181,9 +181,9 @@ getaddrinfo_unix(const char *path, const struct addrinfo * hintsp,
 	MemSet(&hints, 0, sizeof(hints));
 
 #if defined(_AIX) && (_SS_MAXSIZE == 1025 || _SS_MAX_SIZE == 1280)
-	if (strlen(path) >= 108)
+	if (path == NULL || strlen(path) >= 108)
 #else
-	if (strlen(path) >= sizeof(unp->sun_path))
+	if (path == NULL || strlen(path) >= sizeof(unp->sun_path))
 #endif
 		return EAI_FAIL;
 


### PR DESCRIPTION
Avoid passing NULL pointer to the strlen function

In the getaddrinfo_unix function, the path pointer (that is passed to the strlen
function) can be NULL when calling the ident_inet -> pg_getaddrinfo_all ->
getaddrinfo_unix function chain.

This patch prevents strlen from being called with a NULL pointer.