### PR TITLE
ADBDEV-4793-106 Add null check for ppartcnstrCovered

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithExternalPartitions.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithExternalPartitions.cpp
@@ -104,6 +104,7 @@ CXformExpandDynamicGetWithExternalPartitions::Transform(
 	CPartConstraint *ppartcnstrRel = CUtils::PpartcnstrFromMDPartCnstr(
 		mp, mda, popGet->PdrgpdrgpcrPart(), relation->MDPartConstraint(),
 		popGet->PdrgpcrOutput());
+	GPOS_ASSERT(NULL != ppartcnstrCovered);
 	ppartcnstrRest = ppartcnstrRel->PpartcnstrRemaining(mp, ppartcnstrCovered);
 
 	// PpartcnstrRemaining() returns NULL if ppartcnstrCovered has no constraint


### PR DESCRIPTION
Add null check for ppartcnstrCovered

CXformExpandDynamicGetWithExternalPartitions::Transform dereferences ppartcnstrCovered without making null check. This patch adds an assertion