### PR TITLE
ADBDEV-4907-50: Reorder check for XLogReadRecord result

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1708,8 +1708,6 @@ PrescanPreparedTransactions(TransactionId **xids_p, int *nxids_p)
 		TransactionId xid;
 
 		tfRecord = XLogReadRecord(xlogreader, tfXLogRecPtr, &errormsg);
-		hdr = (TwoPhaseFileHeader *) XLogRecGetData(tfRecord);
-		xid = hdr->xid;
 
 		if (tfRecord == NULL)
 		{
@@ -1730,6 +1728,9 @@ PrescanPreparedTransactions(TransactionId **xids_p, int *nxids_p)
 						(errcode(ERRCODE_DATA_CORRUPTED),
 						 errmsg("xlog record is invalid")));
 		}
+
+		hdr = (TwoPhaseFileHeader *) XLogRecGetData(tfRecord);
+		xid = hdr->xid;
 
 		if (TransactionIdDidCommit(xid) == false && TransactionIdDidAbort(xid) == false)
 		{


### PR DESCRIPTION
Reorder check for XLogReadRecord result

The PrescanPreparedTransactions function checked what the XLogReadRecord function
returned after using the result. Because of this, a null pointer dereference was
possible. This patch fixes the check order.