### PR TITLE
Avoid linking AO aux tables to extension

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1778,9 +1778,14 @@ heap_create_with_catalog(const char *relname,
 	 *
 	 * Also, skip this in bootstrap mode, since we don't make dependencies
 	 * while bootstrapping.
+	 *
+	 * GPDB: The section about TOAST is still relevant for AO aux tables.
 	 */
 	if (relkind != RELKIND_COMPOSITE_TYPE &&
 		relkind != RELKIND_TOASTVALUE &&
+		relkind != RELKIND_AOSEGMENTS &&
+		relkind != RELKIND_AOBLOCKDIR &&
+		relkind != RELKIND_AOVISIMAP &&
 		!IsBootstrapProcessingMode())
 	{
 		ObjectAddress myself,

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -97,6 +97,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
+#include "catalog/aocatalog.h"
 #include "catalog/oid_dispatch.h"
 #include "catalog/pg_appendonly.h"
 #include "catalog/pg_stat_last_operation.h"
@@ -1783,9 +1784,7 @@ heap_create_with_catalog(const char *relname,
 	 */
 	if (relkind != RELKIND_COMPOSITE_TYPE &&
 		relkind != RELKIND_TOASTVALUE &&
-		relkind != RELKIND_AOSEGMENTS &&
-		relkind != RELKIND_AOBLOCKDIR &&
-		relkind != RELKIND_AOVISIMAP &&
+		!IsAppendonlyMetadataRelkind(relkind) &&
 		!IsBootstrapProcessingMode())
 	{
 		ObjectAddress myself,

--- a/src/test/modules/test_extensions/expected/test_extensions.out
+++ b/src/test/modules/test_extensions/expected/test_extensions.out
@@ -469,3 +469,32 @@ drop schema issue6716 cascade;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to function issue6716.test_func1(integer,integer)
 drop cascades to extension test_ext_cau
+--
+-- Test that extension not depends on AO aux tables
+--
+-- Change default access method. This cause extension tables to be created with
+-- column engine.
+set default_table_access_method = ao_column;
+create extension test_ext8;
+-- Reset access method to default. All necessary tables are already created.
+reset default_table_access_method;
+-- Detach tables from extension.
+alter extension test_ext8 drop table ext8_table1;
+alter extension test_ext8 drop table ext8_temp_table1;
+-- The following select should give 0 rows, as there no extension related
+-- tables left.
+select count(*) cnt
+from pg_depend
+where refobjid = (select oid from pg_extension where extname='test_ext8')
+and (pg_identify_object(classid, objid, objsubid)).identity like '%pg_ao%';
+ cnt 
+-----
+   0
+(1 row)
+
+-- Drop should be finished successfully, as extension not depends on AO aux
+-- tables
+drop table ext8_table1;
+drop table ext8_temp_table1;
+-- Cleanup
+drop extension test_ext8;

--- a/src/test/modules/test_extensions/sql/test_extensions.sql
+++ b/src/test/modules/test_extensions/sql/test_extensions.sql
@@ -321,3 +321,29 @@ show search_path;
 
 reset search_path;
 drop schema issue6716 cascade;
+
+--
+-- Test that extension not depends on AO aux tables
+--
+
+-- Change default access method. This cause extension tables to be created with
+-- column engine.
+set default_table_access_method = ao_column;
+create extension test_ext8;
+-- Reset access method to default. All necessary tables are already created.
+reset default_table_access_method;
+-- Detach tables from extension.
+alter extension test_ext8 drop table ext8_table1;
+alter extension test_ext8 drop table ext8_temp_table1;
+-- The following select should give 0 rows, as there no extension related
+-- tables left.
+select count(*) cnt
+from pg_depend
+where refobjid = (select oid from pg_extension where extname='test_ext8')
+and (pg_identify_object(classid, objid, objsubid)).identity like '%pg_ao%';
+-- Drop should be finished successfully, as extension not depends on AO aux
+-- tables
+drop table ext8_table1;
+drop table ext8_temp_table1;
+-- Cleanup
+drop extension test_ext8;


### PR DESCRIPTION
Avoid linking AO aux tables to extension

Unlike TOAST tables, AO aux tables are [linked](https://github.com/arenadata/gpdb/blob/1710ca20c6de81dd533b3d40e3fe0c1e1544daa1/src/backend/catalog/heap.c#L1802) to extension during its creation.
When table is dropped from extension using ALTER, aux tables are left as
extension dependencies. It means we can't DROP a table after that, because AO
aux tables are still used by extension. In other words, this behavior makes
impossible to DROP AO table that was created by extension without extension
DROP.

The goal of the patch is to change this behavior, allowing to DROP a table.
Unnecessary dependencies are now not created in heap_create_with_catalog(). The
behavior is the same as for TOAST tables, which are aux tables too. The
dependency [created](https://github.com/arenadata/gpdb/blob/1710ca20c6de81dd533b3d40e3fe0c1e1544daa1/src/backend/catalog/aocatalog.c#L235) in CreateAOAuxiliaryTable() is enough.

The patch contains a test that describes target behavior. However, the test can
be run only manually. GPDB is not ready to run tests in modules subdir
automatically.

___________
The impossibility of running tests automatically is an old [story](https://github.com/greenplum-db/gpdb/pull/14534) and should be resolved in a separate PR.

The example of test running is:
```
REGRESS_OPTS=--init-file=$(pwd)/src/test/regress/init_file make -C src/test/modules/test_extensions installcheck
```
The attentive reviewer may find that I don't test blockdir. This is done intentionally to minimize patch diff. There are no test extensions with index and I wanted to avoid creation of our own. I hope this will not be a problem during review as changes are simple and intuitive.