### PR TITLE
ADBDEV-4726-63 Add null-check for myState

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -819,10 +819,9 @@ Oid
 GetIntoRelOid(QueryDesc *queryDesc)
 {
 	DR_intorel *myState = (DR_intorel *) queryDesc->dest;
-	Relation    into_rel = myState->rel;
 
-	if (myState && myState->pub.mydest == DestIntoRel && into_rel)
-		return RelationGetRelid(into_rel);
+	if (myState && myState->pub.mydest == DestIntoRel && myState->rel)
+		return RelationGetRelid(myState->rel);
 	else
 		return InvalidOid;
 }


### PR DESCRIPTION
Add null-check for myState

GetIntoRelOid dereferences myState without null-check and assigns it to a new
variable making segfault possible. This patch adds null-check before
dereferencing and removes this variable because it's not used somewhere else