### PR TITLE
ADBDEV-4904-28: Add check that prefix is not NULL to the patternsel function

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1281,11 +1281,12 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 			Selectivity heursel;
 			Selectivity prefixsel;
 
-			Assert(prefix);
-
 			if (pstatus == Pattern_Prefix_Partial)
+			{
+				Insist(prefix != NULL);
 				prefixsel = prefix_selectivity(root, &vardata, vartype,
 											   opfamily, prefix);
+			}
 			else
 				prefixsel = 1.0;
 			heursel = prefixsel * rest_selec;

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1281,6 +1281,8 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 			Selectivity heursel;
 			Selectivity prefixsel;
 
+			Assert(prefix);
+
 			if (pstatus == Pattern_Prefix_Partial)
 				prefixsel = prefix_selectivity(root, &vardata, vartype,
 											   opfamily, prefix);

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -1241,6 +1241,8 @@ patternsel(PG_FUNCTION_ARGS, Pattern_Type ptype, bool negate)
 
 		if (eqopr == InvalidOid)
 			elog(ERROR, "no = operator for opfamily %u", opfamily);
+
+		Insist(prefix != NULL);
 		result = var_eq_const(&vardata, eqopr, prefix->constvalue,
 							  false, true);
 	}


### PR DESCRIPTION
Add check that prefix is not NULL to the patternsel function

The prefix pointer can be NULL at the patternsel function in case of it was not
set at the pattern_fixed_prefix function.

Insist was added for checking this situation, since prefix can be NULL only if
pstatus is Pattern_Prefix_None.