### PR TITLE
ADBDEV-4908-57: Remove redundant pElem check for NULL.

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -2074,7 +2074,6 @@ validate_partition_spec(CreateStmtContext *cxt,
 		 */
 		pElem->partno = ++partno;
 
-		if (pElem)
 		{
 			pBSpec = (PartitionBoundSpec *) pElem->boundSpec;
 			vstate->spec = (Node *) pBSpec;
@@ -2153,13 +2152,6 @@ validate_partition_spec(CreateStmtContext *cxt,
 				else
 					snprintf(namBuf, sizeof(namBuf), " number %d", partno);
 			}
-		}
-		else
-		{
-			if (pElem->AddPartDesc)
-				snprintf(namBuf, sizeof(namBuf), "%s", pElem->AddPartDesc);
-			else
-				snprintf(namBuf, sizeof(namBuf), " number %d", partno);
 		}
 
 		/* don't have to validate default partition boundary specs */


### PR DESCRIPTION
Remove redundant pElem check for NULL.

At this point pElem is always not NULL, so I removed the extra pElem check for
NULL and also removed the dead code.