### PR TITLE
ADBDEV-4910-73: Remove redundant check for prule->topRule

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16612,6 +16612,7 @@ ATPExecPartDrop(Relation rel,
 								 "final partition ")));
 
 		}
+		Assert(prule->topRule != NULL);
 		rel2 = heap_open(prule->topRule->parchildrelid, NoLock);
 
 		elog(DEBUG5, "dropping partition oid %u", prule->topRule->parchildrelid);
@@ -16627,7 +16628,7 @@ ATPExecPartDrop(Relation rel,
 		ds->removeType = OBJECT_TABLE;
 		ds->bAllowPartn = true; /* allow drop of partitions */
 
-		if (prule->topRule && prule->topRule->children)
+		if (prule->topRule->children)
 		{
 			List *l1 = atpxDropList(rel2, prule->topRule->children);
 
@@ -16647,7 +16648,7 @@ ATPExecPartDrop(Relation rel,
 					   NULL);
 
 		/* Notify of name if did not use name for partition id spec */
-		if (prule->topRule && prule->topRule->children
+		if (prule->topRule->children
 			&& (ds->behavior != DROP_CASCADE ))
 		{
 			ereport(NOTICE,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16627,7 +16627,7 @@ ATPExecPartDrop(Relation rel,
 		ds->removeType = OBJECT_TABLE;
 		ds->bAllowPartn = true; /* allow drop of partitions */
 
-		if (prule->topRule->children)
+		if (prule->topRule && prule->topRule->children)
 		{
 			List *l1 = atpxDropList(rel2, prule->topRule->children);
 


### PR DESCRIPTION
Remove redundant check for prule->topRule

prule->topRule can't be NULL, because prule->topRule->parchildrelid is accessed
before the condition.

Assert that prule->topRule exists and remove redundant NULL check.