### PR TITLE
ADBDEV-5436: Fix gpstop -u not updating GUCs on segments (#881)

### DIFF
--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -112,12 +112,13 @@ DtxContextInfo_CreateOnCoordinator(DtxContextInfo *dtxContextInfo, bool inCursor
 			 dtxContextInfo->curcid);
 
 		elog((Debug_print_full_dtm ? LOG : DEBUG5),
-			 "DtxContextInfo_CreateOnCoordinator txnOptions = 0x%x, needDtx = %s, explicitBegin = %s, isoLevel = %s, readOnly = %s.",
+			 "DtxContextInfo_CreateOnCoordinator txnOptions = 0x%x, needDtx = %s, explicitBegin = %s, isoLevel = %s, readOnly = %s, synchronizationSet = %s.",
 			 txnOptions,
 			 (isMppTxOptions_NeedDtx(txnOptions) ? "true" : "false"),
 			 (isMppTxOptions_ExplicitBegin(txnOptions) ? "true" : "false"),
 			 IsoLevelAsUpperString(mppTxOptions_IsoLevel(txnOptions)),
-			 (isMppTxOptions_ReadOnly(txnOptions) ? "true" : "false"));
+			 (isMppTxOptions_ReadOnly(txnOptions) ? "true" : "false"),
+			 (isMppTxOptions_SynchronizationSet(txnOptions) ? "true" : "false"));
 	}
 }
 

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -116,6 +116,12 @@ int gp_gxid_prefetch_num;
 
 #define GP_OPT_EXPLICT_BEGIN      						0x0020
 
+/*
+ * Some context to distinguish between user-invoked SET commands and explicit
+ * QD to QE config synchronization.
+ */
+#define GP_OPT_SYNCHRONIZATION_SET						0x0040
+
 /*=========================================================================
  * FUNCTIONS PROTOTYPES
  */
@@ -1163,6 +1169,17 @@ mppTxnOptions(bool needDtx)
 }
 
 int
+mppTxnOptionsForSync(bool needDtx, bool isSync)
+{
+	int flags = mppTxnOptions(needDtx);
+
+	if (isSync)
+		flags |= GP_OPT_SYNCHRONIZATION_SET;
+
+	return flags;
+}
+
+int
 mppTxOptions_IsoLevel(int txnOptions)
 {
 	if ((txnOptions & GP_OPT_ISOLATION_LEVEL_MASK) == GP_OPT_SERIALIZABLE)
@@ -1196,6 +1213,12 @@ bool
 isMppTxOptions_ExplicitBegin(int txnOptions)
 {
 	return ((txnOptions & GP_OPT_EXPLICT_BEGIN) != 0);
+}
+
+bool
+isMppTxOptions_SynchronizationSet(int txnOptions)
+{
+	return ((txnOptions & GP_OPT_SYNCHRONIZATION_SET) != 0);
 }
 
 /*=========================================================================

--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -126,16 +126,8 @@ STRING			\'([^'\\\n]|\\.|\'\')*\'
 
 /* LCOV_EXCL_STOP */
 
-/*
- * Exported function to read and process the configuration file. The
- * parameter indicates in what context the file is being read --- either
- * postmaster startup (including standalone-backend startup) or SIGHUP.
- * All options mentioned in the configuration file are set to new values.
- * If a hard error occurs, no values will be changed.  (There can also be
- * errors that prevent just one value from being changed.)
- */
-void
-ProcessConfigFile(GucContext context)
+static void
+ProcessConfigFileInContext(GucContext context, List ** changed_gucs_out)
 {
 	int			elevel;
 	MemoryContext config_cxt;
@@ -168,7 +160,7 @@ ProcessConfigFile(GucContext context)
 	/*
 	 * Read and apply the config file.  We don't need to examine the result.
 	 */
-	(void) ProcessConfigFileInternal(context, true, elevel);
+	(void) ProcessConfigFileInternal(context, true, elevel, caller_cxt, changed_gucs_out);
 
 	/* Clean up */
 	MemoryContextSwitchTo(caller_cxt);
@@ -183,7 +175,7 @@ ProcessConfigFile(GucContext context)
  * by show_all_file_settings().
  */
 static ConfigVariable *
-ProcessConfigFileInternal(GucContext context, bool applySettings, int elevel)
+ProcessConfigFileInternal(GucContext context, bool applySettings, int elevel, MemoryContext caller_cxt, List ** changed_gucs_out)
 {
 	bool		error = false;
 	bool		applying = false;
@@ -192,6 +184,7 @@ ProcessConfigFileInternal(GucContext context, bool applySettings, int elevel)
 			   *head,
 			   *tail;
 	int			i;
+	List	   *changed_gucs = NIL;
 
 	/* Parse the main config file into a list of option names and values */
 	ConfFileWithError = ConfigFileName;
@@ -404,6 +397,12 @@ ProcessConfigFileInternal(GucContext context, bool applySettings, int elevel)
 				ereport(elevel,
 						(errmsg("parameter \"%s\" removed from configuration file, reset to default",
 								gconf->name)));
+			if (changed_gucs_out)
+			{
+				MemoryContext old_cxt = MemoryContextSwitchTo(caller_cxt);
+				changed_gucs = lappend(changed_gucs, gconf);
+				MemoryContextSwitchTo(old_cxt);
+			}
 		}
 	}
 
@@ -472,6 +471,17 @@ ProcessConfigFileInternal(GucContext context, bool applySettings, int elevel)
 									item->name, item->value)));
 			}
 			item->applied = true;
+
+			if (changed_gucs_out)
+			{
+				struct config_generic *gconf = find_option(item->name, false, elevel);
+				if (gconf != NULL)
+				{
+					MemoryContext old_cxt = MemoryContextSwitchTo(caller_cxt);
+					changed_gucs = lappend(changed_gucs, gconf);
+					MemoryContextSwitchTo(old_cxt);
+				}
+			}
 		}
 		else if (scres == 0)
 		{
@@ -524,8 +534,39 @@ bail_out:
 							ConfFileWithError)));
 	}
 
+	if (changed_gucs_out)
+		*changed_gucs_out = changed_gucs;
+	else
+		Assert(changed_gucs == NIL);
+
 	/* Successful or otherwise, return the collected data list */
 	return head;
+}
+
+/*
+ * Exported function to read and process the configuration file. The
+ * parameter indicates in what context the file is being read --- either
+ * postmaster startup (including standalone-backend startup) or SIGHUP.
+ * All options mentioned in the configuration file are set to new values.
+ * If a hard error occurs, no values will be changed.  (There can also be
+ * errors that prevent just one value from being changed.)
+ */
+void
+ProcessConfigFile(GucContext context)
+{
+	ProcessConfigFileInContext(context, NULL);
+}
+
+/*
+ * This works the same way as the ProcessConfigFile(), except that it returns a
+ * list of options (config_generic *) that were changed.
+ */
+List *
+ProcessConfigFileForSync(GucContext context)
+{
+	List * changed_gucs;
+	ProcessConfigFileInContext(context, &changed_gucs);
+	return changed_gucs;
 }
 
 /*

--- a/src/include/cdb/cdbdisp_query.h
+++ b/src/include/cdb/cdbdisp_query.h
@@ -33,6 +33,10 @@
  * indicate whether the command should be dispatched to qExecs along with a snapshot.
  */
 #define DF_WITH_SNAPSHOT  0x4
+/*
+ * indicate whether a SET command was an explicit QD to QE config synchronization.
+ */
+#define DF_SYNC_SET 0x8
 
 struct QueryDesc;
 struct SerializedParams;
@@ -67,6 +71,13 @@ extern void CdbDispatchPlan(struct QueryDesc *queryDesc,
  * gangs, both reader and writer
  */
 extern void CdbDispatchSetCommand(const char *strCommand, bool cancelOnError);
+
+/*
+ * The same as CdbDispatchSetCommand(), but bypasses priveleges and always uses
+ * PGC_S_CLIENT context.
+ */
+void
+CdbDispatchSetCommandForSync(const char *strCommand);
 
 /*
  * CdbDispatchCommand

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -327,10 +327,12 @@ extern int	tmShmemSize(void);
 extern void verify_shared_snapshot_ready(int cid);
 
 int			mppTxnOptions(bool needDtx);
+int			mppTxnOptionsForSync(bool needDtx, bool isSync);
 int			mppTxOptions_IsoLevel(int txnOptions);
 bool		isMppTxOptions_ReadOnly(int txnOptions);
 bool		isMppTxOptions_NeedDtx(int txnOptions);
 bool		isMppTxOptions_ExplicitBegin(int txnOptions);
+bool		isMppTxOptions_SynchronizationSet(int txnOptions);
 
 extern void getAllDistributedXactStatus(TMGALLXACTSTATUS **allDistributedXactStatus);
 extern bool getNextDistributedXactStatus(TMGALLXACTSTATUS *allDistributedXactStatus, TMGXACTSTATUS **distributedXactStatus);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -713,6 +713,7 @@ extern const char *GetConfigOption(const char *name, bool missing_ok,
 extern const char *GetConfigOptionResetString(const char *name);
 extern int	GetConfigOptionFlags(const char *name, bool missing_ok);
 extern void ProcessConfigFile(GucContext context);
+extern List *ProcessConfigFileForSync(GucContext context);
 extern void InitializeGUCOptions(void);
 extern bool SelectConfigFiles(const char *userDoption, const char *progname);
 extern void ResetAllOptions(void);
@@ -821,5 +822,6 @@ extern bool gpvars_check_statement_mem(int *newval, void **extra, GucSource sour
 extern bool gpvars_check_rg_query_fixed_mem(int *newval, void **extra, GucSource source);
 extern int guc_name_compare(const char *namea, const char *nameb);
 extern void DispatchSyncPGVariable(struct config_generic * gconfig);
+extern void DispatchSyncPGVariableExplicit(struct config_generic * gconfig);
 
 #endif							/* GUC_H */

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -590,3 +590,86 @@ reset optimizer;
 drop function cleanupAllGangs();
 drop table t_create_gang_time;
 
+--
+-- Backend process GUCs marked as GUC_GPDB_NEED_SYNC are overwritten by
+-- coordinator upon receiving a new connection.
+--
+-- GUCs that were changed in the configuration file of the QD should be re-sent
+-- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
+--
+
+-- start_ignore
+DROP ROLE IF EXISTS dispatch_test_user2;
+-- end_ignore
+
+-- Use a separate user without any priveleges to catch possible context issues.
+CREATE ROLE dispatch_test_user2 NOSUPERUSER;
+SET SESSION AUTHORIZATION dispatch_test_user2;
+
+CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
+RETURNS table (guc_name text, guc_setting text)
+EXECUTE ON ALL SEGMENTS AS $$
+BEGIN
+	RETURN QUERY SELECT name, setting FROM pg_settings WHERE show_name = name;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Explicitly set GUCs through gpconfig, then run gpstop -u.
+--
+-- log_min_messages has GUC_GPDB_NEED_SYNC in flags, so it should be
+-- synchronized across the segments, and a context of PGC_SUSET, that it should
+-- not be possible to change it without superuser priveleges.
+--
+-- constraint_exclusion is not synchronized, so it should remain unchanged on
+-- segments.
+
+--start_ignore
+-- Set default values and reconnect.
+\!gpconfig -c log_min_messages -v 'warning'
+\!gpconfig -c constraint_exclusion -v 'on'
+\!gpstop -u
+--end_ignore
+
+-- PGC_SUSET, we don't have enough priveleges.
+RESET log_min_messages;
+-- Successfully reset.
+RESET constraint_exclusion;
+
+SHOW log_min_messages;
+SELECT * from show_on_segments('log_min_messages');
+
+SHOW constraint_exclusion;
+SELECT * from show_on_segments('constraint_exclusion');
+
+--start_ignore
+\!gpconfig -c log_min_messages -v 'warning' -m 'notice'
+\!gpconfig -c constraint_exclusion -v 'off' -m 'partition'
+\!gpstop -u
+--end_ignore
+
+-- Should be 'notice', synchronized with segments.
+SHOW log_min_messages;
+SELECT * from show_on_segments('log_min_messages');
+
+-- Should be 'partition' on QD, 'off' on QEs.
+SHOW constraint_exclusion;
+SELECT * from show_on_segments('constraint_exclusion');
+
+--start_ignore
+\!gpconfig -r log_min_messages
+\!gpconfig -r constraint_exclusion
+\!gpstop -u
+--end_ignore
+
+-- After reset, QD and QE should hold the default value, 'warning'.
+SHOW log_min_messages;
+SELECT * from show_on_segments('log_min_messages');
+
+-- After reset, QD and QE should hold the default value, 'on'.
+SHOW constraint_exclusion;
+SELECT * from show_on_segments('constraint_exclusion');
+
+RESET SESSION AUTHORIZATION;
+
+DROP FUNCTION show_on_segments(show_name text);
+DROP ROLE dispatch_test_user2;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1009,3 +1009,134 @@ reset gp_print_create_gang_time;
 reset optimizer;
 drop function cleanupAllGangs();
 drop table t_create_gang_time;
+--
+-- Backend process GUCs marked as GUC_GPDB_NEED_SYNC are overwritten by
+-- coordinator upon receiving a new connection.
+--
+-- GUCs that were changed in the configuration file of the QD should be re-sent
+-- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
+--
+-- Use a separate user without any priveleges to catch possible context issues.
+CREATE ROLE dispatch_test_user2 NOSUPERUSER;
+SET SESSION AUTHORIZATION dispatch_test_user2;
+CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
+RETURNS table (guc_name text, guc_setting text)
+EXECUTE ON ALL SEGMENTS AS $$
+BEGIN
+	RETURN QUERY SELECT name, setting FROM pg_settings WHERE show_name = name;
+END;
+$$ LANGUAGE plpgsql;
+-- Explicitly set GUCs through gpconfig, then run gpstop -u.
+--
+-- log_min_messages has GUC_GPDB_NEED_SYNC in flags, so it should be
+-- synchronized across the segments, and a context of PGC_SUSET, that it should
+-- not be possible to change it without superuser priveleges.
+--
+-- constraint_exclusion is not synchronized, so it should remain unchanged on
+-- segments.
+-- PGC_SUSET, we don't have enough priveleges.
+RESET log_min_messages;
+ERROR:  permission denied to set parameter "log_min_messages"
+-- Successfully reset.
+RESET constraint_exclusion;
+SHOW log_min_messages;
+ log_min_messages 
+------------------
+ warning
+(1 row)
+
+SELECT * from show_on_segments('log_min_messages');
+     guc_name     | guc_setting 
+------------------+-------------
+ log_min_messages | warning
+ log_min_messages | warning
+ log_min_messages | warning
+(3 rows)
+
+SHOW constraint_exclusion;
+ constraint_exclusion 
+----------------------
+ on
+(1 row)
+
+SELECT * from show_on_segments('constraint_exclusion');
+       guc_name       | guc_setting 
+----------------------+-------------
+ constraint_exclusion | on
+ constraint_exclusion | on
+ constraint_exclusion | on
+(3 rows)
+
+--start_ignore
+\!gpconfig -c log_min_messages -v 'warning' -m 'notice'
+\!gpconfig -c constraint_exclusion -v 'off' -m 'partition'
+\!gpstop -u
+--end_ignore
+-- Should be 'notice', synchronized with segments.
+SHOW log_min_messages;
+ log_min_messages 
+------------------
+ notice
+(1 row)
+
+SELECT * from show_on_segments('log_min_messages');
+     guc_name     | guc_setting 
+------------------+-------------
+ log_min_messages | notice
+ log_min_messages | notice
+ log_min_messages | notice
+(3 rows)
+
+-- Should be 'partition' on QD, 'off' on QEs.
+SHOW constraint_exclusion;
+ constraint_exclusion 
+----------------------
+ partition
+(1 row)
+
+SELECT * from show_on_segments('constraint_exclusion');
+       guc_name       | guc_setting 
+----------------------+-------------
+ constraint_exclusion | off
+ constraint_exclusion | off
+ constraint_exclusion | off
+(3 rows)
+
+--start_ignore
+\!gpconfig -r log_min_messages
+\!gpconfig -r constraint_exclusion
+\!gpstop -u
+--end_ignore
+-- After reset, QD and QE should hold the default value, 'warning'.
+SHOW log_min_messages;
+ log_min_messages 
+------------------
+ warning
+(1 row)
+
+SELECT * from show_on_segments('log_min_messages');
+     guc_name     | guc_setting 
+------------------+-------------
+ log_min_messages | warning
+ log_min_messages | warning
+ log_min_messages | warning
+(3 rows)
+
+-- After reset, QD and QE should hold the default value, 'on'.
+SHOW constraint_exclusion;
+ constraint_exclusion 
+----------------------
+ on
+(1 row)
+
+SELECT * from show_on_segments('constraint_exclusion');
+       guc_name       | guc_setting 
+----------------------+-------------
+ constraint_exclusion | on
+ constraint_exclusion | on
+ constraint_exclusion | on
+(3 rows)
+
+RESET SESSION AUTHORIZATION;
+DROP FUNCTION show_on_segments(show_name text);
+DROP ROLE dispatch_test_user2;


### PR DESCRIPTION
Fix gpstop -u not updating GUCs on segments (#881)

Backend process GUCs marked as GUC_GPDB_NEED_SYNC are overwritten by
coordinator upon receiving a new connection. The coordinator sends it's
configuration to the segments the same way as if it were a frontend
communicating with the coordinator. This means the default priority for these
GUCs becomes client priority.

Previously, when gpstop -u was executed, it sent a SIGHUP signal, prompting
the coordinator and segments to re-read their configuration files. However,
the priority of options derived from the configuration file is lower than that
of client options. This difference caused the segments to ignore overwritten
GUCs when they re-read their configuration files, and these GUCs were not
re-dispatched by the QD either. This situation resulted in a desynchronization
of GUCs that are required to be synchronized between the coordinator and the
segments.

The solution is to explicitly dispatch the changed configuration from the
coordinator to the segments, similar to how it is done when initializing the
backend process.

When the QD receives a SIGHUP signal, it reads its configuration file to
identify any GUCs that have been modified. If these GUCs are marked with the
GUC_GPDB_NEED_SYNC flag, the QD dispatches SET commands containing these
modified GUCs to the QEs. To differentiate between this type of
synchronization and user-initiated SET commands, a flag
GP_OPT_SYNCHRONIZATION_SET has been introduced to the distributed transaction
options.

Changes from original commit:
- In `guc-file.l` move the return value of `ProcessConfigFileInternal` to an
out parameter `changed_gucs_out`.
- Add memory context switching to it so that the `changed_gucs_out` list is in
the correct memory context.
- Change GUC parameter in the test from `backslash_quote` to
`constraint_exclusion` since `backslash_quote` now has a sync flag.

(cherry picked from commit 6934f3deb6917ab6128fd327261c1216847fbb77)

---
Note: do not squash the commit to preserve authorship.
