### PR TITLE
ADBDEV-4911-83: Remove redundant queryDesc->plannedstmt check for NULL.

### DIFF
--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -282,7 +282,6 @@ ProcessQuery(Portal portal,
 	 * Call ExecutorStart to prepare the plan for execution
 	 */
 	if (Gp_role == GP_ROLE_EXECUTE &&
-		queryDesc->plannedstmt &&
 		queryDesc->plannedstmt->intoClause != NULL)
 		eflag = GetIntoRelEFlags(queryDesc->plannedstmt->intoClause);
 


### PR DESCRIPTION
Remove redundant queryDesc->plannedstmt check for NULL.

At this point queryDesc->plannedstmt is always not NULL, so I removed the
redundant queryDesc->plannedstmt check for NULL.