### PR TITLE
ADBDEV-4911-89: Make sure seginfo->seg is not NULL.

### DIFF
--- a/src/backend/access/gin/gindatapage.c
+++ b/src/backend/access/gin/gindatapage.c
@@ -757,8 +757,12 @@ ginVacuumPostingTreeLeaf(Relation indexrel, Buffer buffer, GinVacuumState *gvs)
 		int			ncleaned;
 
 		if (!seginfo->items)
+		{
+			Insist(seginfo->seg != NULL);
 			seginfo->items = ginPostingListDecode(seginfo->seg,
 												  &seginfo->nitems);
+		}
+
 		if (seginfo->seg)
 			oldsegsize = SizeOfGinPostingList(seginfo->seg);
 		else


### PR DESCRIPTION
Make sure seginfo->seg is not NULL.

If the data is compressed, then the seginfo->items pointer is not equal to NULL,
and if it is uncompressed, then the seginfo->seg pointer is not equal to NULL.
So at this point the seginfo->seg pointer could be NULL, but decompression
requires a non-NULL pointer, so I added Insist to make sure of this.