### PR TITLE
ADBDEV-4904-26: Remove the isnull check for NULL.

### DIFF
--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -556,7 +556,7 @@ heap_getsysattr(HeapTuple tup, int attnum, TupleDesc tupleDesc, bool *isnull)
 
 	Assert(tup);
 	Assert(!is_memtuple((GenericTuple) tup));
-	Assert(isnull);
+	Assert(isnull != NULL);
 
 	/* Currently, no sys attribute ever reads as NULL. */
 	*isnull = false;

--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -558,7 +558,8 @@ heap_getsysattr(HeapTuple tup, int attnum, TupleDesc tupleDesc, bool *isnull)
 	Assert(!is_memtuple((GenericTuple) tup));
 
 	/* Currently, no sys attribute ever reads as NULL. */
-	*isnull = false;
+	if (isnull)
+		*isnull = false;
 
 	switch (attnum)
 	{

--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -556,10 +556,10 @@ heap_getsysattr(HeapTuple tup, int attnum, TupleDesc tupleDesc, bool *isnull)
 
 	Assert(tup);
 	Assert(!is_memtuple((GenericTuple) tup));
+	Assert(isnull);
 
 	/* Currently, no sys attribute ever reads as NULL. */
-	if (isnull)
-		*isnull = false;
+	*isnull = false;
 
 	switch (attnum)
 	{

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1544,8 +1544,8 @@ slot_getsysattr(TupleTableSlot *slot, int attnum, Datum *result, bool *isnull)
 
 		*result = 0;
         /* Currently, no sys attribute ever reads as NULL. */
-        if (isnull)
-                *isnull = false;
+        Assert(isnull != NULL);
+        *isnull = false;
 
         /* HeapTuple */
         if (slot->PRIVATE_tts_heaptuple)


### PR DESCRIPTION
Remove the isnull check for NULL.

The slot_getsysattr function is always called with the isnull argument not equal
to NULL, so I changed the isnull comparison with NULL to an assertion and also
added an assertion to the heap_getsysattr function.