### PR TITLE
ADBDEV-4910-71: Move memcpy() under a check

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -442,12 +442,16 @@ plan_grouping_extension(PlannerInfo *root,
 	context.canonical_rollups = NIL;
 	context.curr_grpset_no = 0;
 
-	if (*p_grpColIdx != NULL)
+	if (*p_numGroupCols > 0)
+	{
+		Assert(*p_grpColIdx);
+		Assert(*p_grpOperators);
+
 		memcpy(context.grpColIdx, *p_grpColIdx,
 			   context.numGroupCols * sizeof(AttrNumber));
-	if (*p_grpOperators != NULL)
 		memcpy(context.grpOperators, *p_grpOperators,
 			   context.numGroupCols * sizeof(Oid));
+	}
 
 	/*
 	 * GPDB_91_MERGE_FIXME: The code in this file assumes that there is a

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -430,11 +430,7 @@ plan_grouping_extension(PlannerInfo *root,
 	context.qual = qual;
 	context.numGroupCols = *p_numGroupCols;
 	context.grpColIdx = palloc0(context.numGroupCols * sizeof(AttrNumber));
-	memcpy(context.grpColIdx, *p_grpColIdx,
-		   context.numGroupCols * sizeof(AttrNumber));
 	context.grpOperators = palloc0(context.numGroupCols * sizeof(Oid));
-	memcpy(context.grpOperators, *p_grpOperators,
-		   context.numGroupCols * sizeof(Oid));
 	context.numDistinctCols = 0;
 	context.distinctColIdx = NULL;
 	context.agg_costs = agg_costs;
@@ -518,6 +514,11 @@ plan_grouping_extension(PlannerInfo *root,
 			(Oid *) palloc0((*p_numGroupCols + 2) * sizeof(Oid));
 	}
 	
+	memcpy(context.grpColIdx, *p_grpColIdx,
+		   context.numGroupCols * sizeof(AttrNumber));
+	memcpy(context.grpOperators, *p_grpOperators,
+		   context.numGroupCols * sizeof(Oid));
+
 	(*p_numGroupCols) += 2;
 
 	*p_tlist = context.tlist;

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -430,7 +430,11 @@ plan_grouping_extension(PlannerInfo *root,
 	context.qual = qual;
 	context.numGroupCols = *p_numGroupCols;
 	context.grpColIdx = palloc0(context.numGroupCols * sizeof(AttrNumber));
+	memcpy(context.grpColIdx, *p_grpColIdx,
+		   context.numGroupCols * sizeof(AttrNumber));
 	context.grpOperators = palloc0(context.numGroupCols * sizeof(Oid));
+	memcpy(context.grpOperators, *p_grpOperators,
+		   context.numGroupCols * sizeof(Oid));
 	context.numDistinctCols = 0;
 	context.distinctColIdx = NULL;
 	context.agg_costs = agg_costs;
@@ -514,11 +518,6 @@ plan_grouping_extension(PlannerInfo *root,
 			(Oid *) palloc0((*p_numGroupCols + 2) * sizeof(Oid));
 	}
 	
-	memcpy(context.grpColIdx, *p_grpColIdx,
-		   context.numGroupCols * sizeof(AttrNumber));
-	memcpy(context.grpOperators, *p_grpOperators,
-		   context.numGroupCols * sizeof(Oid));
-
 	(*p_numGroupCols) += 2;
 
 	*p_tlist = context.tlist;

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -430,11 +430,7 @@ plan_grouping_extension(PlannerInfo *root,
 	context.qual = qual;
 	context.numGroupCols = *p_numGroupCols;
 	context.grpColIdx = palloc0(context.numGroupCols * sizeof(AttrNumber));
-	memcpy(context.grpColIdx, *p_grpColIdx,
-		   context.numGroupCols * sizeof(AttrNumber));
 	context.grpOperators = palloc0(context.numGroupCols * sizeof(Oid));
-	memcpy(context.grpOperators, *p_grpOperators,
-		   context.numGroupCols * sizeof(Oid));
 	context.numDistinctCols = 0;
 	context.distinctColIdx = NULL;
 	context.agg_costs = agg_costs;
@@ -445,6 +441,13 @@ plan_grouping_extension(PlannerInfo *root,
 	context.querynode_changed = false;
 	context.canonical_rollups = NIL;
 	context.curr_grpset_no = 0;
+
+	if (*p_grpColIdx != NULL)
+		memcpy(context.grpColIdx, *p_grpColIdx,
+			   context.numGroupCols * sizeof(AttrNumber));
+	if (*p_grpOperators != NULL)
+		memcpy(context.grpOperators, *p_grpOperators,
+			   context.numGroupCols * sizeof(Oid));
 
 	/*
 	 * GPDB_91_MERGE_FIXME: The code in this file assumes that there is a


### PR DESCRIPTION
Move memcpy() under a check

*p_grpColIdx was passed to memcpy() as a source before it was checked if it's
NULL. There is a NULL check right after.

In that condition, *p_grpColIdx is assumed to be non-NULL if *p_numGroupCols
is > 0.

Move memcpy() calls to be called only if *p_grpColIdx > 0 and add asserts for
*p_grpColIdx and *p_grpOperators.