### PR TITLE
ADBDEV-4910-79: Move pstrdup() under a null check

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -3004,7 +3004,7 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 						   *ltop;
 				Oid			restypid;
 				Type		typ;
-				char	   *outputstr;
+				char	   *outputstr = NULL;
 				int32		coltypmod;
 				Oid			coltypid;
 

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -3216,10 +3216,11 @@ partition_range_every(ParseState *pstate, PartitionBy *pBy, List *coltypes,
 				}
 				else
 				{
-					allNewCols = lappend(allNewCols, pstrdup(outputstr));
-
 					if (outputstr)
+					{
+						allNewCols = lappend(allNewCols, pstrdup(outputstr));
 						pfree(outputstr);
+					}
 
 					sqlRc = 1;
 				}


### PR DESCRIPTION
Move pstrdup() under a null check

outputstr is passed to pstrdup() in lappend(), but in some cases it might be
NULL. There is a NULL check for outputstr right after.

Move pstrdup() under a null check.