### PR TITLE
ADBDEV-4726-67 Fix null-check for par_prule

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16061,7 +16061,7 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 		Assert(par_prule);
 
 		*plrelname = par_prule->relname;
-		
+
 		if (par_prule->topRule && par_prule->topRule->children)
 			*ppNode = par_prule->topRule->children;
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16057,7 +16057,6 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 		*ppar_prule = (PgPartRule*) lfirst(lc);
 
 		par_prule = *ppar_prule;
-
 		Assert(par_prule);
 
 		*plrelname = par_prule->relname;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16058,10 +16058,11 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 
 		par_prule = *ppar_prule;
 
-		*plrelname = par_prule->relname;
-
 		if (par_prule && par_prule->topRule && par_prule->topRule->children)
+		{
 			*ppNode = par_prule->topRule->children;
+			*plrelname = par_prule->relname;
+		}
 
 		lc = lnext(lc);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16058,11 +16058,12 @@ wack_pid_relname(AlterPartitionId 		 *pid,
 
 		par_prule = *ppar_prule;
 
-		if (par_prule && par_prule->topRule && par_prule->topRule->children)
-		{
+		Assert(par_prule);
+
+		*plrelname = par_prule->relname;
+		
+		if (par_prule->topRule && par_prule->topRule->children)
 			*ppNode = par_prule->topRule->children;
-			*plrelname = par_prule->relname;
-		}
 
 		lc = lnext(lc);
 


### PR DESCRIPTION
Add assertion for par_prule

wack_pid_relname dereferences par_prule before null-check making segfault
possible. This patch adds an assertion