### PR TITLE
ADBDEV-4935-7: Fix the potential dereference of the null pointer in CErrorHandlerStandard

### DIFF
--- a/src/backend/gporca/libgpos/src/error/CErrorHandlerStandard.cpp
+++ b/src/backend/gporca/libgpos/src/error/CErrorHandlerStandard.cpp
@@ -39,6 +39,7 @@ CErrorHandlerStandard::Process(CException exception)
 	IErrorContext *err_ctxt = task->GetErrCtxt();
 	CLogger *log = dynamic_cast<CLogger *>(task->GetErrorLogger());
 
+	GPOS_ASSERT(NULL != log && "No logger in current context");
 	GPOS_ASSERT(err_ctxt->IsPending() && "No error to process");
 	GPOS_ASSERT(err_ctxt->GetException() == exception &&
 				"Exception processed different from pending");


### PR DESCRIPTION
Fix the potential dereference of the null pointer in CErrorHandlerStandard

In the CErrorHandlerStandard method::Process is used by dynamic_cast to cast the
ILogger interface to the CLogger implementation. At the moment, the ILogger
interface has only one CLogger implementation, but in the future others may
appear and then dynamic_cast may return null and the null pointer will be
dereferenced.

This patch adds verification of the dynamic_cast result.