### PR TITLE
ADBDEV-4909-18: Add lost events->tail check for NULL.

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -3466,7 +3466,7 @@ afterTriggerAddEvent(AfterTriggerEventList *events,
 
 		if (events->head == NULL)
 			events->head = chunk;
-		else
+		else if (events->tail != NULL)
 			events->tail->next = chunk;
 		events->tail = chunk;
 		/* events->tailfree is now out of sync, but we'll fix it below */


### PR DESCRIPTION
Add lost events->tail check for NULL.

The afterTriggerAddEvent function contains a path where the events->tail pointer
is not checked for NULL before dereferencing. That's why I added this check.