### PR TITLE
ADBDEV-4941-83: Add an assertion for CTask::Self()

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -638,12 +638,15 @@ COptTasks::OptimizeTask(void *ptr)
 		CRefCount::SafeRelease(plan_dxl);
 		CMDCache::Shutdown();
 
-		IErrorContext *errctxt = CTask::Self()->GetErrCtxt();
+		CTask *task = CTask::Self();
+		IErrorContext *errctxt = (NULL != task) ? task->GetErrCtxt() : NULL;
 
 		opt_ctxt->m_should_error_out = ShouldErrorOut(ex);
 		opt_ctxt->m_is_unexpected_failure = IsLoggableFailure(ex);
 		opt_ctxt->m_error_msg =
-			CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg());
+			(NULL != errctxt)
+				? CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg())
+				: NULL;
 
 		GPOS_RETHROW(ex);
 	}

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -638,15 +638,12 @@ COptTasks::OptimizeTask(void *ptr)
 		CRefCount::SafeRelease(plan_dxl);
 		CMDCache::Shutdown();
 
-		CTask *task = CTask::Self();
-		IErrorContext *errctxt = (NULL != task) ? task->GetErrCtxt() : NULL;
+		IErrorContext *errctxt = CTask::Self()->GetErrCtxt();
 
 		opt_ctxt->m_should_error_out = ShouldErrorOut(ex);
 		opt_ctxt->m_is_unexpected_failure = IsLoggableFailure(ex);
 		opt_ctxt->m_error_msg =
-			(NULL != errctxt)
-				? CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg())
-				: NULL;
+			CreateMultiByteCharStringFromWCString(errctxt->GetErrorMsg());
 
 		GPOS_RETHROW(ex);
 	}

--- a/src/backend/gporca/libgpos/include/gpos/task/CTask.h
+++ b/src/backend/gporca/libgpos/include/gpos/task/CTask.h
@@ -285,7 +285,9 @@ public:
 	static CTask *
 	Self()
 	{
-		return dynamic_cast<CTask *>(ITask::Self());
+		CTask *task = dynamic_cast<CTask *>(ITask::Self());
+		GPOS_ASSERT(NULL != task);
+		return task;
 	}
 
 };	// class CTask


### PR DESCRIPTION
Add an assertion for CTask::Self()

CTask::Self() casts are always successful, because ITask has only one
implementation.