### PR TITLE
ADBDEV-4938: Add assertions to return from dynamic_cast.

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostParams.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostParams.cpp
@@ -131,6 +131,7 @@ CParseHandlerCostParams::EndElement(const XMLCh *const,	 // element_uri,
 	{
 		CParseHandlerCostParam *parse_handler_cost_params =
 			dynamic_cast<CParseHandlerCostParam *>((*this)[ul]);
+		GPOS_ASSERT(NULL != parse_handler_cost_params);
 		m_cost_model_params->SetParam(
 			parse_handler_cost_params->GetName(),
 			parse_handler_cost_params->Get(),

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
@@ -204,12 +204,17 @@ CParseHandlerIndexScan::EndElementHelper(const XMLCh *const element_local_name,
 	CParseHandlerTableDescr *table_descr_parse_handler =
 		dynamic_cast<CParseHandlerTableDescr *>((*this)[5]);
 
+	GPOS_ASSERT(NULL != prop_parse_handler);
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
+	GPOS_ASSERT(NULL != filter_parse_handler);
+	GPOS_ASSERT(NULL != index_condition_list_parse_handler);
+	GPOS_ASSERT(NULL != index_descr_parse_handler);
 	GPOS_ASSERT(NULL != table_descr_parse_handler);
+
 	CDXLTableDescr *dxl_table_descr =
 		table_descr_parse_handler->GetDXLTableDescr();
 	dxl_table_descr->AddRef();
 
-	GPOS_ASSERT(NULL != index_descr_parse_handler);
 	CDXLIndexDescr *dxl_index_descr =
 		index_descr_parse_handler->GetDXLIndexDescr();
 	dxl_index_descr->AddRef();
@@ -238,15 +243,11 @@ CParseHandlerIndexScan::EndElementHelper(const XMLCh *const element_local_name,
 	}
 
 	// set statistics and physical properties
-	GPOS_ASSERT(NULL != prop_parse_handler);
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children
-	GPOS_ASSERT(NULL != proj_list_parse_handler);
 	AddChildFromParseHandler(proj_list_parse_handler);
-	GPOS_ASSERT(NULL != filter_parse_handler);
 	AddChildFromParseHandler(filter_parse_handler);
-	GPOS_ASSERT(NULL != index_condition_list_parse_handler);
 	AddChildFromParseHandler(index_condition_list_parse_handler);
 
 	// deactivate handler

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
@@ -204,10 +204,12 @@ CParseHandlerIndexScan::EndElementHelper(const XMLCh *const element_local_name,
 	CParseHandlerTableDescr *table_descr_parse_handler =
 		dynamic_cast<CParseHandlerTableDescr *>((*this)[5]);
 
+	GPOS_ASSERT(NULL != table_descr_parse_handler);
 	CDXLTableDescr *dxl_table_descr =
 		table_descr_parse_handler->GetDXLTableDescr();
 	dxl_table_descr->AddRef();
 
+	GPOS_ASSERT(NULL != index_descr_parse_handler);
 	CDXLIndexDescr *dxl_index_descr =
 		index_descr_parse_handler->GetDXLIndexDescr();
 	dxl_index_descr->AddRef();
@@ -236,11 +238,15 @@ CParseHandlerIndexScan::EndElementHelper(const XMLCh *const element_local_name,
 	}
 
 	// set statistics and physical properties
+	GPOS_ASSERT(NULL != prop_parse_handler);
 	CParseHandlerUtils::SetProperties(m_dxl_node, prop_parse_handler);
 
 	// add children
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
 	AddChildFromParseHandler(proj_list_parse_handler);
+	GPOS_ASSERT(NULL != filter_parse_handler);
 	AddChildFromParseHandler(filter_parse_handler);
+	GPOS_ASSERT(NULL != index_condition_list_parse_handler);
 	AddChildFromParseHandler(index_condition_list_parse_handler);
 
 	// deactivate handler

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -214,11 +214,16 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 	CParseHandlerLogicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerLogicalOp *>((*this)[4]);
 
-	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != col_descr_parse_handler &&
+				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
+				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != opfamilies_parse_handler &&
+				NULL != opfamilies_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != opclasses_parse_handler &&
+				NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != child_parse_handler &&
+				NULL != child_parse_handler->CreateDXLNode());
 
 	CDXLColDescrArray *dxl_column_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();
@@ -232,11 +237,13 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 	IMdIdArray *distr_opfamilies =
 		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
 			->GetMdIdArray();
+	GPOS_ASSERT(NULL != distr_opfamilies);
 	distr_opfamilies->AddRef();
 
 	IMdIdArray *distr_opclasses =
 		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
 			->GetMdIdArray();
+	GPOS_ASSERT(NULL != distr_opclasses);
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -234,17 +234,20 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		ctas_options_parse_handler->GetDxlCtasStorageOption();
 	dxl_ctas_storage_opt->AddRef();
 
-
+	CParseHandlerMetadataIdList *copfamilies_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != copfamilies_parse_handler);
 	IMdIdArray *distr_opfamilies =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
-			->GetMdIdArray();
-	GPOS_ASSERT(NULL != distr_opfamilies);
+
+		copfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
 
+	CParseHandlerMetadataIdList *copclasses_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler);
+	GPOS_ASSERT(NULL != copclasses_parse_handler);
 	IMdIdArray *distr_opclasses =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
-			->GetMdIdArray();
-	GPOS_ASSERT(NULL != distr_opclasses);
+
+		copclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -239,6 +239,7 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
+
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
 		m_mp,
 		GPOS_NEW(m_mp) CDXLLogicalCTAS(

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -214,16 +214,17 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 	CParseHandlerLogicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerLogicalOp *>((*this)[4]);
 
-	GPOS_ASSERT(NULL != col_descr_parse_handler &&
-				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
-				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != opfamilies_parse_handler &&
-				NULL != opfamilies_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != opclasses_parse_handler &&
-				NULL != opclasses_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != child_parse_handler &&
-				NULL != child_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+	GPOS_ASSERT(NULL != child_parse_handler);
+
+	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
 
 	CDXLColDescrArray *dxl_column_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -234,22 +234,10 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		ctas_options_parse_handler->GetDxlCtasStorageOption();
 	dxl_ctas_storage_opt->AddRef();
 
-	CParseHandlerMetadataIdList *copfamilies_parse_handler =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler);
-	GPOS_ASSERT(NULL != copfamilies_parse_handler);
-	IMdIdArray *distr_opfamilies =
-
-		copfamilies_parse_handler->GetMdIdArray();
+	IMdIdArray *distr_opfamilies = opfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
-
-	CParseHandlerMetadataIdList *copclasses_parse_handler =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler);
-	GPOS_ASSERT(NULL != copclasses_parse_handler);
-	IMdIdArray *distr_opclasses =
-
-		copclasses_parse_handler->GetMdIdArray();
+	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
-
 
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
 		m_mp,

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
@@ -133,8 +133,8 @@ CParseHandlerLogicalConstTable::EndElement(
 
 		CParseHandlerColDescr *col_descr_parse_handler =
 			dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
-		GPOS_ASSERT(NULL != col_descr_parse_handler &&
-					NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+		GPOS_ASSERT(NULL != col_descr_parse_handler);
+		GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 		CDXLColDescrArray *dxl_col_descr_array =
 			col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
@@ -133,7 +133,8 @@ CParseHandlerLogicalConstTable::EndElement(
 
 		CParseHandlerColDescr *col_descr_parse_handler =
 			dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
-		GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+		GPOS_ASSERT(NULL != col_descr_parse_handler &&
+					NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 		CDXLColDescrArray *dxl_col_descr_array =
 			col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
@@ -212,7 +212,8 @@ CParseHandlerLogicalSetOp::EndElement(const XMLCh *const,  // element_uri,
 	// get the columns descriptors
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
-	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler &&
+				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	CDXLColDescrArray *cold_descr_dxl_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
@@ -212,8 +212,8 @@ CParseHandlerLogicalSetOp::EndElement(const XMLCh *const,  // element_uri,
 	// get the columns descriptors
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
-	GPOS_ASSERT(NULL != col_descr_parse_handler &&
-				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	CDXLColDescrArray *cold_descr_dxl_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
@@ -260,6 +260,7 @@ CParseHandlerMDGPDBScalarOp::EndElement(const XMLCh *const,	 // element_uri,
 		{
 			CParseHandlerMetadataIdList *mdid_list_parse_handler =
 				dynamic_cast<CParseHandlerMetadataIdList *>((*this)[0]);
+			GPOS_ASSERT(NULL != mdid_list_parse_handler);
 			mdid_opfamilies_array = mdid_list_parse_handler->GetMdIdArray();
 			mdid_opfamilies_array->AddRef();
 		}

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
@@ -291,14 +291,18 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerMetadataIdList *pphMdidlCheckConstraints =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL != pphMdlIndexInfo->GetMdIndexInfoArray());
-	GPOS_ASSERT(NULL != pphMdidlCheckConstraints->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler &&
+				NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL != pphMdlIndexInfo &&
+				NULL != pphMdlIndexInfo->GetMdIndexInfoArray());
+	GPOS_ASSERT(NULL != pphMdidlCheckConstraints &&
+				NULL != pphMdidlCheckConstraints->GetMdIdArray());
 
 	// refcount child objects
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CMDIndexInfoArray *md_index_info_array =
 		pphMdlIndexInfo->GetMdIndexInfoArray();
+	GPOS_ASSERT(NULL != pphMdidlTriggers);
 	IMdIdArray *mdid_triggers_array = pphMdidlTriggers->GetMdIdArray();
 	IMdIdArray *mdid_check_constraint_array =
 		pphMdidlCheckConstraints->GetMdIdArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
@@ -247,6 +247,7 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 {
 	CParseHandlerMDIndexInfoList *pphMdlIndexInfo =
 		dynamic_cast<CParseHandlerMDIndexInfoList *>((*this)[1]);
+	GPOS_ASSERT(NULL != pphMdlIndexInfo);
 	if (0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenPartConstraint),
 				 element_local_name))
@@ -292,7 +293,7 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
 	GPOS_ASSERT(NULL != md_cols_parse_handler);
-	GPOS_ASSERT(NULL != pphMdlIndexInfo);
+	GPOS_ASSERT(NULL != pphMdidlTriggers);
 	GPOS_ASSERT(NULL != pphMdidlCheckConstraints);
 
 	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
@@ -303,7 +304,6 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CMDIndexInfoArray *md_index_info_array =
 		pphMdlIndexInfo->GetMdIndexInfoArray();
-	GPOS_ASSERT(NULL != pphMdidlTriggers);
 	IMdIdArray *mdid_triggers_array = pphMdidlTriggers->GetMdIdArray();
 	IMdIdArray *mdid_check_constraint_array =
 		pphMdidlCheckConstraints->GetMdIdArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
@@ -291,12 +291,13 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerMetadataIdList *pphMdidlCheckConstraints =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler &&
-				NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL != pphMdlIndexInfo &&
-				NULL != pphMdlIndexInfo->GetMdIndexInfoArray());
-	GPOS_ASSERT(NULL != pphMdidlCheckConstraints &&
-				NULL != pphMdidlCheckConstraints->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler);
+	GPOS_ASSERT(NULL != pphMdlIndexInfo);
+	GPOS_ASSERT(NULL != pphMdidlCheckConstraints);
+
+	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL != pphMdlIndexInfo->GetMdIndexInfoArray());
+	GPOS_ASSERT(NULL != pphMdidlCheckConstraints->GetMdIdArray());
 
 	// refcount child objects
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -194,16 +194,20 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	md_col_array->AddRef();
 	dxl_ctas_storage_options->AddRef();
 
+	CParseHandlerMetadataIdList *copfamilies_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != copfamilies_parse_handler);
 	IMdIdArray *distr_opfamilies =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
-			->GetMdIdArray();
-	GPOS_ASSERT(NULL != distr_opfamilies);
+
+		copfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
 
+	CParseHandlerMetadataIdList *copclasses_parse_handler =
+		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler);
+	GPOS_ASSERT(NULL != copclasses_parse_handler);
 	IMdIdArray *distr_opclasses =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
-			->GetMdIdArray();
-	GPOS_ASSERT(NULL != distr_opclasses);
+
+		copclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -177,14 +177,15 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerMetadataIdList *opclasses_parse_handler =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler &&
-				NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
-				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != opfamilies_parse_handler &&
-				NULL != opfamilies_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != opclasses_parse_handler &&
-				NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+
+	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
 
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CDXLCtasStorageOptions *dxl_ctas_storage_options =

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -199,6 +199,7 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
+
 	m_imd_obj = GPOS_NEW(m_mp) CMDRelationCtasGPDB(
 		m_mp, m_mdid, m_mdname_schema, m_mdname, m_is_temp_table, m_has_oids,
 		m_rel_storage_type, m_rel_distr_policy, md_col_array, m_distr_col_array,

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -194,22 +194,10 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	md_col_array->AddRef();
 	dxl_ctas_storage_options->AddRef();
 
-	CParseHandlerMetadataIdList *copfamilies_parse_handler =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler);
-	GPOS_ASSERT(NULL != copfamilies_parse_handler);
-	IMdIdArray *distr_opfamilies =
-
-		copfamilies_parse_handler->GetMdIdArray();
+	IMdIdArray *distr_opfamilies = opfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
-
-	CParseHandlerMetadataIdList *copclasses_parse_handler =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler);
-	GPOS_ASSERT(NULL != copclasses_parse_handler);
-	IMdIdArray *distr_opclasses =
-
-		copclasses_parse_handler->GetMdIdArray();
+	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
-
 
 	m_imd_obj = GPOS_NEW(m_mp) CMDRelationCtasGPDB(
 		m_mp, m_mdid, m_mdname_schema, m_mdname, m_is_temp_table, m_has_oids,

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -177,10 +177,14 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerMetadataIdList *opclasses_parse_handler =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler &&
+				NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
+				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != opfamilies_parse_handler &&
+				NULL != opfamilies_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != opclasses_parse_handler &&
+				NULL != opclasses_parse_handler->GetMdIdArray());
 
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CDXLCtasStorageOptions *dxl_ctas_storage_options =
@@ -192,11 +196,13 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	IMdIdArray *distr_opfamilies =
 		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
 			->GetMdIdArray();
+	GPOS_ASSERT(NULL != distr_opfamilies);
 	distr_opfamilies->AddRef();
 
 	IMdIdArray *distr_opclasses =
 		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
 			->GetMdIdArray();
+	GPOS_ASSERT(NULL != distr_opclasses);
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -255,10 +255,11 @@ CParseHandlerMDRelationExternal::EndElement(
 	if (m_rel_distr_policy == IMDRelation::EreldistrHash &&
 		m_opfamilies_parse_handler != NULL)
 	{
-		distr_opfamilies = dynamic_cast<CParseHandlerMetadataIdList *>(
-							   m_opfamilies_parse_handler)
-							   ->GetMdIdArray();
-		GPOS_ASSERT(NULL != distr_opfamilies);
+		CParseHandlerMetadataIdList *copfamilies_parse_handler =
+			dynamic_cast<CParseHandlerMetadataIdList *>(
+				m_opfamilies_parse_handler);
+		GPOS_ASSERT(NULL != copfamilies_parse_handler);
+		distr_opfamilies = copfamilies_parse_handler->GetMdIdArray();
 		distr_opfamilies->AddRef();
 	}
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -227,15 +227,19 @@ CParseHandlerMDRelationExternal::EndElement(
 	CParseHandlerMetadataIdList *mdid_check_constraint_parse_handler =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL !=
-				md_index_info_list_parse_handler->GetMdIndexInfoArray());
-	GPOS_ASSERT(NULL != mdid_check_constraint_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler &&
+				NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL != md_index_info_list_parse_handler &&
+				NULL !=
+					md_index_info_list_parse_handler->GetMdIndexInfoArray());
+	GPOS_ASSERT(NULL != mdid_check_constraint_parse_handler &&
+				NULL != mdid_check_constraint_parse_handler->GetMdIdArray());
 
 	// refcount child objects
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CMDIndexInfoArray *md_index_info_array =
 		md_index_info_list_parse_handler->GetMdIndexInfoArray();
+	GPOS_ASSERT(NULL != mdid_triggers_parse_list);
 	IMdIdArray *mdid_triggers_array = mdid_triggers_parse_list->GetMdIdArray();
 	IMdIdArray *mdid_check_constraint_array =
 		mdid_check_constraint_parse_handler->GetMdIdArray();
@@ -252,6 +256,7 @@ CParseHandlerMDRelationExternal::EndElement(
 		distr_opfamilies = dynamic_cast<CParseHandlerMetadataIdList *>(
 							   m_opfamilies_parse_handler)
 							   ->GetMdIdArray();
+		GPOS_ASSERT(NULL != distr_opfamilies);
 		distr_opfamilies->AddRef();
 	}
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -193,6 +193,7 @@ CParseHandlerMDRelationExternal::EndElement(
 		//		{
 		CParseHandlerScalarOp *pphPartCnstr =
 			dynamic_cast<CParseHandlerScalarOp *>((*this)[Length() - 1]);
+		GPOS_ASSERT(NULL != pphPartCnstr);
 		CDXLNode *pdxlnPartConstraint = pphPartCnstr->CreateDXLNode();
 		pdxlnPartConstraint->AddRef();
 		m_part_constraint = GPOS_NEW(m_mp) CMDPartConstraintGPDB(

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -228,19 +228,20 @@ CParseHandlerMDRelationExternal::EndElement(
 	CParseHandlerMetadataIdList *mdid_check_constraint_parse_handler =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
-	GPOS_ASSERT(NULL != md_cols_parse_handler &&
-				NULL != md_cols_parse_handler->GetMdColArray());
-	GPOS_ASSERT(NULL != md_index_info_list_parse_handler &&
-				NULL !=
-					md_index_info_list_parse_handler->GetMdIndexInfoArray());
-	GPOS_ASSERT(NULL != mdid_check_constraint_parse_handler &&
-				NULL != mdid_check_constraint_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != md_cols_parse_handler);
+	GPOS_ASSERT(NULL != md_index_info_list_parse_handler);
+	GPOS_ASSERT(NULL != mdid_triggers_parse_list);
+	GPOS_ASSERT(NULL != mdid_check_constraint_parse_handler);
+
+	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
+	GPOS_ASSERT(NULL !=
+				md_index_info_list_parse_handler->GetMdIndexInfoArray());
+	GPOS_ASSERT(NULL != mdid_check_constraint_parse_handler->GetMdIdArray());
 
 	// refcount child objects
 	CMDColumnArray *md_col_array = md_cols_parse_handler->GetMdColArray();
 	CMDIndexInfoArray *md_index_info_array =
 		md_index_info_list_parse_handler->GetMdIndexInfoArray();
-	GPOS_ASSERT(NULL != mdid_triggers_parse_list);
 	IMdIdArray *mdid_triggers_array = mdid_triggers_parse_list->GetMdIdArray();
 	IMdIdArray *mdid_check_constraint_array =
 		mdid_check_constraint_parse_handler->GetMdIdArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
@@ -109,6 +109,7 @@ CParseHandlerNLJIndexParamList::EndElement(
 		CParseHandlerNLJIndexParam *nest_param_parse_handler =
 			dynamic_cast<CParseHandlerNLJIndexParam *>((*this)[idx]);
 
+		GPOS_ASSERT(NULL != nest_param_parse_handler);
 		CDXLColRef *nest_param_colref_dxl =
 			nest_param_parse_handler->GetNestParamColRefDxl();
 		nest_param_colref_dxl->AddRef();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
@@ -108,8 +108,8 @@ CParseHandlerNLJIndexParamList::EndElement(
 	{
 		CParseHandlerNLJIndexParam *nest_param_parse_handler =
 			dynamic_cast<CParseHandlerNLJIndexParam *>((*this)[idx]);
-
 		GPOS_ASSERT(NULL != nest_param_parse_handler);
+
 		CDXLColRef *nest_param_colref_dxl =
 			nest_param_parse_handler->GetNestParamColRefDxl();
 		nest_param_colref_dxl->AddRef();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
@@ -216,16 +216,23 @@ CParseHandlerPhysicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[3]);
 	CParseHandlerProjList *proj_list_parse_handler =
 		dynamic_cast<CParseHandlerProjList *>((*this)[4]);
-	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != prop_parse_handler &&
+				NULL != proj_list_parse_handler->CreateDXLNode());
 	CParseHandlerPhysicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
 
-	GPOS_ASSERT(NULL != prop_parse_handler->GetProperties());
-	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
-	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != prop_parse_handler &&
+				NULL != prop_parse_handler->GetProperties());
+	GPOS_ASSERT(NULL != opclasses_parse_handler &&
+				NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler &&
+				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
+				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != proj_list_parse_handler &&
+				NULL != proj_list_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != child_parse_handler &&
+				NULL != child_parse_handler->CreateDXLNode());
 
 	CDXLColDescrArray *dxl_col_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
@@ -216,23 +216,23 @@ CParseHandlerPhysicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[3]);
 	CParseHandlerProjList *proj_list_parse_handler =
 		dynamic_cast<CParseHandlerProjList *>((*this)[4]);
-	GPOS_ASSERT(NULL != prop_parse_handler &&
-				NULL != proj_list_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
+	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
 	CParseHandlerPhysicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
 
-	GPOS_ASSERT(NULL != prop_parse_handler &&
-				NULL != prop_parse_handler->GetProperties());
-	GPOS_ASSERT(NULL != opclasses_parse_handler &&
-				NULL != opclasses_parse_handler->GetMdIdArray());
-	GPOS_ASSERT(NULL != col_descr_parse_handler &&
-				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
-	GPOS_ASSERT(NULL != ctas_options_parse_handler &&
-				NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
-	GPOS_ASSERT(NULL != proj_list_parse_handler &&
-				NULL != proj_list_parse_handler->CreateDXLNode());
-	GPOS_ASSERT(NULL != child_parse_handler &&
-				NULL != child_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != prop_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != child_parse_handler);
+
+	GPOS_ASSERT(NULL != prop_parse_handler->GetProperties());
+	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
+	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
+	GPOS_ASSERT(NULL != child_parse_handler->CreateDXLNode());
 
 	CDXLColDescrArray *dxl_col_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
@@ -119,6 +119,7 @@ CParseHandlerScalarBitmapIndexProbe::EndElement(
 	CParseHandlerIndexDescr *index_descr_parse_handler =
 		dynamic_cast<CParseHandlerIndexDescr *>((*this)[1]);
 
+	GPOS_ASSERT(NULL != index_descr_parse_handler);
 	CDXLIndexDescr *dxl_index_descr =
 		index_descr_parse_handler->GetDXLIndexDescr();
 	dxl_index_descr->AddRef();
@@ -128,6 +129,7 @@ CParseHandlerScalarBitmapIndexProbe::EndElement(
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
 
 	// add children
+	GPOS_ASSERT(NULL != index_cond_list_parse_handler);
 	AddChildFromParseHandler(index_cond_list_parse_handler);
 
 	// deactivate handler

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
@@ -120,6 +120,8 @@ CParseHandlerScalarBitmapIndexProbe::EndElement(
 		dynamic_cast<CParseHandlerIndexDescr *>((*this)[1]);
 
 	GPOS_ASSERT(NULL != index_descr_parse_handler);
+	GPOS_ASSERT(NULL != index_cond_list_parse_handler);
+
 	CDXLIndexDescr *dxl_index_descr =
 		index_descr_parse_handler->GetDXLIndexDescr();
 	dxl_index_descr->AddRef();
@@ -129,7 +131,6 @@ CParseHandlerScalarBitmapIndexProbe::EndElement(
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
 
 	// add children
-	GPOS_ASSERT(NULL != index_cond_list_parse_handler);
 	AddChildFromParseHandler(index_cond_list_parse_handler);
 
 	// deactivate handler

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
@@ -150,6 +150,7 @@ CParseHandlerSearchStage::EndElement(const XMLCh *const,  // element_uri,
 	{
 		CParseHandlerXform *xform_set_parse_handler =
 			dynamic_cast<CParseHandlerXform *>((*this)[idx]);
+		GPOS_ASSERT(NULL != xform_set_parse_handler);
 #ifdef GPOS_DEBUG
 		BOOL fSet =
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
@@ -136,7 +136,8 @@ CParseHandlerTableDescr::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
 
-	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler &&
+				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 	CDXLColDescrArray *dxl_column_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
@@ -136,8 +136,8 @@ CParseHandlerTableDescr::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
 
-	GPOS_ASSERT(NULL != col_descr_parse_handler &&
-				NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 	CDXLColDescrArray *dxl_column_descr_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerWindowKeyList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerWindowKeyList.cpp
@@ -116,6 +116,7 @@ CParseHandlerWindowKeyList::EndElement(const XMLCh *const,	// element_uri,
 	{
 		CParseHandlerWindowKey *window_key_parse_handler =
 			dynamic_cast<CParseHandlerWindowKey *>((*this)[idx]);
+		GPOS_ASSERT(NULL != window_key_parse_handler);
 		m_dxl_window_key_array->Append(
 			window_key_parse_handler->GetDxlWindowKeyGen());
 	}


### PR DESCRIPTION
Add assertions to return from dynamic_cast.

dynamic_cast may return NULL, so I added assertions.

In the CParseHandlerLogicalCTAS::EndElement and
CParseHandlerMDRelationCtas::EndElement methods, dynamic_cast has been removed
for the variables opfamilies_parse_handler and opclasses_parse_handler, which
already have the corresponding type CParseHandlerMetadataIdList*.