### PR TITLE
ADBDEV-5273 Use std::nothrow for new allocations

### DIFF
--- a/gpcontrib/gpcloud/src/gpreader.cpp
+++ b/gpcontrib/gpcloud/src/gpreader.cpp
@@ -33,9 +33,6 @@ unsigned long gpcloud_id_function(void) {
 
 int thread_setup(void) {
     mutex_buf = new pthread_mutex_t[CRYPTO_num_locks()];
-    if (mutex_buf == NULL) {
-        return 0;
-    }
     for (int i = 0; i < CRYPTO_num_locks(); i++) {
         MUTEX_SETUP(mutex_buf[i]);
     }
@@ -102,9 +99,6 @@ GPReader* reader_init(const char* url_with_options) {
         PrepareS3MemContext(params);
 
         reader = new GPReader(params);
-        if (reader == NULL) {
-            return NULL;
-        }
 
         reader->open(params);
         return reader;

--- a/gpcontrib/gpcloud/src/gpreader.cpp
+++ b/gpcontrib/gpcloud/src/gpreader.cpp
@@ -32,7 +32,7 @@ unsigned long gpcloud_id_function(void) {
 }
 
 int thread_setup(void) {
-    mutex_buf = new pthread_mutex_t[CRYPTO_num_locks()];
+    mutex_buf = new(std::nothrow) pthread_mutex_t[CRYPTO_num_locks()];
     if (mutex_buf == NULL) {
         return 0;
     }
@@ -101,7 +101,7 @@ GPReader* reader_init(const char* url_with_options) {
         // Prepare memory to be used for thread chunk buffer.
         PrepareS3MemContext(params);
 
-        reader = new GPReader(params);
+        reader = new(std::nothrow) GPReader(params);
         if (reader == NULL) {
             return NULL;
         }

--- a/gpcontrib/gpcloud/src/gpreader.cpp
+++ b/gpcontrib/gpcloud/src/gpreader.cpp
@@ -33,6 +33,9 @@ unsigned long gpcloud_id_function(void) {
 
 int thread_setup(void) {
     mutex_buf = new pthread_mutex_t[CRYPTO_num_locks()];
+    if (mutex_buf == NULL) {
+        return 0;
+    }
     for (int i = 0; i < CRYPTO_num_locks(); i++) {
         MUTEX_SETUP(mutex_buf[i]);
     }
@@ -99,6 +102,9 @@ GPReader* reader_init(const char* url_with_options) {
         PrepareS3MemContext(params);
 
         reader = new GPReader(params);
+        if (reader == NULL) {
+            return NULL;
+        }
 
         reader->open(params);
         return reader;

--- a/gpcontrib/gpcloud/src/gpwriter.cpp
+++ b/gpcontrib/gpcloud/src/gpwriter.cpp
@@ -81,7 +81,7 @@ GPWriter* writer_init(const char* url_with_options, const char* format) {
         PrepareS3MemContext(params);
 
         string extName = params.isAutoCompress() ? string(format) + ".gz" : format;
-        writer = new GPWriter(params, extName);
+        writer = new(std::nothrow) GPWriter(params, extName);
         if (writer == NULL) {
             return NULL;
         }

--- a/gpcontrib/gpcloud/src/gpwriter.cpp
+++ b/gpcontrib/gpcloud/src/gpwriter.cpp
@@ -82,9 +82,6 @@ GPWriter* writer_init(const char* url_with_options, const char* format) {
 
         string extName = params.isAutoCompress() ? string(format) + ".gz" : format;
         writer = new GPWriter(params, extName);
-        if (writer == NULL) {
-            return NULL;
-        }
 
         writer->open(params);
         return writer;

--- a/gpcontrib/gpcloud/src/gpwriter.cpp
+++ b/gpcontrib/gpcloud/src/gpwriter.cpp
@@ -82,6 +82,9 @@ GPWriter* writer_init(const char* url_with_options, const char* format) {
 
         string extName = params.isAutoCompress() ? string(format) + ".gz" : format;
         writer = new GPWriter(params, extName);
+        if (writer == NULL) {
+            return NULL;
+        }
 
         writer->open(params);
         return writer;


### PR DESCRIPTION
New allocations need to be exception safe, so we replaced regular new operator
by that one that doesn't throw exceptions.