### PR TITLE
Replace gpdb-specific dbid detection in the pg_rewind

### DIFF
--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -30,7 +30,8 @@ REGRESS = basictest extrafiles databases pg_xlog_symlink unclean_shutdown \
 	simple_no_rewind_required ao_rewind bitmaptest \
 	tablespaces_objects_created_before_promotion \
 	tablespaces_objects_created_after_promotion \
-	tablespaces_objects_removed_after_promotion
+	tablespaces_objects_removed_after_promotion \
+	empty_conf
 REGRESS_OPTS=--init-file=./regress_init_file --use-existing --launcher=./launcher
 
 all: pg_rewind

--- a/src/bin/pg_rewind/expected/empty_conf.out
+++ b/src/bin/pg_rewind/expected/empty_conf.out
@@ -1,0 +1,13 @@
+Master initialized.
+Master running.
+Standby initialized and running.
+Standby promoted.
+Running pg_rewind...
+Old master restarted after rewind.
+SELECT state FROM pg_stat_replication;
+   state   
+-----------
+ streaming
+(1 row)
+
+Master promoted.

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -21,6 +21,7 @@
 
 #include "access/timeline.h"
 #include "access/xlog_internal.h"
+#include "catalog/catalog.h"
 #include "catalog/catversion.h"
 #include "catalog/pg_control.h"
 #include "getopt_long.h"
@@ -911,8 +912,8 @@ get_target_dbid(const char *argv0)
 					 "Check your installation.\n", full_path, progname);
 	}
 
-	snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -C gp_dbid",
-			 exec_path, datadir_target);
+	snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -C gp_dbid -c config_file=\"%s/%s\"",
+			 exec_path, datadir_target, datadir_target, GP_INTERNAL_AUTO_CONF_FILE_NAME);
 
 	if ((output = popen(cmd, "r")) == NULL ||
 		fgets(cmd_output, sizeof(cmd_output), output) == NULL)

--- a/src/bin/pg_rewind/sql/empty_conf.sql
+++ b/src/bin/pg_rewind/sql/empty_conf.sql
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This file has the .sql extension, but it is actually launched as a shell
+# script. This contortion is necessary because pg_regress normally uses
+# psql to run the input scripts, and requires them to have the .sql
+# extension, but we use a custom launcher script that runs the scripts using
+# a shell instead.
+
+TESTNAME=empty_conf
+
+. sql/config_test.sh
+
+# pg_rewind should handle empty (or even removed) postgres.conf
+# gp_dbid is taken from internal.auto.conf
+function after_promotion
+{
+cp $TEST_MASTER/postgresql.conf $TESTROOT/master-postgresql-full.conf.tmp
+echo "" > $TEST_MASTER/postgresql.conf
+}
+
+# Move postgresql.conf back and start master instance
+# pg_rewind is already finished
+function before_master_restart_after_rewind
+{
+mv $TESTROOT/master-postgresql-full.conf.tmp $TEST_MASTER/postgresql.conf
+}
+
+# Run the test
+. sql/run_test.sh


### PR DESCRIPTION
Replace gpdb-specific dbid detection in the pg_rewind

pg_rewind util has gpdb-specific [logic](https://github.com/arenadata/gpdb/blob/eeee4d43b7179a69cd7ea4234736d214d4dffaf7/src/bin/pg_rewind/pg_rewind.c#L253) to detect current dbid. It [runs](https://github.com/arenadata/gpdb/blob/eeee4d43b7179a69cd7ea4234736d214d4dffaf7/src/bin/pg_rewind/pg_rewind.c#L914)
`postgres` which parses `postgresql.conf` and all included `.conf` files. Among
others, this file includes `internal.auto.conf` file which contains gp_dbid
parameter. There is no need to parse the whole `postgresql.conf` to get just
gp_dbid. More, this file may be zeroed by unsuccessful pg_rewind sync or may be
moved somewhere. The only needed file to run specific logic is
`internal.auto.conf`, which is [not synced](https://github.com/arenadata/gpdb/blob/eeee4d43b7179a69cd7ea4234736d214d4dffaf7/src/bin/pg_rewind/filemap.c#L117), so the solution is to pass it as
config to `postgres`.
New test file was created to show solution works when `postgresql.conf` is
zeroed.