### PR TITLE
ADBDEV-4940-81: Add assertion to return from GetReqdRelationalProps.

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CReqdPropRelational.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CReqdPropRelational.cpp
@@ -120,7 +120,9 @@ CReqdPropRelational::Compute(CMemoryPool *mp, CExpressionHandle &exprhdl,
 CReqdPropRelational *
 CReqdPropRelational::GetReqdRelationalProps(CReqdProp *prp)
 {
-	return dynamic_cast<CReqdPropRelational *>(prp);
+	CReqdPropRelational *prprel = dynamic_cast<CReqdPropRelational *>(prp);
+	GPOS_ASSERT(NULL != prprel);
+	return prprel;
 }
 
 


### PR DESCRIPTION
Add assertion to return from GetReqdRelationalProps.

The GetReqdRelationalProps method can return NULL because it returns
dynamic_cast which can return NULL, so I added assertion.