### PR TITLE
ADBDEV-4904-30: Remove pNode check for NULL.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5694,6 +5694,7 @@ atpxPartAddList(Relation rel,
 
 	Assert((PARTTYP_LIST == part_type) || (PARTTYP_RANGE == part_type));
 	Assert(pelem);
+	Assert(pNode);
 
 	/* XXX XXX: handle case of missing boundary spec for range with EVERY */
 
@@ -6169,7 +6170,7 @@ atpxPartAddList(Relation rel,
 				}				/* end if prule */
 
 				/* check for basic case of START > last partition */
-				if (pNode && pNode->rules && list_length(pNode->rules))
+				if (pNode->rules && list_length(pNode->rules))
 				{
 					bool		bstat;
 					PartitionRule *a_rule = /* get last rule */
@@ -6401,7 +6402,7 @@ atpxPartAddList(Relation rel,
 				}				/* end if prule */
 
 				/* check for case of END < first partition */
-				if (pNode && pNode->rules && list_length(pNode->rules))
+				if (pNode->rules && list_length(pNode->rules))
 				{
 					bool		bstat;
 					PartitionRule *a_rule = /* get first rule */
@@ -6861,7 +6862,7 @@ atpxPartAddList(Relation rel,
 			}
 
 			/* give a new maxpartno for the list partition */
-			if (pNode && pNode->rules && list_length(pNode->rules))
+			if (pNode->rules && list_length(pNode->rules))
 			{
 				ListCell   *lc;
 				PartitionRule *rule = NULL;
@@ -6886,7 +6887,7 @@ atpxPartAddList(Relation rel,
 			errmsg("too many partitions, parruleord overflow")));
 	}
 
-	if (newPos == FIRST && pNode && list_length(pNode->rules) > 0)
+	if (newPos == FIRST && list_length(pNode->rules) > 0)
 	{
 		/*
 		 * Adding new partition at the beginning.  Find a hole in existing
@@ -6920,7 +6921,7 @@ atpxPartAddList(Relation rel,
 								false /* closegap */ );
 		}
 	}
-	else if (newPos == LAST && pNode && list_length(pNode->rules) > 0)
+	else if (newPos == LAST && list_length(pNode->rules) > 0)
 	{
 		/*
 		 * Adding the new partition at the end.	 Find the hole closest to the


### PR DESCRIPTION
Remove pNode check for NULL.

The atpxPartAddList function is always called from the ATPExecPartAdd function
with a non-NULL pNode argument. Therefore, I replaced the pNode check for NULL
with an assertion.