### PR TITLE
ADBDEV-4793-100 Check dynamic_cast result

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
@@ -628,8 +628,7 @@ CLogicalGbAgg::PstatsDerive(CMemoryPool *mp, IStatistics *child_stats,
 	GPOS_ASSERT(NULL != cchild_stats);
 
 	IStatistics *stats = CGroupByStatsProcessor::CalcGroupByStats(
-		mp, cchild_stats, pdrgpulGroupingCols,
-		pdrgpulComputedCols, keys);
+		mp, cchild_stats, pdrgpulGroupingCols, pdrgpulComputedCols, keys);
 
 	// clean up
 	pdrgpulGroupingCols->Release();

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
@@ -625,7 +625,7 @@ CLogicalGbAgg::PstatsDerive(CMemoryPool *mp, IStatistics *child_stats,
 	}
 
 	CStatistics *cchild_stats = dynamic_cast<CStatistics *>(child_stats);
-	GPOS_ASSERT(cchild_stats);
+	GPOS_ASSERT(NULL != cchild_stats);
 
 	IStatistics *stats = CGroupByStatsProcessor::CalcGroupByStats(
 		mp, cchild_stats, pdrgpulGroupingCols,

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGbAgg.cpp
@@ -624,8 +624,11 @@ CLogicalGbAgg::PstatsDerive(CMemoryPool *mp, IStatistics *child_stats,
 		pdrgpulGroupingCols->Append(GPOS_NEW(mp) ULONG(colref->Id()));
 	}
 
+	CStatistics *cchild_stats = dynamic_cast<CStatistics *>(child_stats);
+	GPOS_ASSERT(cchild_stats);
+
 	IStatistics *stats = CGroupByStatsProcessor::CalcGroupByStats(
-		mp, dynamic_cast<CStatistics *>(child_stats), pdrgpulGroupingCols,
+		mp, cchild_stats, pdrgpulGroupingCols,
 		pdrgpulComputedCols, keys);
 
 	// clean up

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalUnary.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalUnary.cpp
@@ -75,8 +75,11 @@ CLogicalUnary::PstatsDeriveProject(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	ULongPtrArray *colids = GPOS_NEW(mp) ULongPtrArray(mp);
 	pcrs->ExtractColIds(mp, colids);
 
+	CStatistics *cchild_stats = dynamic_cast<CStatistics *>(child_stats);
+	GPOS_ASSERT(cchild_stats);
+
 	IStatistics *stats = CProjectStatsProcessor::CalcProjStats(
-		mp, dynamic_cast<CStatistics *>(child_stats), colids, phmuldatum);
+		mp, cchild_stats, colids, phmuldatum);
 
 	// clean up
 	colids->Release();

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalUnary.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalUnary.cpp
@@ -76,7 +76,7 @@ CLogicalUnary::PstatsDeriveProject(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	pcrs->ExtractColIds(mp, colids);
 
 	CStatistics *cchild_stats = dynamic_cast<CStatistics *>(child_stats);
-	GPOS_ASSERT(cchild_stats);
+	GPOS_ASSERT(NULL != cchild_stats);
 
 	IStatistics *stats = CProjectStatsProcessor::CalcProjStats(
 		mp, cchild_stats, colids, phmuldatum);


### PR DESCRIPTION
Check dynamic_cast result

dynamic_cast results are used without null check. This patch adds assertions
