### PR TITLE
ADBDEV-4793_batch4 Add null check for (*pexpr)[0]

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -212,7 +212,9 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 	COperator *pop = pexpr->Pop();
 	BOOL quantified = CUtils::FQuantifiedSubquery(pop);
 	if (quantified)
+	{
 		GPOS_ASSERT(NULL != (*pexpr)[0]);
+	}
 
 	if (quantified && 1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -210,8 +210,11 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries(CMemoryPool *mp,
 	GPOS_ASSERT(NULL != pexpr);
 
 	COperator *pop = pexpr->Pop();
-	if (CUtils::FQuantifiedSubquery(pop) &&
-		1 == (*pexpr)[0]->DeriveMaxCard().Ull())
+	BOOL quantified = CUtils::FQuantifiedSubquery(pop);
+	if (quantified)
+		GPOS_ASSERT(NULL != (*pexpr)[0]);
+
+	if (quantified && 1 == (*pexpr)[0]->DeriveMaxCard().Ull())
 	{
 		CExpression *pexprInner = (*pexpr)[0];
 


### PR DESCRIPTION
Add null check for (*pexpr)[0]

PexprSimplifyQuantifiedSubqueries dereferences (*pexpr)[0] without making null
check. This patch adds this check