### PR TITLE
add check for "rule->parname is not NULL" before using

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -11010,7 +11010,7 @@ get_partition_recursive(PartitionNode *pn, deparse_context *head,
 			{
 				if (!bLeafTablename && rule->parrangeevery)
 				{
-					if (!rule->parname || !strlen(rule->parname))
+					if (rule->parname == NULL || !strlen(rule->parname))
 					{
 						first_every_rule = rule;
 						prev_rule		 = NULL;
@@ -11117,7 +11117,7 @@ get_partition_recursive(PartitionNode *pn, deparse_context *head,
 					{
 						first_every_rule = NULL;
 
-						if (!rule->parname || !strlen(rule->parname))
+						if (rule->parname == NULL || !strlen(rule->parname))
 							prev_rule = first_every_rule = rule;
 						else
 						{

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -11010,7 +11010,7 @@ get_partition_recursive(PartitionNode *pn, deparse_context *head,
 			{
 				if (!bLeafTablename && rule->parrangeevery)
 				{
-					if (!strlen(rule->parname))
+					if (!rule->parname || !strlen(rule->parname))
 					{
 						first_every_rule = rule;
 						prev_rule		 = NULL;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -11117,7 +11117,7 @@ get_partition_recursive(PartitionNode *pn, deparse_context *head,
 					{
 						first_every_rule = NULL;
 
-						if (!strlen(rule->parname))
+						if (!rule->parname || !strlen(rule->parname))
 							prev_rule = first_every_rule = rule;
 						else
 						{


### PR DESCRIPTION
The PartitionRule structure can be allocated in the add_part_to_catalog
function, where the parname argument may be NULL. It means, that the parname
field at this structure will not be set. When this structure will be processed
at the get_partition_recursive function, this filed will be used without
checking. It can lead to segfault.