### PR TITLE
ADBDEV-4793-108 Add null check for pexprPred

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -3468,6 +3468,7 @@ CXformUtils::CreateBitmapIndexProbesWithOrWithoutPredBreakdown(
 	CExpressionArray *pdrgpexprRecheckTemp =
 		GPOS_NEW(pmp) CExpressionArray(pmp);
 
+	GPOS_ASSERT(pexprPred);
 	pexprPred->AddRef();
 
 	while (NULL != pexprPred)


### PR DESCRIPTION
Add null check for pexprPred

CreateBitmapIndexProbesWithOrWithoutPredBreakdown dereferences pexprPred without making null check. This patch adds an assertion