### PR TITLE
ADBDEV-4908-53: Make sure ps is not NULL.

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -957,16 +957,14 @@ ExecHashTableInsert(HashState *hashState, HashJoinTable hashtable,
 		{
 			ExecHashIncreaseNumBatches(hashtable);
 
-			if (ps && ps->instrument)
+			Assert(ps);
+			if (ps->instrument)
 			{
 				ps->instrument->workfileCreated = true;
 			}
 
 			/* Gpmon stuff */
-			if(ps)
-			{
-				CheckSendPlanStateGpmonPkt(ps);
-			}
+			CheckSendPlanStateGpmonPkt(ps);
 		}
 	}
 	else


### PR DESCRIPTION
Make sure ps is not NULL.

Using memory accounting in the ExecHashTableInsert function requires a non-zero
hashState argument. Therefore, I replaced the check with an assertion.
