### PR TITLE
ADBDEV-4910-74: Remove redundant check for prule->topRule

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17126,6 +17126,7 @@ ATPExecPartRename(Relation rel,
 								lrelname,
 								NULL);
 
+		Assert(prule->topRule != NULL);
 		targetrelation = relation_open(prule->topRule->parchildrelid,
 									   AccessExclusiveLock);
 
@@ -17136,7 +17137,7 @@ ATPExecPartRename(Relation rel,
 
 		relation_close(targetrelation, AccessExclusiveLock);
 
-		if (prule->topRule && 0 == prule->topRule->parparentoid)
+		if (0 == prule->topRule->parparentoid)
 		{
 			StrNCpy(parentname,
 					RelationGetRelationName(rel), NAMEDATALEN);
@@ -17180,7 +17181,7 @@ ATPExecPartRename(Relation rel,
 		renStmt->newname = relname;
 		renStmt->bAllowPartn = true; /* allow rename of partitions */
 
-		if (prule && prule->topRule && prule->topRule->children)
+		if (prule->topRule->children)
 				pNode = prule->topRule->children;
 		else
 				pNode = NULL;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17136,7 +17136,7 @@ ATPExecPartRename(Relation rel,
 
 		relation_close(targetrelation, AccessExclusiveLock);
 
-		if (0 == prule->topRule->parparentoid)
+		if (prule->topRule && 0 == prule->topRule->parparentoid)
 		{
 			StrNCpy(parentname,
 					RelationGetRelationName(rel), NAMEDATALEN);


### PR DESCRIPTION
Remove redundant check for prule->topRule

prule->topRule can't be NULL, because prule->topRule->parchildrelid is accessed
before the condition.

Assert that prule->topRule exists and remove redundant NULL check.