### PR TITLE
ADBDEV-4991: Fix resgroup_memory_limit test.

### DIFF
--- a/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
@@ -26,12 +26,12 @@ BEGIN
 1: SHOW statement_mem;
  statement_mem 
 ---------------
- 125MB         
+ 250MB         
 (1 row)
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
  func_memory_test 
 ------------------
- 128000kB         
+ 256000kB         
 (1 row)
 
 -- session2: test alter resource group's memory limit


### PR DESCRIPTION
Fix resgroup_memory_limit test.

Upstream runs tests on resource groups in an environment with the default value
of statement_mem = 125MB, while on our CI we run the same tests in an
environment with an explicit statement_mem = 250MB. This patch corrects the
output of the resgroup_memory_limit test for such an environment.