### PR TITLE
ADBDEV-4909-16: Remove redundant scanPlan->flow check for NULL.

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -479,7 +479,8 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		 * unnest(array[typoutput, typsend]) from pg_type) then 'upg_catalog.'
 		 * else 'pg_catalog.' end) FROM pg_proc p;
 		 **/
-		if (scanPlan->flow && (scanPlan->flow->locustype == CdbLocusType_Entry))
+		Assert(scanPlan->flow);
+		if (scanPlan->flow->locustype == CdbLocusType_Entry)
 			return (Node *) node;
 
 		/**


### PR DESCRIPTION
Remove redundant scanPlan->flow check for NULL.

At this point scanPlan->flow is always not NULL, so I replaced the redundant
scanPlan->flow check for NULL with an assertion.