### PR TITLE
ADBDEV-4726-36 Check that pstate is not null

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -538,7 +538,7 @@ coerce_type(ParseState *pstate, Node *node,
 		return result;
 	}
 	if (inputTypeId == RECORDOID &&
-		ISCOMPLEX(targetTypeId))
+		ISCOMPLEX(targetTypeId) && pstate != NULL)
 	{
 		/* Coerce a RECORD to a specific complex type */
 		return coerce_record_to_complex(pstate, node, targetTypeId,


### PR DESCRIPTION
Check that pstate is not null

coerce_type passes pstate where it's dereferenced without checking that it's not
null. We can't guarantee that pstate is always valid. This patch adds null-check