### PR TITLE
ADBDEV-4908-59: Remove redundant pTemp check for NULL.

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmmon.c
+++ b/gpAux/gpperfmon/src/gpmon/gpmmon.c
@@ -1155,7 +1155,7 @@ static int read_conf_file(char *conffile)
 			char *pName = NULL, *pVal = NULL, *pTemp = NULL;
 			/* is it a comment? */
 			pTemp = p;
-			while (pTemp && *pTemp)
+			while (*pTemp)
 			{
 				if (*pTemp == '#')
 				{


### PR DESCRIPTION
Remove redundant pTemp check for NULL.

Just before, there is a condition which indexes into the same pointer, therefore
pTemp can't be NULL, and the extra check was removed.