### PR TITLE
ADBDEV-5556 [PORT FROM 6X] Close COPY TO/FROM PROGRAM descriptors in case of error

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -282,7 +282,7 @@ static GpDistributionData *InitDistributionData(CopyState cstate, EState *estate
 static void FreeDistributionData(GpDistributionData *distData);
 static void InitCopyFromDispatchSplit(CopyState cstate, GpDistributionData *distData, EState *estate);
 static unsigned int GetTargetSeg(GpDistributionData *distData, TupleTableSlot *slot);
-static ProgramPipes *open_program_pipes(char *command, bool forwrite);
+static ProgramPipes *open_program_pipes(CopyState cstate, bool forwrite);
 static void close_program_pipes(CopyState cstate, bool ifThrow);
 CopyIntoClause*
 MakeCopyIntoClause(CopyStmt *stmt);
@@ -2406,7 +2406,7 @@ BeginCopyToOnSegment(QueryDesc *queryDesc)
 
 	if (cstate->is_program)
 	{
-		cstate->program_pipes = open_program_pipes(cstate->filename, true);
+		cstate->program_pipes = open_program_pipes(cstate, true);
 		cstate->copy_file = fdopen(cstate->program_pipes->pipes[0], PG_BINARY_W);
 
 		if (cstate->copy_file == NULL)
@@ -2625,7 +2625,7 @@ BeginCopyTo(ParseState *pstate,
 		if (is_program)
 		{
 			progress_vals[1] = PROGRESS_COPY_TYPE_PROGRAM;
-			cstate->program_pipes = open_program_pipes(cstate->filename, true);
+			cstate->program_pipes = open_program_pipes(cstate, true);
 			cstate->copy_file = fdopen(cstate->program_pipes->pipes[0], PG_BINARY_W);
 
 			if (cstate->copy_file == NULL)
@@ -5101,7 +5101,7 @@ BeginCopyFrom(ParseState *pstate,
 		if (cstate->is_program)
 		{
 			progress_vals[1] = PROGRESS_COPY_TYPE_PROGRAM;
-			cstate->program_pipes = open_program_pipes(cstate->filename, false);
+			cstate->program_pipes = open_program_pipes(cstate, false);
 			cstate->copy_file = fdopen(cstate->program_pipes->pipes[0], PG_BINARY_R);
 			if (cstate->copy_file == NULL)
 				ereport(ERROR,
@@ -8014,9 +8014,21 @@ GetTargetSeg(GpDistributionData *distData, TupleTableSlot *slot)
 	return target_seg;
 }
 
-static ProgramPipes*
-open_program_pipes(char *command, bool forwrite)
+static void
+close_program_pipes_on_reset(void *arg)
 {
+	if (!IsAbortInProgress())
+		return;
+
+	CopyState	cstate = arg;
+
+	close_program_pipes(cstate, false);
+}
+
+static ProgramPipes*
+open_program_pipes(CopyState cstate, bool forwrite)
+{
+	char	   *command = cstate->filename;
 	int save_errno;
 	pqsigfunc save_SIGPIPE;
 	/* set up extvar */
@@ -8054,6 +8066,12 @@ open_program_pipes(char *command, bool forwrite)
 				 errmsg("can not start command: %s", command)));
 	}
 
+	MemoryContextCallback *callback = MemoryContextAlloc(cstate->copycontext, sizeof(MemoryContextCallback));
+
+	callback->arg = cstate;
+	callback->func = close_program_pipes_on_reset;
+	MemoryContextRegisterResetCallback(cstate->copycontext, callback);
+
 	return program_pipes;
 }
 
@@ -8063,8 +8081,7 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 	Assert(cstate->is_program);
 
 	int ret = 0;
-	StringInfoData sinfo;
-	initStringInfo(&sinfo);
+	StringInfoData sinfo = {0};
 
 	if (cstate->copy_file)
 	{
@@ -8077,8 +8094,11 @@ close_program_pipes(CopyState cstate, bool ifThrow)
 	{
 		return;
 	}
-	
+
+	if (ifThrow)
+		initStringInfo(&sinfo);
 	ret = pclose_with_stderr(cstate->program_pipes->pid, cstate->program_pipes->pipes, &sinfo);
+	cstate->program_pipes = NULL;
 
 	if (ret == 0 || !ifThrow)
 	{

--- a/src/backend/storage/file/execute_pipe.c
+++ b/src/backend/storage/file/execute_pipe.c
@@ -191,7 +191,8 @@ pclose_with_stderr(int pid, int *pipes, StringInfo sinfo)
 	/* close the data pipe. we can now read from error pipe without being blocked */
 	close(pipes[EXEC_DATA_P]);
 
-	read_err_msg(pipes[EXEC_ERR_P], sinfo);
+	if (sinfo->data)
+		read_err_msg(pipes[EXEC_ERR_P], sinfo);
 
 	close(pipes[EXEC_ERR_P]);
 

--- a/src/test/regress/expected/copy2.out
+++ b/src/test/regress/expected/copy2.out
@@ -548,3 +548,14 @@ SELECT * FROM copy_eoc_marker;
 (1 row)
 
 DROP TABLE copy_eoc_marker;
+-- Ensure we close COPY TO/FROM PROGRAM descriptors in case of error
+CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
+COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
+ERROR:  value "32768" is out of range for type smallint
+CONTEXT:  COPY test_copy_error, line 2769, column a: "32768"
+\! pgrep cat;
+INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
+COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
+ERROR:  division by zero
+\! pgrep cat;
+DROP TABLE test_copy_error;

--- a/src/test/regress/sql/copy2.sql
+++ b/src/test/regress/sql/copy2.sql
@@ -469,3 +469,12 @@ COPY copy_eoc_marker FROM stdin LOG ERRORS SEGMENT REJECT LIMIT 5;
 \.
 SELECT * FROM copy_eoc_marker;
 DROP TABLE copy_eoc_marker;
+
+-- Ensure we close COPY TO/FROM PROGRAM descriptors in case of error
+CREATE TABLE test_copy_error (a SMALLINT) DISTRIBUTED BY (a);
+COPY test_copy_error FROM PROGRAM 'seq 30000 90000 | cat -';
+\! pgrep cat;
+INSERT INTO test_copy_error SELECT CASE WHEN i = 10 THEN 0 ELSE i END FROM generate_series(1, 100) i;
+COPY (SELECT 1 / a FROM test_copy_error) TO PROGRAM 'cat -';
+\! pgrep cat;
+DROP TABLE test_copy_error;


### PR DESCRIPTION
Close COPY TO/FROM PROGRAM descriptors in case of error

This is a port of commit 75981ebc9c368ac26a231e376ab2edbb1e8928b6.

In case of error during COPY TO/FROM PROGRAM opened program pipe
descriptors weren't closed. That made the program hang until the end of session.

That behaviour occured due to absence of close_program_pipes() function call in
error cases. Originally, this call was present in catch block of DoCopy()
function (110b825), however it was removed in 25a9039.

This patch fixed the erroneous behaviour by adding a callback for closing
handles on errors, which is called before deleting the memory context of the
copy state.
