### PR TITLE
Fix potential NULL pointer dereferencing in doDispatchDtxProtocolCommand

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1286,7 +1286,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 							 int serializedDtxContextInfoLen)
 {
 	int			i,
-				resultCount,
+				resultCount = 0,
 				numOfFailed = 0;
 
 	char	   *dtxProtocolCommandStr = 0;
@@ -1336,8 +1336,8 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 
 	if (results == NULL)
 	{
-		numOfFailed++;			/* If we got no results, we need to treat it
-								 * as an error! */
+		/* If we got no results, we need to treat it as an error! */
+		return false;
 	}
 
 	for (i = 0; i < resultCount; i++)
@@ -1420,8 +1420,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 	if (waitGxids)
 		pfree(waitGxids);
 
-	if (results)
-		pfree(results);
+	pfree(results);
 
 	return (numOfFailed == 0);
 }

--- a/src/backend/cdb/dispatcher/cdbdisp_dtx.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_dtx.c
@@ -129,6 +129,8 @@ CdbDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		}
 
 		cdbdisp_destroyDispatcherState(ds);
+
+		*numresults = 0;
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix potential NULL pointer dereferencing in doDispatchDtxProtocolCommand

Problem:
In the 'doDispatchDtxProtocolCommand' function, the variable 'resultCount' was 
declared, but not initialized. As it is an automatic variable, its value was 
undefined. The pointer to 'resultCount' is passed to
'CdbDispatchDtxProtocolCommand' function as 'numresults'.
'CdbDispatchDtxProtocolCommand' didn't set the '*numresults' to 0 in case it 
returned NULL. This return value is assigned to 'results'. So, if the 'results' 
was NULL, 'resultCount' could have a non-zero value. And in this case, 'results'
could be dereferenced.

Fix:
Function 'doDispatchDtxProtocolCommand' is changed to immediately return false 
if 'results' is NULL. It is equivalent to previous intended behavior, as for 
empty 'results', the 'resultCount' is supposed to be 0. Plus 'resultCount' is 
now initialized to 0, and CdbDispatchDtxProtocolCommand' additionally sets 
'*numresults' to 0 in case it returns NULL.

Tests are not added, as it is a hypothetical situation.
