### PR TITLE
ADBDEV-4726-64 Fix null-check for sparams

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1388,11 +1388,11 @@ deserializeParamListInfo(const char *str, int slen)
 	int			iparam;
 
 	sparams = (List *) readNodeFromBinaryString(str, slen);
+	if (!sparams)
+		return NULL;
+
 	if (!IsA(sparams, List))
 		elog(ERROR, "could not deserialize query parameters");
-
-	if (!sparams)
-		return NULL;;
 
 	/*
 	 * If a transient record type cache was included, load it into


### PR DESCRIPTION
Fix null-check for sparams

deserializeParamListInfo dereferences sparams without null-check making segfault
possible. This patch adds null-check before dereferencing