### PR TITLE
ADBDEV-4793-99 Check dynamic_cast result

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDynamicTableScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerDynamicTableScan.cpp
@@ -149,6 +149,10 @@ CParseHandlerDynamicTableScan::EndElement(const XMLCh *const,  // element_uri,
 	CParseHandlerTableDescr *table_descr_parse_handler =
 		dynamic_cast<CParseHandlerTableDescr *>((*this)[3]);
 
+	GPOS_ASSERT(NULL != prop_parse_handler);
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
+	GPOS_ASSERT(NULL != filter_parse_handler);
+	GPOS_ASSERT(NULL != table_descr_parse_handler);
 
 	// set table descriptor
 	CDXLTableDescr *table_descr = table_descr_parse_handler->GetDXLTableDescr();


### PR DESCRIPTION
Check dynamic_cast result

dynamic_cast results are used without null check. This patch adds assertions
