### PR TITLE
ADBDEV-4911-81: Remove residual NULL-pstate handling in addRangeTableEntry.

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1036,9 +1036,6 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation,
 /*
  * Add an entry for a relation to the pstate's range table (p_rtable).
  *
- * If pstate is NULL, we just build an RTE and return it without adding it
- * to an rtable list.
- *
  * Note: formerly this checked for refname conflicts, but that's wrong.
  * Caller is responsible for checking for conflicts in the appropriate scope.
  */
@@ -1055,6 +1052,8 @@ addRangeTableEntry(ParseState *pstate,
 	LockingClause *locking;
 	Relation	rel;
 	ParseCallbackState pcbstate;
+
+	Assert(pstate != NULL);
 
 	rte->alias = alias;
 	rte->rtekind = RTE_RELATION;
@@ -1138,8 +1137,7 @@ addRangeTableEntry(ParseState *pstate,
 	 * Add completed RTE to pstate's range table list, but not to join list
 	 * nor namespace --- caller must do that if appropriate.
 	 */
-	if (pstate != NULL)
-		pstate->p_rtable = lappend(pstate->p_rtable, rte);
+	pstate->p_rtable = lappend(pstate->p_rtable, rte);
 
 	return rte;
 }


### PR DESCRIPTION
Remove residual NULL-pstate handling in addRangeTableEntry.

Passing a NULL pstate wouldn't actually work, because isLockedRefname()
isn't prepared to cope with it; and there hasn't been any in-core code
that tries in over a decade.  So just remove the residual NULL handling.

Spotted by Coverity; analysis and patch by Michael Paquier.

This is backport of commit 5223dda