### PR TITLE
ADBDEV-4969: Fix resource group tests

### DIFF
--- a/arenadata/readme.md
+++ b/arenadata/readme.md
@@ -107,3 +107,9 @@ For example, cross_subnet tests or tests with tag `concourse_cluster` currently 
 Tests in a docker-compose cluster use the same ssh keys for `gpadmin` user and pre-add the cluster hosts to `.ssh/know_hosts` and `/etc/hosts`.
 
 Docker containers have installed `sigar` libraries. It is required only for `gpperfmon` tests.
+
+## Resource group test
+
+```bash
+bash arenadata/scripts/run_resgroup_test.bash
+```

--- a/arenadata/scripts/init_containers.sh
+++ b/arenadata/scripts/init_containers.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eo pipefail
+
+project="$1"
+
+mkdir ssh_keys -p
+if [ ! -e "ssh_keys/id_rsa" ]
+then
+  ssh-keygen -P "" -f ssh_keys/id_rsa
+fi
+
+shift
+
+#up services specified in argument or all if service list is not specified
+docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d $@
+
+
+if [[ $# -eq 0 ]]; then
+  services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
+else
+  services="$@"
+fi
+# Prepare ALL containers first
+for service in $services
+do
+  docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
+    $service bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
+      source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
+      ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
+done
+wait
+
+# Add host keys to known_hosts after containers setup
+for service in $services
+do
+  docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
+    $service bash -c "ssh-keyscan ${services/$service/} >> /home/gpadmin/.ssh/known_hosts" &
+done
+wait

--- a/arenadata/scripts/init_containers.sh
+++ b/arenadata/scripts/init_containers.sh
@@ -11,8 +11,13 @@ fi
 
 shift
 
-docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d
-services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
+docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d $@
+
+if [[ $# -eq 0 ]]; then
+  services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
+else
+  services="$@"
+fi
 
 # Prepare ALL containers first
 for service in $services

--- a/arenadata/scripts/init_containers.sh
+++ b/arenadata/scripts/init_containers.sh
@@ -11,15 +11,9 @@ fi
 
 shift
 
-#up services specified in argument or all if service list is not specified
-docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d $@
+docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d
+services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
 
-
-if [[ $# -eq 0 ]]; then
-  services=$(docker-compose -p $project -f arenadata/docker-compose.yaml config --services | tr '\n' ' ')
-else
-  services="$@"
-fi
 # Prepare ALL containers first
 for service in $services
 do

--- a/arenadata/scripts/init_containers.sh
+++ b/arenadata/scripts/init_containers.sh
@@ -3,12 +3,6 @@ set -eo pipefail
 
 project="$1"
 
-mkdir ssh_keys -p
-if [ ! -e "ssh_keys/id_rsa" ]
-then
-  ssh-keygen -P "" -f ssh_keys/id_rsa
-fi
-
 shift
 
 docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env up -d $@

--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -28,6 +28,11 @@ processes=3
 
 rm -rf allure-results
 mkdir allure-results -pm 777
+mkdir ssh_keys -p
+if [ ! -e "ssh_keys/id_rsa" ]
+then
+  ssh-keygen -P "" -f ssh_keys/id_rsa
+fi
 
 run_feature() {
   local feature=$1

--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -28,11 +28,6 @@ processes=3
 
 rm -rf allure-results
 mkdir allure-results -pm 777
-mkdir ssh_keys -p
-if [ ! -e "ssh_keys/id_rsa" ]
-then
-  ssh-keygen -P "" -f ssh_keys/id_rsa
-fi
 
 run_feature() {
   local feature=$1

--- a/arenadata/scripts/run_resgroup_test.bash
+++ b/arenadata/scripts/run_resgroup_test.bash
@@ -2,6 +2,12 @@
 
 project="resgroup"
 
+mkdir ssh_keys -p
+if [ ! -e "ssh_keys/id_rsa" ]
+then
+  ssh-keygen -P "" -f ssh_keys/id_rsa
+fi
+
 #install gpdb and setup gpadmin user
 bash arenadata/scripts/init_containers.sh $project cdw sdw1
 

--- a/arenadata/scripts/run_resgroup_test.bash
+++ b/arenadata/scripts/run_resgroup_test.bash
@@ -3,7 +3,7 @@
 project="resgroup"
 
 #install gpdb and setup gpadmin user
-bash arenadata/scripts/init_containers.sh $project
+bash arenadata/scripts/init_containers.sh $project cdw sdw1
 
 for service in 'cdw' 'sdw1'
 do
@@ -35,8 +35,7 @@ docker-compose -p $project -f arenadata/docker-compose.yaml exec -Tu gpadmin cdw
             ${CONFIGURE_FLAGS}
 
         make -C /home/gpadmin/gpdb_src/src/test/regress
-        ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/regress </dev/null
-        ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/isolation2 </dev/null
+        ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/{regress,isolation2} </dev/null
         scp /home/gpadmin/gpdb_src/src/test/regress/regress.so \
             gpadmin@sdw1:/home/gpadmin/gpdb_src/src/test/regress/
 

--- a/arenadata/scripts/run_resgroup_test.bash
+++ b/arenadata/scripts/run_resgroup_test.bash
@@ -1,67 +1,29 @@
 #!/bin/bash
 
-mkdir ssh_keys -p
-if [ ! -e "ssh_keys/id_rsa" ]
-then
-  ssh-keygen -P "" -f ssh_keys/id_rsa
-fi
-
-docker network create resgroup_net
-
-#start cdw and sdw1 containers
-docker run -d --rm \
-       	--name=resgroup-cdw -h cdw \
-       	-e TEST_OS=centos \
-       	--network=resgroup_net \
-       	-v "$PWD/ssh_keys/id_rsa:/home/gpadmin/.ssh/id_rsa" \
-       	-v "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub" \
-       	--privileged \
-       	--sysctl kernel.sem="500 1024000 200 4096" \
-       	$IMAGE \
-       	bash -c 'set -e && sleep infinity'
-
-docker run -d --rm \
-        --name=resgroup-sdw1 -h sdw1 \
-       	-e TEST_OS=centos \
-       	--network=resgroup_net \
-       	-v "$PWD/ssh_keys/id_rsa:/home/gpadmin/.ssh/id_rsa" \
-       	-v "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub" \
-       	--privileged \
-       	--sysctl kernel.sem="500 1024000 200 4096" \
-       	$IMAGE bash -c 'set -e && sleep infinity'
+project="resgroup"
 
 #install gpdb and setup gpadmin user
-docker exec resgroup-cdw bash -c "
-	source gpdb_src/concourse/scripts/common.bash &&
-	install_and_configure_gpdb &&
-	gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
-
-docker exec resgroup-sdw1 bash -c "
-	source gpdb_src/concourse/scripts/common.bash &&
-	install_and_configure_gpdb &&
-	gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
-wait
-
-#add host key to known hosts
-docker exec resgroup-cdw bash -c "ssh-keyscan cdw sdw1 >> /home/gpadmin/.ssh/known_hosts"
-docker exec resgroup-sdw1 bash -c "ssh-keyscan cdw sdw1 >> /home/gpadmin/.ssh/known_hosts"
+bash arenadata/scripts/init_containers.sh $project cdw sdw1
 
 #grant access rights to group controllers
-docker exec resgroup-cdw bash -c "chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
+docker-compose -p $project -f arenadata/docker-compose.yaml exec cdw bash -c "
+  chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
 	mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
 	chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
 	chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
 
-docker exec resgroup-sdw1 bash -c "chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
-        mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-        chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-        chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
+docker-compose -p $project -f arenadata/docker-compose.yaml exec sdw1 bash -c "
+  chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
+	mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+	chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+	chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
 
 #create cluster
-docker exec resgroup-cdw bash -c "source gpdb_src/concourse/scripts/common.bash && HOSTS_LIST='sdw1' make_cluster"
+docker-compose -p $project -f arenadata/docker-compose.yaml exec cdw \
+ bash -c "source gpdb_src/concourse/scripts/common.bash && HOSTS_LIST='sdw1' make_cluster"
 
 #run tests
-docker exec -iu gpadmin resgroup-cdw bash -ex <<EOF
+docker-compose -p $project -f arenadata/docker-compose.yaml exec -Tu gpadmin cdw bash -ex <<EOF
         source /usr/local/greenplum-db-devel/greenplum_path.sh
         source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
         export LDFLAGS="-L\${GPHOME}/lib"
@@ -99,6 +61,4 @@ EOF1
 EOF
 
 #clear
-docker stop resgroup-cdw resgroup-sdw1
-docker network rm resgroup_net
-
+docker-compose -p $project -f arenadata/docker-compose.yaml --env-file arenadata/.env down

--- a/arenadata/scripts/run_resgroup_test.bash
+++ b/arenadata/scripts/run_resgroup_test.bash
@@ -3,20 +3,17 @@
 project="resgroup"
 
 #install gpdb and setup gpadmin user
-bash arenadata/scripts/init_containers.sh $project cdw sdw1
+bash arenadata/scripts/init_containers.sh $project
 
-#grant access rights to group controllers
-docker-compose -p $project -f arenadata/docker-compose.yaml exec cdw bash -c "
-  chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
-	mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-	chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-	chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
-
-docker-compose -p $project -f arenadata/docker-compose.yaml exec sdw1 bash -c "
-  chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
-	mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-	chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
-	chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
+for service in 'cdw' 'sdw1'
+do
+  #grant access rights to group controllers
+  docker-compose -p $project -f arenadata/docker-compose.yaml exec $service bash -c "
+    chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
+    mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+    chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+    chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
+done
 
 #create cluster
 docker-compose -p $project -f arenadata/docker-compose.yaml exec cdw \

--- a/arenadata/scripts/run_resgroup_test.bash
+++ b/arenadata/scripts/run_resgroup_test.bash
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+mkdir ssh_keys -p
+if [ ! -e "ssh_keys/id_rsa" ]
+then
+  ssh-keygen -P "" -f ssh_keys/id_rsa
+fi
+
+docker network create resgroup_net
+
+#start cdw and sdw1 containers
+docker run -d --rm \
+       	--name=resgroup-cdw -h cdw \
+       	-e TEST_OS=centos \
+       	--network=resgroup_net \
+       	-v "$PWD/ssh_keys/id_rsa:/home/gpadmin/.ssh/id_rsa" \
+       	-v "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub" \
+       	--privileged \
+       	--sysctl kernel.sem="500 1024000 200 4096" \
+       	$IMAGE \
+       	bash -c 'set -e && sleep infinity'
+
+docker run -d --rm \
+        --name=resgroup-sdw1 -h sdw1 \
+       	-e TEST_OS=centos \
+       	--network=resgroup_net \
+       	-v "$PWD/ssh_keys/id_rsa:/home/gpadmin/.ssh/id_rsa" \
+       	-v "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub" \
+       	--privileged \
+       	--sysctl kernel.sem="500 1024000 200 4096" \
+       	$IMAGE bash -c 'set -e && sleep infinity'
+
+#install gpdb and setup gpadmin user
+docker exec resgroup-cdw bash -c "
+	source gpdb_src/concourse/scripts/common.bash &&
+	install_and_configure_gpdb &&
+	gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
+
+docker exec resgroup-sdw1 bash -c "
+	source gpdb_src/concourse/scripts/common.bash &&
+	install_and_configure_gpdb &&
+	gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
+wait
+
+#add host key to known hosts
+docker exec resgroup-cdw bash -c "ssh-keyscan cdw sdw1 >> /home/gpadmin/.ssh/known_hosts"
+docker exec resgroup-sdw1 bash -c "ssh-keyscan cdw sdw1 >> /home/gpadmin/.ssh/known_hosts"
+
+#grant access rights to group controllers
+docker exec resgroup-cdw bash -c "chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
+	mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+	chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+	chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
+
+docker exec resgroup-sdw1 bash -c "chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset} &&
+        mkdir /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+        chmod -R 777 /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb &&
+        chown -R gpadmin:gpadmin /sys/fs/cgroup/{memory,cpu,cpuset}/gpdb"
+
+#create cluster
+docker exec resgroup-cdw bash -c "source gpdb_src/concourse/scripts/common.bash && HOSTS_LIST='sdw1' make_cluster"
+
+#run tests
+docker exec -iu gpadmin resgroup-cdw bash -ex <<EOF
+        source /usr/local/greenplum-db-devel/greenplum_path.sh
+        source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+        export LDFLAGS="-L\${GPHOME}/lib"
+        export CPPFLAGS="-I\${GPHOME}/include"
+        export USER=gpadmin
+
+        cd /home/gpadmin/gpdb_src
+        ./configure --prefix=/usr/local/greenplum-db-devel \
+            --without-zlib --without-rt --without-libcurl \
+            --without-libedit-preferred --without-docdir --without-readline \
+            --disable-gpcloud --disable-gpfdist --disable-orca \
+            ${CONFIGURE_FLAGS}
+
+        make -C /home/gpadmin/gpdb_src/src/test/regress
+        ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/regress </dev/null
+        ssh sdw1 mkdir -p /home/gpadmin/gpdb_src/src/test/isolation2 </dev/null
+        scp /home/gpadmin/gpdb_src/src/test/regress/regress.so \
+            gpadmin@sdw1:/home/gpadmin/gpdb_src/src/test/regress/
+
+        make PGOPTIONS="-c optimizer=off" installcheck-resgroup || (
+            errcode=\$?
+            find src/test/isolation2 -name regression.diffs \
+            | while read diff; do
+                cat <<EOF1
+
+======================================================================
+DIFF FILE: \$diff
+----------------------------------------------------------------------
+
+EOF1
+                cat \$diff
+              done
+            exit \$errcode
+        )
+EOF
+
+#clear
+docker stop resgroup-cdw resgroup-sdw1
+docker network rm resgroup_net
+

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -132,10 +132,8 @@ cleanDemo(){
     ##
 
     if [ "${GPDEMO_DESTRUCTIVE_CLEAN}" != "false" ]; then
-        if gpssh -f hostfile [ -d ${DATADIRS} ]; then
-            echo "Deleting ${DATADIRS} on hosts"
-            gpssh -f hostfile rm -rf ${DATADIRS}
-        fi
+        echo "Deleting ${DATADIRS} on hosts"
+        gpssh -f hostfile rm -rf ${DATADIRS}
 
         if [ -f hostfile ];  then
             echo "Deleting hostfile"
@@ -258,14 +256,12 @@ fi
 
 LOCALHOST=`hostname`
 
-HOSTS_OPTS=""
-TRUSTED_SHELL="`pwd`/lalshell"
-rm -f hostfile
-if [[ -v HOSTS_LIST  ]]; then
+if [ -n HOSTS_LIST  ]; then
+  rm -f hostfile
   for host in $HOSTS_LIST; do
     if ! ssh $host /bin/true; then
       echo "can't access to the host $host, exiting"
-      exit 0
+      exit 1
     fi
 
     echo $host >> hostfile
@@ -274,10 +270,13 @@ if [[ -v HOSTS_LIST  ]]; then
   TRUSTED_SHELL="ssh"
 else
   echo $LOCALHOST > hostfile
+  HOSTS_OPTS=""
+  TRUSTED_SHELL="`pwd`/lalshell"
 fi
 
 if [ -d $DATADIRS ]; then
   rm -rf $DATADIRS
+  gpssh -f hostfile rm -rf $DATADIRS
 fi
 mkdir $DATADIRS
 mkdir $QDDIR
@@ -286,12 +285,10 @@ mkdir $DATADIRS/gpAdminLogs
 for (( i=1; i<=$NUM_PRIMARY_MIRROR_PAIRS; i++ ))
 do
   PRIMARY_DIR=$DATADIRS/dbfast$i
-  gpssh -f hostfile rm -rf $PRIMARY_DIR
   gpssh -f hostfile mkdir -p $PRIMARY_DIR
   PRIMARY_DIRS_LIST="$PRIMARY_DIRS_LIST $PRIMARY_DIR"
 
   MIRROR_DIR=$DATADIRS/dbfast_mirror$i
-  gpssh -f hostfile rm -rf $MIRROR_DIR
   gpssh -f hostfile mkdir -p $MIRROR_DIR
   MIRROR_DIRS_LIST="$MIRROR_DIRS_LIST $MIRROR_DIR"
 done

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -276,8 +276,9 @@ fi
 
 if [ -d $DATADIRS ]; then
   rm -rf $DATADIRS
-  gpssh -f hostfile rm -rf $DATADIRS
 fi
+gpssh -f hostfile rm -rf $DATADIRS
+
 mkdir $DATADIRS
 mkdir $QDDIR
 mkdir $DATADIRS/gpAdminLogs

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -256,7 +256,7 @@ fi
 
 LOCALHOST=`hostname`
 
-if [ -n HOSTS_LIST  ]; then
+if [ -n "$HOSTS_LIST" ]; then
   rm -f hostfile
   for host in $HOSTS_LIST; do
     if ! ssh $host /bin/true; then

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -132,6 +132,11 @@ cleanDemo(){
     ##
 
     if [ "${GPDEMO_DESTRUCTIVE_CLEAN}" != "false" ]; then
+        if gpssh -f hostfile [ -d ${DATADIRS} ]; then
+            echo "Deleting ${DATADIRS} on hosts"
+            gpssh -f hostfile rm -rf ${DATADIRS}
+        fi
+
         if [ -f hostfile ];  then
             echo "Deleting hostfile"
             rm -f hostfile
@@ -247,6 +252,30 @@ if [ ! -x $GPPATH/gpinitsystem ]; then
     exit 1
 fi
 
+#*****************************************************************************************
+# Host configuration
+#*****************************************************************************************
+
+LOCALHOST=`hostname`
+
+HOSTS_OPTS=""
+TRUSTED_SHELL="`pwd`/lalshell"
+rm -f hostfile
+if [[ -v HOSTS_LIST  ]]; then
+  for host in $HOSTS_LIST; do
+    if ! ssh $host /bin/true; then
+      echo "can't access to the host $host, exiting"
+      exit 0
+    fi
+
+    echo $host >> hostfile
+  done
+  HOSTS_OPTS="-h hostfile"
+  TRUSTED_SHELL="ssh"
+else
+  echo $LOCALHOST > hostfile
+fi
+
 if [ -d $DATADIRS ]; then
   rm -rf $DATADIRS
 fi
@@ -257,22 +286,17 @@ mkdir $DATADIRS/gpAdminLogs
 for (( i=1; i<=$NUM_PRIMARY_MIRROR_PAIRS; i++ ))
 do
   PRIMARY_DIR=$DATADIRS/dbfast$i
-  mkdir -p $PRIMARY_DIR
+  gpssh -f hostfile rm -rf $PRIMARY_DIR
+  gpssh -f hostfile mkdir -p $PRIMARY_DIR
   PRIMARY_DIRS_LIST="$PRIMARY_DIRS_LIST $PRIMARY_DIR"
 
   MIRROR_DIR=$DATADIRS/dbfast_mirror$i
-  mkdir -p $MIRROR_DIR
+  gpssh -f hostfile rm -rf $MIRROR_DIR
+  gpssh -f hostfile mkdir -p $MIRROR_DIR
   MIRROR_DIRS_LIST="$MIRROR_DIRS_LIST $MIRROR_DIR"
 done
 PRIMARY_DIRS_LIST=${PRIMARY_DIRS_LIST#* }
 MIRROR_DIRS_LIST=${MIRROR_DIRS_LIST#* }
-
-#*****************************************************************************************
-# Host configuration
-#*****************************************************************************************
-
-LOCALHOST=`hostname`
-echo $LOCALHOST > hostfile
 
 #*****************************************************************************************
 # Name of the system configuration file.
@@ -315,7 +339,7 @@ cat >> $CLUSTER_CONFIG <<-EOF
 	MASTER_PORT=${MASTER_DEMO_PORT}
 	
 	# Shell to use to execute commands on all hosts
-	TRUSTED_SHELL="`pwd`/lalshell"
+	TRUSTED_SHELL="$TRUSTED_SHELL"
 	
 	CHECK_POINT_SEGMENTS=8
 	
@@ -406,10 +430,10 @@ echo ""
 
 echo "=========================================================================================="
 echo "executing:"
-echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} \"$@\""
+echo "  $GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG $HOSTS_OPTS -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} \"$@\""
 echo "=========================================================================================="
 echo ""
-$GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} "$@"
+$GPPATH/gpinitsystem -a -c $CLUSTER_CONFIG $HOSTS_OPTS -l $DATADIRS/gpAdminLogs -p ${CLUSTER_CONFIG_POSTGRES_ADDONS} ${STANDBY_INIT_OPTS} "$@"
 RETURN=$?
 
 echo "========================================"
@@ -429,8 +453,8 @@ if [ "$enable_gpfdist" = "yes" ] && [ "$with_openssl" = "yes" ]; then
 
 	for (( i=1; i<=$NUM_PRIMARY_MIRROR_PAIRS; i++ ))
 	do
-		cp -r certificate/gpfdists $DATADIRS/dbfast$i/${SEG_PREFIX}$((i-1))/
-		cp -r certificate/gpfdists $DATADIRS/dbfast_mirror$i/${SEG_PREFIX}$((i-1))/
+		gpscp -f hostfile -r certificate/gpfdists =:$DATADIRS/dbfast$i/${SEG_PREFIX}$((i-1))/
+		gpscp -f hostfile -r certificate/gpfdists =:$DATADIRS/dbfast_mirror$i/${SEG_PREFIX}$((i-1))/
 	done
 	echo ""
 fi


### PR DESCRIPTION
Fix resource group tests

Patch 52bbf95d91155517a711b193bbffbaec880e7389 increased memory consumption on
the coordinator and caused the resgroup_cpu_rate_limit test to fail.

This patch adds the ability to create a demo cluster on multiple hosts, which
allows us to create an environment close to the upstream.
Also disables the ORCA planner for resource group tests for two reasons. First,
starting with commit 39de39eb6edb0d0f94f533e96e04b66d6c790d14, upstream runs
tests without it. Secondly, in the resgroup_cpu_rate_limit test, there is a
problem that when the CPU is limited, ORCA can plan a query for a long time,
which leads to the test failing.