### PR TITLE
ADBDEV-4793-110 Add null check for pgexprCurrent

### DIFF
--- a/src/backend/gporca/libgpopt/src/search/CGroup.cpp
+++ b/src/backend/gporca/libgpopt/src/search/CGroup.cpp
@@ -663,6 +663,7 @@ CGroup::PgexprAnyCTEConsumer()
 	{
 		CGroupProxy gp(this);
 		pgexprCurrent = gp.PgexprNextLogical(NULL /*pgexpr*/);
+		GPOS_ASSERT(NULL != pgexprCurrent);
 		fFoundCTEConsumer =
 			(COperator::EopLogicalCTEConsumer == pgexprCurrent->Pop()->Eopid());
 	}


### PR DESCRIPTION
Add null check for pgexprCurrent

PgexprAnyCTEConsumer dereferences pgexprCurrent without making null check. This patch adds an assertion