### PR TITLE
ADBDEV-4911-84: Remove redundant qnotifies->relname check for NULL.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -1232,8 +1232,7 @@ processResults(CdbDispatchResult *dispatchResult)
 		else
 		{
 			/* Got an unknown PGnotify, just record it in log */
-			if (qnotifies->relname)
-				elog(LOG, "got an unknown notify message : %s", qnotifies->relname);
+			elog(LOG, "got an unknown notify message : %s", qnotifies->relname);
 		}
 
 		if (qnotifies)


### PR DESCRIPTION
Remove redundant qnotifies->relname check for NULL.

At this point, the value of the qnotify->relname pointer is always non-NULL
because the relname and extra fields are not separate allocations in the
PGnotify structure in the getNotify function, so I removed the additional
qnotify->relname check for NULL.