### PR TITLE
ADBDEV-4910-77: Move for loop under a null check

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -540,13 +540,13 @@ void
 free_canonical_groupingsets(CanonicalGroupingSets *canonical_grpsets)
 {
 	int grpset_no;
-	for (grpset_no=0; grpset_no<canonical_grpsets->ngrpsets; grpset_no++)
-	{
-		bms_free(canonical_grpsets->grpsets[grpset_no]);
-	}
-	
 	if (canonical_grpsets)
 	{
+		for (grpset_no=0; grpset_no<canonical_grpsets->ngrpsets; grpset_no++)
+		{
+			bms_free(canonical_grpsets->grpsets[grpset_no]);
+		}
+
 		if (canonical_grpsets->grpsets)
 			pfree(canonical_grpsets->grpsets);
 		if (canonical_grpsets->grpset_counts)

--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -539,13 +539,10 @@ plan_grouping_extension(PlannerInfo *root,
 void
 free_canonical_groupingsets(CanonicalGroupingSets *canonical_grpsets)
 {
-	int grpset_no;
 	if (canonical_grpsets)
 	{
-		for (grpset_no=0; grpset_no<canonical_grpsets->ngrpsets; grpset_no++)
-		{
+		for (int grpset_no=0; grpset_no<canonical_grpsets->ngrpsets; grpset_no++)
 			bms_free(canonical_grpsets->grpsets[grpset_no]);
-		}
 
 		if (canonical_grpsets->grpsets)
 			pfree(canonical_grpsets->grpsets);


### PR DESCRIPTION
Move for loop under a null check

Move for loop that is supposed to free gpsets from canonical_grpsets under a
null check to avoid dereferencing a NULL pointer, if canonical_grpsets was
passed as NULL to free_canonical_groupingsets().