### PR TITLE
ADBDEV-4911-82: Remove redundant check of best_path->jpath.outerjoinpath for NULL.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3687,6 +3687,7 @@ create_hashjoin_plan(PlannerInfo *root,
 	 * Rearrange hashclauses, if needed, so that the outer variable is always
 	 * on the left.
 	 */
+	Assert(best_path->jpath.outerjoinpath != NULL);
 	hashclauses = get_switched_clauses(best_path->path_hashclauses,
 							 best_path->jpath.outerjoinpath->parent->relids);
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3768,8 +3768,7 @@ create_hashjoin_plan(PlannerInfo *root,
 	 * (allowing us to check the outer for rows before building the
 	 * hash-table).
 	 */
-	if (best_path->jpath.outerjoinpath == NULL ||
-		best_path->jpath.outerjoinpath->motionHazard ||
+	if (best_path->jpath.outerjoinpath->motionHazard ||
 		best_path->jpath.innerjoinpath->motionHazard)
 	{
 		join_plan->join.prefetch_inner = true;


### PR DESCRIPTION
Remove redundant check of best_path->jpath.outerjoinpath for NULL.

At this point, best_path->jpath.outerjoinpath is always non-NULL because of the
create_hashjoin_path function, so I removed redundant check of
best_path->jpath.outerjoinpath for NULL and added assert.