### PR TITLE
ADBDEV-4726-34 Check that elems is not null

### DIFF
--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -945,7 +945,7 @@ CopyArrayEls(ArrayType *array,
 	int			bitmask = 1;
 	int			i;
 
-	Assert(values || nitems == 0);
+	Insist(values);
 
 	if (typbyval)
 		freedata = false;

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -945,8 +945,6 @@ CopyArrayEls(ArrayType *array,
 	int			bitmask = 1;
 	int			i;
 
-	Insist(values);
-
 	if (typbyval)
 		freedata = false;
 
@@ -3062,7 +3060,7 @@ construct_md_array(Datum *elems,
 	memcpy(ARR_DIMS(result), dims, ndims * sizeof(int));
 	memcpy(ARR_LBOUND(result), lbs, ndims * sizeof(int));
 
-	if (elems==NULL && fixedwidthtype) 
+	if (elems==NULL || fixedwidthtype) 
 	{
 		/* do nothing */
 	} 

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -945,6 +945,8 @@ CopyArrayEls(ArrayType *array,
 	int			bitmask = 1;
 	int			i;
 
+	Assert(values || nitems == 0);
+
 	if (typbyval)
 		freedata = false;
 


### PR DESCRIPTION
Check that elems is not null

construct_md_array passes elems to CopyArrayEls where it's dereferenced without
checking that it's not null. We can't guarantee that elems is always valid.
This patch checks that it won't happen