### PR TITLE
ADBDEV-4902-10: Add a null check for `tab`

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7810,7 +7810,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	 * If we are adding an OID column, we have to tell Phase 3 to rewrite the
 	 * table to fix that.
 	 */
-	if (isOid)
+	if (tab && isOid)
 		tab->rewrite = true;
 
 	/*
@@ -7886,7 +7886,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	 * We have to do it while processing the root partition because that's the
 	 * only level where the `ADD COLUMN` subcommands are populated.
 	 */
-	if (!recursing && tab->relkind == RELKIND_RELATION)
+	if (!recursing && tab && tab->relkind == RELKIND_RELATION)
 	{
 		bool	aocs_write_new_columns_only;
 		/*


### PR DESCRIPTION
Add a null check for tab

tab is null if ATExecAddColumn() is called by "CREATE OR REPLACE VIEW" which
can't have any default value or tab.

Add a check whether tab is NULL before dereferencing it.