### PR TITLE
Add dockerfile which is based on Ubuntu 22.04

### DIFF
--- a/README.linux.md
+++ b/README.linux.md
@@ -61,7 +61,7 @@
 
 - Install dependencies using README.ubuntu.bash script:
   ```bash
-  ./README.ubuntu.bash
+  sudo ./README.ubuntu.bash
   ```
 
 - Create symbolic link to Python 2 in `/usr/bin`:

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -9,12 +9,14 @@ apt-get install -y \
   g++ \
   gcc \
   git \
+  iproute2 \
   iputils-ping \
   libapr1-dev \
   libaprutil1-dev \
   libbz2-dev \
   libcurl4-openssl-dev \
   libevent-dev \
+  libipc-run-perl \
   libkrb5-dev \
   libpam-dev \
   libperl-dev \
@@ -33,4 +35,5 @@ apt-get install -y \
   pkg-config \
   python2 \
   python2-dev \
+  rsync \
   zlib1g-dev

--- a/README.ubuntu.bash
+++ b/README.ubuntu.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-sudo apt-get update
-sudo apt-get install -y \
+apt-get update
+apt-get install -y \
   bison \
   cmake \
   curl \
@@ -11,20 +11,26 @@ sudo apt-get install -y \
   git \
   iputils-ping \
   libapr1-dev \
+  libaprutil1-dev \
   libbz2-dev \
   libcurl4-openssl-dev \
   libevent-dev \
   libkrb5-dev \
+  libpam-dev \
   libperl-dev \
   libreadline-dev \
   libssl-dev \
+  libtool \
+  libuv1-dev \
   libxml2-dev \
+  libxslt-dev \
   libyaml-dev \
   libzstd-dev \
   locales \
   net-tools \
   openssh-client \
   openssh-server \
+  pkg-config \
   python2 \
   python2-dev \
   zlib1g-dev

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -12,7 +12,17 @@ RUN set -eux; \
     wget $sigar $sigar_headers $libxerces $libxerces_dev; \
     apt install -y ./*.deb; \
     rm ./*.deb; \
-    ln -s python2 /usr/bin/python
+    ln -s python2 /usr/bin/python; \
+# Install pg_bsd_indent used by pgindent utility
+    wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf -; \
+    make install -C pg_bsd_indent; \
+    rm -r pg_bsd_indent; \
+# The en_US.UTF-8 locale is needed to run GPDB
+    locale-gen en_US.UTF-8; \
+# To run sshd directly, but not using `/etc/init.d/ssh start`
+    mkdir /run/sshd; \
+# Alter precedence in favor of IPv4 during resolving
+    echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
 
 WORKDIR /home/gpadmin
 
@@ -38,22 +48,9 @@ FROM base as test
 COPY --from=code /home/gpadmin/gpdb_src gpdb_src
 COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
 
-# Install entab and pg_bsd_indent used by pgindent utility.
+# Install entab used by pgindent utility.
 # This should be done using gpdb sources.
-RUN set -eux; \
-    make -C gpdb_src/src/tools/entab install clean; \
-    wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf -; \
-    make install -C pg_bsd_indent; \
-    rm -r pg_bsd_indent; \
-# libipc-run-perl and rsync are needed to run regression tests
-# iproute2 is needed to run GPDB
-    apt install -y libipc-run-perl rsync iproute2; \
-# The en_US.UTF-8 locale is needed to run GPDB
-    locale-gen en_US.UTF-8; \
-# To run sshd directly, but not using `/etc/init.d/ssh start`
-    mkdir /run/sshd; \
-# Alter precedence in favor of IPv4 during resolving
-    echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
+RUN make -C gpdb_src/src/tools/entab install clean
 
 # Volume for tests output
 VOLUME /home/gpadmin/gpdb_src/src/test

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -5,8 +5,6 @@ ARG sigar_headers=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/
 ARG libxerces=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/libxerces-c31_3.1.2-3304_amd64.deb
 ARG libxerces_dev=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/libxerces-c31-dev_3.1.2-3304_amd64.deb
 
-WORKDIR /home/gpadmin
-
 COPY README.ubuntu.bash ./
 RUN set -eux; \
     ./README.ubuntu.bash; \
@@ -15,6 +13,8 @@ RUN set -eux; \
     apt install -y ./*.deb; \
     rm ./*.deb; \
     ln -s python2 /usr/bin/python
+
+WORKDIR /home/gpadmin
 
 FROM base as build
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -8,11 +8,12 @@ ARG libxerces_dev=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/
 WORKDIR /home/gpadmin
 
 COPY README.ubuntu.bash ./
-RUN ./README.ubuntu.bash && \
-    rm README.ubuntu.bash && \
-    wget $sigar $sigar_headers $libxerces $libxerces_dev && \
-    apt install ./*.deb && \
-    rm ./*.deb && \
+RUN set -eux; \
+    ./README.ubuntu.bash; \
+    rm README.ubuntu.bash; \
+    wget $sigar $sigar_headers $libxerces $libxerces_dev; \
+    apt install -y ./*.deb; \
+    rm ./*.deb; \
     ln -s python2 /usr/bin/python
 
 FROM base as build
@@ -39,17 +40,18 @@ COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
 
 # Install entab and pg_bsd_indent used by pgindent utility.
 # This should be done using gpdb sources.
-RUN make -C gpdb_src/src/tools/entab install clean && \
-    wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf - && \
-    make install -C pg_bsd_indent && \
-    rm -r pg_bsd_indent && \
+RUN set -eux; \
+    make -C gpdb_src/src/tools/entab install clean; \
+    wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf -; \
+    make install -C pg_bsd_indent; \
+    rm -r pg_bsd_indent; \
 # libipc-run-perl and rsync are needed to run regression tests
 # iproute2 is needed to run GPDB
-    apt install -y libipc-run-perl rsync iproute2 && \
+    apt install -y libipc-run-perl rsync iproute2; \
 # The en_US.UTF-8 locale is needed to run GPDB
-    locale-gen en_US.UTF-8 && \
+    locale-gen en_US.UTF-8; \
 # To run sshd directly, but not using `/etc/init.d/ssh start`
-    mkdir /run/sshd && \
+    mkdir /run/sshd; \
 # Alter precedence in favor of IPv4 during resolving
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04 as base
+
+ARG sigar=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/sigar_1.6.5-3304%2Bgite8961a6_all.deb
+ARG sigar_headers=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/sigar-headers_1.6.5-3304%2Bgite8961a6_all.deb
+ARG libxerces=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/libxerces-c31_3.1.2-3304_amd64.deb
+ARG libxerces_dev=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/libxerces-c31-dev_3.1.2-3304_amd64.deb
+
+WORKDIR /home/gpadmin
+
+COPY README.ubuntu.bash ./
+RUN ./README.ubuntu.bash && \
+    rm README.ubuntu.bash && \
+    wget $sigar $sigar_headers $libxerces $libxerces_dev && \
+    apt install ./*.deb && \
+    rm ./*.deb && \
+    ln -s python2 /usr/bin/python
+
+FROM base as build
+
+COPY . gpdb_src
+
+RUN mkdir /home/gpadmin/bin_gpdb
+
+ENV TARGET_OS=ubuntu
+ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend" 
+
+# Compile with running mocking tests
+RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash
+
+FROM base as code
+# Use --exclude, when it will be available in stable syntax.
+COPY . gpdb_src
+RUN rm -rf gpdb_src/.git/
+
+FROM base as test
+COPY --from=code /home/gpadmin/gpdb_src gpdb_src
+COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
+
+# Install entab and pg_bsd_indent used by pgindent utility.
+# This should be done using gpdb sources.
+RUN make -C gpdb_src/src/tools/entab install clean && \
+    wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz -O - | tar -xzf - && \
+    make install -C pg_bsd_indent && \
+    rm -r pg_bsd_indent && \
+# libipc-run-perl and rsync are needed to run regression tests
+# iproute2 is needed to run GPDB
+    apt install -y libipc-run-perl rsync iproute2 && \
+# The en_US.UTF-8 locale is needed to run GPDB
+    locale-gen en_US.UTF-8 && \
+# To run sshd directly, but not using `/etc/init.d/ssh start`
+    mkdir /run/sshd && \
+# Alter precedence in favor of IPv4 during resolving
+    echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
+
+# Volume for tests output
+VOLUME /home/gpadmin/gpdb_src/src/test


### PR DESCRIPTION
Add dockerfile which is based on Ubuntu 22.04

There is no sudo in the ubuntu:22.04 image, so sudo is moved from
README.ubuntu.bash to README.linux.md. Add packages, which are required to build
and run GPDB, to README.ubuntu.bash. The new Dockerfile.ubuntu file is similar
to arenadata/Dockerfile. The first RUN setups the environment to run
compile_gpdb.bash and contains all changes to the ubuntu:22.04 image, which can
be made without the source code. So this layer will not be rebuilt for every
commit.