### PR TITLE
ADBDEV-4959: Fix segfault when copying dropped column ACLs to a new partition.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2321,6 +2321,9 @@ CopyRelationAcls(Oid srcId, Oid destId)
 		bool		nulls[Natts_pg_attribute];
 		bool		replaces[Natts_pg_attribute];
 
+		if (attSrcForm->attisdropped)
+			continue;
+
 		aclDatum = SysCacheGetAttr(ATTNUM, attSrcTuple, Anum_pg_attribute_attacl,
 								   &isNull);
 		if (isNull)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -9337,3 +9337,16 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+-- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
+CREATE ROLE user_prt_acl;
+CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
+   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
+ALTER TABLE public.t_part_acl DROP COLUMN d;
+ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+DROP TABLE public.t_part_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -9255,3 +9255,16 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+-- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
+CREATE ROLE user_prt_acl;
+CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
+   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
+ALTER TABLE public.t_part_acl DROP COLUMN d;
+ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+DROP TABLE public.t_part_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4444,3 +4444,14 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+
+-- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
+CREATE ROLE user_prt_acl;
+CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
+   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
+ALTER TABLE public.t_part_acl DROP COLUMN d;
+ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+DROP TABLE public.t_part_acl;
+DROP ROLE user_prt_acl;


### PR DESCRIPTION
Fix segfault when copying dropped column ACLs to a new partition.

The CopyRelationAcls function copies ACLs without paying attention to dropped
columns. This can lead to a segfault when adding a new partition. This patch
skips dropped columns when copying ACLs.