### PR TITLE
ADBDEV-4909-17: Add lost query_block check for NULL.

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1680,7 +1680,7 @@ get_ao_distribution(PG_FUNCTION_ARGS)
 	funcctx = SRF_PERCALL_SETUP();
 
 	query_block = (QueryInfo *) funcctx->user_fctx;
-	if (query_block->index < query_block->rows)
+	if (query_block != NULL && query_block->index < query_block->rows)
 	{
 		/*
 		 * Get heaptuple from SPI, then deform it, and reform it using our
@@ -1713,7 +1713,8 @@ get_ao_distribution(PG_FUNCTION_ARGS)
 	/*
 	 * do when there is no more left
 	 */
-	pfree(query_block);
+	if (query_block != NULL)
+		pfree(query_block);
 
 	SPI_finish();
 


### PR DESCRIPTION
Add lost query_block check for NULL.

The get_ao_distribution function contains paths where the query_block pointer is
not checked for NULL. That's why I added these checks.