### PR TITLE
ADBDEV-4726-70 Add null-check for oldTupDesc

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6512,6 +6512,8 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 		oldslot = MakeSingleTupleTableSlot(oldTupDesc);
 		newslot = MakeSingleTupleTableSlot(newTupDesc);
 
+		Insist(newTupDesc && oldTupDesc);
+
 		/* Preallocate values/isnull arrays */
 		i = Max(newTupDesc->natts, oldTupDesc->natts);
 		values = (Datum *) palloc0(i * sizeof(Datum));

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6504,6 +6504,8 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 
 		econtext = GetPerTupleExprContext(estate);
 
+		Insist(newTupDesc && oldTupDesc);
+
 		/*
 		 * Make tuple slots for old and new tuples.  Note that even when the
 		 * tuples are the same, the tupDescs might not be (consider ADD COLUMN
@@ -6511,8 +6513,6 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 		 */
 		oldslot = MakeSingleTupleTableSlot(oldTupDesc);
 		newslot = MakeSingleTupleTableSlot(newTupDesc);
-
-		Insist(newTupDesc && oldTupDesc);
 
 		/* Preallocate values/isnull arrays */
 		i = Max(newTupDesc->natts, oldTupDesc->natts);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6504,7 +6504,7 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 
 		econtext = GetPerTupleExprContext(estate);
 
-		Insist(newTupDesc && oldTupDesc);
+		Assert(newTupDesc && oldTupDesc);
 
 		/*
 		 * Make tuple slots for old and new tuples.  Note that even when the

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6800,13 +6800,9 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 			 * We use the old tuple descriptor instead of oldrel's tuple descriptor,
 			 * which may already contain altered column.
 			 */
-			if (oldTupDesc)
-			{
-				Assert(oldTupDesc->natts <= nvp);
-				memset(proj, true, oldTupDesc->natts);
-			}
-			else
-				memset(proj, true, nvp);
+			
+			Assert(oldTupDesc->natts <= nvp);
+			memset(proj, true, oldTupDesc->natts);
 
 			if(newrel)
 				idesc = aocs_insert_init(newrel, segno, false);


### PR DESCRIPTION
Add null-check for oldTupDesc

ATRewriteTable dereferences oldTupDesc before null-check making segfault
possible. This patch adds an assertion