### PR TITLE
ADBDEV-4910-76: Remove redundant check for prule->topRule

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -19367,7 +19367,7 @@ ATPExecPartTruncate(Relation rel,
 
 		rv->location = pc->location;
 
-		if (prule->topRule->children)
+		if (prule->topRule && prule->topRule->children)
 		{
 			List *l1 = atpxTruncateList(rel2, prule->topRule->children);
 
@@ -19386,7 +19386,7 @@ ATPExecPartTruncate(Relation rel,
 					   NULL);
 
 		/* Notify of name if did not use name for partition id spec */
-		if (prule && prule->topRule && prule->topRule->children
+		if (prule->topRule && prule->topRule->children
 			&& (ts->behavior != DROP_CASCADE ))
 		{
 			ereport(NOTICE,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -19356,6 +19356,7 @@ ATPExecPartTruncate(Relation rel,
 		DestReceiver 	*dest = None_Receiver;
 		Relation	  	 rel2;
 
+		Assert(prule->topRule != NULL);
 		rel2 = heap_open(prule->topRule->parchildrelid, AccessShareLock);
 		if (RelationIsExternal(rel2))
 			ereport(ERROR,
@@ -19367,7 +19368,7 @@ ATPExecPartTruncate(Relation rel,
 
 		rv->location = pc->location;
 
-		if (prule->topRule && prule->topRule->children)
+		if (prule->topRule->children)
 		{
 			List *l1 = atpxTruncateList(rel2, prule->topRule->children);
 
@@ -19386,7 +19387,7 @@ ATPExecPartTruncate(Relation rel,
 					   NULL);
 
 		/* Notify of name if did not use name for partition id spec */
-		if (prule->topRule && prule->topRule->children
+		if (prule->topRule->children
 			&& (ts->behavior != DROP_CASCADE ))
 		{
 			ereport(NOTICE,


### PR DESCRIPTION
Remove redundant check for prule->topRule

prule->topRule can't be NULL, because prule->topRule->parchildrelid is accessed
before the condition.