### PR TITLE
ADBDEV-5267: Fix a possible segmentation fault in make_partition_rules

### DIFF
--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -654,7 +654,7 @@ transformPartitionBy(CreateStmtContext *cxt,
 		/* XXX: temporarily add rule creation code for debugging */
 
 		/* now that we have the child table name, make the rule */
-		if (!(pElem && pElem->isDefault))
+		if (pElem && !pElem->isDefault)
 		{
 			ListCell   *lc_rule = NULL;
 			int			everycount = every ?
@@ -1253,10 +1253,7 @@ make_partition_rules(CreateStmtContext *cxt, CreateStmt *stmt,
 		ListCell   *lc_every_val = NULL;
 		List	   *allNewCols = NIL;
 
-		if (pElem)
-		{
-			pBSpec = (PartitionBoundSpec *) pElem->boundSpec;
-		}
+		pBSpec = (PartitionBoundSpec *) pElem->boundSpec;
 
 		initStringInfo(&ANDBuf);
 		initStringInfo(&ORBuf);

--- a/src/backend/parser/parse_partition.c
+++ b/src/backend/parser/parse_partition.c
@@ -1248,12 +1248,10 @@ make_partition_rules(CreateStmtContext *cxt, CreateStmt *stmt,
 		StringInfoData ANDBuf;
 		StringInfoData ORBuf;
 		int			range_idx;
-		PartitionBoundSpec *pBSpec = NULL;
+		PartitionBoundSpec *pBSpec = (PartitionBoundSpec *) pElem->boundSpec;
 
 		ListCell   *lc_every_val = NULL;
 		List	   *allNewCols = NIL;
-
-		pBSpec = (PartitionBoundSpec *) pElem->boundSpec;
 
 		initStringInfo(&ANDBuf);
 		initStringInfo(&ORBuf);


### PR DESCRIPTION
The make_partition_rules function expects pElem to be non-NULL, but checking
before calling allows pElem to be NULL.

This patch corrects the condition to prevent calling make_partition_rules with
pElem being NULL.