### PR TITLE
Add check plan->flow is not NULL to the ExplainNode function

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1535,7 +1535,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 						/* In Gather Motion always display receiver size as 1 */
 						motion_recv = 1;
 					}
-					else
+					else if (plan->flow != NULL)
 					{
 						/* Otherwise find out receiver size from plan */
 						motion_recv = plan->flow->numsegments;


### PR DESCRIPTION
Add check plan->flow is not NULL to the ExplainNode function

The plan->flow pointer may be NULL. It uses to get number of segments without
checking on NULL. At the other places at the ExplainNode function this pointer
is checked before using. Needed check was added.