### PR TITLE
Release 6.26.0_arenadata54

### DIFF
--- a/gpAux/gpperfmon/src/gpmon/gpmondb.h
+++ b/gpAux/gpperfmon/src/gpmon/gpmondb.h
@@ -88,7 +88,7 @@ APR_DECLARE (apr_status_t) gpdb_harvest_one(const char* table);
 
 APR_DECLARE (apr_status_t) remove_segid_constraint(void);
 
-APR_DECLARE (apr_hash_t *) get_active_queries(apr_pool_t* pool);
+APR_DECLARE (apr_hash_t *) get_active_sessions(apr_pool_t* pool);
 
 APR_DECLARE (void) create_log_alert_table(void);
 

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -90,6 +90,17 @@ Feature: gpperfmon
         Then wait until the results from boolean sql "SELECT count(*) = 0 FROM queries_history WHERE query_text like '--alter distributed by%'" is "true"
         And wait until the results from boolean sql "SELECT count(*) = 1 FROM queries_history WHERE query_text like '--end flag%'" is "true"
 
+    @gpperfmon_query_history
+    Scenario: gpperfmon does not lose the query text if its text differs from the text in pg_stat_activity
+        Given gpperfmon is configured and running in qamode
+        When the user truncates "queries_history" tables in "gpperfmon"
+        When below sql is executed in "gptest" db
+        """
+        SET log_min_messages = "debug4";
+        DO $$ BEGIN PERFORM pg_sleep(80); END$$;
+        """
+        Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text = 'SELECT pg_sleep(80)'" is "true"
+
     @gpperfmon_system_history
     Scenario: gpperfmon adds to system_history table
         Given gpperfmon is configured and running in qamode


### PR DESCRIPTION
This release is a hot-fix. What is why the patches below will be cherry-picked to be merged directly to `adb-6.x`. A patch 765974d34e5b6222ea9f2051e6965e5d8501bf66 for ABI tests will be merged from `adb-6.x-dev`  later.

Fixes:

1. #646 
2. #676 