### PR TITLE
ADBDEV-4793-103 Check dynamic_cast result

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
@@ -170,12 +170,12 @@ CLogicalUnionAll::PstatsDeriveUnionAll(CMemoryPool *mp,
 		CStatistics *cresult_stats = dynamic_cast<CStatistics *>(result_stats);
 		GPOS_ASSERT(NULL != cresult_stats);
 
-		CStatistics *cchild_stats = dynamic_cast<CStatistics *>(exprhdl.Pstats(ul));
+		CStatistics *cchild_stats =
+			dynamic_cast<CStatistics *>(exprhdl.Pstats(ul));
 		GPOS_ASSERT(NULL != cchild_stats);
 
 		CStatistics *stats = CUnionAllStatsProcessor::CreateStatsForUnionAll(
-			mp, cresult_stats,
-			cchild_stats,
+			mp, cresult_stats, cchild_stats,
 			CColRef::Pdrgpul(mp, pdrgpcrOutput),
 			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[0]),
 			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[ul]));

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalUnionAll.cpp
@@ -167,10 +167,15 @@ CLogicalUnionAll::PstatsDeriveUnionAll(CMemoryPool *mp,
 	const ULONG arity = exprhdl.Arity();
 	for (ULONG ul = 1; ul < arity; ul++)
 	{
-		IStatistics *child_stats = exprhdl.Pstats(ul);
+		CStatistics *cresult_stats = dynamic_cast<CStatistics *>(result_stats);
+		GPOS_ASSERT(NULL != cresult_stats);
+
+		CStatistics *cchild_stats = dynamic_cast<CStatistics *>(exprhdl.Pstats(ul));
+		GPOS_ASSERT(NULL != cchild_stats);
+
 		CStatistics *stats = CUnionAllStatsProcessor::CreateStatsForUnionAll(
-			mp, dynamic_cast<CStatistics *>(result_stats),
-			dynamic_cast<CStatistics *>(child_stats),
+			mp, cresult_stats,
+			cchild_stats,
 			CColRef::Pdrgpul(mp, pdrgpcrOutput),
 			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[0]),
 			CColRef::Pdrgpul(mp, (*pdrgpdrgpcrInput)[ul]));


### PR DESCRIPTION
Check dynamic_cast result

dynamic_cast results are used without null check. This patch adds assertions