### PR TITLE
ADBDEV-5400: Close COPY TO/FROM PROGRAM descriptors in case of error

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -819,7 +819,8 @@ pclose_with_stderr(int pid, int *pipes, StringInfo sinfo)
 	/* close the data pipe. we can now read from error pipe without being blocked */
 	close(pipes[EXEC_DATA_P]);
 
-	read_err_msg(pipes[EXEC_ERR_P], sinfo);
+	if (sinfo->data)
+		read_err_msg(pipes[EXEC_ERR_P], sinfo);
 
 	close(pipes[EXEC_ERR_P]);
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7956,8 +7956,11 @@ GetTargetSeg(GpDistributionData *distData, Datum *baseValues, bool *baseNulls)
 }
 
 static void close_program_pipes_on_reset(void *arg) {
-	CopyState cstate = arg;
-	close_program_pipes(cstate, !IsAbortInProgress());
+	if (IsAbortInProgress())
+	{
+		CopyState cstate = arg;
+		close_program_pipes(cstate, false);
+	}
 }
 
 static ProgramPipes*
@@ -8016,7 +8019,6 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 
 	int ret = 0;
 	StringInfoData sinfo;
-	initStringInfo(&sinfo);
 
 	if (cstate->copy_file)
 	{
@@ -8030,6 +8032,7 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 		return;
 	}
 	
+	initStringInfo(&sinfo);
 	ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
 	cstate->program_pipes = NULL;
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7955,18 +7955,21 @@ GetTargetSeg(GpDistributionData *distData, Datum *baseValues, bool *baseNulls)
 	return target_seg;
 }
 
-static void close_program_pipes_on_reset(void *arg) {
+static void
+close_program_pipes_on_reset(void *arg)
+{
 	if (!IsAbortInProgress())
 		return;
 
-	CopyState cstate = arg;
+	CopyState	cstate = arg;
+
 	close_program_pipes(cstate, false);
 }
 
 static ProgramPipes*
 open_program_pipes(CopyState cstate, bool forwrite)
 {
-	char *command = cstate->filename;
+	char	   *command = cstate->filename;
 	int save_errno;
 	pqsigfunc save_SIGPIPE;
 	/* set up extvar */
@@ -8005,6 +8008,7 @@ open_program_pipes(CopyState cstate, bool forwrite)
 	}
 
 	MemoryContextCallback *callback = MemoryContextAlloc(cstate->copycontext, sizeof(MemoryContextCallback));
+
 	callback->arg = cstate;
 	callback->func = close_program_pipes_on_reset;
 	MemoryContextRegisterResetCallback(cstate->copycontext, callback);
@@ -8031,7 +8035,7 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 	{
 		return;
 	}
-	
+
 	if (ifThrow)
 		initStringInfo(&sinfo);
 	ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -421,3 +421,14 @@ SELECT * FROM copy_eoc_marker;
 (1 row)
 
 DROP TABLE copy_eoc_marker;
+-- Ensure we close COPY TO/FROM PROGRAM descriptors in case of error
+CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
+COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
+ERROR:  value "32768" is out of range for type smallint
+CONTEXT:  COPY test_copy_error, line 2769, column a: "32768"
+\! ps aux | grep cat | grep -v grep;
+INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
+COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
+ERROR:  division by zero
+\! ps aux | grep cat | grep -v grep;
+DROP TABLE test_copy_error;

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -426,9 +426,9 @@ CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
 COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
 ERROR:  value "32768" is out of range for type smallint
 CONTEXT:  COPY test_copy_error, line 2769, column a: "32768"
-\! ps aux | grep cat | grep -v grep;
+\! pgrep cat;
 INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
 COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
 ERROR:  division by zero
-\! ps aux | grep cat | grep -v grep;
+\! pgrep cat;
 DROP TABLE test_copy_error;

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -358,8 +358,8 @@ DROP TABLE copy_eoc_marker;
 -- Ensure we close COPY TO/FROM PROGRAM descriptors in case of error
 CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
 COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
-\! ps aux | grep cat | grep -v grep;
+\! pgrep cat;
 INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
 COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
-\! ps aux | grep cat | grep -v grep;
+\! pgrep cat;
 DROP TABLE test_copy_error;

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -354,3 +354,12 @@ COPY copy_eoc_marker FROM stdin LOG ERRORS SEGMENT REJECT LIMIT 5;
 \.
 SELECT * FROM copy_eoc_marker;
 DROP TABLE copy_eoc_marker;
+
+-- Ensure we close COPY TO/FROM PROGRAM descriptors in case of error
+CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
+COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
+\! ps aux | grep cat | grep -v grep;
+INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
+COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
+\! ps aux | grep cat | grep -v grep;
+DROP TABLE test_copy_error;


### PR DESCRIPTION
Close COPY TO/FROM PROGRAM descriptors in case of error

Commit 110b825 added an ifThrow argument to the close_program_pipes function.
That commit contained a call to close_program_pipes(cstate, false) on errors.
But then this function call was lost. And now, in case of errors, open pipes are
not closed until the end of the session.

This patch adds a callback for closing handles on errors, which is called before
deleting the memory context of the copy state.