### PR TITLE
ADBDEV-4726-37 Check that plan is not null

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -640,6 +640,8 @@ use_physical_tlist(PlannerInfo *root, RelOptInfo *rel)
 static void
 disuse_physical_tlist(PlannerInfo *root, Plan *plan, Path *path)
 {
+	Assert(plan);
+
 	/* Only need to undo it for path types handled by create_scan_plan() */
 	switch (path->pathtype)
 	{

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -640,7 +640,7 @@ use_physical_tlist(PlannerInfo *root, RelOptInfo *rel)
 static void
 disuse_physical_tlist(PlannerInfo *root, Plan *plan, Path *path)
 {
-	Assert(plan);
+	Insist(plan);
 
 	/* Only need to undo it for path types handled by create_scan_plan() */
 	switch (path->pathtype)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -640,8 +640,6 @@ use_physical_tlist(PlannerInfo *root, RelOptInfo *rel)
 static void
 disuse_physical_tlist(PlannerInfo *root, Plan *plan, Path *path)
 {
-	Insist(plan);
-
 	/* Only need to undo it for path types handled by create_scan_plan() */
 	switch (path->pathtype)
 	{
@@ -3697,8 +3695,8 @@ create_hashjoin_plan(PlannerInfo *root,
 	 * either!
 	 */
 	disuse_physical_tlist(root, inner_plan, best_path->jpath.innerjoinpath);
-	if (outer_plan)
-		disuse_physical_tlist(root, outer_plan, best_path->jpath.outerjoinpath);
+	Assert(outer_plan);
+	disuse_physical_tlist(root, outer_plan, best_path->jpath.outerjoinpath);
 
 	/* If we expect batching, suppress excess columns in outer tuples too */
 	if (best_path->num_batches > 1)


### PR DESCRIPTION
Check that plan is not null

create_hash_join passes outer_plan to disuse_physical_tlist where it's
dereferenced without checking that it's not null. We can't guarantee that
outer_plan is always valid. This patch adds an assertion