### PR TITLE
ADBDEV-5393: Fix segfault when copying dropped column ACLs to a new partition

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2321,9 +2321,6 @@ CopyRelationAcls(Oid srcId, Oid destId)
 		bool		nulls[Natts_pg_attribute];
 		bool		replaces[Natts_pg_attribute];
 
-		if (attSrcForm->attisdropped)
-			continue;
-
 		aclDatum = SysCacheGetAttr(ATTNUM, attSrcTuple, Anum_pg_attribute_attacl,
 								   &isNull);
 		if (isNull)

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -9337,3 +9337,28 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+-- test copying ACLs on columns when adding a new partition if the table has
+-- dropped columns.
+-- start_ignore
+-- end_ignore
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE TABLE t_part_acl (b INT, c INT, d INT, e INT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON t_part_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_acl TO user_prt_acl;
+ALTER TABLE t_part_acl DROP COLUMN d;
+ALTER TABLE t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+DROP TABLE t_part_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -9337,16 +9337,3 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
--- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
-CREATE ROLE user_prt_acl;
-CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
-  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
-   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
-GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
-ALTER TABLE public.t_part_acl DROP COLUMN d;
-ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
-DROP TABLE public.t_part_acl;
-DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -9255,3 +9255,28 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+-- test copying ACLs on columns when adding a new partition if the table has
+-- dropped columns.
+-- start_ignore
+-- end_ignore
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE TABLE t_part_acl (b INT, c INT, d INT, e INT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON t_part_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_acl TO user_prt_acl;
+ALTER TABLE t_part_acl DROP COLUMN d;
+ALTER TABLE t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+DROP TABLE t_part_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -9255,16 +9255,3 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
--- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
-CREATE ROLE user_prt_acl;
-CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
-  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
-   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
-GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
-ALTER TABLE public.t_part_acl DROP COLUMN d;
-ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
-NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
-DROP TABLE public.t_part_acl;
-DROP ROLE user_prt_acl;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4444,14 +4444,3 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
-
--- Make sure that we do not copy ACLs from dropped columns (which led to segfault)
-CREATE ROLE user_prt_acl;
-CREATE TABLE public.t_part_acl (b INT, c INT, d TEXT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
-  (PARTITION "10" START (1) INCLUSIVE END (10) EXCLUSIVE,
-   PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
-GRANT SELECT(d) ON public.t_part_acl TO user_prt_acl;
-ALTER TABLE public.t_part_acl DROP COLUMN d;
-ALTER TABLE public.t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
-DROP TABLE public.t_part_acl;
-DROP ROLE user_prt_acl;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4444,3 +4444,25 @@ DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
 (
   PARTITION part1 VALUES(('(1,1)', 1))
 );
+
+-- test copying ACLs on columns when adding a new partition if the table has
+-- dropped columns.
+-- start_ignore
+DROP TABLE IF EXISTS t_part_acl;
+DROP ROLE IF EXISTS user_prt_acl;
+-- end_ignore
+
+CREATE ROLE user_prt_acl;
+CREATE TABLE t_part_acl (b INT, c INT, d INT, e INT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+GRANT SELECT(d) ON t_part_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_acl TO user_prt_acl;
+ALTER TABLE t_part_acl DROP COLUMN d;
+ALTER TABLE t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+
+DROP TABLE t_part_acl;
+DROP ROLE user_prt_acl;


### PR DESCRIPTION
Fix segfault when copying dropped column ACLs to a new partition

While copying columns ACLs when adding a new partition, we assumed that the
attribute numbers in the source and target relation would match, which is not
true in the case of the dropped columns in the original relation. In this case,
we would try to get an ACL for a non-existent column in the target table, which
would lead to a segfault.

This patch adds a separate iterator for the list of columns in the target
relation to obtain the correct skipping of dropped columns in the original
relation and obtain the correct attribute number for the target relation. We 
assume that there are no dropped columns in the target relation, since this is a
newly created relation.