### PR TITLE
ADBDEV-4911-85: Remove redundant rel->rd_smgr check for NULL.

### DIFF
--- a/src/backend/access/heap/visibilitymap.c
+++ b/src/backend/access/heap/visibilitymap.c
@@ -525,8 +525,7 @@ visibilitymap_truncate(Relation rel, BlockNumber nheapblocks)
 	 * invalidate their copy of smgr_vm_nblocks, and this one too at the next
 	 * command boundary.  But this ensures it isn't outright wrong until then.
 	 */
-	if (rel->rd_smgr)
-		rel->rd_smgr->smgr_vm_nblocks = newnblocks;
+	rel->rd_smgr->smgr_vm_nblocks = newnblocks;
 }
 
 /*

--- a/src/backend/storage/freespace/freespace.c
+++ b/src/backend/storage/freespace/freespace.c
@@ -328,8 +328,7 @@ FreeSpaceMapTruncateRel(Relation rel, BlockNumber nblocks)
 	 * at the next command boundary.  But this ensures it isn't outright wrong
 	 * until then.
 	 */
-	if (rel->rd_smgr)
-		rel->rd_smgr->smgr_fsm_nblocks = new_nfsmblocks;
+	rel->rd_smgr->smgr_fsm_nblocks = new_nfsmblocks;
 }
 
 /*


### PR DESCRIPTION
Remove redundant rel->rd_smgr check for NULL.

At this point, rel->rd_smgr is always NULL, so I removed the redundant
rel->rd_smgr check for NULL.