### PR TITLE
ADBDEV-4798: Fix gprecoverseg behave test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1018,6 +1018,7 @@ Feature: gprecoverseg tests
     And the segments are synchronized
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And user immediately stops all primary processes for content 0,1
+    And user can start transactions
     And the user suspend the walsender on the primary on content 2
     And the user asynchronously runs pg_basebackup with primary of content 2 as source and the process is saved
     And an FTS probe is triggered


### PR DESCRIPTION
Fix gprecoverseg behave test

In the scenario "gprecoverseg should not give warning if pg_basebackup is
running for the up segments", after stopping the primary segments, there is no
waiting for switching to mirrors, and therefore the step "the user suspend the
walsender on the primary on content 2" fails.

This patch adds the "user can start transactions" step after stop primary
segments to wait for switching to mirrors. As is done in other scenarios.