### PR TITLE
ADBDEV-4726-65 Fix null-check for funcexpr

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -2256,10 +2256,6 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 
 	callerContext = CurrentMemoryContext;
 
-	funcrettype = exprType((Node *) funcexpr->expr);
-
-	returnsTuple = type_is_rowtype(funcrettype);
-
 	/*
 	 * Prepare a resultinfo node for communication.  We always do this even if
 	 * not expecting a set result, so that we can pass expectedDesc.  In the
@@ -2293,6 +2289,9 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 	{
 		FuncExprState *fcache = (FuncExprState *) funcexpr;
 		ExprDoneCond argDone;
+
+		funcrettype = exprType((Node *) funcexpr->expr);
+		returnsTuple = type_is_rowtype(funcrettype);
 
 		/*
 		 * This path is similar to ExecMakeFunctionResult.

--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -2254,7 +2254,13 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 	bool		direct_function_call;
 	bool		first_time = true;
 
+	Assert(funcexpr);
+
 	callerContext = CurrentMemoryContext;
+
+	funcrettype = exprType((Node *) funcexpr->expr);
+
+	returnsTuple = type_is_rowtype(funcrettype);
 
 	/*
 	 * Prepare a resultinfo node for communication.  We always do this even if
@@ -2284,14 +2290,10 @@ ExecMakeTableFunctionResult(ExprState *funcexpr,
 	 * don't get a chance to pass a special ReturnSetInfo to any functions
 	 * buried in the expression.
 	 */
-	if (funcexpr && IsA(funcexpr, FuncExprState) &&
-		IsA(funcexpr->expr, FuncExpr))
+	if (IsA(funcexpr, FuncExprState) && IsA(funcexpr->expr, FuncExpr))
 	{
 		FuncExprState *fcache = (FuncExprState *) funcexpr;
 		ExprDoneCond argDone;
-
-		funcrettype = exprType((Node *) funcexpr->expr);
-		returnsTuple = type_is_rowtype(funcrettype);
 
 		/*
 		 * This path is similar to ExecMakeFunctionResult.


### PR DESCRIPTION
Fix null-check for funcexpr

ExecMakeTableFunctionResult dereferences funcexpr before null-check making
segfault possible. This patch adds an assertion