### PR TITLE
Replace gpdb-specific dbid detection in the pg_rewind

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -20,6 +20,7 @@
 
 #include "access/timeline.h"
 #include "access/xlog_internal.h"
+#include "catalog/catalog.h"
 #include "catalog/catversion.h"
 #include "catalog/pg_control.h"
 #include "common/controldata_utils.h"
@@ -1013,8 +1014,8 @@ get_target_dbid(const char *argv0)
 					 "Check your installation.\n", full_path, progname);
 	}
 
-	snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -C gp_dbid",
-			 exec_path, datadir_target);
+	snprintf(cmd, MAXCMDLEN, "\"%s\" -D \"%s\" -C gp_dbid -c config_file=\"%s/%s\"",
+			 exec_path, datadir_target, datadir_target, GP_INTERNAL_AUTO_CONF_FILE_NAME);
 
 	if ((output = popen(cmd, "r")) == NULL ||
 		fgets(cmd_output, sizeof(cmd_output), output) == NULL)

--- a/src/bin/pg_rewind/t/107_empty_conf.pl
+++ b/src/bin/pg_rewind/t/107_empty_conf.pl
@@ -28,7 +28,6 @@ sub run_test
 		"$tmp_folder/master-postgresql-full.conf.tmp");
 
 	open my $file, '>', "$master_pgdata/postgresql.conf";
-	print $file "";
 
 	RewindTest::run_pg_rewind($test_mode, do_not_start_master => 1);
 
@@ -40,7 +39,6 @@ sub run_test
 	RewindTest::promote_master();
 
 	RewindTest::clean_rewind_test();
-	return;
 }
 
 # Run the test in both modes

--- a/src/bin/pg_rewind/t/107_empty_conf.pl
+++ b/src/bin/pg_rewind/t/107_empty_conf.pl
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use TestLib;
+use Test::More tests => 3;
+
+use FindBin;
+use lib $FindBin::RealBin;
+use File::Copy;
+
+use RewindTest;
+
+sub run_test
+{
+	my $test_mode     = shift;
+
+	RewindTest::setup_cluster($test_mode);
+	RewindTest::start_master();
+	RewindTest::create_standby($test_mode);
+	RewindTest::promote_standby(1);
+
+	my $master_pgdata = $node_master->data_dir();
+	my $tmp_folder    = TestLib::tempdir;
+
+	# pg_rewind should handle empty (or even removed) postgres.conf
+	# gp_dbid is taken from internal.auto.conf
+	copy(
+		"$master_pgdata/postgresql.conf",
+		"$tmp_folder/master-postgresql-full.conf.tmp");
+
+	open my $file, '>', "$master_pgdata/postgresql.conf";
+	print $file "";
+
+	RewindTest::run_pg_rewind($test_mode, do_not_start_master => 1);
+
+	copy(
+		"$tmp_folder/master-postgresql-full.conf.tmp",
+		"$master_pgdata/postgresql.conf");
+
+	$node_master->start;
+	RewindTest::promote_master();
+
+	RewindTest::clean_rewind_test();
+	return;
+}
+
+# Run the test in both modes
+run_test('local');
+run_test('remote');
+
+exit(0);


### PR DESCRIPTION
Replace gpdb-specific dbid detection in the pg_rewind

pg_rewind util has gpdb-specific logic to detect current dbid. It runs
`postgres` which parses `postgresql.conf` and all included `.conf` files. Among
others, this file includes `internal.auto.conf` file which contains gp_dbid
parameter. There is no need to parse the whole `postgresql.conf` to get just
gp_dbid. More, this file may be zeroed by unsuccessful pg_rewind sync or may be
moved somewhere. The only needed file to run specific logic is
`internal.auto.conf`, which is not synced, so the solution is to pass it as
config to `postgres`.
New test file was created to show solution works when `postgresql.conf` is
zeroed.

Test was changed, because all tests were rewritten to Perl.

(cherry picked from commit b20df8a482cfe1075948102db5643535bc8007d7)
