### PR TITLE
ADBDEV-4910-75: Remove redundant check for prule->topRule

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -18362,11 +18362,12 @@ ATPExecPartSplit(Relation *rel,
 			else if (intopid)
 				ErrorOnInvalidDefaultPartition(rel, intopid);
 
-			if (prule->topRule->parisdefault && i == into_exists)
+			if (prule->topRule &&
+				prule->topRule->parisdefault && i == into_exists)
 			{
 				/* nothing to do */
 			}
-			else
+			else if (prule->topRule != NULL)
 			{
 				if (prule->pNode->part->parkind == 'r')
 				{
@@ -18384,8 +18385,7 @@ ATPExecPartSplit(Relation *rel,
 						/* MPP-6589: if the partition has an "open"
 						 * START, pass a NULL partStart
 						 */
-						if (prule->topRule &&
-							prule->topRule->parrangestart)
+						if (prule->topRule->parrangestart)
 						{
 							ri = makeNode(PartitionRangeItem);
 							ri->location = -1;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17921,6 +17921,7 @@ ATPExecPartSplit(Relation *rel,
 		prule = get_part_rule(*rel, pid, true, true, NULL, false);
 
 		/* Error out on external partition */
+		Assert(prule->topRule != NULL);
 		existrel = heap_open(prule->topRule->parchildrelid, NoLock);
 		if (RelationIsExternal(existrel))
 		{
@@ -18362,12 +18363,11 @@ ATPExecPartSplit(Relation *rel,
 			else if (intopid)
 				ErrorOnInvalidDefaultPartition(rel, intopid);
 
-			if (prule->topRule &&
-				prule->topRule->parisdefault && i == into_exists)
+			if (prule->topRule->parisdefault && i == into_exists)
 			{
 				/* nothing to do */
 			}
-			else if (prule->topRule != NULL)
+			else
 			{
 				if (prule->pNode->part->parkind == 'r')
 				{
@@ -18423,8 +18423,7 @@ ATPExecPartSplit(Relation *rel,
 						/* MPP-6589: if the partition has an "open"
 						 * END, pass a NULL partEnd
 						 */
-						if (prule->topRule &&
-							prule->topRule->parrangeend)
+						if (prule->topRule->parrangeend)
 						{
 							ri = makeNode(PartitionRangeItem);
 							ri->location = -1;


### PR DESCRIPTION
Remove redundant check for prule->topRule

prule->topRule can't be NULL, because prule->topRule->parchildrelid is accessed
before the condition.