### PR TITLE
ADBDEV-5187: Fix case pg_rewind_fail_missing_xlog

### DIFF
--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -7,6 +7,11 @@ CREATE
 include: helpers/server_helpers.sql;
 CREATE
 
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE
+CREATE OR REPLACE FUNCTION connectSeg(n int, port int, hostname text) RETURNS bool AS $$ import os import subprocess import time for i in range(n): try: cmd = 'PGOPTIONS="-c gp_session_role=utility" psql -h %s -p %d -d postgres -Xc "select 1"' % (hostname, port) proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True) proc.communicate() if proc.returncode == 0: return True except Exception as e: time.sleep(1) raise Exception("wait connection timeout") $$ LANGUAGE plpythonu;
+CREATE
+
 SHOW gp_keep_all_xlog;
  gp_keep_all_xlog 
 ------------------
@@ -199,6 +204,12 @@ INSERT 3
  gp_request_fts_probe_scan 
 ---------------------------
  t                         
+(1 row)
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
+ connectseg 
+------------
+ t          
 (1 row)
 -- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted
 3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
@@ -474,6 +485,12 @@ INSERT 3
  t                         
 (1 row)
 
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
+ connectseg 
+------------
+ t          
+(1 row)
 -- Reset faults and confirm FTS configuration
 3: SELECT gp_inject_fault('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
  gp_inject_fault 
@@ -638,6 +655,8 @@ DROP
 1Uq: ... <quitting>
 
 5: DROP TABLE tst_missing_tbl;
+DROP
+5: DROP FUNCTION connectSeg(n int, port int, hostname text);
 DROP
 !\retcode gpconfig -r wal_keep_segments;
 -- start_ignore

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -5,6 +5,24 @@
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 include: helpers/server_helpers.sql;
 
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE OR REPLACE FUNCTION connectSeg(n int, port int, hostname text) RETURNS bool AS $$
+import os
+import subprocess
+import time
+for i in range(n):
+    try:
+        cmd = 'PGOPTIONS="-c gp_session_role=utility" psql -h %s -p %d -d postgres -Xc "select 1"' % (hostname, port)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        proc.communicate()
+        if proc.returncode == 0:
+            return True
+    except Exception as e:
+        time.sleep(1)
+raise Exception("wait connection timeout")
+$$
+LANGUAGE plpythonu;
+
 SHOW gp_keep_all_xlog;
 CREATE TABLE tst_missing_tbl (a int);
 INSERT INTO tst_missing_tbl values(2),(1),(5);
@@ -96,6 +114,8 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 -- Stop the primary immediately and promote the mirror.
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
 3: SELECT gp_request_fts_probe_scan();
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
 -- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted
 3: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
 3: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
@@ -224,6 +244,8 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
 3: SELECT gp_request_fts_probe_scan();
 
+-- Wait for the segment promotion finished and accept the connection
+3: select connectSeg(600,port,hostname) from gp_segment_configuration where content = 1 and role = 'p';
 -- Reset faults and confirm FTS configuration
 3: SELECT gp_inject_fault('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
 3: SELECT gp_inject_fault('checkpoint_control_file_updated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
@@ -297,5 +319,6 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 1Uq:
 
 5: DROP TABLE tst_missing_tbl;
+5: DROP FUNCTION connectSeg(n int, port int, hostname text);
 !\retcode gpconfig -r wal_keep_segments;
 !\retcode gpstop -ari;


### PR DESCRIPTION
Fix case pg_rewind_fail_missing_xlog

When execute inject fault `checkpoint_after_redo_calculated` or
'checkpoint_control_file_updated' in a newly promoted mirror node,
connection failed, error occurs due to the fatal log 'mirror is being
promoted'. It means when connection state is MIRROR_READY but the
role changes to primary during promoting, the connection will be
declined to avoid confusion.

Wait for segment promotion finished and accept connection before
inject fault.

Co-authored-by: Xing Guo <higuoxing@gmail.com>

This is a backport of commit 01d9c59.
The connectSeg function has been adapted for the old Python.