### PR TITLE
ADBDEV-4909-15: Add lost f check for NULL.

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -432,7 +432,8 @@ fallback:
 		compSetDir(comp, FALLBACK_COMP_DIR);
 	}
 
-	fclose(f);
+	if (f != NULL)
+		fclose(f);
 }
 
 /*


### PR DESCRIPTION
Add lost f check for NULL.

The detectCompDirs function contains a path where the f pointer is not checked
for NULL. That's why I added this check.