### PR TITLE
ADBDEV-4909-11: Remove redundant funcexpr check for NULL.

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1355,7 +1355,8 @@ addRangeTableEntryForFunction(ParseState *pstate,
 		 * mark this here because this is where we know that the function is being
 		 * used as a RangeTableEntry.
 		 */
-		if (funcexpr && IsA(funcexpr, FuncExpr))
+		Assert(funcexpr);
+		if (IsA(funcexpr, FuncExpr))
 		{
 			FuncExpr		*func = (FuncExpr *) funcexpr;
 


### PR DESCRIPTION
Remove redundant funcexpr check for NULL.

At this point, funcexpr is always not NULL, so I replaced funcexpr's redundant
NULL check with an assertion.