### PR TITLE
ADBDEV-4726-68 Remove redundant null-check for planstate

### DIFF
--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -979,7 +979,6 @@ ExecSetParamPlan(SubPlanState *node, ExprContext *econtext, QueryDesc *queryDesc
 	volatile bool explainRecvStats = false;
 
 	if (Gp_role == GP_ROLE_DISPATCH &&
-		planstate != NULL &&
 		planstate->plan != NULL &&
 		subplan->initPlanParallel)
 		shouldDispatch = true;


### PR DESCRIPTION
Remove redundant null-check for planstate

At this point planstate is always not NULL, so I removed the redundant planstate
null-check