### PR TITLE
ADBDEV-4907-48: Add check for PyObject_Str result

### DIFF
--- a/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
+++ b/gpMgmt/bin/pythonSrc/PyGreSQL-4.0/pgmodule.c
@@ -2620,6 +2620,15 @@ pg_inserttable(pgobject * self, PyObject * args)
 			else if (PyInt_Check(item) || PyLong_Check(item))
 			{
 				PyObject* s = PyObject_Str(item);
+
+				if (s == NULL)
+				{
+					free(buffer);
+					PyErr_SetString(PyExc_MemoryError,
+						"fail to compute a string representation.");
+					return NULL;
+				}
+
 				const char* t = PyString_AsString(s);
 				while (*t && bufsiz)
 				{


### PR DESCRIPTION
Add check for PyObject_Str result

The pg_inserttable function does not check what the PyObject_Str function
returns. Because of this, a null pointer dereference was possible. This patch
adds such a check.