### PR TITLE
ADBDEV-4954 gpexpand: skip expanded/broken tables when redistributing

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -10,6 +10,7 @@ import copy
 import datetime
 import os
 import random
+import re
 import sys
 import json
 import shutil
@@ -1384,7 +1385,7 @@ class gpexpand:
         dbconn.execSQL(self.conn, "CHECKPOINT")
         self.conn.close()
 
-        # increase expand version 
+        # increase expand version
         self.conn = dbconn.connect(self.dburl, utility=True, encoding='UTF8')
         dbconn.execSQL(self.conn, "select gp_expand_bump_version()")
         self.conn.close()
@@ -2110,7 +2111,17 @@ class ExpandTable():
         # check is atomic in python
         if not cancel_flag:
             if sql:
-                dbconn.execSQL(table_conn, sql)
+                try:
+                    dbconn.execSQL(table_conn, sql)
+                except DatabaseError as e:
+                    if re.search('DETAIL:\s*table has already been expanded', str(e)):
+                        logger.info('Table %s.%s seems to be already expanded, marking as done' % (self.dbname, self.fq_name))
+                    elif re.search('\s*relation not found (OID \d+ )?', str(e)):
+                        logger.warning('Encountered unexpected issue when expanding table %s.%s, skipping' % (self.dbname, self.fq_name))
+                        table_conn.rollback()
+                        return False
+                    else:
+                        raise
                 table_conn.commit()
             if self.options.analyze:
                 sql = 'ANALYZE %s' % (self.fq_name)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -660,3 +660,33 @@ Feature: expand the cluster by adding more segments
         And verify that the path "gpperfmon/logs" in each segment data directory does not exist
         And verify that the path "promote" in each segment data directory does not exist
         And verify that the path "db_analyze" in each segment data directory does not exist
+
+    @gpexpand_no_mirrors
+    @gpexpand_segment
+    Scenario: gpexpand should skip already expanded/broken tables when redistributing
+        Given the database is not running
+        # need to remove this log because otherwise SCAN_LOG may pick up a previous error/warning in the log
+        And the user runs command "rm -rf ~/gpAdminLogs/gpinitsystem*"
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with no mirrors on "cdw" and "sdw1"
+        And database "gptest" exists
+        And the user runs psql with "-c 'CREATE TABLE test_good_1(a int)'" against database "gptest"
+        And the user runs psql with "-c 'CREATE TABLE test_already_expanded(a int)'" against database "gptest"
+        And the user runs psql with "-c 'CREATE TABLE test_broken(a int)'" against database "gptest"
+        And the user runs psql with "-c 'CREATE TABLE test_good_2(a int)'" against database "gptest"
+        And the user runs sql "DROP TABLE test_broken" in "gptest" on primary segment with content 0
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "cdw,sdw1"
+        When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 2 new segments
+        And the user runs psql with "-c 'ALTER TABLE test_already_expanded expand table'" against database "gptest"
+        When the user runs gpexpand to redistribute
+        Then gpexpand should print "[WARNING]:-Encountered unexpected issue when expanding table gptest.public.test_broken, skipping" escaped to stdout
+        And gpexpand should print "[INFO]:-Table gptest.public.test_already_expanded seems to be already expanded, marking as done" escaped to stdout
+        And table "test_good_1" should be marked as expanded
+        And table "test_good_2" should be marked as expanded
+        And table "test_already_expanded" should be marked as expanded
+        And table "test_broken" should not be marked as expanded


### PR DESCRIPTION

This commit is a cherry-pick of https://github.com/arenadata/gpdb/commit/6b7e4c3dbb586fde520d31e19ff4a781e8dcfdaa.
In summary `gpexpand redistribution` earlier used to error out when the table
would have been already expanded manually by the user or the table would have
been damaged. This commit changes this behaviour so that any expanded/broken
tables are skipped without affecting the redistribution for other tables.

New error message was added to gpexpand for search since we can fail with two
different messages in different cases.
execSingleton was changed to execSQLForSingleton in mgmt_utils.py to make it
work on 6x. Also, gpexpand.feature test was brought to a common standard by
adding 'rm -rf ~/gpAdminLogs/gpinitsystem*'. Without this line a failing
test would cause other tests to fail.