### PR TITLE
ADBDEV-5263: Fix incorrect file descriptor dup when creating a pipe

### DIFF
--- a/gpMgmt/bin/pythonSrc/subprocess32/_posixsubprocess.c
+++ b/gpMgmt/bin/pythonSrc/subprocess32/_posixsubprocess.c
@@ -791,6 +791,7 @@ subprocess_cloexec_pipe(PyObject *self, PyObject *noargs)
         if (write_fd < 0)  /* We don't support F_DUPFD_CLOEXEC / other error */
 #endif
         {
+            write_fd = fds[1];
             /* Use dup a few times until we get a desirable fd. */
             for (; fds_to_close_idx < 3; ++fds_to_close_idx) {
                 fds_to_close[fds_to_close_idx] = write_fd;

--- a/gpMgmt/bin/pythonSrc/subprocess32/_posixsubprocess.c
+++ b/gpMgmt/bin/pythonSrc/subprocess32/_posixsubprocess.c
@@ -791,7 +791,9 @@ subprocess_cloexec_pipe(PyObject *self, PyObject *noargs)
         if (write_fd < 0)  /* We don't support F_DUPFD_CLOEXEC / other error */
 #endif
         {
+#ifdef F_DUPFD_CLOEXEC
             write_fd = fds[1];
+#endif
             /* Use dup a few times until we get a desirable fd. */
             for (; fds_to_close_idx < 3; ++fds_to_close_idx) {
                 fds_to_close[fds_to_close_idx] = write_fd;


### PR DESCRIPTION
Fix incorrect file descriptor dup when creating a pipe

If fcntl fails with F_DUPFD_CLOEXEC, attempts are made to duplicate the file
descriptor using a regular dup. But since, as a result of fcntl failure,
write_fd will become -1 and dup will also fail.

This patch returns write_fd to its original value in case of fcntl failure.