### PR TITLE
Make frozen_insert_crash test stable

### DIFF
--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -254,7 +254,8 @@ INSERT 0 1
 --------------------------
  Success:                 
 (1 row)
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for an inserting session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        
@@ -349,7 +350,8 @@ rmgr: Heap2       len (rec/tot):     64/    64, tx: ##, lsn: #/########, prev #/
 --------------------------
  Success:                 
 (1 row)
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for an inserting session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -140,7 +140,8 @@ $$ LANGUAGE plpgsql;
 -- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for an inserting session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:
@@ -176,7 +177,8 @@ $$ LANGUAGE plpgsql;
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
 -- skip FTS probe to prevent unexpected mirror promotion
 1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
-1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+-- Add panic only for an inserting session.
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid, sess_id) from gp_segment_configuration join pg_stat_activity on query = 'insert into tab_fi values(2, 2);' where role = 'p' and content = 0;
 1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
 2<:


### PR DESCRIPTION
Make frozen_insert_crash test stable

Commit 8accc02 introduced a new flaking test. The test expects a panic to occur
in the process that performs the insert. But sometimes the panic happens first
in process which started by dtx recovery process that periodically checks for
orphaned transactions. Which leads to an error in the test. The solution is to
panic only the required process, which is done by extracting session from
pg_stat_activity by query.

Cherry-pick of 3d4cc61b6d697e7eb524078285d8dfbb19949e57
