### PR TITLE
ADBDEV-5434: Do not treat interruption of LDAP requests by signals as an auth error (#899)

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -2837,6 +2837,16 @@ InitializeLDAPConnection(Port *port, LDAP **ldap)
 		return STATUS_ERROR;
 	}
 
+	if ((r = ldap_set_option(*ldap, LDAP_OPT_RESTART, LDAP_OPT_ON)) != LDAP_SUCCESS)
+	{
+		ereport(LOG,
+				(errmsg("could not set LDAP restart: %s",
+						ldap_err2string(r)),
+				 errdetail_for_ldap(*ldap)));
+		ldap_unbind(*ldap);
+		return STATUS_ERROR;
+	}
+
 	if (port->hba->ldaptls)
 	{
 #ifndef WIN32

--- a/src/template/linux
+++ b/src/template/linux
@@ -37,3 +37,5 @@ if test "$SUN_STUDIO_CC" = "yes" ; then
     ;;
   esac
 fi
+
+EXTRA_LDAP_LIBS="-llber"


### PR DESCRIPTION
Do not treat interruption of LDAP requests by signals as an auth error.

When authorizing via ldap, the ldap_simple_bind_s function may return an error.
This occurs when an internal call to the ldap_int_poll utility function is
interrupted by a signal. The openldap library can handle this properly using the
LDAP_OPT_RESTART option. Setting this option to LDAP_OPT_ON causes the select()
system call to be restarted when interrupted by a signal. The default value is
LDAP_OPT_OFF. This patch sets the value to LDAP_OPT_ON (also it requires
explicitly specifying the -llber library to build) after ldap is initialized.

Changes for 7.2.0: Fix error reporting to match the surrounding code.

(cherry picked from commit edacbaffa49273e632bb99ee48dff2cf2caab346)

---
Note: do not squash the commit to preserve authorship.