### PR TITLE
ADBDEV-5773 Row marks list contains links to not-existent RTE

### DIFF
--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2355,6 +2355,53 @@ UNION ALL
  c      | 1
 (7 rows)
 
+--start_ignore
+DROP TABLE IF EXISTS es1;
+NOTICE:  table "es1" does not exist, skipping
+DROP TABLE IF EXISTS es2;
+NOTICE:  table "es2" does not exist, skipping
+--end_ignore
+CREATE TABLE es1 (i INT) DISTRIBUTED BY(i);
+CREATE TABLE es2 (i INT) DISTRIBUTED BY(i);
+SET gp_cte_sharing = ON;
+WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+ i | i 
+---+---
+(0 rows)
+
+EXPLAIN (VERBOSE ON, COSTS OFF) WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: share0_ref1.i, share0_ref1.i_1
+   ->  Append
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.i, share0_ref1.i_1
+               ->  Update on public.es1
+                     Output: es1.i, es2.i
+                     ->  Hash Join
+                           Output: es1.i, es1.ctid, es1.gp_segment_id, es2.ctid, es2.i
+                           Hash Cond: (es1.i = es2.i)
+                           ->  Seq Scan on public.es1
+                                 Output: es1.i, es1.ctid, es1.gp_segment_id
+                           ->  Hash
+                                 Output: es2.ctid, es2.i
+                                 ->  Seq Scan on public.es2
+                                       Output: es2.ctid, es2.i
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref2.i, share0_ref2.i_1
+ Optimizer: Postgres-based planner
+ Settings: gp_cte_sharing = 'on', optimizer = 'off'
+(20 rows)
+
+DROP TABLE es1;
+DROP TABLE es2;
 -- Test forced materialization (sharing) of CTEs with non-SELECT DML inside.
 create table with_dml (i int, j int) distributed by (i);
 explain (costs off)

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2364,6 +2364,53 @@ UNION ALL
  c      | 1
 (7 rows)
 
+--start_ignore
+DROP TABLE IF EXISTS es1;
+NOTICE:  table "es1" does not exist, skipping
+DROP TABLE IF EXISTS es2;
+NOTICE:  table "es2" does not exist, skipping
+--end_ignore
+CREATE TABLE es1 (i INT) DISTRIBUTED BY(i);
+CREATE TABLE es2 (i INT) DISTRIBUTED BY(i);
+SET gp_cte_sharing = ON;
+WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+ i | i 
+---+---
+(0 rows)
+
+EXPLAIN (VERBOSE ON, COSTS OFF) WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: share0_ref1.i, share0_ref1.i_1
+   ->  Append
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.i, share0_ref1.i_1
+               ->  Update on public.es1
+                     Output: es1.i, es2.i
+                     ->  Hash Join
+                           Output: es1.i, es1.ctid, es1.gp_segment_id, es2.ctid, es2.i
+                           Hash Cond: (es1.i = es2.i)
+                           ->  Seq Scan on public.es1
+                                 Output: es1.i, es1.ctid, es1.gp_segment_id
+                           ->  Hash
+                                 Output: es2.ctid, es2.i
+                                 ->  Seq Scan on public.es2
+                                       Output: es2.ctid, es2.i
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref2.i, share0_ref2.i_1
+ Optimizer: Postgres-based planner
+ Settings: gp_cte_sharing = 'on'
+(20 rows)
+
+DROP TABLE es1;
+DROP TABLE es2;
 -- Test forced materialization (sharing) of CTEs with non-SELECT DML inside.
 create table with_dml (i int, j int) distributed by (i);
 explain (costs off)

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -462,6 +462,27 @@ UNION ALL
 UNION ALL
   SELECT 'c', j FROM cte;
 
+--start_ignore
+DROP TABLE IF EXISTS es1;
+DROP TABLE IF EXISTS es2;
+--end_ignore
+
+CREATE TABLE es1 (i INT) DISTRIBUTED BY(i);
+CREATE TABLE es2 (i INT) DISTRIBUTED BY(i);
+SET gp_cte_sharing = ON;
+WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+
+EXPLAIN (VERBOSE ON, COSTS OFF) WITH cte AS (
+	UPDATE es1 SET i = es1.i FROM es2 WHERE es2.i = es1.i RETURNING *
+)
+SELECT * FROM cte UNION ALL SELECT * FROM cte;
+
+DROP TABLE es1;
+DROP TABLE es2;
+
 -- Test forced materialization (sharing) of CTEs with non-SELECT DML inside.
 --start_ignore
 drop table if exists with_dml;


### PR DESCRIPTION
Fix RowMarks adjustments for shared CTEs

When executing query with shared CTE containing UPDATE/DELETE operations
planner wrongly adjusted PlanRowMark entries inside the set_plan_references().
Because CTE was shared the adjustment was performed twice (in case of 2 cte
references), however at the second time the final rte indexes were modified
with wrong offset. This happend because entries of root->rowMarks for f.e.
ModifyTable node were modified between these 2 adjustments in shared CTE. As the
result the executor could access a list element by wrong index. That led to
assertion or execution errors.

This patch protects PlanRowMarks from being adjusted more than one time by
adding a rowmark_list_has_rowmark() function, which checks whether the
PlanRowMark has already been processed.