### PR TITLE
ADBDEV-4793-109 Add null check for (*pexpr)[0]

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -214,6 +214,7 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 		1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{
 		CExpression *pexprInner = (*pexpr)[0];
+		GPOS_ASSERT(NULL != pexprInner);
 
 		// skip intermediate unary nodes
 		CExpression *pexprChild = pexprInner;

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -208,11 +208,13 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 	GPOS_CHECK_STACK_SIZE;
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != pexpr);
-	GPOS_ASSERT(NULL != (*pexpr)[0]);
-
+	
 	COperator *pop = pexpr->Pop();
-	if (CUtils::FQuantifiedSubquery(pop) &&
-		1 == (*pexpr)[0]->DeriveMaxCard().Ull())
+	BOOL quantified = CUtils::FQuantifiedSubquery(pop);
+	if (quantified)
+		GPOS_ASSERT(NULL != (*pexpr)[0]);
+
+	if (quantified && 1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{
 		CExpression *pexprInner = (*pexpr)[0];
 

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -208,7 +208,7 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 	GPOS_CHECK_STACK_SIZE;
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != pexpr);
-	
+
 	COperator *pop = pexpr->Pop();
 	BOOL quantified = CUtils::FQuantifiedSubquery(pop);
 	if (quantified)

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -208,13 +208,13 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 	GPOS_CHECK_STACK_SIZE;
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(NULL != pexpr);
+	GPOS_ASSERT(NULL != (*pexpr)[0]);
 
 	COperator *pop = pexpr->Pop();
 	if (CUtils::FQuantifiedSubquery(pop) &&
 		1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{
 		CExpression *pexprInner = (*pexpr)[0];
-		GPOS_ASSERT(NULL != pexprInner);
 
 		// skip intermediate unary nodes
 		CExpression *pexprChild = pexprInner;


### PR DESCRIPTION
Add null check for (*pexpr)[0]

PexprSimplifyQuantifiedSubqueries dereferences (*pexpr)[0] without making null check. This patch adds this check