### PR TITLE
ADBDEV-4792: Мake the gpexpand test more stable.

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -15,9 +15,7 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
         And user has created expansiontest tables
-        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
-        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
          And add 5 seconds sleep after first table expand
          And the user runs gpexpand to redistribute with duration "00:00:02"
@@ -41,9 +39,7 @@ Feature: expand the cluster by adding more segments
         And the cluster is setup for an expansion on hosts "cdw,sdw1"
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then user has created expansiontest tables
-        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
-        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
         And add 5 seconds sleep after first table expand
         When the user runs gpexpand to redistribute with duration "00:00:02"
@@ -62,9 +58,7 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
         Then the number of segments have been saved
         And user has created expansiontest tables
-        And 4000000 rows are inserted into table "expansiontest0" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
-        And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
          And add 5 seconds sleep after first table expand
          And the user runs gpexpand to redistribute with the --end flag

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -19,6 +19,7 @@ Feature: expand the cluster by adding more segments
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+         And add 5 seconds sleep after first table expand
          And the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
         And verify that the cluster has 2 new segments
@@ -44,6 +45,7 @@ Feature: expand the cluster by adding more segments
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        And add 5 seconds sleep after first table expand
         When the user runs gpexpand to redistribute with duration "00:00:02"
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
 
@@ -64,6 +66,7 @@ Feature: expand the cluster by adding more segments
         And 4000000 rows are inserted into table "expansiontest1" in schema "public" with column type list "int"
         And 4000000 rows are inserted into table "expansiontest2" in schema "public" with column type list "int"
         When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+         And add 5 seconds sleep after first table expand
          And the user runs gpexpand to redistribute with the --end flag
         Then gpexpand should print "End time reached.  Stopping expansion." to stdout
         And verify that the cluster has 2 new segments

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4276,6 +4276,15 @@ def impl(context, logdir, stage):
         if attempt == num_retries:
             raise Exception('Timed out after {} retries'.format(num_retries))
 
+@when('add {seconds} seconds sleep after first table expand')
+def impl(context, seconds):
+    create_fault_query = "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"
+    execute_sql(context.dbname, create_fault_query)
+    # We use the after_swap_relation_files fault injector to simulate a long
+    # table expansion time because during the expansion of the table, we swap
+    # the relation files.
+    inject_fault_query = f"SELECT gp_inject_fault('after_swap_relation_files', 'sleep', '', '', '', 1, 1, {seconds}, 2);"
+    execute_sql(context.dbname, inject_fault_query)
 
 def verify_elements_in_file(filename, elements):
     with open(filename, 'r') as file:


### PR DESCRIPTION
Мake the gpexpand test more stable.
    
In some gpexpand tests, checks if the expand is interrupted after a set time,
but sometimes gpexpand may expand faster than the set time and the test will
fail.
    
This patch adds a 5-second sleep after the expansion of the first table to
stimulate a long expansion without increasing the amount of data. To add sleep,
a fault injector in the finish_heap_swap is used, which occurs during the
expansion of the table.

There was also a revert commit 41646c8d46ced65df8e1c712fc85716522f3c0d8 since we
no longer need such a volume of data for the test.