### PR TITLE
ADBDEV-4793-98 Check dynamic_cast result

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
@@ -363,7 +363,7 @@ CLogicalDynamicGetBase::PstatsDeriveFilter(CMemoryPool *mp,
 
 	CStatistics *pstatsFullTable = dynamic_cast<CStatistics *>(
 		PstatsBaseTable(mp, exprhdl, m_ptabdesc, pcrsStat));
-
+	GPOS_ASSERT(NULL != pstatsFullTable);
 	pcrsStat->Release();
 
 	if (NULL == pexprFilterNew || pexprFilterNew->DeriveHasSubquery())


### PR DESCRIPTION
Check dynamic_cast result

dynamic_cast result is used without null check. This patch adds an assertion