### PR TITLE
ADBDEV-4726-31 Check that lefttree is not null

### DIFF
--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -585,6 +585,8 @@ ExecReScanNestLoop(NestLoopState *node)
 {
 	PlanState  *outerPlan = outerPlanState(node);
 
+	Insist(outerPlan);
+
 	/*
 	 * If outerPlan->chgParam is not null then plan will be automatically
 	 * re-scanned by first ExecProcNode.


### PR DESCRIPTION
Check that lefttree is not null

ExecReScanNestLoop dereferences lefttree without checking that it's not null.
This patch adds Insist