### PR TITLE
ADBDEV-4911-90: Remove redundant parent check for NULL.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -514,8 +514,7 @@ create_scan_plan(PlannerInfo *root, Path *best_path)
 	/* Decorate the top node of the plan with a Flow node. */
 	plan->flow = cdbpathtoplan_create_flow(root,
 										   best_path->locus,
-								best_path->parent ? best_path->parent->relids
-										   : NULL,
+										   best_path->parent->relids,
 										   plan);
 
 	/*
@@ -1319,7 +1318,7 @@ create_projection_plan(PlannerInfo *root, ProjectionPath *best_path)
 		copy_path_costsize(root, plan, (Path *) best_path);
 		plan->flow = cdbpathtoplan_create_flow(root,
 											   best_path->path.locus,
-											   best_path->path.parent ? best_path->path.parent->relids : NULL,
+											   best_path->path.parent->relids,
 											   plan);
 	}
 


### PR DESCRIPTION
Remove redundant parent check for NULL.

In function create_scan_plan pointer best_path->parent cannot be NULL, because
first rel = best_path->parent and a little later scan_clauses =
rel->baserestrictinfo.

In function create_projection_plan pointer best_path->path.parent cannot be NULL
because it is dereferenced above in the function tlist = build_path_tlist(root,
&best_path->path).

So I removed the redundant check for parent for NULL.