### PR TITLE
ADBDEV-4726-66 Add null-check for p->attrs

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2768,15 +2768,16 @@ partition_policies_equal(GpPolicy *p, PartitionNode *pn)
 			}
 			else
 			{
-				if (p->attrs == 0)
-					/* random policy, skip */
-					;
-				if (memcmp(p->attrs, rel->rd_cdbpolicy->attrs,
+				if (p->attrs && memcmp(p->attrs, rel->rd_cdbpolicy->attrs,
 						   (sizeof(AttrNumber) * p->nattrs)))
 				{
 					heap_close(rel, NoLock);
 					return false;
 				}
+
+				if (p->attrs == 0)
+					/* random policy, skip */
+					;
 			}
 			if (!partition_policies_equal(p, rule->children))
 			{

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -2768,16 +2768,15 @@ partition_policies_equal(GpPolicy *p, PartitionNode *pn)
 			}
 			else
 			{
-				if (p->attrs && memcmp(p->attrs, rel->rd_cdbpolicy->attrs,
+				if (p->attrs == 0)
+					/* random policy, skip */
+					;
+				else if (memcmp(p->attrs, rel->rd_cdbpolicy->attrs,
 						   (sizeof(AttrNumber) * p->nattrs)))
 				{
 					heap_close(rel, NoLock);
 					return false;
 				}
-
-				if (p->attrs == 0)
-					/* random policy, skip */
-					;
 			}
 			if (!partition_policies_equal(p, rule->children))
 			{


### PR DESCRIPTION
Add null-check for p->attrs

partition_policies_equal dereferences p->attrs before null-check making segfault
possible. This patch adds null-check