### PR TITLE
ADBDEV-4793-105 Add null check for pprevdatum

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CConstraintInterval.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraintInterval.cpp
@@ -312,6 +312,7 @@ CConstraintInterval::PcnstrIntervalFromScalarArrayCmp(CMemoryPool *mp,
 				pprevdatum = datum;
 			}
 
+			GPOS_ASSERT(NULL != pprevdatum);
 			// add the last datum, making range (last, inf)
 			IMDId *mdid = pprevdatum->MDId();
 			pprevdatum->AddRef();


### PR DESCRIPTION
Add null check for pprevdatum

PcnstrIntervalFromScalarArrayCmp dereferences pprevdatum without making null check. This patch adds an assertion