### PR TITLE
ADBDEV-4938-47: Add assertions to return from dynamic_cast.

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
@@ -260,6 +260,7 @@ CParseHandlerMDGPDBScalarOp::EndElement(const XMLCh *const,	 // element_uri,
 		{
 			CParseHandlerMetadataIdList *mdid_list_parse_handler =
 				dynamic_cast<CParseHandlerMetadataIdList *>((*this)[0]);
+			GPOS_ASSERT(NULL != mdid_list_parse_handler);
 			mdid_opfamilies_array = mdid_list_parse_handler->GetMdIdArray();
 			mdid_opfamilies_array->AddRef();
 		}


### PR DESCRIPTION
Add assertions to return from dynamic_cast.

dynamic_cast may return NULL, so I added assertions.