### PR TITLE
ADBDEV-4726-38 Check that instrument is not null

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2668,6 +2668,8 @@ show_sort_info(SortState *sortstate, ExplainState *es)
 	if (!es->analyze)
 		return;
 
+	Assert(((PlanState *) sortstate)->instrument);
+
 	ns = ((PlanState *) sortstate)->instrument->cdbNodeSummary;
 	/* Might not have received stats from qExecs if they hit errors. */
 	if (!ns)

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2668,7 +2668,7 @@ show_sort_info(SortState *sortstate, ExplainState *es)
 	if (!es->analyze)
 		return;
 
-	Assert(((PlanState *) sortstate)->instrument);
+	Insist(((PlanState *) sortstate)->instrument);
 
 	ns = ((PlanState *) sortstate)->instrument->cdbNodeSummary;
 	/* Might not have received stats from qExecs if they hit errors. */

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2665,10 +2665,8 @@ show_sort_info(SortState *sortstate, ExplainState *es)
 	CdbExplain_NodeSummary *ns;
 	int			i;
 
-	if (!es->analyze)
+	if (!es->analyze || !((PlanState *) sortstate)->instrument)
 		return;
-
-	Insist(((PlanState *) sortstate)->instrument);
 
 	ns = ((PlanState *) sortstate)->instrument->cdbNodeSummary;
 	/* Might not have received stats from qExecs if they hit errors. */


### PR DESCRIPTION
Check that instrument is not null

show_sort_info dereferences instrument without checking that it's not null.
We can't guarantee that instrument is always valid. This patch adds null-check