### PR TITLE
Change URL for submodule pgbouncer (#959)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "gpAux/extensions/pgbouncer/source"]
 	path = gpAux/extensions/pgbouncer/source
-	url = https://github.com/greenplum-db/pgbouncer.git
+	url = https://github.com/greenplum-db/pgbouncer-archive.git
 [submodule "gpcontrib/gpcloud/test/googletest"]
 	path = gpcontrib/gpcloud/test/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Change URL for submodule pgbouncer

Opensource project pgbouncer was renamed to pgbouncer-archive. Old URL is
unavailable. URL was changed according to new name of pgbouncer.

(cherry picked from commit 28bcd04f8614d7ce6f0c75037d9818bfc250de3f)