### PR TITLE
Flaky appendonly test

### DIFF
--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -848,15 +848,15 @@ drop table test_reporting_c;
 
 -- Test AO functions with execution location on dispatcher.
 -- start_ignore
-drop table if exists t1;
-drop table if exists t2;
+drop table if exists t1_ao_comp_rate;
+drop table if exists t2_ao_comp_rate;
 drop table if exists tables_list;
 -- end_ignore
 
-create table t1 (a int) with (appendoptimized=true, orientation=row);
-create table t2 (a int) with (appendoptimized=true, orientation=column);
+create table t1_ao_comp_rate (a int) with (appendoptimized=true, orientation=row);
+create table t2_ao_comp_rate (a int) with (appendoptimized=true, orientation=column);
 create table tables_list (tname text);
-insert into tables_list values ('t1'), ('t2');
+insert into tables_list values ('t1_ao_comp_rate'), ('t2_ao_comp_rate');
 
 -- Queries below should fail with a proper error message.
 select get_ao_compression_ratio(tname) from tables_list;
@@ -871,6 +871,6 @@ explain (costs off) select get_ao_compression_ratio(tname) from
 select get_ao_compression_ratio(tname) from
 	unnest(array(select tname from tables_list)) as tname;
 
-drop table t1;
-drop table t2;
+drop table t1_ao_comp_rate;
+drop table t2_ao_comp_rate;
 drop table tables_list;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1777,10 +1777,10 @@ drop table test_reporting;
 drop table test_reporting_r;
 drop table test_reporting_c;
 -- Test AO functions with execution location on dispatcher.
-create table t1 (a int) with (appendoptimized=true, orientation=row);
-create table t2 (a int) with (appendoptimized=true, orientation=column);
+create table t1_ao_comp_rate (a int) with (appendoptimized=true, orientation=row);
+create table t2_ao_comp_rate (a int) with (appendoptimized=true, orientation=column);
 create table tables_list (tname text);
-insert into tables_list values ('t1'), ('t2');
+insert into tables_list values ('t1_ao_comp_rate'), ('t2_ao_comp_rate');
 -- Queries below should fail with a proper error message.
 select get_ao_compression_ratio(tname) from tables_list;
 ERROR:  function 'get_ao_compression_ratio' must be executed on the dispatcher
@@ -1809,6 +1809,6 @@ select get_ao_compression_ratio(tname) from
                        -1
 (2 rows)
 
-drop table t1;
-drop table t2;
+drop table t1_ao_comp_rate;
+drop table t2_ao_comp_rate;
 drop table tables_list;


### PR DESCRIPTION
Fix flaky test 'appendonly'

The test in the commit
https://github.com/arenadata/gpdb/commit/3dea58de92a9b040fe5ce194048a97f55bbdb71b 
appeared  to be flaky, because it used table names t1 and t2, which are already
used in another  running in the same parallel group.

This patch renames tables t1 and t2 to unique names in the test appendonly
