### PR TITLE
ADBDEV-4909-13: Add lost p_isnew check for NULL.

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -571,7 +571,8 @@ lookup_agg_hash_entry(AggState *aggstate,
 			++hashtable->num_ht_groups;
 			++hashtable->num_entries;
 
-			*p_isnew = true; /* created a new entry */
+			if (p_isnew != NULL)
+				*p_isnew = true; /* created a new entry */
 		}
 		/*
 		  else no matching entry, and no room to create one. 


### PR DESCRIPTION
Add lost p_isnew check for NULL.

According to the comments before the lookup_agg_hash_entry function, its
argument p_isnew can be NULL, while in the function itself, before dereferencing
the pointer, in one place there is a check for p_isnew for NULL, and in another
- not. Therefore, I added such a check to the second place.