### PR TITLE
ADBDEV-4902-4: Fix checks for partition rules

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5272,7 +5272,15 @@ get_part_rule(Relation rel,
 									pid2,
 									bExistError, bMustExist,
 									pSearch, pNode, sid1.data, &pNode2);
-			Assert(prule2);
+			if (!prule2)
+			{
+				if (!bExistError)
+					return NULL;
+				else if (bMustExist)
+					ereport(ERROR,
+						 (errcode(ERRCODE_INTERNAL_ERROR),
+						  errmsg("Alter Partition Id List does not contain partitioning rule")));
+			}
 
 			pNode = pNode2;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5231,9 +5231,9 @@ get_part_rule(Relation rel,
 
 		if (!prule2)
 		{
-			if (!bExistError)
+			if (!bExistError || !bMustExist)
 				return NULL;
-			else if (bMustExist)
+			else
 				ereport(ERROR,
 					 (errcode(ERRCODE_INTERNAL_ERROR),
 					  errmsg("Alter Partition Id Rule does not contain partitioning rule")));
@@ -5274,9 +5274,9 @@ get_part_rule(Relation rel,
 									pSearch, pNode, sid1.data, &pNode2);
 			if (!prule2)
 			{
-				if (!bExistError)
+				if (!bExistError || !bMustExist)
 					return NULL;
-				else if (bMustExist)
+				else
 					ereport(ERROR,
 						 (errcode(ERRCODE_INTERNAL_ERROR),
 						  errmsg("Alter Partition Id List does not contain partitioning rule")));

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5235,7 +5235,6 @@ get_part_rule(Relation rel,
 		lc = lnext(lc);
 
 		pid2 = (AlterPartitionId *) lfirst(lc);
-		Assert(pid2);
 
 		return get_part_rule1(rel, pid2, bExistError, bMustExist, pSearch,
 							  pNode, pstrdup(prule2->relname), &pNode2);
@@ -5250,9 +5249,6 @@ get_part_rule(Relation rel,
 		StringInfoData sid1,
 					sid2;
 
-		/* prule2 must exist */
-		Assert(bExistError && bMustExist);
-
 		initStringInfo(&sid1);
 		initStringInfo(&sid2);
 		appendStringInfoString(&sid1, relnamBuf);
@@ -5261,12 +5257,12 @@ get_part_rule(Relation rel,
 		{
 
 			pid2 = (AlterPartitionId *) lfirst(lc);
-			Assert(pid2);
 
 			prule2 = get_part_rule1(rel,
 									pid2,
 									bExistError, bMustExist,
 									pSearch, pNode, sid1.data, &pNode2);
+			Assert(prule2);
 
 			pNode = pNode2;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5229,16 +5229,7 @@ get_part_rule(Relation rel,
 		lc = list_head(l1);
 		prule2 = (PgPartRule *) lfirst(lc);
 
-		if (!prule2)
-		{
-			if (!bExistError || !bMustExist)
-				return NULL;
-			else
-				ereport(ERROR,
-					 (errcode(ERRCODE_INTERNAL_ERROR),
-					  errmsg("Alter Partition Id Rule does not contain partitioning rule")));
-		}
-
+		Assert(prule2);
 		if (prule2->topRule && prule2->topRule->children)
 			pNode = prule2->topRule->children;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5264,15 +5264,7 @@ get_part_rule(Relation rel,
 									bExistError, bMustExist,
 									pSearch, pNode, sid1.data, &pNode2);
 			if (!prule2)
-			{
-				if (!bExistError || !bMustExist)
-					return NULL;
-				else
-				{
-					/* get_part_rule1() can't return NULL in this case */
-					Insist(0);
-				}
-			}
+				return NULL;
 
 			pNode = pNode2;
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5277,9 +5277,10 @@ get_part_rule(Relation rel,
 				if (!bExistError || !bMustExist)
 					return NULL;
 				else
-					ereport(ERROR,
-						 (errcode(ERRCODE_INTERNAL_ERROR),
-						  errmsg("Alter Partition Id List does not contain partitioning rule")));
+				{
+					/* get_part_rule1() can't return NULL in this case */
+					Insist(0);
+				}
 			}
 
 			pNode = pNode2;

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5228,12 +5228,14 @@ get_part_rule(Relation rel,
 
 		lc = list_head(l1);
 		prule2 = (PgPartRule *) lfirst(lc);
-		if (prule2 && prule2->topRule && prule2->topRule->children)
+		Assert(prule2);
+		if (prule2->topRule && prule2->topRule->children)
 			pNode = prule2->topRule->children;
 
 		lc = lnext(lc);
 
 		pid2 = (AlterPartitionId *) lfirst(lc);
+		Assert(pid2);
 
 		return get_part_rule1(rel, pid2, bExistError, bMustExist, pSearch,
 							  pNode, pstrdup(prule2->relname), &pNode2);
@@ -5248,6 +5250,9 @@ get_part_rule(Relation rel,
 		StringInfoData sid1,
 					sid2;
 
+		/* prule2 must exist */
+		Assert(bExistError && bMustExist);
+
 		initStringInfo(&sid1);
 		initStringInfo(&sid2);
 		appendStringInfoString(&sid1, relnamBuf);
@@ -5256,6 +5261,7 @@ get_part_rule(Relation rel,
 		{
 
 			pid2 = (AlterPartitionId *) lfirst(lc);
+			Assert(pid2);
 
 			prule2 = get_part_rule1(rel,
 									pid2,
@@ -5266,7 +5272,7 @@ get_part_rule(Relation rel,
 
 			if (!pNode)
 			{
-				if (prule2 && prule2->topRule && prule2->topRule->children)
+				if (prule2->topRule && prule2->topRule->children)
 					pNode = prule2->topRule->children;
 			}
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5228,7 +5228,17 @@ get_part_rule(Relation rel,
 
 		lc = list_head(l1);
 		prule2 = (PgPartRule *) lfirst(lc);
-		Assert(prule2);
+
+		if (!prule2)
+		{
+			if (!bExistError)
+				return NULL;
+			else if (bMustExist)
+				ereport(ERROR,
+					 (errcode(ERRCODE_INTERNAL_ERROR),
+					  errmsg("Alter Partition Id Rule does not contain partitioning rule")));
+		}
+
 		if (prule2->topRule && prule2->topRule->children)
 			pNode = prule2->topRule->children;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16057,10 +16057,11 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 		*ppar_prule = (PgPartRule*) lfirst(lc);
 
 		par_prule = *ppar_prule;
+		Assert(par_prule);
 
 		*plrelname = par_prule->relname;
 
-		if (par_prule && par_prule->topRule && par_prule->topRule->children)
+		if (par_prule->topRule && par_prule->topRule->children)
 			*ppNode = par_prule->topRule->children;
 
 		lc = lnext(lc);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16057,11 +16057,10 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 		*ppar_prule = (PgPartRule*) lfirst(lc);
 
 		par_prule = *ppar_prule;
-		Assert(par_prule);
 
 		*plrelname = par_prule->relname;
 
-		if (par_prule->topRule && par_prule->topRule->children)
+		if (par_prule && par_prule->topRule && par_prule->topRule->children)
 			*ppNode = par_prule->topRule->children;
 
 		lc = lnext(lc);


### PR DESCRIPTION
Fix checks for partition rules

For AT_AP_IDList, add an assert that lfirst() result is not NULL.

For AT_AP_IDRule, return NULL if get_part_rule1() also returned NULL. If the
caller does not expect NULL to be returned, bExistError and bMustExist
parameters are set to true. In that case, get_part_rule1() can't return NULL and
will throw an error if rule does not exist before NULL is returned.