### PR TITLE
ADBDEV-5074: Disable MIN/MAX optimization for inner plans of lateral joins

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1699,12 +1699,13 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		 * from a bunch of conditions that can cause motion in the plan,
 		 * we can only gather it to singleQE and materialize the data because we
 		 * cannot pass params across motion.
+		 * We also set can_have_dependencies to disable other related optimizations.
 		 */
 		if ((!bms_is_empty(required_outer)) &&
 			check_query_for_possible_motion(subquery))
 		{
 			config->force_singleQE = true;
-			config->is_under_subplan = true;
+			config->can_have_dependencies = true;
 		}
 
 		rel->subplan = subquery_planner(root->glob, subquery,

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1700,11 +1700,11 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		 * we can only gather it to singleQE and materialize the data because we
 		 * cannot pass params across motion.
 		 */
-		if (!bms_is_empty(required_outer))
+		if ((!bms_is_empty(required_outer)) &&
+			check_query_for_possible_motion(subquery))
 		{
+			config->force_singleQE = true;
 			config->is_under_subplan = true;
-			if (check_query_for_possible_motion(subquery))
-				config->force_singleQE = true;
 		}
 
 		rel->subplan = subquery_planner(root->glob, subquery,

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1700,9 +1700,12 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		 * we can only gather it to singleQE and materialize the data because we
 		 * cannot pass params across motion.
 		 */
-		if ((!bms_is_empty(required_outer)) &&
-			check_query_for_possible_motion(subquery))
-			config->force_singleQE = true;
+		if (!bms_is_empty(required_outer))
+		{
+			config->is_under_subplan = true;
+			if (check_query_for_possible_motion(subquery))
+				config->force_singleQE = true;
+		}
 
 		rel->subplan = subquery_planner(root->glob, subquery,
 									root,

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -379,7 +379,7 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->honor_order_by = true;
 
-	c1->is_under_subplan = false;
+	c1->can_have_dependencies = false;
 
 	c1->force_singleQE = false;
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -629,9 +629,14 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	if (parse->setOperations)
 		flatten_simple_union_all(root);
 
+	/*
+	 * If this subplan is inside another correlated subplan or if it itself is
+	 * correlated, disable some optimizations that assume the subplan doesn't
+	 * have any dependencies on other parts of the plan.
+	 */
 	if ((parent_root && parent_root->is_correlated_subplan) ||
 		((Gp_role == GP_ROLE_DISPATCH) &&
-		root->config->is_under_subplan &&
+		root->config->can_have_dependencies &&
 		IsSubqueryCorrelated(parse)))
 	{
 		root->is_correlated_subplan = true;

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -635,7 +635,11 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		config->is_under_subplan = true;
+		/*
+		 * This is a subquery, so it can possibly be correlated and depend
+		 * on other parts of the plan
+		 */
+		config->can_have_dependencies = true;
 
 		/*
 		 * Disable CTE sharing in subplan.

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -44,7 +44,12 @@ typedef struct PlannerConfig
 
 	bool		honor_order_by;
 
-	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
+	/*
+	 * True if it's possible for the plan to depend on external parameters,
+	 * for example if it is a clause in a lateral join or a correlated subquery.
+	 * Doesn't guarantee the subquery is actually correlated
+	 */
+	bool		can_have_dependencies;
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -873,6 +873,34 @@ select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
  9999 | 1
 (3 rows)
 
+-- check MIN/MAX optimization for lateral joins (shouldn't be optimized)
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+    on true;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Values Scan on "*VALUES*"
+   ->  Materialize
+         ->  Aggregate
+               ->  Result
+                     Filter: (tenk1.unique1 = "*VALUES*".column1)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Seq Scan on tenk1
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select x from (values (1), (2)) as v(v_col)
+  join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+  on true;
+ x 
+---
+ 1
+ 2
+(2 rows)
+
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);
 create table minmaxtest1() inherits (minmaxtest);

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -901,6 +901,34 @@ select x from (values (1), (2)) as v(v_col)
  2
 (2 rows)
 
+-- check MIN/MAX is still enabled for normal joins
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join (select max(unique1) x from tenk1 where unique1 = 1) as r
+    on true;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Values Scan on "*VALUES*"
+   ->  Materialize
+         ->  Result
+               InitPlan 1 (returns $0)  (slice2)
+                 ->  Limit
+                       ->  Gather Motion 1:1  (slice1; segments: 1)
+                             ->  Index Only Scan using tenk1_unique1 on tenk1
+                                   Index Cond: ((unique1 IS NOT NULL) AND (unique1 = 1))
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select x from (values (1), (2)) as v(v_col)
+  join (select max(unique1) x from tenk1 where unique1 = 1) as r
+  on true;
+ x 
+---
+ 1
+ 1
+(2 rows)
+
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);
 create table minmaxtest1() inherits (minmaxtest);

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -869,6 +869,38 @@ select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
  9999 | 1
 (3 rows)
 
+-- check MIN/MAX optimization for lateral joins (shouldn't be optimized)
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+    on true;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: LATERAL
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Values Scan on "*VALUES*"
+   ->  Materialize
+         ->  Aggregate
+               ->  Result
+                     Filter: (tenk1.unique1 = "*VALUES*".column1)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Seq Scan on tenk1
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select x from (values (1), (2)) as v(v_col)
+  join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+  on true;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: LATERAL
+ x 
+---
+ 1
+ 2
+(2 rows)
+
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -901,6 +901,33 @@ DETAIL:  Feature not supported: LATERAL
  2
 (2 rows)
 
+-- check MIN/MAX is still enabled for normal joins
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join (select max(unique1) x from tenk1 where unique1 = 1) as r
+    on true;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Nested Loop
+   Join Filter: true
+   ->  Aggregate
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Aggregate
+                     ->  Index Only Scan using tenk1_unique1 on tenk1
+                           Index Cond: (unique1 = 1)
+   ->  Values Scan on "Values"
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select x from (values (1), (2)) as v(v_col)
+  join (select max(unique1) x from tenk1 where unique1 = 1) as r
+  on true;
+ x 
+---
+ 1
+ 1
+(2 rows)
+
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1140,7 +1140,23 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:422)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Values Scan on "*VALUES*"
+   ->  Materialize
+         ->  Subquery Scan on ss
+               ->  Limit
+                     ->  Sort
+                           Sort Key: ((gist_tbl_github9733.p <-> ("*VALUES*".column1)[0]))
+                           ->  Result
+                                 Filter: (gist_tbl_github9733.p <@ "*VALUES*".column1)
+                                 ->  Materialize
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Seq Scan on gist_tbl_github9733
+ Optimizer: Postgres query optimizer
+(13 rows)
+
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1156,7 +1156,23 @@ select p from
           (box(point(0.8,0.8), point(1.0,1.0)))) as v(bb)
 cross join lateral
   (select p from gist_tbl_github9733 where p <@ bb order by p <-> bb[0] limit 2) ss;
-ERROR:  could not devise a query plan for the given query (pathnode.c:422)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Values Scan on "*VALUES*"
+   ->  Materialize
+         ->  Subquery Scan on ss
+               ->  Limit
+                     ->  Sort
+                           Sort Key: ((gist_tbl_github9733.p <-> ("*VALUES*".column1)[0]))
+                           ->  Result
+                                 Filter: (gist_tbl_github9733.p <@ "*VALUES*".column1)
+                                 ->  Materialize
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Seq Scan on gist_tbl_github9733
+ Optimizer: Postgres query optimizer
+(13 rows)
+
 reset enable_seqscan;
 explain (costs off)
 select p from

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -310,6 +310,14 @@ explain (costs off)
 select x from (values (1), (2)) as v(v_col)
   join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
   on true;
+-- check MIN/MAX is still enabled for normal joins
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join (select max(unique1) x from tenk1 where unique1 = 1) as r
+    on true;
+select x from (values (1), (2)) as v(v_col)
+  join (select max(unique1) x from tenk1 where unique1 = 1) as r
+  on true;
 
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -302,6 +302,15 @@ explain (costs off)
   select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 select max(unique2), generate_series(1,3) as g from tenk1 order by g desc;
 
+-- check MIN/MAX optimization for lateral joins (shouldn't be optimized)
+explain (costs off)
+  select x from (values (1), (2)) as v(v_col)
+    join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+    on true;
+select x from (values (1), (2)) as v(v_col)
+  join lateral (select max(unique1) x from tenk1 where unique1 = v_col) as r
+  on true;
+
 -- try it on an inheritance tree
 create table minmaxtest(f1 int);
 create table minmaxtest1() inherits (minmaxtest);


### PR DESCRIPTION
Disable MIN/MAX optimization for inner plans of lateral joins

That optimization only applies to uncorrelated subqueries (since it transforms
them to InitPlans) and so it is not applicable for subqueries of lateral joins.

To disable the optimization, the `can_have_dependencies` config flag
(originally named `is_under_subplan`) is set inside lateral join subplans.