### PR TITLE
ADBDEV-4938: Add assertions to return from dynamic_cast.

### DIFF
--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostParams.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerCostParams.cpp
@@ -131,6 +131,7 @@ CParseHandlerCostParams::EndElement(const XMLCh *const,	 // element_uri,
 	{
 		CParseHandlerCostParam *parse_handler_cost_params =
 			dynamic_cast<CParseHandlerCostParam *>((*this)[ul]);
+		GPOS_ASSERT(NULL != parse_handler_cost_params);
 		m_cost_model_params->SetParam(
 			parse_handler_cost_params->GetName(),
 			parse_handler_cost_params->Get(),

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerIndexScan.cpp
@@ -204,6 +204,13 @@ CParseHandlerIndexScan::EndElementHelper(const XMLCh *const element_local_name,
 	CParseHandlerTableDescr *table_descr_parse_handler =
 		dynamic_cast<CParseHandlerTableDescr *>((*this)[5]);
 
+	GPOS_ASSERT(NULL != prop_parse_handler);
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
+	GPOS_ASSERT(NULL != filter_parse_handler);
+	GPOS_ASSERT(NULL != index_condition_list_parse_handler);
+	GPOS_ASSERT(NULL != index_descr_parse_handler);
+	GPOS_ASSERT(NULL != table_descr_parse_handler);
+
 	CDXLTableDescr *dxl_table_descr =
 		table_descr_parse_handler->GetDXLTableDescr();
 	dxl_table_descr->AddRef();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalCTAS.cpp
@@ -214,6 +214,12 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 	CParseHandlerLogicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerLogicalOp *>((*this)[4]);
 
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+	GPOS_ASSERT(NULL != child_parse_handler);
+
 	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
 	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
@@ -228,15 +234,9 @@ CParseHandlerLogicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		ctas_options_parse_handler->GetDxlCtasStorageOption();
 	dxl_ctas_storage_opt->AddRef();
 
-
-	IMdIdArray *distr_opfamilies =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
-			->GetMdIdArray();
+	IMdIdArray *distr_opfamilies = opfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
-
-	IMdIdArray *distr_opclasses =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
-			->GetMdIdArray();
+	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalConstTable.cpp
@@ -133,6 +133,7 @@ CParseHandlerLogicalConstTable::EndElement(
 
 		CParseHandlerColDescr *col_descr_parse_handler =
 			dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
+		GPOS_ASSERT(NULL != col_descr_parse_handler);
 		GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 		CDXLColDescrArray *dxl_col_descr_array =

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalSetOp.cpp
@@ -212,6 +212,7 @@ CParseHandlerLogicalSetOp::EndElement(const XMLCh *const,  // element_uri,
 	// get the columns descriptors
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
 	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 	CDXLColDescrArray *cold_descr_dxl_array =
 		col_descr_parse_handler->GetDXLColumnDescrArray();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
@@ -260,6 +260,7 @@ CParseHandlerMDGPDBScalarOp::EndElement(const XMLCh *const,	 // element_uri,
 		{
 			CParseHandlerMetadataIdList *mdid_list_parse_handler =
 				dynamic_cast<CParseHandlerMetadataIdList *>((*this)[0]);
+			GPOS_ASSERT(NULL != mdid_list_parse_handler);
 			mdid_opfamilies_array = mdid_list_parse_handler->GetMdIdArray();
 			mdid_opfamilies_array->AddRef();
 		}

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelation.cpp
@@ -247,6 +247,7 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 {
 	CParseHandlerMDIndexInfoList *pphMdlIndexInfo =
 		dynamic_cast<CParseHandlerMDIndexInfoList *>((*this)[1]);
+	GPOS_ASSERT(NULL != pphMdlIndexInfo);
 	if (0 == XMLString::compareString(
 				 CDXLTokens::XmlstrToken(EdxltokenPartConstraint),
 				 element_local_name))
@@ -290,6 +291,10 @@ CParseHandlerMDRelation::EndElement(const XMLCh *const,	 // element_uri,
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[2]);
 	CParseHandlerMetadataIdList *pphMdidlCheckConstraints =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
+
+	GPOS_ASSERT(NULL != md_cols_parse_handler);
+	GPOS_ASSERT(NULL != pphMdidlTriggers);
+	GPOS_ASSERT(NULL != pphMdidlCheckConstraints);
 
 	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
 	GPOS_ASSERT(NULL != pphMdlIndexInfo->GetMdIndexInfoArray());

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationCtas.cpp
@@ -177,6 +177,11 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerMetadataIdList *opclasses_parse_handler =
 		dynamic_cast<CParseHandlerMetadataIdList *>((*this)[3]);
 
+	GPOS_ASSERT(NULL != md_cols_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != opfamilies_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+
 	GPOS_ASSERT(NULL != md_cols_parse_handler->GetMdColArray());
 	GPOS_ASSERT(NULL != ctas_options_parse_handler->GetDxlCtasStorageOption());
 	GPOS_ASSERT(NULL != opfamilies_parse_handler->GetMdIdArray());
@@ -189,14 +194,9 @@ CParseHandlerMDRelationCtas::EndElement(const XMLCh *const,	 // element_uri,
 	md_col_array->AddRef();
 	dxl_ctas_storage_options->AddRef();
 
-	IMdIdArray *distr_opfamilies =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opfamilies_parse_handler)
-			->GetMdIdArray();
+	IMdIdArray *distr_opfamilies = opfamilies_parse_handler->GetMdIdArray();
 	distr_opfamilies->AddRef();
-
-	IMdIdArray *distr_opclasses =
-		dynamic_cast<CParseHandlerMetadataIdList *>(opclasses_parse_handler)
-			->GetMdIdArray();
+	IMdIdArray *distr_opclasses = opclasses_parse_handler->GetMdIdArray();
 	distr_opclasses->AddRef();
 
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDRelationExternal.cpp
@@ -255,10 +255,11 @@ CParseHandlerMDRelationExternal::EndElement(
 	if (m_rel_distr_policy == IMDRelation::EreldistrHash &&
 		m_opfamilies_parse_handler != NULL)
 	{
-		distr_opfamilies = dynamic_cast<CParseHandlerMetadataIdList *>(
-							   m_opfamilies_parse_handler)
-							   ->GetMdIdArray();
-		GPOS_ASSERT(NULL != distr_opfamilies);
+		CParseHandlerMetadataIdList *copfamilies_parse_handler =
+			dynamic_cast<CParseHandlerMetadataIdList *>(
+				m_opfamilies_parse_handler);
+		GPOS_ASSERT(NULL != copfamilies_parse_handler);
+		distr_opfamilies = copfamilies_parse_handler->GetMdIdArray();
 		distr_opfamilies->AddRef();
 	}
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
@@ -108,6 +108,7 @@ CParseHandlerNLJIndexParamList::EndElement(
 	{
 		CParseHandlerNLJIndexParam *nest_param_parse_handler =
 			dynamic_cast<CParseHandlerNLJIndexParam *>((*this)[idx]);
+		GPOS_ASSERT(NULL != nest_param_parse_handler);
 
 		CDXLColRef *nest_param_colref_dxl =
 			nest_param_parse_handler->GetNestParamColRefDxl();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalCTAS.cpp
@@ -216,9 +216,16 @@ CParseHandlerPhysicalCTAS::EndElement(const XMLCh *const,  // element_uri,
 		dynamic_cast<CParseHandlerCtasStorageOptions *>((*this)[3]);
 	CParseHandlerProjList *proj_list_parse_handler =
 		dynamic_cast<CParseHandlerProjList *>((*this)[4]);
+	GPOS_ASSERT(NULL != proj_list_parse_handler);
 	GPOS_ASSERT(NULL != proj_list_parse_handler->CreateDXLNode());
 	CParseHandlerPhysicalOp *child_parse_handler =
 		dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
+
+	GPOS_ASSERT(NULL != prop_parse_handler);
+	GPOS_ASSERT(NULL != opclasses_parse_handler);
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
+	GPOS_ASSERT(NULL != ctas_options_parse_handler);
+	GPOS_ASSERT(NULL != child_parse_handler);
 
 	GPOS_ASSERT(NULL != prop_parse_handler->GetProperties());
 	GPOS_ASSERT(NULL != opclasses_parse_handler->GetMdIdArray());

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarBitmapIndexProbe.cpp
@@ -119,6 +119,9 @@ CParseHandlerScalarBitmapIndexProbe::EndElement(
 	CParseHandlerIndexDescr *index_descr_parse_handler =
 		dynamic_cast<CParseHandlerIndexDescr *>((*this)[1]);
 
+	GPOS_ASSERT(NULL != index_descr_parse_handler);
+	GPOS_ASSERT(NULL != index_cond_list_parse_handler);
+
 	CDXLIndexDescr *dxl_index_descr =
 		index_descr_parse_handler->GetDXLIndexDescr();
 	dxl_index_descr->AddRef();

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerSearchStage.cpp
@@ -150,6 +150,7 @@ CParseHandlerSearchStage::EndElement(const XMLCh *const,  // element_uri,
 	{
 		CParseHandlerXform *xform_set_parse_handler =
 			dynamic_cast<CParseHandlerXform *>((*this)[idx]);
+		GPOS_ASSERT(NULL != xform_set_parse_handler);
 #ifdef GPOS_DEBUG
 		BOOL fSet =
 #endif	// GPOS_DEBUG

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerTableDescr.cpp
@@ -136,6 +136,7 @@ CParseHandlerTableDescr::EndElement(const XMLCh *const,	 // element_uri,
 	CParseHandlerColDescr *col_descr_parse_handler =
 		dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
 
+	GPOS_ASSERT(NULL != col_descr_parse_handler);
 	GPOS_ASSERT(NULL != col_descr_parse_handler->GetDXLColumnDescrArray());
 
 	CDXLColDescrArray *dxl_column_descr_array =

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerWindowKeyList.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerWindowKeyList.cpp
@@ -116,6 +116,7 @@ CParseHandlerWindowKeyList::EndElement(const XMLCh *const,	// element_uri,
 	{
 		CParseHandlerWindowKey *window_key_parse_handler =
 			dynamic_cast<CParseHandlerWindowKey *>((*this)[idx]);
+		GPOS_ASSERT(NULL != window_key_parse_handler);
 		m_dxl_window_key_array->Append(
 			window_key_parse_handler->GetDxlWindowKeyGen());
 	}


### PR DESCRIPTION
Add assertions to return from dynamic_cast.

dynamic_cast may return NULL, so I added assertions.

In the CParseHandlerLogicalCTAS::EndElement and
CParseHandlerMDRelationCtas::EndElement methods, dynamic_cast has been removed
for the variables opfamilies_parse_handler and opclasses_parse_handler, which
already have the corresponding type CParseHandlerMetadataIdList*.