### PR TITLE
ADBDEV-6042: Fix error during changing access method to columnar

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -36,7 +36,7 @@
 #include "utils/relcache.h"
 #include "utils/syscache.h"
 
-static void check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present, Size attnum_entry_present_size);
+static void check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present);
 
 /*
  * Transform the lastrownums int64 array into datum 
@@ -612,7 +612,7 @@ AddOrUpdateCOAttributeEncodings(Oid relid, List *attr_encodings)
 	List *filenums = NIL;
 	bool attnumsWithEntries[MaxHeapAttributeNumber];
 
-	check_attribute_encoding_entry_exist(relid, attnumsWithEntries, sizeof(attnumsWithEntries));
+	check_attribute_encoding_entry_exist(relid, attnumsWithEntries);
 
 	if (attr_encodings)
 	{
@@ -960,9 +960,10 @@ ExistValidLastrownums(Oid relid, int natts)
 
 /*
  * Determine which attnums have an entry present in pg_attribute_encoding
+ * Note: only use with attnum_entry_present of size MaxHeapAttributeNumber
  */
 void
-check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present, Size attnum_entry_present_size)
+check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
 {
 	Relation    	rel;
 	SysScanDesc 	scan;
@@ -972,7 +973,7 @@ check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present, Size
 
 	Assert(OidIsValid(relid));
 
-	MemSet(attnum_entry_present, false, attnum_entry_present_size);
+	MemSet(attnum_entry_present, false, sizeof(*attnum_entry_present) * MaxHeapAttributeNumber);
 
 	rel = heap_open(AttributeEncodingRelationId, AccessShareLock);
 

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -610,7 +610,7 @@ AddOrUpdateCOAttributeEncodings(Oid relid, List *attr_encodings)
 	ListCell *lc;
 	ListCell *lc_filenum;
 	List *filenums = NIL;
-	bool attnumsWithEntries[MaxHeapAttributeNumber];
+	bool attnumsWithEntries[MaxHeapAttributeNumber] = {0};
 
 	check_attribute_encoding_entry_exist(relid, attnumsWithEntries);
 
@@ -960,7 +960,7 @@ ExistValidLastrownums(Oid relid, int natts)
 
 /*
  * Determine which attnums have an entry present in pg_attribute_encoding
- * Note: only use with attnum_entry_present of size MaxHeapAttributeNumber
+ * attnum_entry_present must be zero-initialized
  */
 void
 check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
@@ -972,8 +972,6 @@ check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
 	bool 			isnull;
 
 	Assert(OidIsValid(relid));
-
-	MemSet(attnum_entry_present, false, sizeof(*attnum_entry_present) * MaxHeapAttributeNumber);
 
 	rel = heap_open(AttributeEncodingRelationId, AccessShareLock);
 

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -36,7 +36,7 @@
 #include "utils/relcache.h"
 #include "utils/syscache.h"
 
-static void check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present);
+static void check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present, Size attnum_entry_present_size);
 
 /*
  * Transform the lastrownums int64 array into datum 
@@ -612,7 +612,7 @@ AddOrUpdateCOAttributeEncodings(Oid relid, List *attr_encodings)
 	List *filenums = NIL;
 	bool attnumsWithEntries[MaxHeapAttributeNumber];
 
-	check_attribute_encoding_entry_exist(relid, attnumsWithEntries);
+	check_attribute_encoding_entry_exist(relid, attnumsWithEntries, sizeof(attnumsWithEntries));
 
 	if (attr_encodings)
 	{
@@ -962,7 +962,7 @@ ExistValidLastrownums(Oid relid, int natts)
  * Determine which attnums have an entry present in pg_attribute_encoding
  */
 void
-check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
+check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present, Size attnum_entry_present_size)
 {
 	Relation    	rel;
 	SysScanDesc 	scan;
@@ -972,7 +972,7 @@ check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
 
 	Assert(OidIsValid(relid));
 
-	MemSet(attnum_entry_present, false, sizeof(attnum_entry_present));
+	MemSet(attnum_entry_present, false, attnum_entry_present_size);
 
 	rel = heap_open(AttributeEncodingRelationId, AccessShareLock);
 

--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -1193,3 +1193,22 @@ execute checkattributeencoding('t_addcol_p2');
       3 |       1 | {0,100}     | 
 (1 row)
 
+--- test SET ACCESS METHOD ao_column for tables with many columns
+create table t_access_method (
+  c1 int,
+  c2 int,
+  c3 int,
+  c4 int,
+  c5 int,
+  c6 int,
+  c7 int,
+  c8 int,
+  c9 int
+) distributed by (c1);
+alter table t_access_method set access method ao_column;
+select a.amname from pg_class c join pg_am a on c.relam = a.oid where c.relname = 't_access_method';
+  amname   
+-----------
+ ao_column
+(1 row)
+

--- a/src/test/regress/sql/alter_table_ao.sql
+++ b/src/test/regress/sql/alter_table_ao.sql
@@ -675,3 +675,18 @@ execute checkattributeencoding('t_addcol_p1');
 execute checkattributeencoding('t_addcol_p2');
 
 
+--- test SET ACCESS METHOD ao_column for tables with many columns
+create table t_access_method (
+  c1 int,
+  c2 int,
+  c3 int,
+  c4 int,
+  c5 int,
+  c6 int,
+  c7 int,
+  c8 int,
+  c9 int
+) distributed by (c1);
+
+alter table t_access_method set access method ao_column;
+select a.amname from pg_class c join pg_am a on c.relam = a.oid where c.relname = 't_access_method';


### PR DESCRIPTION
Fix error during changing access method to columnar

During execution of `ALTER TABLE SET ACCESS METHOD ao_columnar`, an array named
`attnum_entry_present` was zero-initialized incorrectly inside the function
`check_attribute_encoding_entry_exist`, causing the command to crash on tables
with 9 or more columns. This patch fixes the initialization by moving it to the
outer `AddOrUpdateCOAttributeEncodings` function.