### PR TITLE
Fix yum repos for CentOS 7 (#981)

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -20,6 +20,9 @@ on:
       - '.github/scripts/**'
       - '.abi-check/**'
 
+env:
+  # workaround required for checkout@v3, https://github.com/actions/checkout/issues/1590
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   abi-dump-setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -84,6 +84,9 @@ jobs:
           tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
           cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
           which ctags
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
           yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
           yum install -y git
 
@@ -155,6 +158,9 @@ jobs:
 
       - name: Install abi-compliance-checker and report viewer (lynx)
         run: |
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
           yum install -y epel-release
           yum install -y abi-compliance-checker
           yum install -y lynx

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -2,10 +2,22 @@ FROM centos:centos7 as base
 
 ARG sigar=https://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-1.6.5-1056.git2932df5.el7.x86_64.rpm
 ARG sigar_headers=http://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-headers-1.6.5-1056.git2932df5.el7.x86_64.rpm
+ARG CENTOS_REPOS_URL="https://mirror.axelname.ru/centos"
+ARG CENTOS_REPO_EPEL_URL="https://mirror.yandex.ru/epel"
 
 # Reinstall glibc-common. This is necessary to get langpacks in docker
 # because docker images don't contain them.
-RUN sed -i 's/\(override_install_langs*\)/# \1/' /etc/yum.conf && \
+# Change URL for repos, because Centos 7 EOL 30.06.2024
+RUN if [[ "x86_64" == "$(uname -i)" ]]; then \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+    else \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
+    fi &&\
+    sed -i 's/\(override_install_langs*\)/# \1/' /etc/yum.conf && \
     yum -y reinstall glibc-common && \
 	yum clean all
 
@@ -51,6 +63,14 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
 
 # newer version of gcc and run environment for gpdb
 RUN yum -y install centos-release-scl && \
+    if [[ "x86_64" == "$(uname -i)" ]]; then \
+       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
+    else \
+       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
+    fi && \
+    sed -i "s|metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-7\&arch=\$basearch|baseurl=$CENTOS_REPO_EPEL_URL/\$releasever/\$basearch|g" /etc/yum.repos.d/epel.repo && \
     yum -y install --nogpgcheck devtoolset-7-gcc devtoolset-7-gcc-c++ && yum clean all && \
     pip --no-cache-dir install psi && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake && \


### PR DESCRIPTION
Fix yum repos for CentOS 7

CentOS Linux 7 reached end of life (EOL) on June 30, 2024. Default servers for
yum repos were disabled. This patch changes URLs at yum's configuration files.

(cherry picked from commit 93b64feaf0c71a2f92cf701cc99e7e72c58e5ed3)

##

Fix ABI tests (#986)
    
GitHub actions/checkout@v3 is no longer working and v4 is incompatible with
older Linux versions due to https://github.com/actions/checkout/issues/1590.
    
 This patch uses workaround. The ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION variable
is defined [here](https://github.com/actions/runner/blob/70746ff593636b07ad251a1525a3fabd1a7a36e9/src/Runner.Common/Constants.cs#L257)
and used [here](https://github.com/actions/runner/blob/70746ff593636b07ad251a1525a3fabd1a7a36e9/src/Runner.Worker/Handlers/HandlerFactory.cs#L94-L124).
A warning is added when the variable is not set.
    
(cherry picked from commit 4b34d83358d174ce278df50776437dfb07ffcd42)
