### PR TITLE
ADBDEV-4907-47: Add check for PyTuple_New result

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -1845,6 +1845,9 @@ pgquery_listfields(pgqueryobject * self, PyObject * args)
 	n = PQnfields(self->last_result);
 	fieldstuple = PyTuple_New(n);
 
+	if (fieldstuple == NULL)
+		return NULL;
+
 	for (i = 0; i < n; i++)
 	{
 		name = PQfname(self->last_result, i);


### PR DESCRIPTION
Add check for PyTuple_New result

The pgquery_listfields function does not check what the PyTuple_New function
returns. Because of this, a null pointer dereference was possible. This patch
adds such a check.