### PR TITLE
ADBDEV-4793-102 Check dynamic_cast result

### DIFF
--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1098,16 +1098,17 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 
 	if (NULL != unsupported_pred_stats)
 	{
-		CStatistics *cleft_semi_join_stats = dynamic_cast<CStatistics *>(left_semi_join_stats);
+		CStatistics *cleft_semi_join_stats =
+			dynamic_cast<CStatistics *>(left_semi_join_stats);
 		GPOS_ASSERT(NULL != cleft_semi_join_stats);
 
 		// apply the unsupported join filters as a filter on top of the join results.
 		// TODO,  June 13 2014 we currently only cap NDVs for filters
 		// (also look at CJoinStatsProcessor::CalcAllJoinStats since most of this code was taken from there)
-		IStatistics *stats_after_join_filter =
-			CFilterStatsProcessor::MakeStatsFilter(
-				mp, cleft_semi_join_stats,
-				unsupported_pred_stats, false /* do_cap_NDVs */);
+        IStatistics *stats_after_join_filter =
+                CFilterStatsProcessor::MakeStatsFilter(mp, cleft_semi_join_stats,
+                                                                                           unsupported_pred_stats,
+                                                                                           false /* do_cap_NDVs */);
 		left_semi_join_stats->Release();
 		left_semi_join_stats = stats_after_join_filter;
 	}

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1105,10 +1105,10 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 		// apply the unsupported join filters as a filter on top of the join results.
 		// TODO,  June 13 2014 we currently only cap NDVs for filters
 		// (also look at CJoinStatsProcessor::CalcAllJoinStats since most of this code was taken from there)
-        IStatistics *stats_after_join_filter =
-                CFilterStatsProcessor::MakeStatsFilter(mp, cleft_semi_join_stats,
-                                                                                           unsupported_pred_stats,
-                                                                                           false /* do_cap_NDVs */);
+		IStatistics *stats_after_join_filter =
+			CFilterStatsProcessor::MakeStatsFilter(mp, cleft_semi_join_stats,
+												   unsupported_pred_stats,
+												   false /* do_cap_NDVs */);
 		left_semi_join_stats->Release();
 		left_semi_join_stats = stats_after_join_filter;
 	}

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1099,7 +1099,7 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 	if (NULL != unsupported_pred_stats)
 	{
 		CStatistics *cleft_semi_join_stats = dynamic_cast<CStatistics *>(left_semi_join_stats);
-		GPOS_ASSERT(cleft_semi_join_stats);
+		GPOS_ASSERT(NULL != cleft_semi_join_stats);
 
 		// apply the unsupported join filters as a filter on top of the join results.
 		// TODO,  June 13 2014 we currently only cap NDVs for filters

--- a/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -1098,12 +1098,15 @@ CStatisticsUtils::DeriveStatsForDynamicScan(CMemoryPool *mp,
 
 	if (NULL != unsupported_pred_stats)
 	{
+		CStatistics *cleft_semi_join_stats = dynamic_cast<CStatistics *>(left_semi_join_stats);
+		GPOS_ASSERT(cleft_semi_join_stats);
+
 		// apply the unsupported join filters as a filter on top of the join results.
 		// TODO,  June 13 2014 we currently only cap NDVs for filters
 		// (also look at CJoinStatsProcessor::CalcAllJoinStats since most of this code was taken from there)
 		IStatistics *stats_after_join_filter =
 			CFilterStatsProcessor::MakeStatsFilter(
-				mp, dynamic_cast<CStatistics *>(left_semi_join_stats),
+				mp, cleft_semi_join_stats,
 				unsupported_pred_stats, false /* do_cap_NDVs */);
 		left_semi_join_stats->Release();
 		left_semi_join_stats = stats_after_join_filter;


### PR DESCRIPTION
Check dynamic_cast result

dynamic_cast result is used without null check. This patch adds an assertion
