### PR TITLE
ADBDEV-4935-9: Fix possible segfault during parsing OptimizerConfig

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerOptimizerConfig.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerOptimizerConfig.cpp
@@ -236,6 +236,7 @@ CParseHandlerOptimizerConfig::EndElement(const XMLCh *const,  // element_uri,
 		{
 			CParseHandlerHint *pphHint =
 				dynamic_cast<CParseHandlerHint *>((*this)[5]);
+			GPOS_ASSERT(NULL != pphHint);
 			phint = pphHint->GetHint();
 			GPOS_ASSERT(NULL != phint);
 			phint->AddRef();


### PR DESCRIPTION
When parsing OptimizerConfig from DXL, if the order of the elements in the
OptimizerConfig block does not match the expected order, we may end up with an
element of the wrong type, which will lead to a null pointer dereference.

This patch adds an assert to the dynamic_cast result.