### PR TITLE
ADBDEV-4726-34-2 Fix null-check for elems array

### DIFF
--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -3060,7 +3060,7 @@ construct_md_array(Datum *elems,
 	memcpy(ARR_DIMS(result), dims, ndims * sizeof(int));
 	memcpy(ARR_LBOUND(result), lbs, ndims * sizeof(int));
 
-	if (elems==NULL || fixedwidthtype) 
+	if (elems==NULL) 
 	{
 		/* do nothing */
 	} 

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -3060,7 +3060,7 @@ construct_md_array(Datum *elems,
 	memcpy(ARR_DIMS(result), dims, ndims * sizeof(int));
 	memcpy(ARR_LBOUND(result), lbs, ndims * sizeof(int));
 
-	if (elems==NULL) 
+	if (elems==NULL)
 	{
 		/* do nothing */
 	} 


### PR DESCRIPTION
Fix null-check for elems array

construct_md_array passed elems to CopyArrayEls where it aws dereferenced
without null-check. This patch changes the condition to prevent it.