### PR TITLE
ADBDEV-4907-46: Add check for fopen function result

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -882,6 +882,9 @@ dumpTransProtoStats()
 	snprintf(tmpbuf, 32, "%d." UINT64_FORMAT "txt", MyProcPid, getCurrentTime());
 	FILE	   *ofile = fopen(tmpbuf, "w+");
 
+	if (ofile == NULL)
+		return;
+
 	pthread_mutex_lock(&trans_proto_stats.lock);
 	while (trans_proto_stats.head)
 	{
@@ -6760,6 +6763,9 @@ dumpICBufferList(ICBufferList *list, const char *fname)
 {
 	FILE	   *ofile = fopen(fname, "w+");
 
+	if (ofile == NULL)
+		return;
+
 	dumpICBufferList_Internal(list, ofile);
 	fclose(ofile);
 }
@@ -6773,6 +6779,9 @@ dumpUnackQueueRing(const char *fname)
 {
 	FILE	   *ofile = fopen(fname, "w+");
 	int			i;
+
+	if (ofile == NULL)
+		return;
 
 	fprintf(ofile, "UnackQueueRing: currentTime " UINT64_FORMAT ", idx %d numOutstanding %d numSharedOutstanding %d\n",
 			unack_queue_ring.currentTime, unack_queue_ring.idx,
@@ -6801,6 +6810,9 @@ dumpConnections(ChunkTransportStateEntry *pEntry, const char *fname)
 	MotionConn *conn;
 
 	FILE	   *ofile = fopen(fname, "w+");
+
+	if (ofile == NULL)
+		return;
 
 	fprintf(ofile, "Entry connections: conn num %d \n", pEntry->numConns);
 	fprintf(ofile, "==================================\n");

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -883,7 +883,10 @@ dumpTransProtoStats()
 	FILE	   *ofile = fopen(tmpbuf, "w+");
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", tmpbuf);
 		return;
+	}
 
 	pthread_mutex_lock(&trans_proto_stats.lock);
 	while (trans_proto_stats.head)
@@ -6764,7 +6767,10 @@ dumpICBufferList(ICBufferList *list, const char *fname)
 	FILE	   *ofile = fopen(fname, "w+");
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
+	}
 
 	dumpICBufferList_Internal(list, ofile);
 	fclose(ofile);
@@ -6781,7 +6787,10 @@ dumpUnackQueueRing(const char *fname)
 	int			i;
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
+	}
 
 	fprintf(ofile, "UnackQueueRing: currentTime " UINT64_FORMAT ", idx %d numOutstanding %d numSharedOutstanding %d\n",
 			unack_queue_ring.currentTime, unack_queue_ring.idx,
@@ -6812,7 +6821,10 @@ dumpConnections(ChunkTransportStateEntry *pEntry, const char *fname)
 	FILE	   *ofile = fopen(fname, "w+");
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
+	}
 
 	fprintf(ofile, "Entry connections: conn num %d \n", pEntry->numConns);
 	fprintf(ofile, "==================================\n");

--- a/src/backend/utils/error/debugutils.c
+++ b/src/backend/utils/error/debugutils.c
@@ -179,7 +179,7 @@ dotnode(void *node, const char *fname)
 
 	if (ofile == NULL)
 	{
-		fprintf(stderr, "dotnode: can't open \"%s\" for output", fname);
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
 	}
 
@@ -217,7 +217,7 @@ void dump_tupdesc(TupleDesc tupdesc, const char *fname)
 
     if (ofile == NULL)
     {
-        fprintf(stderr, "dump_tupdesc: can't open \"%s\" for output", fname);
+        elog(WARNING, "could not open dump file %s", fname);
         return;
     }
 
@@ -247,7 +247,7 @@ void dump_mt_bind(MemTupleBinding *mt_bind, const char *fname)
 
     if (ofile == NULL)
     {
-        fprintf(stderr, "dump_mt_bind: can't open \"%s\" for output", fname);
+        elog(WARNING, "could not open dump file %s", fname);
         return;
     }
 

--- a/src/backend/utils/error/debugutils.c
+++ b/src/backend/utils/error/debugutils.c
@@ -178,7 +178,10 @@ dotnode(void *node, const char *fname)
 	FILE *ofile = fopen(fname, "w+");
 
 	if (ofile == NULL)
+	{
+		fprintf(stderr, "dotnode: can't open \"%s\" for output", fname);
 		return;
+	}
 
 	/* Print dot header */
 
@@ -213,7 +216,10 @@ void dump_tupdesc(TupleDesc tupdesc, const char *fname)
     int i;
 
     if (ofile == NULL)
-        return;
+	{
+		fprintf(stderr, "dump_tupdesc: can't open \"%s\" for output", fname);
+		return;
+	}
 
     fprintf(ofile, "TupleDesc: natts %d, hasoid %s\n", tupdesc->natts, tupdesc->tdhasoid ? "true" : "false");
     fprintf(ofile, "Name\t\tattlen\tattbyval\tattalign\n");
@@ -240,7 +246,10 @@ void dump_mt_bind(MemTupleBinding *mt_bind, const char *fname)
     int i;
 
     if (ofile == NULL)
-        return;
+	{
+		fprintf(stderr, "dump_mt_bind: can't open \"%s\" for output", fname);
+		return;
+	}
 
     fprintf(ofile, "Mt_bind: column_align %d, nbm_extra_size %d\n",
             mt_bind->column_align, mt_bind->null_bitmap_extra_size);

--- a/src/backend/utils/error/debugutils.c
+++ b/src/backend/utils/error/debugutils.c
@@ -177,6 +177,9 @@ dotnode(void *node, const char *fname)
 	List *nodelist = NULL;
 	FILE *ofile = fopen(fname, "w+");
 
+	if (ofile == NULL)
+		return;
+
 	/* Print dot header */
 
 	fprintf(ofile, "digraph g {\n");
@@ -209,6 +212,9 @@ void dump_tupdesc(TupleDesc tupdesc, const char *fname)
 	FILE *ofile = fopen(fname, "w+");
     int i;
 
+    if (ofile == NULL)
+        return;
+
     fprintf(ofile, "TupleDesc: natts %d, hasoid %s\n", tupdesc->natts, tupdesc->tdhasoid ? "true" : "false");
     fprintf(ofile, "Name\t\tattlen\tattbyval\tattalign\n");
     fprintf(ofile, "==================================\n");
@@ -232,6 +238,9 @@ void dump_mt_bind(MemTupleBinding *mt_bind, const char *fname)
 {
     FILE *ofile = fopen(fname, "w+");
     int i;
+
+    if (ofile == NULL)
+        return;
 
     fprintf(ofile, "Mt_bind: column_align %d, nbm_extra_size %d\n",
             mt_bind->column_align, mt_bind->null_bitmap_extra_size);

--- a/src/backend/utils/error/debugutils.c
+++ b/src/backend/utils/error/debugutils.c
@@ -216,10 +216,10 @@ void dump_tupdesc(TupleDesc tupdesc, const char *fname)
     int i;
 
     if (ofile == NULL)
-	{
-		fprintf(stderr, "dump_tupdesc: can't open \"%s\" for output", fname);
-		return;
-	}
+    {
+        fprintf(stderr, "dump_tupdesc: can't open \"%s\" for output", fname);
+        return;
+    }
 
     fprintf(ofile, "TupleDesc: natts %d, hasoid %s\n", tupdesc->natts, tupdesc->tdhasoid ? "true" : "false");
     fprintf(ofile, "Name\t\tattlen\tattbyval\tattalign\n");
@@ -246,10 +246,10 @@ void dump_mt_bind(MemTupleBinding *mt_bind, const char *fname)
     int i;
 
     if (ofile == NULL)
-	{
-		fprintf(stderr, "dump_mt_bind: can't open \"%s\" for output", fname);
-		return;
-	}
+    {
+        fprintf(stderr, "dump_mt_bind: can't open \"%s\" for output", fname);
+        return;
+    }
 
     fprintf(ofile, "Mt_bind: column_align %d, nbm_extra_size %d\n",
             mt_bind->column_align, mt_bind->null_bitmap_extra_size);

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -398,7 +398,10 @@ void dump_mc(const char *fname, MemoryContext mc)
 	FILE *ofile = fopen(fname, "w+");
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
+	}
 
 	dump_mc_for(ofile, mc);
 	fclose(ofile);
@@ -416,7 +419,10 @@ void dump_memory_allocation(const char* fname)
 	FILE *ofile = fopen(fname, "w+");
 
 	if (ofile == NULL)
+	{
+		elog(WARNING, "could not open dump file %s", fname);
 		return;
+	}
 
 	dump_memory_allocation_ctxt(ofile, TopMemoryContext);
 	fclose(ofile);

--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -396,6 +396,10 @@ static void dump_mc_for(FILE *file, MemoryContext mc)
 void dump_mc(const char *fname, MemoryContext mc)
 {
 	FILE *ofile = fopen(fname, "w+");
+
+	if (ofile == NULL)
+		return;
+
 	dump_mc_for(ofile, mc);
 	fclose(ofile);
 }
@@ -410,6 +414,10 @@ void dump_mc(const char *fname, MemoryContext mc)
 void dump_memory_allocation(const char* fname)
 {
 	FILE *ofile = fopen(fname, "w+");
+
+	if (ofile == NULL)
+		return;
+
 	dump_memory_allocation_ctxt(ofile, TopMemoryContext);
 	fclose(ofile);
 }


### PR DESCRIPTION
Add check for fopen function result

In some files, the debugging functions did not have a check for what the fopen
function returned, so I added such a check.

This patch also adds a warning when fopen fails, because these are dumping
helper functions and it wouldn't be very nice if they crashed on errors like
opening a file.