### PR TITLE
Checking ao table while looking for column to prevent finding invalid…

### DIFF
--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -811,3 +811,8 @@ insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5)
 select count(*) from fix_ao_truncate_last_sequence;
 abort;
 
+-- Check if system columns in ao table can be selected
+DROP TABLE IF EXISTS ttt_ao;
+CREATE TABLE ttt (id int) WITH (appendonly=true) DISTRIBUTED BY (id);
+INSERT INTO ttt VALUES(1);
+SELECT xmin FROM ttt;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1714,3 +1714,12 @@ select count(*) from fix_ao_truncate_last_sequence;
 (1 row)
 
 abort;
+
+-- Check if system columns in ao table can be selected
+DROP TABLE IF EXISTS ttt_ao;
+CREATE TABLE ttt (id int) WITH (appendonly=true) DISTRIBUTED BY (id);
+INSERT INTO ttt VALUES(1);
+SELECT xmin FROM ttt;
+ERROR:  column "xmin" does not exist
+LINE 1: select xmin from ttt;
+               ^


### PR DESCRIPTION
Now if we run
```
create table ttt (id int) with (appendonly=true) distributed by (id);
insert into ttt values(1);
select xmin from ttt;

```

We will have something like:
`ERROR:  Invalid attnum: -3 (execTuples.c:1600)  (seg1 slice1 127.0.1.1:6003 pid=11576) (execTuples.c:1600)
`

I tried to turn it to getting more useful message:
```
ERROR:  column "xmin" does not exist
LINE 1: select xmin from ttt;
               ^

```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
