### PR TITLE
ADBDEV-5239: Make frozen_insert_crash test stable

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -336,11 +336,23 @@ _bitmap_insert_lov(Relation lovHeap, Relation lovIndex, Datum *datum,
 	result = index_insert(lovIndex, indexDatum, indexNulls,
 					 	  &(tuple->t_self), lovHeap, true);
 
-	SIMPLE_FAULT_INJECTOR("insert_bmlov_before_freeze");
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+							"insert_bmlov_before_freeze",
+							DDLNotSpecified,
+							"", //databaseName
+							RelationGetRelationName(lovHeap));
+#endif
 	/* freeze the tuple */
 	heap_freeze_tuple_wal_logged(lovHeap, tuple);
 
-	SIMPLE_FAULT_INJECTOR("insert_bmlov_after_freeze");
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+							"insert_bmlov_after_freeze",
+							DDLNotSpecified,
+							"", //databaseName
+							RelationGetRelationName(lovHeap));
+#endif
 	pfree(indexDatum);
 	pfree(indexNulls);
 	Assert(result);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -306,7 +306,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			/* fault injection is not set for the specified database name */
 			break;
 	
-		if (strcmp(entryShared->tableName, tableNameLocal) != 0)
+		if (strlen(entryShared->tableName) > 0 && strcmp(entryShared->tableName, tableNameLocal) != 0)
 			/* fault injection is not set for the specified table name */
 			break;
 

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -270,8 +270,7 @@ INSERT 1
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for an inserting session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -366,8 +365,7 @@ rmgr: Heap2       len (rec/tot):     36/    68, tx: ##, lsn: #/########, prev #/
 --------------------------
  Success:                 
 (1 row)
--- Add panic only for an inserting session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -147,8 +147,7 @@ $$ LANGUAGE plpgsql;
 -- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for an inserting session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:
@@ -184,8 +183,7 @@ $$ LANGUAGE plpgsql;
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
--- Add panic only for an inserting session.
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:


### PR DESCRIPTION
Make frozen_insert_crash test stable

Commit 1502bef introduced a new flaking test. This was due to the fact that in
that commit the fault injectors were redesigned because they did not work.
Commit 28baf7a fixes the fault injectors, so this commit restores them to the
way they were in the original.