### PR TITLE
ADBDEV-5066: Make the behave tests more stable

### DIFF
--- a/arenadata/scripts/run_behave_tests.bash
+++ b/arenadata/scripts/run_behave_tests.bash
@@ -51,10 +51,18 @@ run_feature() {
     docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
       $service bash -c "mkdir -p /data/gpdata && chmod -R 777 /data &&
         source gpdb_src/concourse/scripts/common.bash && install_gpdb &&
-       ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash &&
-       ssh-keyscan ${services/$service/} >> /home/gpadmin/.ssh/known_hosts" &
+       ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash" &
   done
   wait
+
+  # Add host keys to known_hosts after containers setup
+  for service in $services
+  do
+    docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
+      $service bash -c "ssh-keyscan ${services/$service/} >> /home/gpadmin/.ssh/known_hosts" &
+  done
+  wait
+
   docker-compose -p $project -f arenadata/docker-compose.yaml exec -T \
     -e FEATURE="$feature" -e BEHAVE_FLAGS="--tags $feature --tags=$cluster \
       -f allure_behave.formatter:AllureFormatter \


### PR DESCRIPTION
Make the behave tests more stable

When initializing containers for behave tests, ssh host keys are created. These
keys are scanned by each container using ssh-keyscan. Because all the containers
are initialized in parallel, a race condition took place. If some containers has
not yet managed to create keys, while the other container has already started
the scanning stage, then the container does not add the keys of some containers
to known_hosts. Lack of a host key in known_hosts led to the failure of the ssh
connection during the tests.

This patch splits container initialization to make host keys scan after
containers initialization when all containers have created host keys.