### PR TITLE
ADBDEV-4909-14: Remove redundant pp_lc_anp check for NULL.

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -1273,7 +1273,7 @@ make_partition_rules(CreateStmtContext *cxt, CreateStmt *stmt,
 			ListCell   *lc_anp = NULL;
 
 			/* check the list of "all new partitions" */
-			if (pp_lc_anp)
+			Assert(pp_lc_anp);
 			{
 				lc_anp = *pp_lc_anp;
 				if (lc_anp)


### PR DESCRIPTION
Remove redundant pp_lc_anp check for NULL.

At this point pp_lc_anp is always not NULL, so I replaced the redundant
pp_lc_anp check for NULL with an assertion.