### PR TITLE
ADBDEV-4935-8: Fix null check for ITask::Self

### DIFF
--- a/src/backend/gporca/libgpopt/src/minidump/CMinidumperUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/minidump/CMinidumperUtils.cpp
@@ -213,7 +213,7 @@ CMinidumperUtils::Finalize(CMiniDumperDXL *pmdmp, BOOL fSerializeErrCtx)
 	CAutoTraceFlag atf3(EtraceSimulateNetError, false);
 	CAutoTraceFlag atf4(EtraceSimulateIOError, false);
 
-	if (fSerializeErrCtx)
+	if (NULL != CTask::Self() && fSerializeErrCtx)
 	{
 		CErrorContext *perrctxt = CTask::Self()->ConvertErrCtxt();
 		perrctxt->Serialize();

--- a/src/backend/gporca/libgpopt/src/minidump/CSerializableStackTrace.cpp
+++ b/src/backend/gporca/libgpopt/src/minidump/CSerializableStackTrace.cpp
@@ -60,7 +60,7 @@ CSerializableStackTrace::~CSerializableStackTrace()
 void
 CSerializableStackTrace::Serialize(COstream &oos)
 {
-	if (!ITask::Self()->HasPendingExceptions())
+	if (NULL == CTask::Self() || !CTask::Self()->HasPendingExceptions())
 	{
 		// no pending exception: no need to serialize stack trace
 		return;

--- a/src/backend/gporca/libgpos/src/error/CException.cpp
+++ b/src/backend/gporca/libgpos/src/error/CException.cpp
@@ -105,7 +105,7 @@ CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
 
 	// during bootstrap there's no context object otherwise, record
 	// all details in the context object
-	if (NULL != ITask::Self())
+	if (NULL != CTask::Self())
 	{
 		CErrorContext *err_ctxt = CTask::Self()->ConvertErrCtxt();
 
@@ -132,7 +132,7 @@ CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
 
 	// during bootstrap there's no context object otherwise, record
 	// all details in the context object
-	if (NULL != ITask::Self())
+	if (NULL != CTask::Self())
 	{
 		CErrorContext *err_ctxt = CTask::Self()->ConvertErrCtxt();
 
@@ -162,7 +162,7 @@ CException::Raise(const CHAR *filename, ULONG line, ULONG major, ULONG minor,
 void
 CException::Reraise(CException exc, BOOL propagate)
 {
-	if (NULL != ITask::Self())
+	if (NULL != CTask::Self())
 	{
 		CErrorContext *err_ctxt = CTask::Self()->ConvertErrCtxt();
 		GPOS_ASSERT(err_ctxt->IsPending());


### PR DESCRIPTION
Fix null check for ITask::Self

In several places, there is a check for ITask::Self() for null, but then CTask
is used. Self in CTask does dynamic_cast the result of ITask::Self(), which can
lead to null pointer dereference.

This patch fixes the null check by checking the result of CTask instead of
ITask, also this patch adds such a check in two other places.