### PR TITLE
ADBDEV-5143: Port the solution for handling outer join distribution

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/JoinCombinedHashSpecNullsNotColocated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinCombinedHashSpecNullsNotColocated.mdp
@@ -12,8 +12,8 @@
   CREATE TABLE t1 (i int) DISTRIBUTED RANDOMLY;
   CREATE TABLE t2 (j int) DISTRIBUTED RANDOMLY;
 
-  INSERT INTO t1 SELECT i FROM generate_series (500, 1500) i;
-  INSERT INTO t2 SELECT i FROM generate_series (1, 1000) i;
+  INSERT INTO t1 SELECT i FROM generate_series (0, 10) i;
+  INSERT INTO t2 SELECT i FROM generate_series (10, 20) i;
   ANALYZE t1;
   ANALYZE t2;
 
@@ -24,34 +24,36 @@
   SELECT i, j
   FROM t1
   LEFT JOIN t2 ON i = j;
-                                                  QUERY PLAN                                                
-  ----------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                   
+  ----------------------------------------------------------------------------------------------------------------
    Gather Motion 3:1  (slice1; segments: 3)
-     ->  HashAggregate
+     ->  GroupAggregate
            Group Key: t1.i, t2.j
-           ->  Hash Anti Join
-                 Hash Cond: ((NOT (t1.i IS DISTINCT FROM t1_1.i)) AND (NOT (t2.j IS DISTINCT FROM t2_1.j)))
-                 ->  Hash Left Join
-                       Hash Cond: (t1.i = t2.j)
-                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                             Hash Key: t1.i
-                             ->  Seq Scan on t1
-                       ->  Hash
-                             ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                   Hash Key: t2.j
-                                   ->  Seq Scan on t2
-                 ->  Hash
+           ->  Sort
+                 Sort Key: t1.i, t2.j
+                 ->  Hash Anti Join
+                       Hash Cond: ((NOT (t1.i IS DISTINCT FROM t1_1.i)) AND (NOT (t2.j IS DISTINCT FROM t2_1.j)))
                        ->  Hash Left Join
-                             Hash Cond: (t1_1.i = t2_1.j)
-                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                   Hash Key: t1_1.i
-                                   ->  Seq Scan on t1 t1_1
+                             Hash Cond: (t1.i = t2.j)
+                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                   Hash Key: t1.i
+                                   ->  Seq Scan on t1
                              ->  Hash
-                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                         Hash Key: t2_1.j
-                                         ->  Seq Scan on t2 t2_1
+                                   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                         Hash Key: t2.j
+                                         ->  Seq Scan on t2
+                       ->  Hash
+                             ->  Hash Left Join
+                                   Hash Cond: (t1_1.i = t2_1.j)
+                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                         Hash Key: t1_1.i
+                                         ->  Seq Scan on t1 t1_1
+                                   ->  Hash
+                                         ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                               Hash Key: t2_1.j
+                                               ->  Seq Scan on t2 t2_1
    Optimizer: GPORCA
-  (25 rows)
+  (27 rows)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -66,7 +68,7 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -173,410 +175,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.57347.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="230"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="230"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="270"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="270"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="370"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="370"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="390"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="390"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="410"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="410"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="490"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="490"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:RelationStatistics Mdid="2.57347.1.0" Name="t2" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.57347.1.0" Name="t2" IsTemporary="false" Rows="1000.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
+      <dxl:RelationStatistics Mdid="2.24591.1.0" Name="t2" Rows="11.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.24591.1.0" Name="t2" IsTemporary="false" Rows="11.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
         <dxl:Columns>
           <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
@@ -590,8 +190,8 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.57344.1.0" Name="t1" Rows="1001.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.57344.1.0" Name="t1" IsTemporary="false" Rows="1001.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
+      <dxl:RelationStatistics Mdid="2.24588.1.0" Name="t1" Rows="11.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.24588.1.0" Name="t1" IsTemporary="false" Rows="11.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
         <dxl:Columns>
           <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
@@ -605,411 +205,22 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.57344.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1010"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1010"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1020"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1020"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1030"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1030"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1040"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1040"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1050"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1050"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1060"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1060"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1070"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1070"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1080"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1080"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1090"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1090"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1110"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1110"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1120"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1120"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1130"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1130"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1140"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1140"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1150"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1150"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1160"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1160"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1170"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1170"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1180"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1180"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1190"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1190"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1210"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1210"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1220"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1220"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1230"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1230"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1240"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1240"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1250"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1250"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1260"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1260"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1270"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1270"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1280"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1280"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1290"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1290"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1310"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1310"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1320"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1320"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1330"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1330"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1340"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1340"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1350"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1350"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1360"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1360"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1370"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1370"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1380"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1380"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1390"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1390"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1410"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1410"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1420"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1420"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1430"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1430"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1440"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1440"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1450"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1450"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1460"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1460"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1470"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1470"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1480"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1480"/>
-          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1490"/>
-        </dxl:StatsBucket>
-        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
-          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1490"/>
-          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
-        </dxl:StatsBucket>
-      </dxl:ColumnStatistics>
-      <dxl:RelationExtendedStatistics Mdid="10.57347.1.0" Name="t2"/>
-      <dxl:RelationExtendedStatistics Mdid="10.57344.1.0" Name="t1"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:RelationExtendedStatistics Mdid="10.24591.1.0" Name="t2"/>
+      <dxl:RelationExtendedStatistics Mdid="10.24588.1.0" Name="t1"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -1027,6 +238,90 @@
           <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.24591.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.24588.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.100000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -1041,7 +336,7 @@
         </dxl:Columns>
         <dxl:LogicalJoin JoinType="Left">
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+            <dxl:TableDescriptor Mdid="6.24588.1.0" TableName="t1" LockMode="1" AclMode="2">
               <dxl:Columns>
                 <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -1055,7 +350,7 @@
             </dxl:TableDescriptor>
           </dxl:LogicalGet>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+            <dxl:TableDescriptor Mdid="6.24591.1.0" TableName="t2" LockMode="1" AclMode="2">
               <dxl:Columns>
                 <dxl:Column ColId="9" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -1075,7 +370,7 @@
         </dxl:LogicalJoin>
         <dxl:LogicalJoin JoinType="Left">
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+            <dxl:TableDescriptor Mdid="6.24588.1.0" TableName="t1" LockMode="1" AclMode="2">
               <dxl:Columns>
                 <dxl:Column ColId="17" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -1089,7 +384,7 @@
             </dxl:TableDescriptor>
           </dxl:LogicalGet>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+            <dxl:TableDescriptor Mdid="6.24591.1.0" TableName="t2" LockMode="1" AclMode="2">
               <dxl:Columns>
                 <dxl:Column ColId="25" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -1112,7 +407,7 @@
     <dxl:Plan Id="0" SpaceSize="528">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.720656" Rows="240.080000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.011797" Rows="3.520000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -1124,9 +419,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.713498" Rows="240.080000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.011692" Rows="3.520000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -1141,9 +436,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.693789" Rows="240.080000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.011673" Rows="3.520000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -1154,24 +449,15 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Not>
-                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:IsDistinctFrom>
-              </dxl:Not>
-              <dxl:Not>
-                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:IsDistinctFrom>
-              </dxl:Not>
-            </dxl:HashCondList>
-            <dxl:HashJoin JoinType="Left">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="LeftAntiSemiJoin">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.162195" Rows="1500.500000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.011582" Rows="3.520000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -1184,30 +470,42 @@
               <dxl:Filter/>
               <dxl:JoinFilter/>
               <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
               </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:HashJoin JoinType="Left">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.012900" Rows="1001.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001923" Rows="22.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="j">
+                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:TableScan>
+                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.006240" Rows="1001.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="11.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -1215,39 +513,39 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:RedistributeMotion>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.012887" Rows="1000.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="j">
-                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="11.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="i">
+                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.24588.1.0" TableName="t1" LockMode="1" AclMode="2">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="11.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="j">
@@ -1255,60 +553,60 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="8" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:RedistributeMotion>
-            </dxl:HashJoin>
-            <dxl:HashJoin JoinType="Left">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.162195" Rows="1500.500000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="16" Alias="i">
-                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="24" Alias="j">
-                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="11.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="j">
+                        <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.24591.1.0" TableName="t2" LockMode="1" AclMode="2">
+                      <dxl:Columns>
+                        <dxl:Column ColId="8" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
+              <dxl:HashJoin JoinType="Left">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.012900" Rows="1001.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.001923" Rows="22.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="16" Alias="i">
                     <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="24" Alias="j">
+                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                     <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:TableScan>
+                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.006240" Rows="1001.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="11.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="16" Alias="i">
@@ -1316,39 +614,39 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="16" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:RedistributeMotion>
-              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.012887" Rows="1000.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="24" Alias="j">
-                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:HashExprList>
-                  <dxl:HashExpr Opfamily="0.1977.1.0">
-                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:HashExpr>
-                </dxl:HashExprList>
-                <dxl:TableScan>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="11.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="16" Alias="i">
+                        <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.24588.1.0" TableName="t1" LockMode="1" AclMode="2">
+                      <dxl:Columns>
+                        <dxl:Column ColId="16" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000142" Rows="11.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="24" Alias="j">
@@ -1356,22 +654,39 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
-                    <dxl:Columns>
-                      <dxl:Column ColId="24" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="26" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="27" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="28" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="29" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="30" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="31" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:RedistributeMotion>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="11.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="24" Alias="j">
+                        <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.24591.1.0" TableName="t2" LockMode="1" AclMode="2">
+                      <dxl:Columns>
+                        <dxl:Column ColId="24" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="26" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="27" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="28" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="29" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="30" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="31" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
             </dxl:HashJoin>
-          </dxl:HashJoin>
+          </dxl:Sort>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/JoinCombinedHashSpecNullsNotColocated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinCombinedHashSpecNullsNotColocated.mdp
@@ -1,0 +1,1379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  Test that matching hashed distribution for the combined distribution of HOJ
+  is calculated correctly. In case below the required distribution of the
+  Hash Anti Join's outer child should be calculated based not on the nullable
+  part of HOJ (inner child, t2_1.j), but on the part where nulls are co-located
+  (t1_1.i). Otherwise, there could be an extra Redistribute Motion on the
+  outer child, what lead to the inconsistent join result.
+
+  DROP TABLE IF EXISTS t1, t2;
+  CREATE TABLE t1 (i int) DISTRIBUTED RANDOMLY;
+  CREATE TABLE t2 (j int) DISTRIBUTED RANDOMLY;
+
+  INSERT INTO t1 SELECT i FROM generate_series (500, 1500) i;
+  INSERT INTO t2 SELECT i FROM generate_series (1, 1000) i;
+  ANALYZE t1;
+  ANALYZE t2;
+
+  EXPLAIN (costs off) SELECT i, j
+  FROM t1
+  LEFT JOIN t2 on i = j
+  EXCEPT
+  SELECT i, j
+  FROM t1
+  LEFT JOIN t2 ON i = j;
+                                                  QUERY PLAN                                                
+  ----------------------------------------------------------------------------------------------------------
+   Gather Motion 3:1  (slice1; segments: 3)
+     ->  HashAggregate
+           Group Key: t1.i, t2.j
+           ->  Hash Anti Join
+                 Hash Cond: ((NOT (t1.i IS DISTINCT FROM t1_1.i)) AND (NOT (t2.j IS DISTINCT FROM t2_1.j)))
+                 ->  Hash Left Join
+                       Hash Cond: (t1.i = t2.j)
+                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                             Hash Key: t1.i
+                             ->  Seq Scan on t1
+                       ->  Hash
+                             ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                   Hash Key: t2.j
+                                   ->  Seq Scan on t2
+                 ->  Hash
+                       ->  Hash Left Join
+                             Hash Cond: (t1_1.i = t2_1.j)
+                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                   Hash Key: t1_1.i
+                                   ->  Seq Scan on t1 t1_1
+                             ->  Hash
+                                   ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                         Hash Key: t2_1.j
+                                         ->  Seq Scan on t2 t2_1
+   Optimizer: GPORCA
+  (25 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,102162,102163,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.57347.1.0.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="490"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.57347.1.0" Name="t2" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.57347.1.0" Name="t2" IsTemporary="false" Rows="1000.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.57344.1.0" Name="t1" Rows="1001.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.57344.1.0" Name="t1" IsTemporary="false" Rows="1001.000000" StorageType="Heap" DistributionPolicy="Random" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4"/>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6"/>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4"/>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4"/>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.57344.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1010"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1010"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1020"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1040"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1040"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1050"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1050"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1060"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1060"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1070"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1080"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1080"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1090"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1350"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1490"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1490"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1500"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationExtendedStatistics Mdid="10.57347.1.0" Name="t2"/>
+      <dxl:RelationExtendedStatistics Mdid="10.57344.1.0" Name="t1"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="j" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:Difference InputColumns="1,9;17,25" CastAcrossInputs="false">
+        <dxl:Columns>
+          <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="9" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+        </dxl:Columns>
+        <dxl:LogicalJoin JoinType="Left">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="9" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+        <dxl:LogicalJoin JoinType="Left">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="17" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="25" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="27" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="28" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="29" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="30" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="31" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="32" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="17" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="25" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+      </dxl:Difference>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="528">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1724.720656" Rows="240.080000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="j">
+            <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1724.713498" Rows="240.080000" Width="8"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="0"/>
+            <dxl:GroupingColumn ColId="8"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="j">
+              <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1724.693789" Rows="240.080000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="j">
+                <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
+            <dxl:HashJoin JoinType="Left">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.162195" Rows="1500.500000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="j">
+                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.012900" Rows="1001.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="i">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.006240" Rows="1001.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="i">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.012887" Rows="1000.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="j">
+                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="j">
+                      <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="8" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+            <dxl:HashJoin JoinType="Left">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.162195" Rows="1500.500000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="16" Alias="i">
+                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="24" Alias="j">
+                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.012900" Rows="1001.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="16" Alias="i">
+                    <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.006240" Rows="1001.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="16" Alias="i">
+                      <dxl:Ident ColId="16" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.57344.1.0" TableName="t1" LockMode="1" AclMode="2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="16" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="18" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="20" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="21" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="22" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.012887" Rows="1000.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="24" Alias="j">
+                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.1977.1.0">
+                    <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.006233" Rows="1000.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="24" Alias="j">
+                      <dxl:Ident ColId="24" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.57347.1.0" TableName="t2" LockMode="1" AclMode="2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="24" Attno="1" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="26" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="27" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="28" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="29" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="30" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="31" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+          </dxl:HashJoin>
+        </dxl:Aggregate>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -608,8 +608,22 @@ CPhysicalHashJoin::PdshashedMatching(
 			}
 		}
 	}
+	// nulls colocated for inner hash joins, but not colocated in outer hash joins
+	BOOL fNullsColocated = true;
+
+	if (!m_is_null_aware &&
+		(COperator::EopPhysicalLeftOuterHashJoin == Eopid() ||
+		 COperator::EopPhysicalRightOuterHashJoin == Eopid()))
+	{
+		fNullsColocated = false;
+	}
+
 	// check if we failed to compute required distribution
-	if (pdrgpexpr->Size() != ulDlvrdSize)
+	// We could fail to find enough key expressions matching the source
+	// distribution, or we need the matching distribution have colocated nulls
+	// but input distribution's nulls are not colocated.
+	if (pdrgpexpr->Size() != ulDlvrdSize ||
+		(fNullsColocated && !pdshashed->FNullsColocated()))
 	{
 		pdrgpexpr->Release();
 		if (nullptr != pdshashed->PdshashedEquiv())
@@ -619,23 +633,10 @@ CPhysicalHashJoin::PdshashedMatching(
 			return PdshashedMatching(mp, pdshashed->PdshashedEquiv(),
 									 ulSourceChild);
 		}
-	}
-	if (pdrgpexpr->Size() != ulDlvrdSize)
-	{
 		// it should never happen, but instead of creating wrong spec, raise an exception
 		GPOS_RAISE(
 			CException::ExmaInvalid, CException::ExmiInvalid,
 			GPOS_WSZ_LIT("Unable to create matching hashed distribution."));
-	}
-
-	// nulls colocated for inner hash joins, but not colocated in outer hash joins
-	BOOL fNullsColocated = true;
-
-	if (!m_is_null_aware &&
-		(COperator::EopPhysicalLeftOuterHashJoin == Eopid() ||
-		 COperator::EopPhysicalRightOuterHashJoin == Eopid()))
-	{
-		fNullsColocated = false;
 	}
 
 	return GPOS_NEW(mp)

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -292,7 +292,8 @@ LeftJoin-With-Pred-On-Inner LeftJoin-With-Pred-On-Inner2
 LeftJoin-With-Col-Const-Pred LeftJoin-With-Coalesce LOJWithFalsePred LeftJoin-DPv2-With-Select
 DPv2GreedyOnly DPv2MinCardOnly DPv2QueryOnly LOJ-PushDown LeftJoinDPv2JoinOrder
 LeftJoinNullsNotColocated InnerJoinBroadcastTableHashSpec LeftJoinBroadcastTableHashSpec InnerJoinReplicatedTableHashSpec
-LeftJoinPruning LeftJoinPruningOuterQuery LeftJoinPruningInnerQuery LeftJoinPruningInOuterInnerQuery;
+LeftJoinPruning LeftJoinPruningOuterQuery LeftJoinPruningInnerQuery LeftJoinPruningInOuterInnerQuery
+JoinCombinedHashSpecNullsNotColocated;
 
 COuterJoin2Test:
 LOJ-IsNullPred Select-Proj-OuterJoin OuterJoin-With-OuterRefs Join-Disj-Subqs


### PR DESCRIPTION
Port the solution for handling outer join distribution

Some hash join operations, that contained outer hash join as their inner part,
could wrongly enforce data redistribution only for the outer part, what lead
to inconsistent join result.

In case when matching distribution has NullsColocated set to true but the input
distribution has NullsColocated set to false, we try to build a matching
distribution spec based on input's equivalent distribution (pdshashedEquiv). If
none of the equivalent specs from combined distribution satisfies the condition
of NULLs colocation, we eventually raise the exception.

The test was adapted for 7.X.

This is a port of bb46b5c.

Co-authored-by: Alexander Kondakov \<a.kondakov@arenadata.io\>