### PR TITLE
ADBDEV-4941-84-2: Add an assertion for CWorker::Self()

### DIFF
--- a/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
+++ b/src/backend/gporca/libgpos/src/task/CAutoTaskProxy.cpp
@@ -131,8 +131,10 @@ CAutoTaskProxy::Create(void *(*pfunc)(void *), void *arg, BOOL *cancel)
 	// auto pointer to hold new task context
 	CAutoP<CTaskContext> task_ctxt;
 
+	CWorker *worker = CWorker::Self();
+	GPOS_ASSERT(NULL != worker);
 	// check if caller is a task
-	ITask *task_parent = CWorker::Self()->GetTask();
+	ITask *task_parent = worker->GetTask();
 	if (NULL == task_parent)
 	{
 		// create new task context


### PR DESCRIPTION
Add an assertion for CWorker::Self()

CWorkerPoolManager::WorkerPoolManager()->Self() always returns CWorker * from
dynamic_cast if the static member is not NULL, because worker pool does not
support more than one worker.