### PR TITLE
Show planner error for SELECT INTO with DML in CTE

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1205,9 +1205,7 @@ cdbllize_build_slice_table(PlannerInfo *root, Plan *top_plan,
 	}
 
 	/*
-	 * If none of the slices require dispatching, we can run everything in one
-	 * slice. Also check in the same loop if we have more than one writing
-	 * gang, which is not yet supported.
+	 * If none of the slices require dispatching, we can run everything in one slice.
 	 */
 	all_root_slices = true;
 	foreach (lc, cxt.slices)

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1276,7 +1276,7 @@ build_slice_table_walker(Node *node, build_slice_table_context *context)
 		{
 			bool		result;
 			int			save_currentSliceIndex;
-			int			save_writingSliceCount;
+			int			save_writingSliceCount = 0;
 
 			context->seen_subplans = bms_add_member(context->seen_subplans, plan_id);
 

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2869,4 +2869,160 @@ select count(*) from cte2 a join cte2 b on a.i=b.i;
      5
 (1 row)
 
+-- Test SELECT INTO and CTAS with modifying CTE
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+-- A bit more complex case with nested CTEs and LIMIT to test a plan
+-- with different types of gangs (reader, singleton reader and writers)
+explain (costs off)
+with cte as
+(
+    with inner_cte as
+    (
+        select j from with_dml limit 1
+    ) delete from with_dml where with_dml.i in (select * from inner_cte)
+    returning *
+) select * into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+-- Test queries with modifying CTE not referenced from the query
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
 drop table with_dml;

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -3025,4 +3025,29 @@ create table t_new as
  Optimizer: Postgres-based planner
 (4 rows)
 
+-- Test if second writer slice is in the InitPlan
+explain (costs off)
+create table t_new as
+with cte1 as
+(
+	insert into with_dml values(1, 1) returning *
+),
+cte2 as
+(
+	select * from unnest(array(select cte1.i from cte1))
+) select * from cte2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: unnest.unnest
+   ->  Function Scan on unnest
+         InitPlan 1 (returns $1)  (slice2)
+           ->  Gather Motion 1:1  (slice3; segments: 1)
+                 ->  Subquery Scan on cte1
+                       ->  Shared Scan (share slice:id 3:0)
+                             ->  Insert on with_dml
+                                   ->  Result
+ Optimizer: Postgres-based planner
+(10 rows)
+
 drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -3034,4 +3034,29 @@ create table t_new as
  Optimizer: Postgres-based planner
 (4 rows)
 
+-- Test if second writer slice is in the InitPlan
+explain (costs off)
+create table t_new as
+with cte1 as
+(
+	insert into with_dml values(1, 1) returning *
+),
+cte2 as
+(
+	select * from unnest(array(select cte1.i from cte1))
+) select * from cte2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: unnest.unnest
+   ->  Function Scan on unnest
+         InitPlan 1 (returns $1)  (slice2)
+           ->  Gather Motion 1:1  (slice3; segments: 1)
+                 ->  Subquery Scan on cte1
+                       ->  Shared Scan (share slice:id 3:0)
+                             ->  Insert on with_dml
+                                   ->  Result
+ Optimizer: Postgres-based planner
+(10 rows)
+
 drop table with_dml;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2878,4 +2878,160 @@ select count(*) from cte2 a join cte2 b on a.i=b.i;
      5
 (1 row)
 
+-- Test SELECT INTO and CTAS with modifying CTE
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from cte
+);
+ERROR:  cannot create plan with several writing gangs
+-- A bit more complex case with nested CTEs and LIMIT to test a plan
+-- with different types of gangs (reader, singleton reader and writers)
+explain (costs off)
+with cte as
+(
+    with inner_cte as
+    (
+        select j from with_dml limit 1
+    ) delete from with_dml where with_dml.i in (select * from inner_cte)
+    returning *
+) select * into t_new from cte;
+ERROR:  cannot create plan with several writing gangs
+-- Test queries with modifying CTE not referenced from the query
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   ->  Subquery Scan on t
+         ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 1:3  (slice1; segments: 1)
+   Hash Key: i.i
+   ->  Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(4 rows)
+
 drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -680,4 +680,118 @@ with cte as (
 ), cte2 as (select * from cte)
 select count(*) from cte2 a join cte2 b on a.i=b.i;
 
+-- Test SELECT INTO and CTAS with modifying CTE
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from cte;
+
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from cte;
+
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from cte;
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from cte
+);
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from cte
+);
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from cte
+);
+
+-- A bit more complex case with nested CTEs and LIMIT to test a plan
+-- with different types of gangs (reader, singleton reader and writers)
+explain (costs off)
+with cte as
+(
+    with inner_cte as
+    (
+        select j from with_dml limit 1
+    ) delete from with_dml where with_dml.i in (select * from inner_cte)
+    returning *
+) select * into t_new from cte;
+
+-- Test queries with modifying CTE not referenced from the query
+explain (costs off)
+with cte as (
+    insert into with_dml select i, i * 100 from generate_series(1, 5) i
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+
+explain (costs off)
+with cte as
+(
+    update with_dml set j = j + 1
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+
+explain (costs off)
+with cte as
+(
+    delete from with_dml where i > 0
+    returning *
+) select into t_new from (select i, i * 100 from generate_series(1, 5) i) t;
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        insert into with_dml select i, i * 100 from generate_series(1, 5) i
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        update with_dml set j = j + 1
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+
+explain (costs off)
+create table t_new as
+(
+    with cte as
+    (
+        delete from with_dml where i > 0
+        returning *
+    ) select * from (select i, i * 100 from generate_series(1, 5) i) t
+);
+
 drop table with_dml;

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -794,4 +794,16 @@ create table t_new as
     ) select * from (select i, i * 100 from generate_series(1, 5) i) t
 );
 
+-- Test if second writer slice is in the InitPlan
+explain (costs off)
+create table t_new as
+with cte1 as
+(
+	insert into with_dml values(1, 1) returning *
+),
+cte2 as
+(
+	select * from unnest(array(select cte1.i from cte1))
+) select * from cte2;
+
 drop table with_dml;


### PR DESCRIPTION
Show planner error for SELECT INTO with DML in CTE

Problem:
Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
queries contain modifying CTEs, because Greenplum cannot have two writer
segworker groups for one query. In current implementation all the plans with
modifying CTE contain motion nodes, which separate slice with DML operation
from the slice, where the new table is created. And during execution stage an
error is thrown, telling that node with DML operation cannot be executed,
because one writer segworker already exists. However, showing the error during
planning stage would be more effective, therefore this commit proposes the
display of the error during planning.

This commit counts the number of writing slices during the plan tree traversal.
If there are more than one writing gang, it throws an error. In case writing
slice is found in the InitPlan, it is counted separately, as InitPlans are
executed independently.

Tests are partially taken from commit: cc2e30f85ef9bc4980c4ec64dedfb1a0ac698ffb

Co-authored-by: Alexander Kondakov <a.kondakov@arenadata.io>