### PR TITLE
ADBDEV-5262: Fix output of non-null-terminated strings.

### DIFF
--- a/src/interfaces/ecpg/ecpglib/misc.c
+++ b/src/interfaces/ecpg/ecpglib/misc.c
@@ -303,8 +303,8 @@ ecpg_log(const char *format,...)
 	/* dump out internal sqlca variables */
 	if (ecpg_internal_regression_mode && sqlca != NULL)
 	{
-		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %.5s\n",
-				sqlca->sqlcode, sqlca->sqlstate);
+		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %.*s\n",
+				sqlca->sqlcode, (int)sizeof(sqlca->sqlstate), sqlca->sqlstate);
 	}
 
 	fflush(debugstream);

--- a/src/interfaces/ecpg/ecpglib/misc.c
+++ b/src/interfaces/ecpg/ecpglib/misc.c
@@ -303,7 +303,7 @@ ecpg_log(const char *format,...)
 	/* dump out internal sqlca variables */
 	if (ecpg_internal_regression_mode && sqlca != NULL)
 	{
-		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %s\n",
+		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %5s\n",
 				sqlca->sqlcode, sqlca->sqlstate);
 	}
 

--- a/src/interfaces/ecpg/ecpglib/misc.c
+++ b/src/interfaces/ecpg/ecpglib/misc.c
@@ -303,7 +303,7 @@ ecpg_log(const char *format,...)
 	/* dump out internal sqlca variables */
 	if (ecpg_internal_regression_mode && sqlca != NULL)
 	{
-		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %5s\n",
+		fprintf(debugstream, "[NO_PID]: sqlca: code: %ld, state: %.5s\n",
 				sqlca->sqlcode, sqlca->sqlstate);
 	}
 


### PR DESCRIPTION
Fix output of non-null-terminated strings.

The sqlca->sqlstate variable is an array of 5 characters, so when it is printed,
the patch explicitly adds size.