### PR TITLE
ADBDEV-4793-104 Check that cur_node is not null

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -1029,6 +1029,7 @@ CTranslatorScalarToDXL::CreateScalarIfStmtFromCaseExpr(
 		CDXLNode *default_result_node =
 			TranslateScalarToDXL(case_expr->defresult, var_colid_mapping);
 		GPOS_ASSERT(NULL != default_result_node);
+		GPOS_ASSERT(NULL != cur_node);
 		cur_node->AddChild(default_result_node);
 	}
 


### PR DESCRIPTION
Check that cur_node is not null

CreateScalarIfStmtFromCaseExpr dereferences cur_node without checking that it's not null. This patch adds an assertion