### PR TITLE
ADBDEV-4910-72: Remove a useless null check

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3086,13 +3086,10 @@ create_foreignscan_path(PlannerInfo *root, RelOptInfo *rel,
 			CdbPathLocus_MakeGeneral(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_ALL_SEGMENTS:
-			if (rel->ftEntry)
 			{
 				ForeignServer *server = GetForeignServer(rel->ftEntry->serverid);
 				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), server->num_segments);
 			}
-			else
-				CdbPathLocus_MakeStrewn(&(pathnode->path.locus), getgpsegmentCount());
 			break;
 		case FTEXECLOCATION_MASTER:
 			CdbPathLocus_MakeEntry(&(pathnode->path.locus));


### PR DESCRIPTION
Remove a useless null check

rel->ftEntry is never null at this point, because it is derefenced just above as
rel->ftEntry->exec_location in switch condition.

Remove a useless NULL check and else block that would never be executed.