### PR TITLE
ADBDEV-4909-20: Remove redundant rel check for NULL.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1099,13 +1099,13 @@ DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed)
 			{
 				cstate->errMode = SREH_IGNORE;
 			}
+			Assert(stmt->relation);
 			cstate->cdbsreh = makeCdbSreh(sreh->rejectlimit,
 										  sreh->is_limit_in_rows,
 										  cstate->filename,
 										  stmt->relation->relname,
 										  log_to_file);
-			if (rel)
-				cstate->cdbsreh->relid = RelationGetRelid(rel);
+			cstate->cdbsreh->relid = RelationGetRelid(rel);
 		}
 		else
 		{


### PR DESCRIPTION
Remove redundant rel check for NULL.

At this point, rel is always not equal to NULL, so I removed the redundant check
for rel for NULL, and also added an assertion that checks that stmt->relation is
also not equal to NULL.