### PR TITLE
ADBDEV-4911-92: Remove redundant best_path->parent->subplan check for NULL.

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2900,10 +2900,6 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 								  scan_relid,
 								  best_path->parent->subplan);
 
-	/* If subplan is not NULL, all costs copied inside make_subqueryscan() */
-	if (!best_path->parent->subplan)
-		copy_path_costsize(root, &scan_plan->scan.plan, best_path);
-
 	return scan_plan;
 }
 


### PR DESCRIPTION
Remove redundant best_path->parent->subplan check for NULL.

At this stage, best_path->parent->subplan is always non-NULL, so I removed the
redundant best_path->parent->subplan check for NULL and the dead code as well.