### PR TITLE
Update instructions for installing dependencies for Ubuntu 20.04 or 22.04

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -152,3 +152,8 @@ To do this, go to [the next step of the main instructions](README.md#xerces).
     ```bash
     sudo ldconfig
     ```
+
+7. Make sure that you download yaml and psutil as submodules. To do this, use git clone --recurse-submodules when downloading the source code. If you want to update the submodules, run:
+    ```bash
+    git submodule update --init --recursive --force
+    ```

--- a/README.linux.md
+++ b/README.linux.md
@@ -57,7 +57,7 @@
     ./README.CentOS.bash
     ```
 
-## For Ubuntu (versions 20.04 or newer):
+## For Ubuntu (versions 20.04 or 22.04):
 
 - Install dependencies using README.ubuntu.bash script:
   ```bash

--- a/README.linux.md
+++ b/README.linux.md
@@ -70,6 +70,11 @@
   sudo ln -s python2 /usr/bin/python
   ```
 
+- Ensure that your system supports American English with an internationally compatible character encoding scheme. To do this, run:
+  ```bash
+  sudo locale-gen "en_US.UTF-8"
+  ```
+  
 - Optionally, installing Kerberos may be required to configure secure access to GPDB. To install Kerberos, run:
   ```bash
   sudo apt-get install -y krb5-kdc krb5-admin-server

--- a/README.linux.md
+++ b/README.linux.md
@@ -158,7 +158,7 @@ To do this, go to [the next step of the main instructions](README.md#xerces).
     sudo ldconfig
     ```
 
-7. Make sure that you download yaml and psutil as submodules. To do this, use git clone --recurse-submodules when downloading the source code. If you want to update the submodules, run:
+7. Make sure that you download yaml and psutil as submodules. To do this, use `git clone --recurse-submodules` when downloading the source code. If you want to update the submodules, run:
     ```bash
     git submodule update --init --recursive --force
     ```

--- a/README.linux.md
+++ b/README.linux.md
@@ -57,30 +57,20 @@
     ./README.CentOS.bash
     ```
 
-## For Ubuntu:
+## For Ubuntu (versions 20.04 or newer):
 
-- Install Dependencies
-  When you run the README.ubuntu.bash script for dependencies, you will be asked to configure realm for kerberos.
-  You can enter any realm, since this is just for testing, and during testing, it will reconfigure a local server/client.
-  If you want to skip this manual configuration, use:
-  `export DEBIAN_FRONTEND=noninteractive`
-
+- Install dependencies using README.ubuntu.bash script:
   ```bash
   ./README.ubuntu.bash
   ```
 
-- If you want to use gcc-6 and g++-6:
+- Create symbolic linc to Python 2 in `/usr/bin`:
 
   ```bash
-  add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  apt-get update
-  apt-get install -y gcc-6 g++-6
+  sudo ln -s python2 /usr/bin/python
   ```
 
 ## Common Platform Tasks:
-
-Make sure that you add `/usr/local/lib` to `/etc/ld.so.conf`,
-then run command `ldconfig`.
 
 1. Create gpadmin and setup ssh keys
 
@@ -148,3 +138,12 @@ then run command `ldconfig`.
 
     EOF'
     ```
+4. Make sure that you add `/usr/local/lib` to `/etc/ld.so.conf`, then run:
+    ```bash
+    sudo ldconfig
+    ```
+5. Install the **correct** version of the Xerces-C++ library. 
+To do this, go to [the next step of the main instructions](README.md#xerces).
+
+
+

--- a/README.linux.md
+++ b/README.linux.md
@@ -122,28 +122,25 @@
     net.core.rmem_max = 2097152
     net.core.wmem_max = 2097152
     vm.overcommit_memory = 2
-
     EOF'
+    sudo sysctl -p # Apply settings
+    ```      
 
+4. Change user and system limits:
+    ```bash
     sudo bash -c 'cat >> /etc/security/limits.conf <<-EOF
     * soft nofile 65536
     * hard nofile 65536
     * soft nproc 131072
     * hard nproc 131072
-
     EOF'
-
-    sudo bash -c 'cat >> /etc/ld.so.conf <<-EOF
-    /usr/local/lib
-
-    EOF'
+    su - $USER # Apply settings
     ```
-4. Make sure that you add `/usr/local/lib` to `/etc/ld.so.conf`, then run:
-    ```bash
-    sudo ldconfig
-    ```
+
 5. Install the **correct** version of the Xerces-C++ library. 
 To do this, go to [the next step of the main instructions](README.md#xerces).
 
-
-
+6. Update the library cache:
+    ```bash
+    sudo ldconfig
+    ```

--- a/README.linux.md
+++ b/README.linux.md
@@ -64,7 +64,7 @@
   ./README.ubuntu.bash
   ```
 
-- Create symbolic linc to Python 2 in `/usr/bin`:
+- Create symbolic link to Python 2 in `/usr/bin`:
 
   ```bash
   sudo ln -s python2 /usr/bin/python

--- a/README.linux.md
+++ b/README.linux.md
@@ -70,6 +70,14 @@
   sudo ln -s python2 /usr/bin/python
   ```
 
+- Optionally, installing Kerberos may be required to configure secure access to GPDB. To install Kerberos, run:
+  ```bash
+  sudo apt-get install -y krb5-kdc krb5-admin-server
+  ```
+  Note: You will be asked to configure realm for Kerberos. You can enter any realm, since this is just for testing,
+  and during testing, it will reconfigure a local server/client. If you want to skip this manual configuration, use:
+  `export DEBIAN_FRONTEND=noninteractive`
+
 ## Common Platform Tasks:
 
 1. Create gpadmin and setup ssh keys

--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ Follow [appropriate linux steps](README.linux.md) for getting your system ready 
 ## xerces
 
 ORCA requires xerces 3.1 or gp-xerces. For the most up-to-date way of
-building gp-xerces, see the README at the following repository:
-
-* https://github.com/greenplum-db/gp-xerces
+building gp-xerces, see the README in [this repository](https://github.com/arenadata/gp-xerces).
 
 ### Build the database
 

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -9,6 +9,7 @@ sudo apt-get install -y \
   g++ \
   gcc \
   git \
+  iputils-ping \
   libapr1-dev \
   libbz2-dev \
   libcurl4-openssl-dev \
@@ -20,6 +21,7 @@ sudo apt-get install -y \
   libxml2-dev \
   libyaml-dev \
   libzstd-dev \
+  locales \
   net-tools \
   openssh-client \
   openssh-server \

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -1,42 +1,28 @@
 #!/bin/bash
 
-apt-get update
-apt-get install -y \
+sudo apt-get update
+sudo apt-get install -y \
   bison \
-  ccache \
   cmake \
   curl \
   flex \
-  git-core \
-  gcc \
   g++ \
-  inetutils-ping \
-  krb5-kdc \
-  krb5-admin-server \
+  gcc \
+  git \
   libapr1-dev \
   libbz2-dev \
-  libcurl4-gnutls-dev \
+  libcurl4-openssl-dev \
   libevent-dev \
   libkrb5-dev \
-  libpam-dev \
   libperl-dev \
   libreadline-dev \
   libssl-dev \
   libxml2-dev \
   libyaml-dev \
   libzstd-dev \
-  locales \
   net-tools \
-  ninja-build \
   openssh-client \
   openssh-server \
-  openssl \
-  python-dev \
-  python-pip \
-  python-psutil \
-  python-yaml \
+  python2 \
+  python2-dev \
   zlib1g-dev
-
-
-pip install conan
-


### PR DESCRIPTION
Add support for Ubuntu version 20.04 or 22.04. List of changes:

- Update installing dependencies.
- Create a symbolic link to Python 2.
- Update some common platform steps.
- Fix a broken link to xerces library in README.md.

The correctness check was performed on a clean versions 20.04 and 22.04 of Ubuntu.