### PR TITLE
ADBDEV-4935-10, 11, 13, 14, 15,  25, 26, 28, 29, 30, 32. : Add a type check when converting Datum to DXL

### DIFF
--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
@@ -296,6 +296,8 @@ CDXLDatum *
 CMDTypeBoolGPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumBoolGPDB *datum_bool = dynamic_cast<CDatumBoolGPDB *>(datum);
+	GPOS_ASSERT(datum_bool);
+
 	m_mdid->AddRef();
 	return GPOS_NEW(mp)
 		CDXLDatumBool(mp, m_mdid, datum_bool->IsNull(), datum_bool->GetValue());
@@ -313,6 +315,7 @@ CDXLScalarConstValue *
 CMDTypeBoolGPDB::GetDXLOpScConst(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumBoolGPDB *datum_bool_gpdb = dynamic_cast<CDatumBoolGPDB *>(datum);
+	GPOS_ASSERT(datum_bool_gpdb);
 
 	m_mdid->AddRef();
 	CDXLDatumBool *dxl_datum = GPOS_NEW(mp) CDXLDatumBool(

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -311,6 +311,8 @@ CMDTypeGenericGPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	m_mdid->AddRef();
 	CDatumGenericGPDB *datum_generic = dynamic_cast<CDatumGenericGPDB *>(datum);
+	GPOS_ASSERT(datum_generic);
+
 	ULONG length = 0;
 	BYTE *pba = NULL;
 	if (!datum_generic->IsNull())

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
@@ -294,6 +294,7 @@ CMDTypeInt2GPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	m_mdid->AddRef();
 	CDatumInt2GPDB *int2_datum = dynamic_cast<CDatumInt2GPDB *>(datum);
+	GPOS_ASSERT(int2_datum);
 
 	return GPOS_NEW(mp)
 		CDXLDatumInt2(mp, m_mdid, int2_datum->IsNull(), int2_datum->Value());
@@ -311,6 +312,7 @@ CDXLScalarConstValue *
 CMDTypeInt2GPDB::GetDXLOpScConst(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumInt2GPDB *int2gpdb_datum = dynamic_cast<CDatumInt2GPDB *>(datum);
+	GPOS_ASSERT(int2gpdb_datum);
 
 	m_mdid->AddRef();
 	CDXLDatumInt2 *dxl_datum = GPOS_NEW(mp) CDXLDatumInt2(

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
@@ -292,6 +292,7 @@ CMDTypeInt4GPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	m_mdid->AddRef();
 	CDatumInt4GPDB *int4_datum = dynamic_cast<CDatumInt4GPDB *>(datum);
+	GPOS_ASSERT(int4_datum);
 
 	return GPOS_NEW(mp)
 		CDXLDatumInt4(mp, m_mdid, int4_datum->IsNull(), int4_datum->Value());
@@ -309,6 +310,7 @@ CDXLScalarConstValue *
 CMDTypeInt4GPDB::GetDXLOpScConst(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumInt4GPDB *int4gpdb_datum = dynamic_cast<CDatumInt4GPDB *>(datum);
+	GPOS_ASSERT(int4gpdb_datum);
 
 	m_mdid->AddRef();
 	CDXLDatumInt4 *dxl_datum = GPOS_NEW(mp) CDXLDatumInt4(

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
@@ -301,6 +301,7 @@ CDXLDatum *
 CMDTypeInt8GPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumInt8GPDB *int8_datum = dynamic_cast<CDatumInt8GPDB *>(datum);
+	GPOS_ASSERT(int8_datum);
 
 	m_mdid->AddRef();
 	return GPOS_NEW(mp)
@@ -319,6 +320,7 @@ CDXLScalarConstValue *
 CMDTypeInt8GPDB::GetDXLOpScConst(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumInt8GPDB *int8gpdb_datum = dynamic_cast<CDatumInt8GPDB *>(datum);
+	GPOS_ASSERT(int8gpdb_datum);
 
 	m_mdid->AddRef();
 	CDXLDatumInt8 *dxl_datum = GPOS_NEW(mp) CDXLDatumInt8(

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
@@ -293,6 +293,7 @@ CMDTypeOidGPDB::GetDatumVal(CMemoryPool *mp, IDatum *datum) const
 {
 	m_mdid->AddRef();
 	CDatumOidGPDB *oid_datum = dynamic_cast<CDatumOidGPDB *>(datum);
+	GPOS_ASSERT(oid_datum);
 
 	return GPOS_NEW(mp)
 		CDXLDatumOid(mp, m_mdid, oid_datum->IsNull(), oid_datum->OidValue());
@@ -310,6 +311,7 @@ CDXLScalarConstValue *
 CMDTypeOidGPDB::GetDXLOpScConst(CMemoryPool *mp, IDatum *datum) const
 {
 	CDatumOidGPDB *datum_oidGPDB = dynamic_cast<CDatumOidGPDB *>(datum);
+	GPOS_ASSERT(datum_oidGPDB);
 
 	m_mdid->AddRef();
 	CDXLDatumOid *dxl_datum = GPOS_NEW(mp) CDXLDatumOid(


### PR DESCRIPTION
Add a type check when converting Datum to DXL

When converting Datum to DXL we do a dynamic_cast and in case of type mismatch a
null pointer dereference may occur.

This patch adds an assert to the result of the cast.