### PR TITLE
ADBDEV-4943-96: Add assertions to return from PtMDType.

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4937,10 +4937,10 @@ CTranslatorDXLToPlStmt::CreateTargetListWithNullsForDroppedCols(
 		Expr *expr = NULL;
 		if (md_col->IsDropped())
 		{
+			const IMDType *md_type = m_md_accessor->PtMDType<IMDTypeInt4>();
+			GPOS_ASSERT(NULL != md_type);
 			// add a NULL element
-			OID oid_type = CMDIdGPDB::CastMdid(
-							   m_md_accessor->PtMDType<IMDTypeInt4>()->MDId())
-							   ->Oid();
+			OID oid_type = CMDIdGPDB::CastMdid(md_type->MDId())->Oid();
 
 			expr = (Expr *) gpdb::MakeNULLConst(oid_type);
 		}

--- a/src/backend/gporca/libgpopt/src/operators/CScalarDMLAction.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarDMLAction.cpp
@@ -48,6 +48,8 @@ IMDId *
 CScalarDMLAction::MdidType() const
 {
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
-	return md_accessor->PtMDType<IMDTypeInt4>()->MDId();
+	const IMDType *md_type = md_accessor->PtMDType<IMDTypeInt4>();
+	GPOS_ASSERT(NULL != md_type);
+	return md_type->MDId();
 }
 // EOF


### PR DESCRIPTION
Add assertions to return from PtMDType.

The PtMDType method can return NULL because it returns dynamic_cast which can
return NULL, so I added assertions.