### PR TITLE
ADBDEV-4941-84: Add an assertion for CWorker::Self()

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/task/CWorker.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CWorker.h
@@ -91,7 +91,9 @@ public:
 	static CWorker *
 	Self()
 	{
-		return dynamic_cast<CWorker *>(IWorker::Self());
+		CWorker *worker = dynamic_cast<CWorker *>(IWorker::Self());
+		GPOS_ASSERT(NULL != worker);
+		return worker;
 	}
 
 	// host system callback function to report abort requests

--- a/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
+++ b/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
@@ -131,8 +131,10 @@ CAutoTaskProxy::Create(void *(*pfunc)(void *), void *arg, BOOL *cancel)
 	// auto pointer to hold new task context
 	CAutoP<CTaskContext> task_ctxt;
 
+	CWorker *worker = CWorker::Self();
+	GPOS_ASSERT(NULL != worker);
 	// check if caller is a task
-	ITask *task_parent = CWorker::Self()->GetTask();
+	ITask *task_parent = worker->GetTask();
 	if (NULL == task_parent)
 	{
 		// create new task context

--- a/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
+++ b/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
@@ -131,10 +131,8 @@ CAutoTaskProxy::Create(void *(*pfunc)(void *), void *arg, BOOL *cancel)
 	// auto pointer to hold new task context
 	CAutoP<CTaskContext> task_ctxt;
 
-	CWorker *worker = CWorker::Self();
-	GPOS_ASSERT(NULL != worker);
 	// check if caller is a task
-	ITask *task_parent = worker->GetTask();
+	ITask *task_parent = CWorker::Self()->GetTask();
 	if (NULL == task_parent)
 	{
 		// create new task context


### PR DESCRIPTION
Add an assertion for CWorker::Self()

CWorkerPoolManager::WorkerPoolManager()->Self() casts are always successful,
because worker pool does not support more than one worker, and IWorker only has
one implementation.