### PR TITLE
ADBDEV-5103: Make frozen_insert_crash test stable

### DIFF
--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -228,6 +228,11 @@ CREATE
 CREATE OR REPLACE FUNCTION insert_bm_lov_res() RETURNS void AS $$ DECLARE lov_table text; /* in func */ sql text; /* in func */ BEGIN /* in func */ drop table if exists bm_lov_res; /* in func */ create temp table bm_lov_res(b int); /* in func */ SELECT c.relname INTO lov_table /* in func */ FROM bm_metap('tab_fi_idx') b /* in func */ JOIN pg_class c ON b.auxrelid = c.oid; /* in func */ sql := format('INSERT INTO bm_lov_res SELECT b FROM pg_bitmapindex.%I', lov_table); /* in func */ EXECUTE sql; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
+-- Save session_id to a replicated table to later add panic only for this session.
+2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+CREATE
+2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
+INSERT 1
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 CREATE
 1: create index tab_fi_idx on tab_fi using bitmap(b);
@@ -270,7 +275,8 @@ INSERT 1
 --------------------------
  Success:                 
 (1 row)
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for a previously saved session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -321,9 +327,16 @@ SET
 0Uq: ... <quitting>
 1: drop table tab_fi;
 DROP
+1: drop table target_session_id_t;
+DROP
 
 -- case 2: suspend and flush WAL after freezing the tuple
 
+-- Save session_id to a replicated table to later add panic only for this session.
+2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+CREATE
+2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
+INSERT 1
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 CREATE
 1: create index tab_fi_idx on tab_fi using bitmap(b);
@@ -365,7 +378,8 @@ rmgr: Heap2       len (rec/tot):     36/    68, tx: ##, lsn: #/########, prev #/
 --------------------------
  Success:                 
 (1 row)
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for a previously saved session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -415,6 +429,10 @@ SET
  1 
  2 
 (2 rows)
+1: drop table tab_fi;
+DROP
+1: drop table target_session_id_t;
+DROP
 
 1: drop extension pageinspect;
 DROP

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -228,11 +228,6 @@ CREATE
 CREATE OR REPLACE FUNCTION insert_bm_lov_res() RETURNS void AS $$ DECLARE lov_table text; /* in func */ sql text; /* in func */ BEGIN /* in func */ drop table if exists bm_lov_res; /* in func */ create temp table bm_lov_res(b int); /* in func */ SELECT c.relname INTO lov_table /* in func */ FROM bm_metap('tab_fi_idx') b /* in func */ JOIN pg_class c ON b.auxrelid = c.oid; /* in func */ sql := format('INSERT INTO bm_lov_res SELECT b FROM pg_bitmapindex.%I', lov_table); /* in func */ EXECUTE sql; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
--- Save session_id to a replicated table to later add panic only for this session.
-2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
-CREATE
-2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
-INSERT 1
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 CREATE
 1: create index tab_fi_idx on tab_fi using bitmap(b);
@@ -276,7 +271,7 @@ INSERT 1
  Success:                 
 (1 row)
 -- Add panic only for a previously saved session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -327,16 +322,9 @@ SET
 0Uq: ... <quitting>
 1: drop table tab_fi;
 DROP
-1: drop table target_session_id_t;
-DROP
 
 -- case 2: suspend and flush WAL after freezing the tuple
 
--- Save session_id to a replicated table to later add panic only for this session.
-2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
-CREATE
-2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
-INSERT 1
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 CREATE
 1: create index tab_fi_idx on tab_fi using bitmap(b);
@@ -379,7 +367,7 @@ rmgr: Heap2       len (rec/tot):     36/    68, tx: ##, lsn: #/########, prev #/
  Success:                 
 (1 row)
 -- Add panic only for a previously saved session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -429,10 +417,6 @@ SET
  1 
  2 
 (2 rows)
-1: drop table tab_fi;
-DROP
-1: drop table target_session_id_t;
-DROP
 
 1: drop extension pageinspect;
 DROP

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -270,7 +270,7 @@ INSERT 1
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for a inserting session.
+-- Add panic only for an inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
@@ -366,7 +366,7 @@ rmgr: Heap2       len (rec/tot):     36/    68, tx: ##, lsn: #/########, prev #/
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for a inserting session.
+-- Add panic only for an inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -270,7 +270,7 @@ INSERT 1
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for a previously saved session.
+-- Add panic only for a inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
@@ -366,7 +366,7 @@ rmgr: Heap2       len (rec/tot):     36/    68, tx: ##, lsn: #/########, prev #/
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for a previously saved session.
+-- Add panic only for a inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -147,7 +147,7 @@ $$ LANGUAGE plpgsql;
 -- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for a inserting session.
+-- Add panic only for an inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
@@ -184,7 +184,7 @@ $$ LANGUAGE plpgsql;
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for a inserting session.
+-- Add panic only for an inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -147,7 +147,7 @@ $$ LANGUAGE plpgsql;
 -- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for a previously saved session.
+-- Add panic only for a inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
@@ -184,7 +184,7 @@ $$ LANGUAGE plpgsql;
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for a previously saved session.
+-- Add panic only for a inserting session.
 1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -128,6 +128,9 @@ BEGIN /* in func */
 END; /* in func */
 $$ LANGUAGE plpgsql;
 
+-- Save session_id to a replicated table to later add panic only for this session.
+2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 1: create index tab_fi_idx on tab_fi using bitmap(b);
 1: insert into tab_fi values(1, 1);
@@ -147,7 +150,8 @@ $$ LANGUAGE plpgsql;
 -- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for a previously saved session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:
@@ -164,9 +168,13 @@ $$ LANGUAGE plpgsql;
 0U: select * from bm_lov_res;
 0Uq:
 1: drop table tab_fi;
+1: drop table target_session_id_t;
 
 -- case 2: suspend and flush WAL after freezing the tuple
 
+-- Save session_id to a replicated table to later add panic only for this session.
+2: create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
+2: insert into target_session_id_t values(current_setting('gp_session_id')::int);
 1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
 1: create index tab_fi_idx on tab_fi using bitmap(b);
 1: insert into tab_fi values(1, 1);
@@ -183,7 +191,8 @@ $$ LANGUAGE plpgsql;
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for a previously saved session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, target_session_id) from gp_segment_configuration join target_session_id_t on true where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:
@@ -198,6 +207,8 @@ $$ LANGUAGE plpgsql;
 0U: set enable_seqscan = on;
 0U: select insert_bm_lov_res();
 0U: select * from bm_lov_res;
+1: drop table tab_fi;
+1: drop table target_session_id_t;
 
 1: drop extension pageinspect;
 


### PR DESCRIPTION
Make frozen_insert_crash test stable

Commit 1502bef introduced a new flaking test. The test expects a panic to occur
in the process that performs the insert. But sometimes the panic happens first
in process which started by dtx recovery process that periodically checks for
orphaned transactions. Which leads to an error in the test. The solution is to
panic only the required process, which is done by extracting session from
pg_stat_activity by query.