### PR TITLE
Fix dereference a potentially null pointer in atpxPart_validate_spec

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5352,6 +5352,8 @@ atpxPart_validate_spec(PartitionBy *pBy,
 	int			result;
 	PartitionNode *pNode_tmpl = NULL;
 
+	Assert(pNode != NULL && pNode->part != NULL);
+
 	spec->partElem = list_make1(pelem);
 
 	pelem->partName = partName;
@@ -5408,6 +5410,8 @@ atpxPart_validate_spec(PartitionBy *pBy,
 			pbykeys = NIL;
 			pbyopclass = NIL;
 
+			Assert(pNode2->part != NULL && pNode2->part->paratts != NULL);
+
 			for (ii = 0; ii < pNode2->part->parnatts; ii++)
 			{
 				AttrNumber	attno =
@@ -5442,7 +5446,7 @@ atpxPart_validate_spec(PartitionBy *pBy,
 
 			parent_pBy2 = pBy2;
 
-			if (pNode2 && (pNode2->rules || pNode2->default_part))
+			if (pNode2->rules || pNode2->default_part)
 			{
 				PartitionRule *prule;
 				PartitionElem *el = NULL;	/* for the subpartn template */
@@ -5456,6 +5460,7 @@ atpxPart_validate_spec(PartitionBy *pBy,
 				{
 					pNode2 = prule->children;
 
+					Assert(pNode2->part != NULL);
 					Assert(('l' == pNode2->part->parkind) ||
 						   ('r' == pNode2->part->parkind));
 
@@ -5626,7 +5631,7 @@ atpxPart_validate_spec(PartitionBy *pBy,
 					}			/* end if pNode_tmpl */
 
 					/* fixup the pnode_tmpl to get the right parlevel */
-					if (pNode2 && (pNode2->rules || pNode2->default_part))
+					if (pNode2->rules || pNode2->default_part)
 					{
 						pNode_tmpl = get_parts(pNode2->part->parrelid,
 											   pNode2->part->parlevel + 1,

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5405,7 +5405,7 @@ atpxPart_validate_spec(PartitionBy *pBy,
 		List	   *pbyopclass = NIL;
 		Oid			accessMethodId = BTREE_AM_OID;
 
-		while (pNode2)
+		while (true)
 		{
 			pbykeys = NIL;
 			pbyopclass = NIL;
@@ -5644,10 +5644,10 @@ atpxPart_validate_spec(PartitionBy *pBy,
 
 				}
 				else
-					pNode2 = NULL;
+					break;
 			}
 			else
-				pNode2 = NULL;
+				break;
 
 		}						/* end while */
 	}

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -5410,10 +5410,12 @@ atpxPart_validate_spec(PartitionBy *pBy,
 			pbykeys = NIL;
 			pbyopclass = NIL;
 
-			Assert(pNode2->part != NULL && pNode2->part->paratts != NULL);
+			Assert(pNode2->part != NULL);
 
 			for (ii = 0; ii < pNode2->part->parnatts; ii++)
 			{
+				Assert(pNode2->part->paratts != NULL);
+
 				AttrNumber	attno =
 				pNode2->part->paratts[ii];
 				Form_pg_attribute attribute =


### PR DESCRIPTION
Fix dereference a potentially null pointer in atpxPart_validate_spec

Problem:
Static code analyzer found a potential issue with 'pNode'/'pNode2' pointer, that
is dereferenced before checking for a NULL value.

Fix:
1. Assert is added at the beginning of the function to ensure that 'pNode' and 
the accessed fields of 'pNode' are not NULL.
2. Asserts are added at the beginning of the loop to ensure that the accessed
fields of 'pNode2' are not NULL.
3. Redundant check for 'pNode2' not being NULL is removed.
4. Assert is added after the update of 'pNode2' to ensure that the accessed
fields of the 'pNode2' are not NULL.
5. Second redundant check for 'pNode2' not being NULL is removed, as it is 
guaranteed above by statements 'if (prule && prule->children)' and
'pNode2 = prule->children;'.
6. Loop exit condition is refactored.