### PR TITLE
add check for "parentPolicy is not NULL" before using

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2031,7 +2031,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 			 * is an inherited table, set the distribution based on the
 			 * parent (or one of the parents)
 			 */
-			if (distrkeys == NIL && parentPolicy && parentPolicy->nattrs >= 0)
+			if (distrkeys == NIL && parentPolicy != NULL && parentPolicy->nattrs >= 0)
 			{
 				if (!bQuiet)
 					ereport(NOTICE,

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2031,7 +2031,7 @@ transformDistributedBy(CreateStmtContext *cxt,
 			 * is an inherited table, set the distribution based on the
 			 * parent (or one of the parents)
 			 */
-			if (distrkeys == NIL && parentPolicy->nattrs >= 0)
+			if (distrkeys == NIL && parentPolicy && parentPolicy->nattrs >= 0)
 			{
 				if (!bQuiet)
 					ereport(NOTICE,


### PR DESCRIPTION
Pointer to the parentPolicy variable is set from pointer
"parentrel->rd_cdbpolicy". This variable  is checked before using at other
places at the transformDistributedBy function in case of the IsBinaryUpgrade
flag is false. At the last "if" the parentPolicy variable is used without
checking. The parentPolicy variable can be NULL for binary upgrade. For binary
upgrade this check runs against a segment in utility mode and the distribution
policy isn't stored in the segments.

The parentPolicy pointer is used at the make_distributedby_for_rel function.
We should execute this function only if the parentPolicy pointer (
"parentrel->rd_cdbpolicy") is not NULL.