### PR TITLE
ADBDEV-4726-33 Check that wfile is not null

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -1878,13 +1878,10 @@ agg_hash_reload(AggState *aggstate)
 		(unsigned) LOG2(spill_file->parent_spill_set->num_spill_files);
 
 
-	if (spill_file->file_info->wfile != NULL)
-	{
-		Assert(spill_file->file_info->suspended);
-		BufFileResume(spill_file->file_info->wfile);
-		spill_file->file_info->suspended = false;
-		hashtable->mem_for_metadata  += FREEABLE_BATCHFILE_METADATA;
-	}
+	Assert(spill_file->file_info->wfile && spill_file->file_info->suspended);
+	BufFileResume(spill_file->file_info->wfile);
+	spill_file->file_info->suspended = false;
+	hashtable->mem_for_metadata  += FREEABLE_BATCHFILE_METADATA;
 
 	while(true)
 	{

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -490,6 +490,8 @@ BufFileRead(BufFile *file, void *ptr, size_t size)
 	size_t		nread = 0;
 	size_t		nthistime;
 
+	Assert(file);
+
 	switch (file->state)
 	{
 		case BFS_RANDOM_ACCESS:

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -490,7 +490,8 @@ BufFileRead(BufFile *file, void *ptr, size_t size)
 	size_t		nread = 0;
 	size_t		nthistime;
 
-	Assert(file);
+	if (!file)
+		elog(ERROR, "failed to acquire spill file");
 
 	switch (file->state)
 	{

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -490,8 +490,7 @@ BufFileRead(BufFile *file, void *ptr, size_t size)
 	size_t		nread = 0;
 	size_t		nthistime;
 
-	if (!file)
-		elog(ERROR, "failed to acquire spill file");
+	Insist(file);
 
 	switch (file->state)
 	{

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -490,8 +490,6 @@ BufFileRead(BufFile *file, void *ptr, size_t size)
 	size_t		nread = 0;
 	size_t		nthistime;
 
-	Insist(file);
-
 	switch (file->state)
 	{
 		case BFS_RANDOM_ACCESS:


### PR DESCRIPTION
Check that wfile is not null

agg_hash_reload passes wfile to BufFileRead where it's dereferenced without
checking that it's not null. We can't guarantee that file is always valid.
This patch replaces redundant null-check with Assert