### PR TITLE
ADBDEV-4935-1: Fix possible segfault in the PexprScalarRepChild method of the CExpressionHandle

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionHandle.cpp
@@ -1374,7 +1374,9 @@ CExpressionHandle::PexprScalarRepChild(ULONG child_index) const
 		return pexprScalar;
 	}
 
-	if (NULL != m_pexpr && NULL != (*m_pexpr)[child_index]->Pgexpr())
+	GPOS_ASSERT(m_pexpr);
+
+	if (NULL != (*m_pexpr)[child_index]->Pgexpr())
 	{
 		// if the expression does not come from a group, but its child does then
 		// get the scalar child from that group


### PR DESCRIPTION
Fix possible segfault in the PexprScalarRepChild method of the CExpressionHandle

If m_pgexpr is NULL then m_pexpr should not be NULL
