### PR TITLE
Fix stuck query after cancel or termination when segment is not responding

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -662,6 +662,9 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 		}
 	}
 
+	/* reset flag in libpq, that is used to avoid stuck in a loop in PQcancel*/
+	PQbypassConnCloseAtCancel(false);
+
 	return;
 }
 

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -944,7 +944,6 @@ signalQEs(CdbDispatchCmdAsync *pParms)
 			elog(LOG, "Unable to cancel: %s",
 				 strlen(errbuf) == 0 ? "cannot allocate PGCancel" : errbuf);
 	}
-	PQbypassConnCloseAtCancel(false);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -944,6 +944,7 @@ signalQEs(CdbDispatchCmdAsync *pParms)
 			elog(LOG, "Unable to cancel: %s",
 				 strlen(errbuf) == 0 ? "cannot allocate PGCancel" : errbuf);
 	}
+	PQbypassConnCloseAtCancel(false);
 }
 
 /*

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -29,6 +29,7 @@
 #include "postmaster/fts.h"
 #include "postmaster/ftsprobe.h"
 #include "postmaster/postmaster.h"
+#include "storage/pmsignal.h"
 #include "utils/snapmgr.h"
 
 
@@ -1175,6 +1176,7 @@ processResponse(fts_context *context)
 					   "triggered successfully",
 					   primary->config->segindex, primary->config->dbid);
 				ftsInfo->state = FTS_RESPONSE_PROCESSED;
+				SendPostmasterSignal(PMSIGNAL_FTS_PROMOTED_MIRROR);
 				break;
 			case FTS_SYNCREP_OFF_SUCCESS:
 				elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5692,6 +5692,9 @@ sigusr1_handler(SIGNAL_ARGS)
 
 	if (CheckPostmasterSignal(PMSIGNAL_FTS_PROMOTED_MIRROR))
 	{
+		/*
+		 * Notify all child coordinator backends that FTS has promoted a mirror.
+		 */
 		if (pmState == PM_RUN &&
 			GpIdentity.segindex == MASTER_CONTENT_ID)
 		{
@@ -5703,7 +5706,9 @@ sigusr1_handler(SIGNAL_ARGS)
 				if (bp->dead_end || !(BACKEND_TYPE_NORMAL & bp->bkend_type))
 					continue;
 
-				SendProcSignal(bp->pid, PROCSIG_FTS_PROMOTED_MIRROR, InvalidBackendId);
+				SendProcSignal(bp->pid,
+							   PROCSIG_FTS_PROMOTED_MIRROR,
+							   InvalidBackendId);
 			}
 		}
 	}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -5690,6 +5690,24 @@ sigusr1_handler(SIGNAL_ARGS)
 		signal_child(DtxRecoveryPID(), SIGINT);
 	}
 
+	if (CheckPostmasterSignal(PMSIGNAL_FTS_PROMOTED_MIRROR))
+	{
+		if (pmState == PM_RUN &&
+			GpIdentity.segindex == MASTER_CONTENT_ID)
+		{
+			dlist_iter	iter;
+			dlist_foreach(iter, &BackendList)
+			{
+				Backend *bp = dlist_container(Backend, elem, iter.cur);
+
+				if (bp->dead_end || !(BACKEND_TYPE_NORMAL & bp->bkend_type))
+					continue;
+
+				SendProcSignal(bp->pid, PROCSIG_FTS_PROMOTED_MIRROR, InvalidBackendId);
+			}
+		}
+	}
+
 	/*
 	 * Try to advance postmaster's state machine, if a child requests it.
 	 *

--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -19,6 +19,7 @@
 
 #include "cdb/cdbvars.h"
 #include "commands/async.h"
+#include "libpq-fe.h"
 #include "miscadmin.h"
 #include "replication/walsender.h"
 #include "storage/latch.h"
@@ -328,6 +329,10 @@ procsignal_sigusr1_handler(SIGNAL_ARGS)
 
 	if (CheckProcSignal(PROCSIG_RESOURCE_GROUP_MOVE_QUERY))
 		HandleMoveResourceGroup();
+
+	if (CheckProcSignal(PROCSIG_FTS_PROMOTED_MIRROR) &&
+		(QueryCancelCleanup || TermSignalReceived))
+		PQbypassConnCloseAtCancel(true);
 
 	if (set_latch_on_sigusr1 && MyProc != NULL)
 		SetLatch(&MyProc->procLatch);

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -35,6 +35,8 @@ typedef enum
 	PMSIGNAL_WAKEN_FTS,         /* wake up FTS to probe segments */
 	PMSIGNAL_WAKEN_DTX_RECOVERY,         /* wake up dtx recovery to abort dtx xacts */
 
+	PMSIGNAL_FTS_PROMOTED_MIRROR, /* FTS has detected failed primary and promoted mirror*/
+
 	NUM_PMSIGNALS				/* Must be last value of enum! */
 } PMSignalReason;
 

--- a/src/include/storage/procsignal.h
+++ b/src/include/storage/procsignal.h
@@ -43,6 +43,9 @@ typedef enum
 	PROCSIG_RECOVERY_CONFLICT_BUFFERPIN,
 	PROCSIG_RECOVERY_CONFLICT_STARTUP_DEADLOCK,
 	PROCSIG_RESOURCE_GROUP_MOVE_QUERY,	/* move query to a new resource group */
+
+	PROCSIG_FTS_PROMOTED_MIRROR, /* FTS has detected failed primary and promoted mirror*/
+
 	NUM_PROCSIGNALS				/* Must be last! */
 } ProcSignalReason;
 

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -3431,6 +3431,11 @@ PQfreeCancel(PGcancel *cancel)
 		free(cancel);
 }
 
+/*
+ * PQbypassConnCloseAtCancel:
+ * set a flag, that allows to fix an issue with internal hanging in
+ * 'internal_cancel'. For details refer to comments in 'internal_cancel'.
+ */
 void PQbypassConnCloseAtCancel(pqbool bypass)
 {
 	bypass_conn_close_at_cancel = bypass;
@@ -3530,6 +3535,22 @@ retry4:
 #ifndef WIN32
 retry5:
 
+	/*
+	 * GPDB: in case this function is called by the coordinator process to
+	 * communicate with the segments (when performing cancel/terminate of a 
+	 * backend) and one of the segments has hanged keeping the listening socket
+	 * open, we will be stuck in this function for infinite amount of time
+	 * (hanging on the 'poll' in a loop). The check below helps to avoid this
+	 * situation:
+	 *  1. The flag 'bypass_conn_close_at_cancel' is set from a signal handler.
+	 *  2. The signal is originally initiated by the FTS, which detects that a
+	 *  segment went down. 
+	 *  3. If the signal comes before the 'poll' is called, it will be just
+	 *  skipped and this function will return an error.
+	 *  4. If the signal comes after the 'poll' is called, the 'poll' will be
+	 *  interrupted with EINTR, and the next iteration will be skipped and this
+	 *  function will return an error.
+	 */
 	if (bypass_conn_close_at_cancel)
 		goto cancel_errReturn;
 

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -325,6 +325,8 @@ extern void PQfreeCancel(PGcancel *cancel);
 /* issue a cancel request */
 extern int	PQcancel(PGcancel *cancel, char *errbuf, int errbufsize);
 
+extern void PQbypassConnCloseAtCancel(pqbool bypass); /* GPDB only */
+
 /* issue a finsh request */
 extern int	PQrequestFinish(PGcancel *cancel, char *errbuf, int errbufsize);
 

--- a/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
@@ -1,0 +1,280 @@
+-- The test below checks that FTS can break the stuck cancelled/terminated
+-- query, if one of the segments has hanged.
+-- Original problem was:
+-- 1. For some reason (the reason itself is not important) at some point segment hangs.
+-- 2. Query to 'gp_resgroup_status_per_segment' also hangs.
+-- 3. If 'pg_cancel_backend' or 'pg_terminate_backend' is called before FTS makes
+-- promotion, the query stays is stuck condition.
+
+-- Change FTS settings to make FTS probe work faster in the test.
+!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
+(exited with code 0)
+!\retcode gpconfig -c gp_fts_probe_retries -v 1 --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+
+include: helpers/server_helpers.sql;
+CREATE
+
+-- Case 1: check the scenario with 'pg_cancel_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+ count 
+-------
+ 4     
+(1 row)
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+
+SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
+
+-- Cancel the hanging query.
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | m    | d      | n    
+ 0       | m              | p    | u      | n    
+(2 rows)
+
+-- Check that no locks are left from the query, meaning it ended completely.
+SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
+ locktype | database | relation | page | tuple | virtualxid | transactionid | classid | objid | objsubid | virtualtransaction | pid | mode | granted | fastpath | mppsessionid | mppiswriter | gp_segment_id 
+----------+----------+----------+------+-------+------------+---------------+---------+-------+----------+--------------------+-----+------+---------+----------+--------------+-------------+---------------
+(0 rows)
+
+-- Recover back the segment
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('exec_simple_query_start', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | m              | p    | u      | s    
+ 0       | p              | m    | u      | s    
+(2 rows)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+
+-- Case 1: check the scenario with 'pg_terminate_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+ count 
+-------
+ 4     
+(1 row)
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+
+SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
+
+-- Terminate the hanging query.
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | m    | d      | n    
+ 0       | m              | p    | u      | n    
+(2 rows)
+
+-- Check that no locks are left from the query, meaning it ended completely.
+SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
+ locktype | database | relation | page | tuple | virtualxid | transactionid | classid | objid | objsubid | virtualtransaction | pid | mode | granted | fastpath | mppsessionid | mppiswriter | gp_segment_id 
+----------+----------+----------+------+-------+------------+---------------+---------+-------+----------+--------------------+-----+------+---------+----------+--------------+-------------+---------------
+(0 rows)
+
+-- Recover back the segment
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('exec_simple_query_start', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | m              | p    | u      | s    
+ 0       | p              | m    | u      | s    
+(2 rows)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1q: ... <quitting>
+
+-- Restore parameters.
+!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+(exited with code 0)
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+

--- a/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
@@ -40,18 +40,21 @@ SELECT gp_request_fts_probe_scan();
 -- 1. Stop the backends from processing requests by injecting a fault.
 -- 2. Stop segment postmaster process. This can't be done by the fault injection,
 -- as we wouldn't be able to recover the postmaster back to life in this case.
-
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
 SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 
-!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
+SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
 
 -- Launch the query again, now it will hang.
 1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
@@ -86,11 +89,13 @@ SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
 (0 rows)
 
 -- Recover back the segment
-!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
+SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
 
 SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
  gp_inject_fault 
@@ -143,7 +148,7 @@ SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
 1<:  <... completed>
 ERROR:  canceling statement due to user request
 
--- Case 1: check the scenario with 'pg_terminate_backend'.
+-- Case 2: check the scenario with 'pg_terminate_backend'.
 
 -- Reset FTS probe interval.
 SELECT gp_request_fts_probe_scan();
@@ -163,18 +168,21 @@ SELECT gp_request_fts_probe_scan();
 -- 1. Stop the backends from processing requests by injecting a fault.
 -- 2. Stop segment postmaster process. This can't be done by the fault injection,
 -- as we wouldn't be able to recover the postmaster back to life in this case.
-
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
 SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 
-!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
+SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
 
 -- Launch the query again, now it will hang.
 1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
@@ -209,11 +217,13 @@ SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
 (0 rows)
 
 -- Recover back the segment
-!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
--- start_ignore
-
--- end_ignore
-(exited with code 0)
+SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
 
 SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
  gp_inject_fault 

--- a/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
@@ -37,18 +37,21 @@ SELECT gp_request_fts_probe_scan();
 (1 row)
 
 -- Emulate hanged segment condition:
+-- 0. Store the name of datadir for seg0 - we will need it on step 2.
 -- 1. Stop the backends from processing requests by injecting a fault.
 -- 2. Stop segment postmaster process. This can't be done by the fault injection,
 -- as we wouldn't be able to recover the postmaster back to life in this case.
 -- Thus do it by sending a STOP signal. We need to do it on all segments (not on
 -- the coordinator), as the segment process may be running on a separate machine.
+2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role='p' AND content=0;
+
 SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 
-SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
  exec_cmd_on_segments 
 ----------------------
  OK                   
@@ -89,7 +92,7 @@ SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
 (0 rows)
 
 -- Recover back the segment
-SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
  exec_cmd_on_segments 
 ----------------------
  OK                   
@@ -176,7 +179,7 @@ SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segme
  Success:        
 (1 row)
 
-SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
  exec_cmd_on_segments 
 ----------------------
  OK                   
@@ -217,7 +220,7 @@ SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
 (0 rows)
 
 -- Recover back the segment
-SELECT exec_cmd_on_segments('ps aux | grep ''dbfast1/demoDataDir0'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
  exec_cmd_on_segments 
 ----------------------
  OK                   

--- a/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
@@ -30,7 +30,7 @@ SELECT gp_request_fts_probe_scan();
 (1 row)
 
 -- Make a successfull query to allocate query executer backends on the segments.
-1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
  count 
 -------
  4     
@@ -43,7 +43,7 @@ SELECT gp_request_fts_probe_scan();
 -- as we wouldn't be able to recover the postmaster back to life in this case.
 -- Thus do it by sending a STOP signal. We need to do it on all segments (not on
 -- the coordinator), as the segment process may be running on a separate machine.
-2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role='p' AND content=0;
+2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
@@ -60,10 +60,10 @@ SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segme
 (3 rows)
 
 -- Launch the query again, now it will hang.
-1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';  <waiting ...>
 
 -- Cancel the hanging query.
-SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = ''default_group'';';
  pg_cancel_backend 
 -------------------
  t                 
@@ -161,7 +161,7 @@ SELECT gp_request_fts_probe_scan();
 (1 row)
 
 -- Make a successfull query to allocate query executer backends on the segments.
-1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
  count 
 -------
  4     
@@ -188,10 +188,10 @@ SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid) FROM gp_segme
 (3 rows)
 
 -- Launch the query again, now it will hang.
-1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';  <waiting ...>
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';  <waiting ...>
 
 -- Terminate the hanging query.
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = ''default_group'';';
  pg_terminate_backend 
 ----------------------
  t                    

--- a/src/test/isolation2/helpers/server_helpers.sql
+++ b/src/test/isolation2/helpers/server_helpers.sql
@@ -213,3 +213,17 @@ create or replace function pg_controldata_redo_lsn(datadir text)
     cmd = 'pg_controldata %s | grep \"Latest checkpoint\'s REDO location\"' % datadir
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).split(':')[1].strip()
 $$ language plpythonu;
+
+--
+-- exec_cmd_on_segments:
+--   Execute shell command on all segments
+--
+create or replace function exec_cmd_on_segments(cmd text)
+returns text as $$
+    import subprocess
+    returncode = subprocess.call(cmd, shell=True)
+    if returncode == 0:
+        return 'OK'
+    else:
+        return 'Fail'
+$$ language plpythonu execute on all segments;

--- a/src/test/isolation2/isolation2_resgroup_schedule
+++ b/src/test/isolation2/isolation2_resgroup_schedule
@@ -15,6 +15,7 @@ test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
 test: resgroup/resgroup_query_mem
+test: resgroup/resgroup_views_seg_down
 
 # functions
 test: resgroup/resgroup_concurrency

--- a/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
@@ -21,7 +21,7 @@ include: helpers/server_helpers.sql;
 SELECT gp_request_fts_probe_scan();
 
 -- Make a successfull query to allocate query executer backends on the segments.
-1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
 
 -- Emulate hanged segment condition:
 -- 0. Store the name of datadir for seg0 - we will need it on step 2.
@@ -30,7 +30,7 @@ SELECT gp_request_fts_probe_scan();
 -- as we wouldn't be able to recover the postmaster back to life in this case.
 -- Thus do it by sending a STOP signal. We need to do it on all segments (not on
 -- the coordinator), as the segment process may be running on a separate machine.
-2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role='p' AND content=0;
+2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 
 SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
@@ -38,11 +38,11 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
 
 -- Launch the query again, now it will hang.
-1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
 
 -- Cancel the hanging query.
 SELECT pg_cancel_backend(pid) FROM pg_stat_activity
-WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = ''default_group'';';
 
 -- Trigger FTS scan.
 SELECT gp_request_fts_probe_scan();
@@ -90,7 +90,7 @@ SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
 SELECT gp_request_fts_probe_scan();
 
 -- Make a successfull query to allocate query executer backends on the segments.
-1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
 
 -- Emulate hanged segment condition:
 -- 1. Stop the backends from processing requests by injecting a fault.
@@ -104,11 +104,11 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
 
 -- Launch the query again, now it will hang.
-1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = 'default_group';
 
 -- Terminate the hanging query.
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname = ''default_group'';';
 
 -- Trigger FTS scan.
 SELECT gp_request_fts_probe_scan();

--- a/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
@@ -1,0 +1,153 @@
+-- The test below checks that FTS can break the stuck cancelled/terminated
+-- query, if one of the segments has hanged.
+-- Original problem was:
+-- 1. For some reason (the reason itself is not important) at some point segment hangs.
+-- 2. Query to 'gp_resgroup_status_per_segment' also hangs.
+-- 3. If 'pg_cancel_backend' or 'pg_terminate_backend' is called before FTS makes
+-- promotion, the query stays is stuck condition.
+
+-- Change FTS settings to make FTS probe work faster in the test.
+!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 1 --masteronly;
+!\retcode gpstop -u;
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+include: helpers/server_helpers.sql;
+
+-- Case 1: check the scenario with 'pg_cancel_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+
+SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+
+-- Cancel the hanging query.
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+-- Check that no locks are left from the query, meaning it ended completely.
+SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
+
+-- Recover back the segment
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
+
+SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+SELECT gp_inject_fault('exec_simple_query_start', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+!\retcode gprecoverseg -ar;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+
+1<:
+
+-- Case 1: check the scenario with 'pg_terminate_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+
+SELECT gp_inject_fault('exec_simple_query_start', 'suspend', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -STOP;
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname='default_group';
+
+-- Terminate the hanging query.
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE rsgname=''default_group'';';
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+-- Check that no locks are left from the query, meaning it ended completely.
+SELECT * FROM pg_locks WHERE mode = 'ExclusiveLock' AND locktype = 'relation';
+
+-- Recover back the segment
+!\retcode ps aux | grep 'dbfast1/demoDataDir0' | awk 'FNR == 1 {print $2; exit}' | xargs kill -CONT;
+
+SELECT gp_inject_fault('exec_simple_query_start', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+SELECT gp_inject_fault('exec_simple_query_start', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+!\retcode gprecoverseg -ar;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+
+1<:
+1q:
+
+-- Restore parameters.
+!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpstop -u;
+


### PR DESCRIPTION
Fix stuck query after cancel or termination when segment is not responding

Problem:
The following scenario caused a stuck state of a coordinator backend process:
1. At some moment one of the segments stopped processing incoming requests (the 
reason itself is not important, as sometimes bad things may happen with any
segment, and the system should be able to recover).
2. A query, which dispatches requests to segments, was executed (for example,
select from 'gp_toolkit.gp_resgroup_status_per_segment'). As one of the segments 
was not responding, the coordinator hanged in 'checkDispatchResult' (it is 
expected, and can be handled by the FTS).
3. The stuck query was canceled or terminated (by 'pg_cancel_backend' or 
'pg_terminate_backend'). It didn't help to return from the stuck state, but
after this step the query became completely unrecoverable. Even after FTS had
detected the malfunction segment and had promoted the mirror, the query was
still hanging forever. 

Expected behavior is that after FTS mirror promotion, all stuck queries are 
unblocked and canceled successfully. 

Note: if FTS mirror promotion happened before step 3, the FTS canceled the 
query successfully.

Root cause:
During cancel or termination, the coordinator tried to do abort of the current
transaction, and it hanged in the function 'internal_cancel' (called from 
PQcancel) on 'poll' system call. It has a timeout of 660 seconds, and, moreover,
after the timeout expired, it looped forever trying to do 'poll' again. So, if 
the socket was opened on the segment side, but nobody replied (as the segment 
process became not available for some reason), 'internal_cancel' had no way to
return.

Fix:
Once FTS promotes a mirror, it sends the  signal to the coordinator
postmaster (with PMSIGNAL_FTS_PROMOTED_MIRROR reason). On receiving of the
signal, the coordinator postmaster sends the SIGUSR1 signal (with 
PROCSIG_FTS_PROMOTED_MIRROR reason) to all of its usual backends. Once the 
backend receives the signal, if it is in the state of cancelling or terminating
of the query, it sets a flag in libpq. 'internal_cancel' checks this flag before
calling the 'poll' system call. If it is set, it will return with an error.
Thus:
a. if the FTS promotion happens before cancel/terminate, the query will be 
canceled by the old logic;
b. if the FTS promotion happens after cancel/terminate, but before the 
'internal_cancel' calls the 'poll', 'internal_cancel' will return an error
without calling the 'poll';
c. if the FTS promotion happens when the 'poll' is already called, the 'poll' 
will return EINTR (as the SIGUSR1 was received), and a new 'poll' will not be
called, as the flag is set.