### PR TITLE
ADBDEV-4946: Free tablespace path memory in case of allocation.

### DIFF
--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -649,6 +649,9 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 				last_tablespace = curr->tablespace = pg_strdup(tablespace);
 				curr->tblsp_alloc = true;
 			}
+
+			if (tablespace != PQgetvalue(res, relnum, i_spclocation))
+				pg_free(tablespace);
 		}
 		else
 			/* A zero reltablespace oid indicates the database tablespace. */

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -637,8 +637,10 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 		/* Is the tablespace oid non-zero? */
 		if (tablespace_oid != 0)
 		{
+			char	   *value = PQgetvalue(res, relnum, i_spclocation);
+
 			tablespace = determine_db_tablespace_path(cluster,
-			                                          PQgetvalue(res, relnum, i_spclocation),
+			                                          value,
 			                                          tablespace_oid);
 
 			/* Can we reuse the previous string allocation? */
@@ -650,7 +652,7 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 				curr->tblsp_alloc = true;
 			}
 
-			if (tablespace != PQgetvalue(res, relnum, i_spclocation))
+			if (tablespace != value)
 				pg_free(tablespace);
 		}
 		else


### PR DESCRIPTION
Free tablespace path memory in case of allocation.

The determine_db_tablespace_path function (which is called from the
get_rel_infos function) returns its second argument or allocates memory for the
tablespace pointer using the pg_strdup function, but get_rel_infos never frees
this pointer.  The patch adds the release of the allocated memory.