### PR TITLE
ADBDEV-5186 Treat missing prototypes as errors

### DIFF
--- a/configure
+++ b/configure
@@ -3311,6 +3311,8 @@ else
 fi
 
 
+
+
 #
 # include debug extensions in gpcontrib
 #
@@ -3391,6 +3393,7 @@ else
   enable_gpperfmon=no
 
 fi
+
 
 
 
@@ -5131,7 +5134,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith"
+  CFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   # GPDB code is full of declarations after statement.
   #PGAC_PROG_CC_CFLAGS_OPT([-Wdeclaration-after-statement])
@@ -11484,12 +11487,11 @@ fi
 fi
 
 if test "$with_zstd" = yes; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
-printf %s "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
-if test ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
+$as_echo_n "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
+if ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-l:libzstd.a  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -11498,36 +11500,37 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char ZSTD_compressCCtx ();
 int
-main (void)
+main ()
 {
 return ZSTD_compressCCtx ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib__libzstd_a_ZSTD_compressCCtx=yes
-else $as_nop
+else
   ac_cv_lib__libzstd_a_ZSTD_compressCCtx=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
-printf "%s\n" "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
-if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
+$as_echo "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
+if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIB_LIBZSTD_A 1
+_ACEOF
 
-	LIBS="-l:libzstd.a $LIBS"
+  LIBS="-l:libzstd.a $LIBS"
 
-printf "%s\n" "#define HAVE_LIBZSTD 1" >>confdefs.h
-
-
-else $as_nop
+else
   as_fn_error $? "zstd library not found
 If you have libzstd already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.
@@ -13962,6 +13965,9 @@ fi
 
 # Check for zstd.h and zstd_errors.h
 if test "$with_zstd" = yes; then
+
+$as_echo "#define HAVE_LIBZSTD 1" >>confdefs.h
+
   ac_fn_c_check_header_mongrel "$LINENO" "zstd.h" "ac_cv_header_zstd_h" "$ac_includes_default"
 if test "x$ac_cv_header_zstd_h" = xyes; then :
 
@@ -18663,8 +18669,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking which random number source to use" >&5
 $as_echo_n "checking which random number source to use... " >&6; }
 
-
-
 if test x"$USE_OPENSSL_RANDOM" = x"1" ; then
 
 $as_echo "#define USE_OPENSSL_RANDOM 1" >>confdefs.h
@@ -18695,6 +18699,7 @@ if test "$PORTNAME" != "win32"; then
 else
   LATCH_IMPLEMENTATION="src/backend/port/win32_latch.c"
 fi
+
 
 # If not set in template file, set bytes to use libc memset()
 if test x"$MEMSET_LOOP_LIMIT" = x"" ; then
@@ -19786,6 +19791,41 @@ fi
 $as_echo "$pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration" >&6; }
 if test x"$pgac_cv_prog_cc_cflags__Werror_implicit_function_declaration" = x"yes"; then
   CFLAGS="$CFLAGS -Werror=implicit-function-declaration"
+fi
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror=missing-prototypes" >&5
+$as_echo_n "checking whether $CC supports -Werror=missing-prototypes... " >&6; }
+if ${pgac_cv_prog_cc_cflags__Werror_missing_prototypes+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+CFLAGS="$pgac_save_CFLAGS -Werror=missing-prototypes"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_cc_cflags__Werror_missing_prototypes=yes
+else
+  pgac_cv_prog_cc_cflags__Werror_missing_prototypes=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_cc_cflags__Werror_missing_prototypes" >&5
+$as_echo "$pgac_cv_prog_cc_cflags__Werror_missing_prototypes" >&6; }
+if test x"$pgac_cv_prog_cc_cflags__Werror_missing_prototypes" = x"yes"; then
+  CFLAGS="$CFLAGS -Werror=missing-prototypes"
 fi
 
 fi

--- a/configure.in
+++ b/configure.in
@@ -586,7 +586,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith"
+  CFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   # GPDB code is full of declarations after statement.
   #PGAC_PROG_CC_CFLAGS_OPT([-Wdeclaration-after-statement])
@@ -1700,6 +1700,7 @@ fi
 
 # Check for zstd.h and zstd_errors.h
 if test "$with_zstd" = yes; then
+  AC_DEFINE([HAVE_LIBZSTD], 1, [Define to 1 if you have zstd support.])
   AC_CHECK_HEADER(zstd.h, [], [AC_MSG_ERROR([header file <zstd.h> is required for zstd support])])
   AC_CHECK_HEADER(zstd_errors.h, [], [AC_MSG_ERROR([header file <zstd_errors.h> is required for zstd support])])
 fi
@@ -2668,6 +2669,7 @@ fi
 if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Werror=uninitialized])
   PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-function-declaration])
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror=missing-prototypes])
 fi
 
 # Begin output steps

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -164,6 +164,11 @@ static void BufFileDumpCompressedBuffer(BufFile *file, const void *buffer, Size 
 static void BufFileEndCompression(BufFile *file);
 static int BufFileLoadCompressedBuffer(BufFile *file, void *buffer, size_t bufsize);
 
+#ifdef HAVE_LIBZSTD
+static void *customAlloc(void *opaque, size_t size);
+static void customFree(void *opaque, void *address);
+#endif
+
 
 /*
  * Create a BufFile given the first underlying physical file.
@@ -1033,13 +1038,13 @@ BufFilePledgeSequential(BufFile *buffile)
 
 #define BUFFILE_ZSTD_COMPRESSION_LEVEL 1
 
-void *
+static void *
 customAlloc(void *opaque, size_t size)
 {
 	return MemoryContextAlloc(TopMemoryContext, size);
 }
 
-void
+static void
 customFree(void *opaque, void *address)
 {
 	pfree(address);
@@ -1281,7 +1286,7 @@ BufFileLoadCompressedBuffer(BufFile *file, void *buffer, size_t bufsize)
 
 	return output.pos;
 }
-#else		/* HAVE_ZSTD */
+#else		/* HAVE_LIBZSTD */
 
 /*
  * Dummy versions of the compression functions, when the server is built


### PR DESCRIPTION
This patch makes gcc treat missing prototypes as errors. Also, it fixes custom allocators for zstd and autoconf file adding HAVE_LIBZSTD flag. This flag was there initially and was generated automatically when linking zstd.so, but since we moved to static linking HAVE_LIBZSTD changed to HAVE_LIB_LIBZSTD which is incorrect
