### PR TITLE
ADBDEV-5260: Remove a null pointer check for canonical_grpsets

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2470,8 +2470,7 @@ grouping_planner(PlannerInfo *root, double tuple_fraction)
 												0, /* rollup_gs_times */
 												result_plan);
 
-				if (canonical_grpsets != NULL &&
-					canonical_grpsets->grpset_counts != NULL &&
+				if (canonical_grpsets->grpset_counts != NULL &&
 					canonical_grpsets->grpset_counts[0] > 1)
 				{
 					result_plan->flow = pull_up_Flow(result_plan, result_plan->lefttree);


### PR DESCRIPTION
Remove a null pointer check for canonical_grpsets

canonical_grpsets is asserted to be not-NULL before the affected condition.
Remove the redundant NULL check.