### PR TITLE
ADBDEV-4726-69 Add null-check for first_rule

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -10867,7 +10867,7 @@ write_out_rule(PartitionRule *rule, PartitionNode *pn, Node *start,
 {
 	char *str;
 
-	if (!*first_rule)
+	if (first_rule && !*first_rule)
 	{
 		appendStringInfoString(body->buf, ", ");
 		*needcomma = false;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -10867,7 +10867,9 @@ write_out_rule(PartitionRule *rule, PartitionNode *pn, Node *start,
 {
 	char *str;
 
-	if (first_rule && !*first_rule)
+	Assert(first_rule);
+
+	if (!*first_rule)
 	{
 		appendStringInfoString(body->buf, ", ");
 		*needcomma = false;
@@ -10893,7 +10895,7 @@ write_out_rule(PartitionRule *rule, PartitionNode *pn, Node *start,
 
 	if (str && strlen(str))
 	{
-		if (strlen(body->buf->data) && first_rule && !*first_rule &&
+		if (strlen(body->buf->data) && !*first_rule &&
 			!PRETTY_INDENT(body))
 			appendStringInfoString(body->buf, " ");
 
@@ -10931,8 +10933,7 @@ write_out_rule(PartitionRule *rule, PartitionNode *pn, Node *start,
 
 	get_partition_recursive(children, head, body, leveldone, bLeafTablename);
 
-	if (*first_rule)
-		*first_rule = false;
+	*first_rule = false;
 }
 
 

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -10893,7 +10893,7 @@ write_out_rule(PartitionRule *rule, PartitionNode *pn, Node *start,
 
 	if (str && strlen(str))
 	{
-		if (strlen(body->buf->data) && !first_rule &&
+		if (strlen(body->buf->data) && first_rule && !*first_rule &&
 			!PRETTY_INDENT(body))
 			appendStringInfoString(body->buf, " ");
 


### PR DESCRIPTION
Add null-check for first_rule

write_out_rule dereferences first_rule before null-check making segfault
possible. This patch adds an assertion