### PR TITLE
Fix segfault in get_ao_compression_ratio (#907)

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -1633,16 +1633,10 @@ aocol_compression_ratio_internal(Relation parentrel)
 	 * namespace, too.
 	 */
 	initStringInfo(&sqlstmt);
-	if (Gp_role == GP_ROLE_DISPATCH)
-		appendStringInfo(&sqlstmt, "select vpinfo "
-						 "from gp_dist_random('%s.%s')",
-						 get_namespace_name(RelationGetNamespace(aosegrel)),
-						 RelationGetRelationName(aosegrel));
-	else
-		appendStringInfo(&sqlstmt, "select vpinfo "
-						 "from %s.%s",
-						 get_namespace_name(RelationGetNamespace(aosegrel)),
-						 RelationGetRelationName(aosegrel));
+	appendStringInfo(&sqlstmt, "select vpinfo "
+					 "from gp_dist_random('%s.%s')",
+					 get_namespace_name(RelationGetNamespace(aosegrel)),
+					 RelationGetRelationName(aosegrel));
 
 	heap_close(aosegrel, AccessShareLock);
 

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -880,3 +880,38 @@ insert into fix_ao_truncate_last_sequence select 1, 1 from generate_series(1, 5)
 select count(*) from fix_ao_truncate_last_sequence;
 abort;
 
+-- Test AO functions with execution location on dispatcher.
+-- start_ignore
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists tables_list;
+-- end_ignore
+
+create table t1 (a int) with (appendoptimized=true, orientation=row);
+create table t2 (a int) with (appendoptimized=true, orientation=column);
+create table tables_list (tname text);
+insert into tables_list values ('t1'), ('t2');
+
+-- Queries below should fail with a proper error message.
+
+-- It's possible that expected error cancels query on the some segment too early for it, after it started transaction
+-- but before it executed function and issued an error. In this case a warning is issued which we can ignore.
+-- start_matchignore
+-- m/WARNING:  ignoring query cancel request for synchronous replication to ensure cluster consistency.*\n/
+-- m/DETAIL:  The transaction has already changed locally, it has to be replicated to standby.*\n/
+-- end_matchignore
+
+select get_ao_compression_ratio(tname) from tables_list;
+select get_ao_distribution(tname) from tables_list;
+
+-- Query below is an example how to get the result
+-- intended by the failing query above.
+explain (costs off) select get_ao_compression_ratio(tname) from
+	unnest(array(select tname from tables_list)) as tname;
+
+select get_ao_compression_ratio(tname) from
+	unnest(array(select tname from tables_list)) as tname;
+
+drop table t1;
+drop table t2;
+drop table tables_list;

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1741,3 +1741,43 @@ select count(*) from fix_ao_truncate_last_sequence;
 (1 row)
 
 abort;
+-- Test AO functions with execution location on dispatcher.
+create table t1 (a int) with (appendoptimized=true, orientation=row);
+create table t2 (a int) with (appendoptimized=true, orientation=column);
+create table tables_list (tname text);
+insert into tables_list values ('t1'), ('t2');
+-- Queries below should fail with a proper error message.
+-- It's possible that expected error cancels query on the some segment too early for it, after it started transaction
+-- but before it executed function and issued an error. In this case a warning is issued which we can ignore.
+-- start_matchignore
+-- m/WARNING:  ignoring query cancel request for synchronous replication to ensure cluster consistency.*\n/
+-- m/DETAIL:  The transaction has already changed locally, it has to be replicated to standby.*\n/
+-- end_matchignore
+select get_ao_compression_ratio(tname) from tables_list;
+ERROR:  function 'get_ao_compression_ratio' must be executed on the dispatcher
+select get_ao_distribution(tname) from tables_list;
+ERROR:  function 'get_ao_distribution' must be executed on the dispatcher
+-- Query below is an example how to get the result
+-- intended by the failing query above.
+explain (costs off) select get_ao_compression_ratio(tname) from
+	unnest(array(select tname from tables_list)) as tname;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Function Scan on unnest tname
+   InitPlan 1 (returns $0)  (slice1)
+     ->  Gather Motion 3:1  (slice2; segments: 3)
+           ->  Seq Scan on tables_list
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select get_ao_compression_ratio(tname) from
+	unnest(array(select tname from tables_list)) as tname;
+ get_ao_compression_ratio 
+--------------------------
+                        1
+                       -1
+(2 rows)
+
+drop table t1;
+drop table t2;
+drop table tables_list;


### PR DESCRIPTION
Problem:
Segfault happened in the queries with 'get_ao_compression_ratio' function
in the target list and the argument for this function that was taken from 
a table. The problem was reproduced in the release build. In the development 
build the same queries led to assertion.

Cause:
Function 'get_ao_compression_ratio' executes a query on 'pg_aoseg.pg_aoseg_' 
table to calculate the compression ratio. A function that accesses 
hash-distributed or randomly distributed tables must be executed on 
coordinator. But the planner created plans with the 'get_ao_compression_ratio'
function which was executed on segments. Inside 'get_ao_compression_ratio' 
there was an assert to check this case, but on the release build the assert 
was removed. So, the code of the function was executed on a segment and got 
unexpected results from 'pg_aoseg.pg_aoseg_', that led to a segfault.

Fix:
Assert is changed to a runtime check. Now, if the planner creates a plan with
the function which is executed on segments, the user will get a proper error 
message. It is also done for the similar functions 'gp_update_ao_master_stats' 
and 'get_ao_distribution'. Plus, unreachable code is removed from internal 
functions.

Note: it seems that a fully proper way would be to mark these functions as 
PROEXECLOCATION_MASTER instead of PROEXECLOCATION_ANY, but that would require 
changing of the system catalog, and it is acceptable only between major 
versions update. So this approach is not used.

Note2: for an empty column-oriented table 'get_ao_compression_ratio' returns -1,
but for an empty row-oriented table 'get_ao_compression_ratio' returns 1. 
This behavior is inconsistent, but it is not altered by this commit as not 
related to the original issue. It has a reflection in the added test case. 
Be aware.

Changes comparing to the original commit:

1. Adopted parameters to GetAppendOnlyEntryAuxOids() in aosegfiles.c
2. Added ignore for warning "ignoring query cancel request for synchronous
replication to ensure cluster consistency." in tests
3. Removed gp_update_ao_master_stats which is not in 7.2

(cherry picked from commit 3dea58de92a9b040fe5ce194048a97f55bbdb71b)

Note: do not squash the commit to preserve authorship.