### PR TITLE
ADBDEV-5897: Fix ABI tests

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -19,6 +19,7 @@ on:
       - '.github/workflows/**'
       - '.github/scripts/**'
       - '.abi-check/**'
+
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -21,6 +21,7 @@ on:
       - '.abi-check/**'
 
 env:
+  # workaround required for checkout@v3, https://github.com/actions/checkout/issues/1590
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   abi-dump-setup:

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -19,7 +19,8 @@ on:
       - '.github/workflows/**'
       - '.github/scripts/**'
       - '.abi-check/**'
-
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   abi-dump-setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix ABI tests

GitHub actions/checkout@v3 is no longer working and v4 is incompatible with
older Linux versions due to https://github.com/actions/checkout/issues/1590.

This patch uses workaround.

---

Variable ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION is defined [here](https://github.com/actions/runner/blob/70746ff593636b07ad251a1525a3fabd1a7a36e9/src/Runner.Common/Constants.cs#L257) and used [here](https://github.com/actions/runner/blob/70746ff593636b07ad251a1525a3fabd1a7a36e9/src/Runner.Worker/Handlers/HandlerFactory.cs#L94-L124). This code adds warning when pointed variable not set.