### PR TITLE
ADBDEV-4908-54: Make sure flow is not NULL.

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3126,10 +3126,8 @@ cdbpathlocus_from_flow(Flow *flow)
 {
 	CdbPathLocus locus;
 
+	Assert(flow);
 	CdbPathLocus_MakeNull(&locus, flow->numsegments);
-
-	if (!flow)
-		return locus;
 
 	switch (flow->flotype)
 	{


### PR DESCRIPTION
Make sure flow is not NULL.

The cdbpathlocus_from_flow function is called in two places (in the
add_motion_to_dqa_child and grouping_planner functions) and both times with a
non-zero flow argument. So I replaced the NULL check with an assert.