### PR TITLE
ADBDEV-4726-35 Check that scalarVal is not null 

### DIFF
--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -585,7 +585,7 @@ pushJsonbValueScalar(JsonbParseState **pstate, JsonbIteratorToken seq,
 			appendKey(*pstate, scalarVal);
 			break;
 		case WJB_VALUE:
-			Assert(IsAJsonbScalar(scalarVal));
+			Assert(scalarVal && IsAJsonbScalar(scalarVal));
 			appendValue(*pstate, scalarVal);
 			break;
 		case WJB_ELEM:

--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -585,7 +585,7 @@ pushJsonbValueScalar(JsonbParseState **pstate, JsonbIteratorToken seq,
 			appendKey(*pstate, scalarVal);
 			break;
 		case WJB_VALUE:
-			Assert(scalarVal && IsAJsonbScalar(scalarVal));
+			Assert(IsAJsonbScalar(scalarVal));
 			appendValue(*pstate, scalarVal);
 			break;
 		case WJB_ELEM:
@@ -676,6 +676,7 @@ appendValue(JsonbParseState *pstate, JsonbValue *scalarVal)
 {
 	JsonbValue *object = &pstate->contVal;
 
+	Insist(scalarVal);
 	Assert(object->type == jbvObject);
 
 	object->val.object.pairs[object->val.object.nPairs++].value = *scalarVal;

--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -581,15 +581,15 @@ pushJsonbValueScalar(JsonbParseState **pstate, JsonbIteratorToken seq,
 														 (*pstate)->size);
 			break;
 		case WJB_KEY:
-			Assert(scalarVal->type == jbvString);
+			Assert(scalarVal && scalarVal->type == jbvString);
 			appendKey(*pstate, scalarVal);
 			break;
 		case WJB_VALUE:
-			Assert(IsAJsonbScalar(scalarVal));
+			Assert(scalarVal && IsAJsonbScalar(scalarVal));
 			appendValue(*pstate, scalarVal);
 			break;
 		case WJB_ELEM:
-			Assert(IsAJsonbScalar(scalarVal));
+			Assert(scalarVal && IsAJsonbScalar(scalarVal));
 			appendElement(*pstate, scalarVal);
 			break;
 		case WJB_END_OBJECT:
@@ -690,6 +690,7 @@ appendElement(JsonbParseState *pstate, JsonbValue *scalarVal)
 {
 	JsonbValue *array = &pstate->contVal;
 
+	Insist(scalarVal);
 	Assert(array->type == jbvArray);
 
 	if (array->val.array.nElems >= JSONB_MAX_ELEMS)

--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -647,6 +647,7 @@ appendKey(JsonbParseState *pstate, JsonbValue *string)
 {
 	JsonbValue *object = &pstate->contVal;
 
+	Insist(string);
 	Assert(object->type == jbvObject);
 	Assert(string->type == jbvString);
 


### PR DESCRIPTION
Check that scalarVal is not null

appendValue and appendKey dereference scalarVal without checking that it's not
null. We can't guarantee that scalarVal is always valid. This patch adds Insist
for release builds and Assert for debug builds