### PR TITLE
ADBDEV-4908-52: Remove redundant NULL comparisons.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7070,7 +7070,7 @@ atpxPartAddList(Relation rel,
 			 * XXX XXX: fix the first Alter Table Statement to have the
 			 * correct maxpartno.  Whoohoo!!
 			 */
-			if (bFixFirstATS && q && IsA(q, AlterTableStmt))
+			if (bFixFirstATS && IsA(q, AlterTableStmt))
 			{
 				PartitionSpec *spec = NULL;
 				AlterTableStmt *ats;


### PR DESCRIPTION
Remove redundant NULL comparisons.

This patch removes the redundant comparison with NULL, because according to the
comment, the macro lfirst() was used to mean "the data in this cons cell", and
therefore cannot return NULL.
