### PR TITLE
ADBDEV-4726-62 Add null-check for parser

### DIFF
--- a/gpcontrib/gpmapreduce/src/parse.c
+++ b/gpcontrib/gpmapreduce/src/parse.c
@@ -15,8 +15,11 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj);
 /* -------------------------------------------------------------------------- */
 int mapred_parse_error(mapred_parser_t *parser, char *fmt, ...)
 {
-	mapred_object_t *obj = parser->current_obj;
+	mapred_object_t *obj;
 	va_list arg;
+
+	if (parser)
+		obj = parser->current_obj;
 
 	if (parser && parser->current_doc)
 	{

--- a/gpcontrib/gpmapreduce/src/parse.c
+++ b/gpcontrib/gpmapreduce/src/parse.c
@@ -15,7 +15,7 @@ int mapred_verify_object(mapred_parser_t *parser, mapred_object_t *obj);
 /* -------------------------------------------------------------------------- */
 int mapred_parse_error(mapred_parser_t *parser, char *fmt, ...)
 {
-	mapred_object_t *obj;
+	mapred_object_t *obj = NULL;
 	va_list arg;
 
 	if (parser)


### PR DESCRIPTION
Add null-check for parser

mapred_parse_error dereferences parser without null-check making segfault
possible. This patch add null-check before dereferencing