### PR TITLE
ADBDEV-4902-7: Fix checks for `prule`

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16756,12 +16756,11 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		pn = RelationBuildPartitionDesc(rel, false);
 		pcols = get_partition_attrs(pn);
 
+		Assert(pid);
 		prule = get_part_rule(rel, pid, true, true, NULL, false);
 
-		if (!prule)
-			return;
-
-		if (prule && prule->topRule && prule->topRule->children)
+		Assert(prule && prule->topRule);
+		if (prule->topRule->children)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot EXCHANGE PARTITION for "

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16756,10 +16756,11 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		pn = RelationBuildPartitionDesc(rel, false);
 		pcols = get_partition_attrs(pn);
 
-		Assert(pid);
 		prule = get_part_rule(rel, pid, true, true, NULL, false);
 
-		Assert(prule && prule->topRule);
+		if (!prule || !prule->topRule)
+			return;
+
 		if (prule->topRule->children)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16758,7 +16758,7 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 
 		prule = get_part_rule(rel, pid, true, true, NULL, false);
 
-		if (!prule || !prule->topRule)
+		if (!prule || prule->topRule == NULL)
 			return;
 
 		if (prule->topRule->children)


### PR DESCRIPTION
Fix checks for prule

Add a null check for prule->topRule.
Remove extra check for prule, because it is checked earlier.