### PR TITLE
Add -Werror to compile GPDB

### DIFF
--- a/.abi-check/7.2.0_arenadata4/postgres.symbols.ignore
+++ b/.abi-check/7.2.0_arenadata4/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+tsCompareString

--- a/config/c-compiler.m4
+++ b/config/c-compiler.m4
@@ -71,7 +71,7 @@ AC_CACHE_CHECK([whether $1 is 64 bits], [Ac_cachevar],
 ac_int64 a = 20000001;
 ac_int64 b = 40000005;
 
-int does_int64_work()
+static int does_int64_work()
 {
   ac_int64 c,d;
 

--- a/configure
+++ b/configure
@@ -5431,47 +5431,6 @@ if test "$GCC" = yes -a "$ICC" = no; then
     PERMIT_DECLARATION_AFTER_STATEMENT=-Wno-declaration-after-statement
   fi
 
-  # Really don't want VLAs to be used in our dialect of C
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror=vla, for CFLAGS" >&5
-$as_echo_n "checking whether ${CC} supports -Werror=vla, for CFLAGS... " >&6; }
-if ${pgac_cv_prog_CC_cflags__Werror_vla+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-pgac_save_CC=$CC
-CC=${CC}
-CFLAGS="${CFLAGS} -Werror=vla"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_CC_cflags__Werror_vla=yes
-else
-  pgac_cv_prog_CC_cflags__Werror_vla=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-CC="$pgac_save_CC"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Werror_vla" >&5
-$as_echo "$pgac_cv_prog_CC_cflags__Werror_vla" >&6; }
-if test x"$pgac_cv_prog_CC_cflags__Werror_vla" = x"yes"; then
-  CFLAGS="${CFLAGS} -Werror=vla"
-fi
-
-
   # -Wvla is not applicable for C++
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Wendif-labels, for CFLAGS" >&5
@@ -6063,50 +6022,6 @@ if test x"$pgac_cv_prog_CC_cflags__Wno_unused_but_set_variable" = x"yes"; then
   CFLAGS="${CFLAGS} -Wno-unused-but-set-variable"
 fi
 
-
-
-  # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
-  # some compilers (clang) don't recognize those and give spurious errors. Make
-  # sure the compiler supports fallthrough comments by explicitly requesting
-  # implicit-fallthrough level 3 (GCC's default).
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror=implicit-fallthrough=3, for CFLAGS" >&5
-$as_echo_n "checking whether ${CC} supports -Werror=implicit-fallthrough=3, for CFLAGS... " >&6; }
-if ${pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-pgac_save_CC=$CC
-CC=${CC}
-CFLAGS="${CFLAGS} -Werror=implicit-fallthrough=3"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3=yes
-else
-  pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-CC="$pgac_save_CC"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3" >&5
-$as_echo "$pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3" >&6; }
-if test x"$pgac_cv_prog_CC_cflags__Werror_implicit_fallthrough_3" = x"yes"; then
-  CFLAGS="${CFLAGS} -Werror=implicit-fallthrough=3"
-fi
 
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} supports -fexcess-precision=standard, for CXXFLAGS" >&5
@@ -19309,7 +19224,7 @@ typedef long int ac_int64;
 ac_int64 a = 20000001;
 ac_int64 b = 40000005;
 
-int does_int64_work()
+static int does_int64_work()
 {
   ac_int64 c,d;
 
@@ -19393,7 +19308,7 @@ typedef long long int ac_int64;
 ac_int64 a = 20000001;
 ac_int64 b = 40000005;
 
-int does_int64_work()
+static int does_int64_work()
 {
   ac_int64 c,d;
 
@@ -21723,89 +21638,7 @@ fi
 # Check for test tools
 #
 if test "$enable_tap_tests" = yes; then
-  # Check for necessary modules, unless user has specified the "prove" to use;
-  # in that case it's her responsibility to have a working configuration.
-  # (prove might be part of a different Perl installation than perl, eg on
-  # MSys, so the result of AX_PROG_PERL_MODULES could be irrelevant anyway.)
-  if test -z "$PROVE"; then
-    # Test::More and Time::HiRes are supposed to be part of core Perl,
-    # but some distros omit them in a minimal installation.
-    # The required minimum versions are all quite ancient now, but specify
-    # them anyway for documentation's sake.
-
-# Make sure we have perl
-if test -z "$PERL"; then
-# Extract the first word of "perl", so it can be a program name with args.
-set dummy perl; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_PERL+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$PERL"; then
-  ac_cv_prog_PERL="$PERL" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_PERL="perl"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-PERL=$ac_cv_prog_PERL
-if test -n "$PERL"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PERL" >&5
-$as_echo "$PERL" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-fi
-
-if test "x$PERL" != x; then
-  ax_perl_modules_failed=0
-  for ax_perl_module in 'IPC::Run 0.79' 'Test::More 0.98' 'Time::HiRes 1.52' ; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for perl module $ax_perl_module" >&5
-$as_echo_n "checking for perl module $ax_perl_module... " >&6; }
-
-    # Would be nice to log result here, but can't rely on autoconf internals
-    modversion=`$PERL -e "use $ax_perl_module; my \\\$x=q($ax_perl_module); \\\$x =~ s/ .*//; \\\$x .= q(::VERSION); eval qq{print \\\\$\\\$x\\n}; exit;" 2>/dev/null`
-    if test $? -ne 0; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; };
-      ax_perl_modules_failed=1
-   else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $modversion" >&5
-$as_echo "$modversion" >&6; };
-    fi
-  done
-
-  # Run optional shell commands
-  if test "$ax_perl_modules_failed" = 0; then
-    :
-
-  else
-    :
-    as_fn_error $? "Additional Perl modules are required to run TAP tests" "$LINENO" 5
-  fi
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: could not find perl" >&5
-$as_echo "$as_me: WARNING: could not find perl" >&2;}
-fi
-  fi
-  # Now make sure we know where prove is
+  # Make sure we know where prove is.
   if test -z "$PROVE"; then
   for ac_prog in prove
 do
@@ -22073,15 +21906,15 @@ fi
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror=uninitialized, for CFLAGS" >&5
-$as_echo_n "checking whether ${CC} supports -Werror=uninitialized, for CFLAGS... " >&6; }
-if ${pgac_cv_prog_CC_cflags__Werror_uninitialized+:} false; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Wall, for CFLAGS" >&5
+$as_echo_n "checking whether ${CC} supports -Wall, for CFLAGS... " >&6; }
+if ${pgac_cv_prog_CC_cflags__Wall+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   pgac_save_CFLAGS=$CFLAGS
 pgac_save_CC=$CC
 CC=${CC}
-CFLAGS="${CFLAGS} -Werror=uninitialized"
+CFLAGS="${CFLAGS} -Wall"
 ac_save_c_werror_flag=$ac_c_werror_flag
 ac_c_werror_flag=yes
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -22096,32 +21929,32 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_CC_cflags__Werror_uninitialized=yes
+  pgac_cv_prog_CC_cflags__Wall=yes
 else
-  pgac_cv_prog_CC_cflags__Werror_uninitialized=no
+  pgac_cv_prog_CC_cflags__Wall=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_c_werror_flag=$ac_save_c_werror_flag
 CFLAGS="$pgac_save_CFLAGS"
 CC="$pgac_save_CC"
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Werror_uninitialized" >&5
-$as_echo "$pgac_cv_prog_CC_cflags__Werror_uninitialized" >&6; }
-if test x"$pgac_cv_prog_CC_cflags__Werror_uninitialized" = x"yes"; then
-  CFLAGS="${CFLAGS} -Werror=uninitialized"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Wall" >&5
+$as_echo "$pgac_cv_prog_CC_cflags__Wall" >&6; }
+if test x"$pgac_cv_prog_CC_cflags__Wall" = x"yes"; then
+  CFLAGS="${CFLAGS} -Wall"
 fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror=implicit-function-declaration, for CFLAGS" >&5
-$as_echo_n "checking whether ${CC} supports -Werror=implicit-function-declaration, for CFLAGS... " >&6; }
-if ${pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration+:} false; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror, for CFLAGS" >&5
+$as_echo_n "checking whether ${CC} supports -Werror, for CFLAGS... " >&6; }
+if ${pgac_cv_prog_CC_cflags__Werror+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   pgac_save_CFLAGS=$CFLAGS
 pgac_save_CC=$CC
 CC=${CC}
-CFLAGS="${CFLAGS} -Werror=implicit-function-declaration"
+CFLAGS="${CFLAGS} -Werror"
 ac_save_c_werror_flag=$ac_c_werror_flag
 ac_c_werror_flag=yes
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -22136,19 +21969,19 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration=yes
+  pgac_cv_prog_CC_cflags__Werror=yes
 else
-  pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration=no
+  pgac_cv_prog_CC_cflags__Werror=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_c_werror_flag=$ac_save_c_werror_flag
 CFLAGS="$pgac_save_CFLAGS"
 CC="$pgac_save_CC"
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration" >&5
-$as_echo "$pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration" >&6; }
-if test x"$pgac_cv_prog_CC_cflags__Werror_implicit_function_declaration" = x"yes"; then
-  CFLAGS="${CFLAGS} -Werror=implicit-function-declaration"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Werror" >&5
+$as_echo "$pgac_cv_prog_CC_cflags__Werror" >&6; }
+if test x"$pgac_cv_prog_CC_cflags__Werror" = x"yes"; then
+  CFLAGS="${CFLAGS} -Werror"
 fi
 
 

--- a/configure
+++ b/configure
@@ -21945,6 +21945,57 @@ if test x"$pgac_cv_prog_CC_cflags__Werror" = x"yes"; then
 fi
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} supports -Werror, for CXXFLAGS" >&5
+$as_echo_n "checking whether ${CXX} supports -Werror, for CXXFLAGS... " >&6; }
+if ${pgac_cv_prog_CXX_cxxflags__Werror+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CXXFLAGS=$CXXFLAGS
+pgac_save_CXX=$CXX
+CXX=${CXX}
+CXXFLAGS="${CXXFLAGS} -Werror"
+ac_save_cxx_werror_flag=$ac_cxx_werror_flag
+ac_cxx_werror_flag=yes
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  pgac_cv_prog_CXX_cxxflags__Werror=yes
+else
+  pgac_cv_prog_CXX_cxxflags__Werror=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+ac_cxx_werror_flag=$ac_save_cxx_werror_flag
+CXXFLAGS="$pgac_save_CXXFLAGS"
+CXX="$pgac_save_CXX"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CXX_cxxflags__Werror" >&5
+$as_echo "$pgac_cv_prog_CXX_cxxflags__Werror" >&6; }
+if test x"$pgac_cv_prog_CXX_cxxflags__Werror" = x"yes"; then
+  CXXFLAGS="${CXXFLAGS} -Werror"
+fi
+
+
 fi
 
 BLD_ARCH=`echo $BLD_ARCH`

--- a/configure
+++ b/configure
@@ -5418,7 +5418,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough=3 -Wvla"
   CXXFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS
@@ -21905,46 +21905,6 @@ fi
 # error should be last step after all autoconf checks are performed, otherwise
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Wall, for CFLAGS" >&5
-$as_echo_n "checking whether ${CC} supports -Wall, for CFLAGS... " >&6; }
-if ${pgac_cv_prog_CC_cflags__Wall+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  pgac_save_CFLAGS=$CFLAGS
-pgac_save_CC=$CC
-CC=${CC}
-CFLAGS="${CFLAGS} -Wall"
-ac_save_c_werror_flag=$ac_c_werror_flag
-ac_c_werror_flag=yes
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  pgac_cv_prog_CC_cflags__Wall=yes
-else
-  pgac_cv_prog_CC_cflags__Wall=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_c_werror_flag=$ac_save_c_werror_flag
-CFLAGS="$pgac_save_CFLAGS"
-CC="$pgac_save_CC"
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Wall" >&5
-$as_echo "$pgac_cv_prog_CC_cflags__Wall" >&6; }
-if test x"$pgac_cv_prog_CC_cflags__Wall" = x"yes"; then
-  CFLAGS="${CFLAGS} -Wall"
-fi
-
-
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Werror, for CFLAGS" >&5
 $as_echo_n "checking whether ${CC} supports -Werror, for CFLAGS... " >&6; }

--- a/configure
+++ b/configure
@@ -5418,8 +5418,8 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla"
-  CXXFLAGS="-Wall -Wpointer-arith"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla -Wno-deprecated-declarations"
+  CXXFLAGS="-Wall -Wpointer-arith -Wno-deprecated-declarations"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS
   # GPDB code is full of declarations after statement.

--- a/configure
+++ b/configure
@@ -5418,7 +5418,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough=3 -Wvla"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla"
   CXXFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS

--- a/configure.in
+++ b/configure.in
@@ -2787,6 +2787,7 @@ fi
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
   PGAC_PROG_CC_CFLAGS_OPT([-Werror])
+  PGAC_PROG_CXX_CFLAGS_OPT([-Werror])
 fi
 
 [BLD_ARCH=`echo $BLD_ARCH`]

--- a/configure.in
+++ b/configure.in
@@ -515,7 +515,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough=3 -Wvla"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla"
   CXXFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS

--- a/configure.in
+++ b/configure.in
@@ -515,7 +515,7 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough=3 -Wvla"
   CXXFLAGS="-Wall -Wpointer-arith"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS
@@ -2786,8 +2786,7 @@ fi
 # error should be last step after all autoconf checks are performed, otherwise
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
-   PGAC_PROG_CC_CFLAGS_OPT([-Wall])
-   PGAC_PROG_CC_CFLAGS_OPT([-Werror])
+  PGAC_PROG_CC_CFLAGS_OPT([-Werror])
 fi
 
 [BLD_ARCH=`echo $BLD_ARCH`]

--- a/configure.in
+++ b/configure.in
@@ -528,8 +528,6 @@ if test "$GCC" = yes -a "$ICC" = no; then
     PERMIT_DECLARATION_AFTER_STATEMENT=-Wno-declaration-after-statement
   fi
   AC_SUBST(PERMIT_DECLARATION_AFTER_STATEMENT)
-  # Really don't want VLAs to be used in our dialect of C
-  PGAC_PROG_CC_CFLAGS_OPT([-Werror=vla])
   # -Wvla is not applicable for C++
   PGAC_PROG_CC_CFLAGS_OPT([-Wendif-labels])
   PGAC_PROG_CXX_CFLAGS_OPT([-Wendif-labels])
@@ -554,11 +552,6 @@ if test "$GCC" = yes -a "$ICC" = no; then
   # remove this.
   PGAC_PROG_CC_CFLAGS_OPT([-Wno-unused-but-set-variable])
 
-  # We rely on /* fallthrough */ comments to signal explicit fallthrough, but
-  # some compilers (clang) don't recognize those and give spurious errors. Make
-  # sure the compiler supports fallthrough comments by explicitly requesting
-  # implicit-fallthrough level 3 (GCC's default).
-  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-fallthrough=3])
   PGAC_PROG_CXX_CFLAGS_OPT([-fexcess-precision=standard])
   # Optimization flags for specific files that benefit from vectorization
   PGAC_PROG_CC_VAR_OPT(CFLAGS_VECTOR, [-funroll-loops])
@@ -2793,8 +2786,8 @@ fi
 # error should be last step after all autoconf checks are performed, otherwise
 # false side-effects happens.
 if test "$GCC" = yes -a "$ICC" = no; then
-  PGAC_PROG_CC_CFLAGS_OPT([-Werror=uninitialized])
-  PGAC_PROG_CC_CFLAGS_OPT([-Werror=implicit-function-declaration])
+   PGAC_PROG_CC_CFLAGS_OPT([-Wall])
+   PGAC_PROG_CC_CFLAGS_OPT([-Werror])
 fi
 
 [BLD_ARCH=`echo $BLD_ARCH`]

--- a/configure.in
+++ b/configure.in
@@ -515,8 +515,8 @@ fi
 # but has its own.  Also check other compiler-specific flags here.
 
 if test "$GCC" = yes -a "$ICC" = no; then
-  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla"
-  CXXFLAGS="-Wall -Wpointer-arith"
+  CFLAGS="-Wall -Wmissing-prototypes -Wpointer-arith -Wimplicit-fallthrough -Wvla -Wno-deprecated-declarations"
+  CXXFLAGS="-Wall -Wpointer-arith -Wno-deprecated-declarations"
   # These work in some but not all gcc versions
   save_CFLAGS=$CFLAGS
   # GPDB code is full of declarations after statement.

--- a/gpcontrib/orafce/convert.c
+++ b/gpcontrib/orafce/convert.c
@@ -806,8 +806,8 @@ pg_unicode_to_server(pg_wchar c, unsigned char *s)
 	FunctionCall5(orafce_Utf8ToServerConvProc,
 				  Int32GetDatum(PG_UTF8),
 				  Int32GetDatum(server_encoding),
-				  CStringGetDatum(c_as_utf8),
-				  CStringGetDatum(s),
+				  PointerGetDatum(c_as_utf8),
+				  PointerGetDatum(s),
 				  Int32GetDatum(c_as_utf8_len));
 }
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -2168,13 +2168,12 @@ aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 {
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
 	int64		rowNum = AOTupleIdGet_rowNum(aoTupleId);
-	int			numCols = aocsFetchDesc->relation->rd_att->natts;
 	int			colno = 0; /* initialize to placate compiler, but it should be overwritten later in any case */
 	bool		found = true;
 	bool		isSnapshotAny = (aocsFetchDesc->snapshot == SnapshotAny);
 	bool 		valmissing;
 
-	Assert(numCols > 0);
+	Assert(aocsFetchDesc->relation->rd_att->natts > 0);
 
 	Assert(segmentFileNum >= 0);
 

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -2140,16 +2140,6 @@ insertsetbit(Relation rel, BlockNumber lovBlock, OffsetNumber lovOffset,
 	buf->last_word = lovItem->bm_last_word;
 	buf->is_last_compword_fill = (lovItem->lov_words_header >= 2);
 	buf->last_tid = lovItem->bm_last_setbit;
-	if (buf->cwords)
-	{
-		MemSet(buf->cwords, 0,
-				buf->num_cwords * sizeof(BM_HRL_WORD));
-	}
-	MemSet(buf->hwords, 0, sizeof(buf->hwords));
-	if (buf->last_tids)
-		MemSet(buf->last_tids, 0,
-				buf->num_cwords * sizeof(uint64));
-	buf->curword = 0;
 
 	/*
 	 * Usually, tidnum is greater than lovItem->bm_last_setbit.

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -2145,8 +2145,7 @@ insertsetbit(Relation rel, BlockNumber lovBlock, OffsetNumber lovOffset,
 		MemSet(buf->cwords, 0,
 				buf->num_cwords * sizeof(BM_HRL_WORD));
 	}
-	MemSet(buf->hwords, 0,
-		   BM_CALC_H_WORDS(buf->num_cwords) * sizeof(BM_HRL_WORD));
+	MemSet(buf->hwords, 0, sizeof(buf->hwords));
 	if (buf->last_tids)
 		MemSet(buf->last_tids, 0,
 				buf->num_cwords * sizeof(uint64));

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6938,7 +6938,7 @@ XactLogCommitRecord(TimestampTz commit_time,
 	if (xl_xinfo.xinfo & XACT_XINFO_HAS_TWOPHASE)
 	{
 		XLogRegisterData((char *) (&xl_twophase), sizeof(xl_xact_twophase));
-		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid)
+		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid != NULL)
 			XLogRegisterData(unconstify(char *, twophase_gid), strlen(twophase_gid) + 1);
 	}
 
@@ -7096,7 +7096,7 @@ XactLogAbortRecord(TimestampTz abort_time,
 	if (xl_xinfo.xinfo & XACT_XINFO_HAS_TWOPHASE)
 	{
 		XLogRegisterData((char *) (&xl_twophase), sizeof(xl_xact_twophase));
-		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid)
+		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid != NULL)
 			XLogRegisterData(unconstify(char *, twophase_gid), strlen(twophase_gid) + 1);
 	}
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6938,7 +6938,7 @@ XactLogCommitRecord(TimestampTz commit_time,
 	if (xl_xinfo.xinfo & XACT_XINFO_HAS_TWOPHASE)
 	{
 		XLogRegisterData((char *) (&xl_twophase), sizeof(xl_xact_twophase));
-		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID)
+		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid)
 			XLogRegisterData(unconstify(char *, twophase_gid), strlen(twophase_gid) + 1);
 	}
 

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -7096,7 +7096,7 @@ XactLogAbortRecord(TimestampTz abort_time,
 	if (xl_xinfo.xinfo & XACT_XINFO_HAS_TWOPHASE)
 	{
 		XLogRegisterData((char *) (&xl_twophase), sizeof(xl_xact_twophase));
-		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID)
+		if (xl_xinfo.xinfo & XACT_XINFO_HAS_GID && twophase_gid)
 			XLogRegisterData(unconstify(char *, twophase_gid), strlen(twophase_gid) + 1);
 	}
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1788,8 +1788,6 @@ destroyConnHashTable(ConnHashTable *ht)
 static inline void
 sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerLen)
 {
-	int			n = 0;
-
 #ifdef USE_ASSERT_CHECKING
 	if (testmode_inject_fault(gp_udpic_dropacks_percent))
 	{
@@ -1805,12 +1803,10 @@ sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerL
 		addCRC(pkt);
 
 	/* retry 10 times for sending control message */
-	int counter = 0;
-	while (counter < 10)
+	for (int counter = 0; counter < 10; counter++)
 	{
-		counter++;
-		n = sendto(fd, (const char *) pkt, pkt->len, 0, addr, peerLen);
-		if (n < 0)
+		int const sent_bytes = sendto(fd, (const char *) pkt, pkt->len, 0, addr, peerLen);
+		if (sent_bytes < 0)
 		{
 			if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 				continue;
@@ -1819,10 +1815,11 @@ sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerL
 				return;
 			}
 		}
-		break;
+
+		if (sent_bytes < pkt->len)
+			write_log("sendcontrolmessage: got error %d errno %d seq %d", sent_bytes, errno, pkt->seq);
+		return;
 	}
-	if (n < pkt->len)
-		write_log("sendcontrolmessage: got error %d errno %d seq %d", n, errno, pkt->seq);
 }
 
 /*

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1788,7 +1788,7 @@ destroyConnHashTable(ConnHashTable *ht)
 static inline void
 sendControlMessage(icpkthdr *pkt, int fd, struct sockaddr *addr, socklen_t peerLen)
 {
-	int			n;
+	int			n = 0;
 
 #ifdef USE_ASSERT_CHECKING
 	if (testmode_inject_fault(gp_udpic_dropacks_percent))

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4488,9 +4488,9 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
 		GPOS_ASSERT(nullptr != sort_grouping_col_mapping ||
-					nullptr !=
+					(nullptr !=
 						sort_grouping_col_mapping->Find(&sort_group_ref) &&
-					"Grouping column with no mapping");
+					"Grouping column with no mapping"));
 
 		if (0 < sort_group_ref && 0 < colid &&
 			nullptr == sort_grouping_col_mapping->Find(&sort_group_ref))

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4489,6 +4489,7 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		GPOS_ASSERT_IMP(
 			nullptr == sort_grouping_col_mapping,
+			sort_grouping_col_mapping &&
 			nullptr != sort_grouping_col_mapping->Find(&sort_group_ref) &&
 				"Grouping column with no mapping");
 

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4487,11 +4487,10 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
-		GPOS_ASSERT_IMP(
-			nullptr == sort_grouping_col_mapping,
-			sort_grouping_col_mapping &&
-			nullptr != sort_grouping_col_mapping->Find(&sort_group_ref) &&
-				"Grouping column with no mapping");
+		GPOS_ASSERT(sort_grouping_col_mapping &&
+					nullptr !=
+						sort_grouping_col_mapping->Find(&sort_group_ref) &&
+					"Grouping column with no mapping");
 
 		if (0 < sort_group_ref && 0 < colid &&
 			nullptr == sort_grouping_col_mapping->Find(&sort_group_ref))

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4487,7 +4487,7 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
-		GPOS_ASSERT(nullptr != sort_grouping_col_mapping &&
+		GPOS_ASSERT(nullptr != sort_grouping_col_mapping ||
 					nullptr !=
 						sort_grouping_col_mapping->Find(&sort_group_ref) &&
 					"Grouping column with no mapping");

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4487,10 +4487,10 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
-		GPOS_ASSERT(nullptr != sort_grouping_col_mapping ||
-					(nullptr !=
-						sort_grouping_col_mapping->Find(&sort_group_ref) &&
-					"Grouping column with no mapping"));
+		GPOS_ASSERT(
+			nullptr != sort_grouping_col_mapping ||
+			(nullptr != sort_grouping_col_mapping->Find(&sort_group_ref) &&
+			 "Grouping column with no mapping"));
 
 		if (0 < sort_group_ref && 0 < colid &&
 			nullptr == sort_grouping_col_mapping->Find(&sort_group_ref))

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4487,10 +4487,8 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
-		GPOS_ASSERT(
-			nullptr != sort_grouping_col_mapping ||
-			(nullptr != sort_grouping_col_mapping->Find(&sort_group_ref) &&
-			 "Grouping column with no mapping"));
+		GPOS_ASSERT(nullptr != sort_grouping_col_mapping &&
+					"Grouping column with no mapping");
 
 		if (0 < sort_group_ref && 0 < colid &&
 			nullptr == sort_grouping_col_mapping->Find(&sort_group_ref))

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4487,7 +4487,7 @@ CTranslatorQueryToDXL::CreateDXLProjectNullsForGroupingSets(
 
 		INT sort_group_ref = INT(target_entry->ressortgroupref);
 
-		GPOS_ASSERT(sort_grouping_col_mapping &&
+		GPOS_ASSERT(nullptr != sort_grouping_col_mapping &&
 					nullptr !=
 						sort_grouping_col_mapping->Find(&sort_group_ref) &&
 					"Grouping column with no mapping");

--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
@@ -55,6 +55,10 @@ public:
 	// hash function
 	static ULONG HashValue(const CWStringConst *string);
 
+	// There is the same Equals at the CWStringBase, add it here
+	// not to hidden it. [-Woverloaded-virtual]
+	using CWStringBase::Equals;
+
 	// checks whether the string is byte-wise equal to another string
 	BOOL Equals(const CWStringBase *str) const override;
 };

--- a/src/backend/utils/adt/interpolate.c
+++ b/src/backend/utils/adt/interpolate.c
@@ -300,7 +300,7 @@ linterp_int64(PG_FUNCTION_ARGS)
 	else 
 	{
 		r = round(y0+p*(y1-y0));
-		if ( r < LONG_MIN || r > LONG_MAX )
+		if ( r < (float8)LONG_MIN || r > (float8)LONG_MAX )
 			ereport(ERROR,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%f\" is out of range for type bigint", r)));

--- a/src/backend/utils/adt/tsvector_op.c
+++ b/src/backend/utils/adt/tsvector_op.c
@@ -1168,7 +1168,7 @@ tsvector_concat(PG_FUNCTION_ARGS)
  * if isPrefix = true then it returns zero value iff b has prefix a
  */
 int32
-tsCompareString(char *a, int lena, char *b, int lenb, bool prefix)
+tsCompareString(char *a, size_t lena, char *b, size_t lenb, bool prefix)
 {
 	int			cmp;
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5266,7 +5266,8 @@ add_placeholder_variable(const char *name, int elevel)
 struct config_generic *
 find_option(const char *name, bool create_placeholders, int elevel)
 {
-	const char **key = &name;
+	struct config_generic confa = {.name = name};
+	struct config_generic *ptr= &confa;
 	struct config_generic **res;
 	int			i;
 
@@ -5276,7 +5277,7 @@ find_option(const char *name, bool create_placeholders, int elevel)
 	 * By equating const char ** with struct config_generic *, we are assuming
 	 * the name field is first in config_generic.
 	 */
-	res = (struct config_generic **) bsearch((void *) &key,
+	res = (struct config_generic **) bsearch((void *) &ptr,
 											 (void *) guc_variables,
 											 num_guc_variables,
 											 sizeof(struct config_generic *),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5266,8 +5266,7 @@ add_placeholder_variable(const char *name, int elevel)
 struct config_generic *
 find_option(const char *name, bool create_placeholders, int elevel)
 {
-	struct config_generic confa = {.name = name};
-	struct config_generic *ptr= &confa;
+	struct config_generic *key = &(struct config_generic){.name = name};
 	struct config_generic **res;
 	int			i;
 
@@ -5277,7 +5276,7 @@ find_option(const char *name, bool create_placeholders, int elevel)
 	 * By equating const char ** with struct config_generic *, we are assuming
 	 * the name field is first in config_generic.
 	 */
-	res = (struct config_generic **) bsearch((void *) &ptr,
+	res = (struct config_generic **) bsearch((void *) &key,
 											 (void *) guc_variables,
 											 num_guc_variables,
 											 sizeof(struct config_generic *),

--- a/src/include/tsearch/ts_utils.h
+++ b/src/include/tsearch/ts_utils.h
@@ -197,7 +197,7 @@ extern bool tsquery_requires_match(QueryItem *curitem);
  * to_ts* - text transformation to tsvector, tsquery
  */
 extern TSVector make_tsvector(ParsedText *prs);
-extern int32 tsCompareString(char *a, int lena, char *b, int lenb, bool prefix);
+extern int32 tsCompareString(char *a, size_t lena, char *b, size_t lenb, bool prefix);
 
 /*
  * Possible strategy numbers for indexes


### PR DESCRIPTION
Add -Werror to compile GPDB
    
All warning were fixed.
1) checking for not-NULL was added before calling strlen().
2) converting long int to float8 was added for comparison between long int and
float8.
3) Unused variables were removed.
4) Useless memset's were removed from the insertsetbit function, because the buf
variable was zeroed before sending to the insertsetbit function.
5) Assert was fixed in the CreateDXLProjectNullsForGroupingSets function.
Execution of the Find method is extra, because it is checked below in the
condition and it may return nullptr.
