### PR TITLE
Fix checking for existing builtin overflow functions

### DIFF
--- a/config/c-compiler.m4
+++ b/config/c-compiler.m4
@@ -258,10 +258,11 @@ fi])# PGAC_C_BUILTIN_CONSTANT_P
 # and define HAVE__BUILTIN_OP_OVERFLOW if so.
 #
 # Check for the most complicated case, 64 bit multiplication, as a
-# proxy for all of the operations.
+# proxy for all of the operations. Have to link to be sure to
+# recognize a missing __builtin_mul_overflow.
 AC_DEFUN([PGAC_C_BUILTIN_OP_OVERFLOW],
 [AC_CACHE_CHECK(for __builtin_mul_overflow, pgac_cv__builtin_op_overflow,
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([],
 [PG_INT64_TYPE result;
 __builtin_mul_overflow((PG_INT64_TYPE) 1, (PG_INT64_TYPE) 2, &result);]
 )],

--- a/config/c-compiler.m4
+++ b/config/c-compiler.m4
@@ -258,13 +258,17 @@ fi])# PGAC_C_BUILTIN_CONSTANT_P
 # and define HAVE__BUILTIN_OP_OVERFLOW if so.
 #
 # Check for the most complicated case, 64 bit multiplication, as a
-# proxy for all of the operations. Have to link to be sure to
-# recognize a missing __builtin_mul_overflow.
+# proxy for all of the operations. Use volatile variables to avoid the
+# compiler computing result at compile time, even though the runtime
+# might not supply operation. Have to link to be sure to recognize a
+# missing __builtin_mul_overflow.
 AC_DEFUN([PGAC_C_BUILTIN_OP_OVERFLOW],
 [AC_CACHE_CHECK(for __builtin_mul_overflow, pgac_cv__builtin_op_overflow,
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([],
-[PG_INT64_TYPE result;
-__builtin_mul_overflow((PG_INT64_TYPE) 1, (PG_INT64_TYPE) 2, &result);]
+[PG_INT64_TYPE a = 1;
+PG_INT64_TYPE b = 1;
+PG_INT64_TYPE result;
+__builtin_mul_overflow(*(volatile PG_INT64_TYPE *) a, *(volatile PG_INT64_TYPE *) b, &result);]
 )],
 [pgac_cv__builtin_op_overflow=yes],
 [pgac_cv__builtin_op_overflow=no])])

--- a/config/c-compiler.m4
+++ b/config/c-compiler.m4
@@ -258,18 +258,19 @@ fi])# PGAC_C_BUILTIN_CONSTANT_P
 # and define HAVE__BUILTIN_OP_OVERFLOW if so.
 #
 # Check for the most complicated case, 64 bit multiplication, as a
-# proxy for all of the operations. Use volatile variables to avoid the
-# compiler computing result at compile time, even though the runtime
-# might not supply operation. Have to link to be sure to recognize a
-# missing __builtin_mul_overflow.
+# proxy for all of the operations.  To detect the case where the compiler
+# knows the function but library support is missing, we must link not just
+# compile, and store the results in global variables so the compiler doesn't
+# optimize away the call.
 AC_DEFUN([PGAC_C_BUILTIN_OP_OVERFLOW],
 [AC_CACHE_CHECK(for __builtin_mul_overflow, pgac_cv__builtin_op_overflow,
-[AC_LINK_IFELSE([AC_LANG_PROGRAM([],
-[PG_INT64_TYPE a = 1;
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([
+PG_INT64_TYPE a = 1;
 PG_INT64_TYPE b = 1;
 PG_INT64_TYPE result;
-__builtin_mul_overflow(*(volatile PG_INT64_TYPE *) a, *(volatile PG_INT64_TYPE *) b, &result);]
-)],
+int oflo;
+],
+[oflo = __builtin_mul_overflow(a, b, &result);])],
 [pgac_cv__builtin_op_overflow=yes],
 [pgac_cv__builtin_op_overflow=no])])
 if test x"$pgac_cv__builtin_op_overflow" = xyes ; then

--- a/configure
+++ b/configure
@@ -17614,6 +17614,8 @@ esac
 
 fi
 
+# has to be down here, rather than with the other builtins, because
+# the test uses PG_INT64_TYPE.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_mul_overflow" >&5
 $as_echo_n "checking for __builtin_mul_overflow... " >&6; }
 if ${pgac_cv__builtin_op_overflow+:} false; then :
@@ -17632,12 +17634,13 @@ __builtin_mul_overflow((PG_INT64_TYPE) 1, (PG_INT64_TYPE) 2, &result);
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   pgac_cv__builtin_op_overflow=yes
 else
   pgac_cv__builtin_op_overflow=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv__builtin_op_overflow" >&5
 $as_echo "$pgac_cv__builtin_op_overflow" >&6; }

--- a/configure
+++ b/configure
@@ -17627,8 +17627,10 @@ else
 int
 main ()
 {
+PG_INT64_TYPE a = 1;
+PG_INT64_TYPE b = 1;
 PG_INT64_TYPE result;
-__builtin_mul_overflow((PG_INT64_TYPE) 1, (PG_INT64_TYPE) 2, &result);
+__builtin_mul_overflow(*(volatile PG_INT64_TYPE *) a, *(volatile PG_INT64_TYPE *) b, &result);
 
   ;
   return 0;

--- a/configure
+++ b/configure
@@ -17624,14 +17624,15 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-int
-main ()
-{
 PG_INT64_TYPE a = 1;
 PG_INT64_TYPE b = 1;
 PG_INT64_TYPE result;
-__builtin_mul_overflow(*(volatile PG_INT64_TYPE *) a, *(volatile PG_INT64_TYPE *) b, &result);
+int oflo;
 
+int
+main ()
+{
+oflo = __builtin_mul_overflow(a, b, &result);
   ;
   return 0;
 }


### PR DESCRIPTION
Commit 1ca5486573e414aa611ec5fd55a57590b85bf7f0 added support of using builtin functions:
```
__builtin_add_overflow
__builtin_sub_overflow
__builtin_mul_overflow
```
Check for existing these functions was added to the `configure` script. But it did not work, because `gcc` printed warning instead of error and returned success code. To the `confdefs.h` macro `#define HAVE__BUILTIN_OP_OVERFLOW 1` was printed and at the `make` step compiler tried to build sources with these builtin functions. It lead to errors: 
```
In file included from arrayfuncs.c:21:0:
../../../../src/include/common/int.h: In function 'pg_add_s16_overflow':
../../../../src/include/common/int.h:32:2: error: implicit declaration of function '__builtin_add_overflow' [-Werror=implicit-function-declaration]
 return __builtin_add_overflow(a, b, result);
 ^
./../../../src/include/common/int.h: In function 'pg_sub_s16_overflow':
../../../../src/include/common/int.h:52:2: error: implicit declaration of function '__builtin_sub_overflow' [-Werror=implicit-function-declaration]
return __builtin_sub_overflow(a, b, result);
^
../../../../src/include/common/int.h: In function 'pg_mul_s16_overflow':
../../../../src/include/common/int.h:72:2: error: implicit declaration of function '__builtin_mul_overflow' [-Werror=implicit-function-declaration]
return __builtin_mul_overflow(a, b, result);
^
cc1: some warnings being treated as errors
make[5]: *** [arrayfuncs.o] Error 1
make[5]: *** Waiting for unfinished jobs....
make[4]: *** [adt-recursive] Error 2
make[3]: *** [utils-recursive] Error 2
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [install-backend-recurse] Error 2
make[1]: *** [install-src-recurse] Error 2
make: *** [dist] Error 2
ERROR: process "/bin/sh -c bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash" did not complete successfully: exit code: 2
```

At PostgreSQL there are commits, which fix the problem. These commits change `AC_COMPILE_IFELSE` to `AC_LINK_IFELSE` for the test program at the `configure` script, which should check for existing builtin functions.

This patch cherry-picks three commits from postgres:
commit 85abb5b297c5b318738f09345ae226f780b88e92
commit c04d35f442a8c4fd5a20103b31839ec52fce3046
commit c6d21d56f1a92b4762a22cbbb694b1e853165e70

DO not squash it.

##

Error at the unit test will be fixed at the other PR. This PR fixes problem at the `configure` script. It means, that only building should be success. It was checked at the [pipeline](https://gitlab.adsw.io/arenadata/github_mirroring/gpdb/-/jobs/1455592#L3485).