### PR TITLE
Replace memcpy with memmove in SWAPN macro

### DIFF
--- a/gpcontrib/gp_sparse_vector/operators.c
+++ b/gpcontrib/gp_sparse_vector/operators.c
@@ -1149,9 +1149,9 @@ svec_pivot(PG_FUNCTION_ARGS)
 { \
 	for (int III=0;III<nlists;III++) /* This should be unrolled as nlists will be small */ \
 	{ \
-	  	memcpy((tmp)[III]                  ,(lists)[III]+I*(widths)[III],(widths)[III]); \
-		memcpy((lists)[III]+I*(widths)[III],(lists)[III]+J*(widths)[III],(widths)[III]); \
-		memcpy((lists)[III]+J*(widths)[III],(tmp)[III]                  ,(widths)[III]); \
+	  	memmove((tmp)[III]                  ,(lists)[III]+I*(widths)[III],(widths)[III]); \
+		memmove((lists)[III]+I*(widths)[III],(lists)[III]+J*(widths)[III],(widths)[III]); \
+		memmove((lists)[III]+J*(widths)[III],(tmp)[III]                  ,(widths)[III]); \
 	} \
 }
 /*


### PR DESCRIPTION
Replace memcpy with memmove in SWAPN macro

memcpy was used to copy overlapping buffers in the SWAPN macro. For memcpy, 
according to its specification, "if the objects overlap, the behavior is 
undefined". Thus, it may potentially cause errors. The memcpy function is 
replaced with memmove, which also copies data from one buffer to another one,
but the buffers may overlap according to its specification. 