### PR TITLE
ADBDEV-4726-32 Check that estate is not null

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4091,7 +4091,7 @@ EvalPlanQualSetTuple(EPQState *epqstate, Index rti, HeapTuple tuple)
 {
 	EState	   *estate = epqstate->estate;
 
-	Assert(estate);
+	Insist(estate);
 	Assert(rti > 0);
 
 	/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4091,6 +4091,7 @@ EvalPlanQualSetTuple(EPQState *epqstate, Index rti, HeapTuple tuple)
 {
 	EState	   *estate = epqstate->estate;
 
+	Assert(estate);
 	Assert(rti > 0);
 
 	/*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4112,6 +4112,7 @@ EvalPlanQualGetTuple(EPQState *epqstate, Index rti)
 {
 	EState	   *estate = epqstate->estate;
 
+	Insist(estate);
 	Assert(rti > 0);
 
 	return estate->es_epqTuple[rti - 1];

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -4091,7 +4091,6 @@ EvalPlanQualSetTuple(EPQState *epqstate, Index rti, HeapTuple tuple)
 {
 	EState	   *estate = epqstate->estate;
 
-	Insist(estate);
 	Assert(rti > 0);
 
 	/*
@@ -4112,7 +4111,6 @@ EvalPlanQualGetTuple(EPQState *epqstate, Index rti)
 {
 	EState	   *estate = epqstate->estate;
 
-	Insist(estate);
 	Assert(rti > 0);
 
 	return estate->es_epqTuple[rti - 1];

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -225,7 +225,10 @@ lnext:
 				}
 
 				/* Store target tuple for relation's scan node */
-				EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, copyTuple);
+				if (node->lr_epqstate.estate != NULL)
+					EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, copyTuple);
+				else
+					elog(ERROR, "valid lr_epqstate was expected");
 
 				/* Continue loop until we have all target tuples */
 				break;

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -225,10 +225,7 @@ lnext:
 				}
 
 				/* Store target tuple for relation's scan node */
-				if (node->lr_epqstate.estate != NULL)
-					EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, copyTuple);
-				else
-					elog(ERROR, "valid lr_epqstate was expected");
+				EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, copyTuple);
 
 				/* Continue loop until we have all target tuples */
 				break;

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -82,8 +82,11 @@ lnext:
 			continue;
 
 		/* clear any leftover test tuple for this rel */
-		if (node->lr_epqstate.estate != NULL)
+		if (epq_started)
+		{
+			Assert(node->lr_epqstate.estate != NULL);
 			EvalPlanQualSetTuple(&node->lr_epqstate, erm->rti, NULL);
+		}
 
 		/* if child rel, must check whether it produced this row */
 		if (erm->rti != erm->prti)


### PR DESCRIPTION
Check that estate is not null

ExecLockRows passes estate to EvalPlanQualSetTuple where it's dereferenced
without checking that it's not null. We can't guarantee that it's always called
with valid estate. This patch adds an assertion