### PR TITLE
ADBDEV-4902-9: Fix null checks in `cdbpullup_findEclassInTargetList()`

### DIFF
--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -382,10 +382,6 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 			}
 			else
 			{
-				/* ignore RelabelType nodes on both sides */
-				while (key && IsA(key, RelabelType))
-					key = (Expr *) ((RelabelType *) key)->arg;
-
 				if (equal(tlexpr, key))
 					return key;
 			}

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -382,14 +382,13 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 			}
 			else
 			{
-				if ((tlexpr || key) && equal(tlexpr, key))
+				if (equal(tlexpr, key))
 					return key;
 			}
 		}
 
 		/* Return this item if all referenced Vars are in targetlist. */
-		if (key &&
-			!IsA(key, Var) &&
+		if (key && !IsA(key, Var) &&
 			!cdbpullup_missingVarWalker((Node *) key, targetlist))
 		{
 			return key;

--- a/src/backend/cdb/cdbpullup.c
+++ b/src/backend/cdb/cdbpullup.c
@@ -360,7 +360,7 @@ cdbpullup_findEclassInTargetList(EquivalenceClass *eclass, List *targetlist,
 			 * Check if targetlist is a List of TargetEntry. (Planner's
 			 * RelOptInfo targetlists don't have TargetEntry nodes.)
 			 */
-			if (tlexpr && IsA(tlexpr, TargetEntry))
+			if (IsA(tlexpr, TargetEntry))
 				tlexpr = (Node *) ((TargetEntry *) tlexpr)->expr;
 
 			/* ignore RelabelType nodes on both sides */


### PR DESCRIPTION
Fix null checks in cdbpullup_findEclassInTargetList()

Removed extra while loop. All values of key with RelabelType kind will be
already skipped at this point by previous while loop with the same condition.
There is no point in the second one.

Added null checks in dangerous places. There is tlist_member_ignore_relabel()
and tlist_member_match_var() which have similar null checks.