### PR TITLE
ADBDEV-4935-12&16: Fix a possible type mismatch when comparing Datums in Orca

### DIFF
--- a/src/backend/gporca/libnaucrates/src/base/CDatumBoolGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumBoolGPDB.cpp
@@ -203,6 +203,12 @@ CDatumBoolGPDB::Matches(const IDatum *other) const
 	const CDatumBoolGPDB *other_cast =
 		dynamic_cast<const CDatumBoolGPDB *>(other);
 
+	// type mismatch
+	if (NULL == other_cast)
+	{
+		return false;
+	}
+
 	if (!other_cast->IsNull() && !IsNull())
 	{
 		return (other_cast->GetValue() == GetValue());

--- a/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumGenericGPDB.cpp
@@ -223,6 +223,12 @@ CDatumGenericGPDB::Matches(const IDatum *datum) const
 	const CDatumGenericGPDB *datum_generic =
 		dynamic_cast<const CDatumGenericGPDB *>(datum);
 
+	// type mismatch
+	if (NULL == datum_generic)
+	{
+		return false;
+	}
+
 	if (datum_generic->IsNull() && IsNull())
 	{
 		return true;

--- a/src/backend/gporca/libnaucrates/src/base/CDatumInt2GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumInt2GPDB.cpp
@@ -205,6 +205,12 @@ CDatumInt2GPDB::Matches(const IDatum *datum) const
 	const CDatumInt2GPDB *datum_cast =
 		dynamic_cast<const CDatumInt2GPDB *>(datum);
 
+	// type mismatch
+	if (NULL == datum_cast)
+	{
+		return false;
+	}
+
 	if (!datum_cast->IsNull() && !IsNull())
 	{
 		return (datum_cast->Value() == Value());

--- a/src/backend/gporca/libnaucrates/src/base/CDatumInt4GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumInt4GPDB.cpp
@@ -205,6 +205,12 @@ CDatumInt4GPDB::Matches(const IDatum *datum) const
 	const CDatumInt4GPDB *datum_cast =
 		dynamic_cast<const CDatumInt4GPDB *>(datum);
 
+	// type mismatch
+	if (NULL == datum_cast)
+	{
+		return false;
+	}
+
 	if (!datum_cast->IsNull() && !IsNull())
 	{
 		return (datum_cast->Value() == Value());

--- a/src/backend/gporca/libnaucrates/src/base/CDatumInt8GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumInt8GPDB.cpp
@@ -203,6 +203,12 @@ CDatumInt8GPDB::Matches(const IDatum *datum) const
 	const CDatumInt8GPDB *datum_cast =
 		dynamic_cast<const CDatumInt8GPDB *>(datum);
 
+	// type mismatch
+	if (NULL == datum_cast)
+	{
+		return false;
+	}
+
 	if (!datum_cast->IsNull() && !IsNull())
 	{
 		return (datum_cast->Value() == Value());

--- a/src/backend/gporca/libnaucrates/src/base/CDatumOidGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/base/CDatumOidGPDB.cpp
@@ -200,6 +200,12 @@ CDatumOidGPDB::Matches(const IDatum *datum) const
 	const CDatumOidGPDB *datum_cast =
 		dynamic_cast<const CDatumOidGPDB *>(datum);
 
+	// type mismatch
+	if (NULL == datum_cast)
+	{
+		return false;
+	}
+
 	if (!datum_cast->IsNull() && !IsNull())
 	{
 		return (datum_cast->OidValue() == OidValue());


### PR DESCRIPTION
Fix a possible type mismatch when comparing Datums in Orca

When comparing Datums, we do dynamic_cast, but if the types are different, it
will return null, which can lead to the dereference of the null pointer

This patch adds a check for the dynamic_cast result and returns false in this
case since the Datums are not the same and due to differences in type.