### PR TITLE
ADBDEV-5264: Prevent integer overflow when forming tuple width estimates.

### DIFF
--- a/src/backend/optimizer/util/placeholder.c
+++ b/src/backend/optimizer/util/placeholder.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "nodes/nodeFuncs.h"
+#include "optimizer/cost.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/placeholder.h"
 #include "optimizer/planmain.h"
@@ -447,6 +448,7 @@ void
 add_placeholders_to_joinrel(PlannerInfo *root, RelOptInfo *joinrel)
 {
 	Relids		relids = joinrel->relids;
+	int64		tuple_width = joinrel->width;
 	ListCell   *lc;
 
 	foreach(lc, root->placeholder_list)
@@ -462,8 +464,10 @@ add_placeholders_to_joinrel(PlannerInfo *root, RelOptInfo *joinrel)
 				/* Yup, add it to the output */
 				joinrel->reltargetlist = lappend(joinrel->reltargetlist,
 												 phinfo->ph_var);
-				joinrel->width += phinfo->ph_width;
+				tuple_width += phinfo->ph_width;
 			}
 		}
 	}
+
+	joinrel->width = clamp_width_est(tuple_width);
 }

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -832,7 +832,7 @@ estimate_rel_size(Relation rel, int32 *attr_widths,
 static int32
 get_rel_data_width(Relation rel, int32 *attr_widths)
 {
-	int32		tuple_width = 0;
+	int64		tuple_width = 0;
 	int			i;
 
 	for (i = 1; i <= RelationGetNumberOfAttributes(rel); i++)
@@ -862,7 +862,7 @@ get_rel_data_width(Relation rel, int32 *attr_widths)
 		tuple_width += item_width;
 	}
 
-	return tuple_width;
+	return clamp_width_est(tuple_width);
 }
 
 /*

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -569,6 +569,7 @@ build_joinrel_tlist(PlannerInfo *root, RelOptInfo *joinrel,
 					List *input_tlist)
 {
 	Relids		relids = joinrel->relids;
+	int64		tuple_width = joinrel->width;
 	ListCell   *vars;
 
 	foreach(vars, input_tlist)
@@ -601,7 +602,7 @@ build_joinrel_tlist(PlannerInfo *root, RelOptInfo *joinrel,
 		    if (bms_nonempty_difference(rci->where_needed, relids))
 		    {
 			    joinrel->reltargetlist = lappend(joinrel->reltargetlist, var);
-			    joinrel->width += rci->attr_width;
+			    tuple_width += rci->attr_width;
 		    }
             continue;
         }
@@ -619,9 +620,11 @@ build_joinrel_tlist(PlannerInfo *root, RelOptInfo *joinrel,
 		{
 			/* Yup, add it to the output */
 			joinrel->reltargetlist = lappend(joinrel->reltargetlist, var);
-			joinrel->width += baserel->attr_widths[ndx];
+			tuple_width += baserel->attr_widths[ndx];
 		}
 	}
+
+	joinrel->width = clamp_width_est(tuple_width);
 }
 
 /*


### PR DESCRIPTION
Prevent integer overflow when forming tuple width estimates.

It's at least theoretically possible to overflow int32 when adding up
column width estimates to make a row width estimate.  (The bug example
isn't terribly convincing as a real use-case, but perhaps wide joins
would provide a more plausible route to trouble.)  This'd lead to
assertion failures or silly planner behavior.  To forestall it, make
the relevant functions compute their running sums in int64 arithmetic
and then clamp to int32 range at the end.  We can reasonably assume
that MaxAllocSize is a hard limit on actual tuple width, so clamping
to that is simply a correction for dubious input values, and there's
no need to go as far as widening width variables to int64 everywhere.

Per bug #18247 from RekGRpth.  There've been no reports of this issue
arising in practical cases, so I feel no need to back-patch.

Richard Guo and Tom Lane

Discussion: https://postgr.es/m/18247-11ac477f02954422@postgresql.org

This is backport of original postgresql commit postgres/postgres@7e1ce2b