### PR TITLE
Fix gpcopy's regression test

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1478,7 +1478,7 @@ abort;
 
 -- start_ignore
 create language plpythonu;
--- end_ingore
+-- end_ignore
 
 create function get_file_lines_12700(segid int) returns int
 as

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1810,7 +1810,7 @@ copy t_12700 from '/tmp/out_12700_<SEGID>' on segment;
 abort;
 -- start_ignore
 create language plpythonu;
--- end_ingore
+-- end_ignore
 create function get_file_lines_12700(segid int) returns int
 as
 $$


### PR DESCRIPTION
Fix gpcopy's regression test

Test passed when query generated unexpected output.
There was a typo on the "--end_ignore" line, which led to ignoring diff after
this line.