### PR TITLE
ADBDEV-4941-82, 85, 86, 87, 88-2: Add assertions after dynamic_cast 

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -696,12 +696,12 @@ Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	const CDXLNode *scalar_subplan_node, CMappingColIdVar *colid_var)
 {
-	CDXLTranslateContext *output_context =
-		(dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))->GetOutputContext();
+	CMappingColIdVarPlStmt *plstmt =
+		dynamic_cast<CMappingColIdVarPlStmt *>(colid_var);
+	GPOS_ASSERT(NULL != plstmt);
 
-	CContextDXLToPlStmt *dxl_to_plstmt_ctxt =
-		(dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))
-			->GetDXLToPlStmtContext();
+	CDXLTranslateContext *output_context = plstmt->GetOutputContext();
+	CContextDXLToPlStmt *dxl_to_plstmt_ctxt = plstmt->GetDXLToPlStmtContext();
 
 	CDXLScalarSubPlan *dxlop =
 		CDXLScalarSubPlan::Cast(scalar_subplan_node->GetOperator());
@@ -762,8 +762,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	// Translate DXL->PlStmt translator to handle subplan's relational children
 	CTranslatorDXLToPlStmt dxl_to_plstmt_translator(
 		m_mp, m_md_accessor,
-		(dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))
-			->GetDXLToPlStmtContext(),
+		plstmt->GetDXLToPlStmtContext(),
 		m_num_of_segments);
 	CDXLTranslationContextArray *prev_siblings_ctxt_arr =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -761,8 +761,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	// generate the child plan,
 	// Translate DXL->PlStmt translator to handle subplan's relational children
 	CTranslatorDXLToPlStmt dxl_to_plstmt_translator(
-		m_mp, m_md_accessor,
-		plstmt->GetDXLToPlStmtContext(),
+		m_mp, m_md_accessor, plstmt->GetDXLToPlStmtContext(),
 		m_num_of_segments);
 	CDXLTranslationContextArray *prev_siblings_ctxt_arr =
 		GPOS_NEW(m_mp) CDXLTranslationContextArray(m_mp);

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -4490,9 +4490,10 @@ CTranslatorExprToDXL::PdxlnMotion(CExpression *pexprMotion,
 		{
 			CPhysicalMotionRoutedDistribute *popMotion =
 				CPhysicalMotionRoutedDistribute::PopConvert(pexprMotion->Pop());
-			CColRef *pcrSegmentId =
-				dynamic_cast<const CDistributionSpecRouted *>(popMotion->Pds())
-					->Pcr();
+			const CDistributionSpecRouted *spec =
+				dynamic_cast<const CDistributionSpecRouted *>(popMotion->Pds());
+			GPOS_ASSERT(NULL != spec);
+			CColRef *pcrSegmentId = spec->Pcr();
 
 			motion = GPOS_NEW(m_mp)
 				CDXLPhysicalRoutedDistributeMotion(m_mp, pcrSegmentId->Id());

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
@@ -312,18 +312,22 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 	if (m_rel_distr_policy == IMDRelation::EreldistrHash &&
 		m_opfamilies_parse_handler != NULL)
 	{
-		distr_opfamilies = dynamic_cast<CParseHandlerMetadataIdList *>(
-							   m_opfamilies_parse_handler)
-							   ->GetMdIdArray();
+		CParseHandlerMetadataIdList *md_id_list =
+			dynamic_cast<CParseHandlerMetadataIdList *>(
+				m_opfamilies_parse_handler);
+		GPOS_ASSERT(NULL != md_id_list);
+		distr_opfamilies = md_id_list->GetMdIdArray();
 		distr_opfamilies->AddRef();
 	}
 
 	IMdIdArray *external_partitions = NULL;
 	if (NULL != m_external_partitions_parse_handler)
 	{
-		external_partitions = dynamic_cast<CParseHandlerMetadataIdList *>(
-								  m_external_partitions_parse_handler)
-								  ->GetMdIdArray();
+		CParseHandlerMetadataIdList *md_id_list =
+			dynamic_cast<CParseHandlerMetadataIdList *>(
+				m_external_partitions_parse_handler);
+		GPOS_ASSERT(NULL != md_id_list);
+		external_partitions = md_id_list->GetMdIdArray();
 		external_partitions->AddRef();
 	}
 


### PR DESCRIPTION
Add assertions after dynamic_cast

dynamic_cast may return NULL, so assertions were added to catch possible NULL
pointers before dereferencing them.