### PR TITLE
ADBDEV-4793-109 Add null check for pexprInner

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -214,6 +214,7 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 		1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{
 		CExpression *pexprInner = (*pexpr)[0];
+		GPOS_ASSERT(NULL != pexprInner);
 
 		// skip intermediate unary nodes
 		CExpression *pexprChild = pexprInner;


### PR DESCRIPTION
Add null check for pexprInner

PexprSimplifyQuantifiedSubqueries dereferences pexprInner without making null check. This patch adds this check