### PR TITLE
Add datadir path to gpsegconfig_dump at cdb dispatcher test

### DIFF
--- a/src/backend/cdb/dispatcher/test/gpsegconfig_dump
+++ b/src/backend/cdb/dispatcher/test/gpsegconfig_dump
@@ -1,4 +1,4 @@
-1 -1 p p n u 6000 localhost localhost
-2 0 p p n u 6002 localhost localhost
-3 1 p p n u 6003 localhost localhost
-4 2 p p n u 6004 localhost localhost
+1 -1 p p n u 6000 localhost localhost /tmp/datadir
+2 0 p p n u 6002 localhost localhost /tmp/datadir
+3 1 p p n u 6003 localhost localhost /tmp/datadir
+4 2 p p n u 6004 localhost localhost /tmp/datadir


### PR DESCRIPTION
Add datadir path to gpsegconfig_dump at cdb dispatcher test

At commit 0cb79ba49c7c8106942e81be7aad0b2877f6f0a3 dumping datadir was added
support to include datadir in segment configuration dump. At the unit test
the gpsegconfig_dump was changed according to this commit.

This patch adds datadir path to each segment configuration at the
gpsegconfig_dump file.
