### PR TITLE
ADBDEV-4904-27: Add check sendingChunkTransportState is not NULL

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1775,7 +1775,7 @@ SetupTCPInterconnect(EState *estate)
 		i = 0;
 		while (n > 0 &&
 			   outgoing_count < expectedTotalOutgoing &&
-			   i < sendingChunkTransportState->numConns)
+			   i < sendingChunkTransportState ? sendingChunkTransportState->numConns : 0)
 		{						/* loop to check outgoing connections */
 			conn = &sendingChunkTransportState->conns[i++];
 			switch (conn->state)

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1234,6 +1234,7 @@ SetupTCPInterconnect(EState *estate)
 {
 	int			i,
 				index,
+				numConns,
 				n;
 	ListCell   *cell;
 	Slice	   *mySlice;
@@ -1462,9 +1463,9 @@ SetupTCPInterconnect(EState *estate)
 
 		/* Outgoing connections */
 		outgoing_count = 0;
-		n = sendingChunkTransportState ? sendingChunkTransportState->numConns : 0;
+		numConns = sendingChunkTransportState ? sendingChunkTransportState->numConns : 0;
 
-		for (i = 0; i < n; i++)
+		for (i = 0; i < numConns; i++)
 		{
 			index = i;
 
@@ -1773,9 +1774,10 @@ SetupTCPInterconnect(EState *estate)
 		 * Check our outgoing connections.
 		 */
 		i = 0;
+		numConns = sendingChunkTransportState ? sendingChunkTransportState->numConns : 0;
 		while (n > 0 &&
 			   outgoing_count < expectedTotalOutgoing &&
-			   i < sendingChunkTransportState ? sendingChunkTransportState->numConns : 0)
+			   i < numConns)
 		{						/* loop to check outgoing connections */
 			conn = &sendingChunkTransportState->conns[i++];
 			switch (conn->state)


### PR DESCRIPTION
Add check sendingChunkTransportState is not NULL

The sendingChunkTransportState pointer is initialized conditionally and may be
NULL. Add missing check in a place where sendingChunkTransportState->numConns is
dereferenced to be 0 if it's NULL.

Introduce numConns which contains sendingChunkTransportState->numConns or 0 to
avoid checking sendingChunkTransportState for NULL every iteration.