### PR TITLE
ADBDEV-4688: Disable row trigger processing in Orca

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -60,7 +60,6 @@ using namespace gpmd;
 
 extern bool optimizer_enable_ctas;
 extern bool optimizer_enable_dml;
-extern bool optimizer_enable_dml_triggers;
 extern bool optimizer_enable_dml_constraints;
 extern bool optimizer_enable_replicated_table;
 extern bool optimizer_enable_multiple_distinct_aggs;
@@ -716,8 +715,7 @@ CTranslatorQueryToDXL::TranslateInsertQueryToDXL()
 		&m_context->m_has_distributed_tables,
 		&m_context->m_has_replicated_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
-	if (!optimizer_enable_dml_triggers &&
-		CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
+	if (CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
 										 Edxldmlinsert))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
@@ -1168,8 +1166,7 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 		&m_context->m_has_distributed_tables,
 		&m_context->m_has_replicated_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
-	if (!optimizer_enable_dml_triggers &&
-		CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
+	if (CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
 										 Edxldmldelete))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
@@ -1250,8 +1247,7 @@ CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 		&m_context->m_has_distributed_tables,
 		&m_context->m_has_replicated_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
-	if (!optimizer_enable_dml_triggers &&
-		CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
+	if (CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
 										 Edxldmlupdate))
 	{
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2930,7 +2930,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"optimizer_enable_dml_triggers", PGC_USERSET, DEVELOPER_OPTIONS,
+		{"optimizer_enable_dml_triggers", PGC_USERSET, DEFUNCT_OPTIONS,
 			gettext_noop("Support DML with triggers."),
 			NULL,
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -482,7 +482,6 @@ extern bool optimizer_enable_outerjoin_to_unionall_rewrite;
 extern bool optimizer_enable_ctas;
 extern bool optimizer_enable_partial_index;
 extern bool optimizer_enable_dml;
-extern bool optimizer_enable_dml_triggers;
 extern bool	optimizer_enable_dml_constraints;
 extern bool optimizer_enable_direct_dispatch;
 extern bool optimizer_enable_master_only_queries;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15231,7 +15231,6 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
 -- GUC should be disabled by default and cannot be enabled
-RESET optimizer_enable_dml_triggers;
 SHOW optimizer_enable_dml_triggers;
  optimizer_enable_dml_triggers 
 -------------------------------
@@ -15240,6 +15239,12 @@ SHOW optimizer_enable_dml_triggers;
 
 SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+SHOW optimizer_enable_dml_triggers;
+ optimizer_enable_dml_triggers 
+-------------------------------
+ off
+(1 row)
+
 -- The next query should be processed by the Postgres planner
 -- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15217,7 +15217,7 @@ WITH e AS (
 (65 rows)
 
 DROP TABLE d, r;
--- Test disable optimizer_enable_dml_triggers GUC 
+-- Test that optimizer_enable_dml_triggers GUC is defunct 
 CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
 -- The next query should be processed by Orca
 INSERT INTO d VALUES (1, 1);
@@ -15230,10 +15230,18 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
+-- GUC should be disabled by default and cannot be enabled
+RESET optimizer_enable_dml_triggers;
+SHOW optimizer_enable_dml_triggers;
+ optimizer_enable_dml_triggers 
+-------------------------------
+ off
+(1 row)
+
 SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 -- The next query should be processed by the Postgres planner
--- because trigger execution in Orca was disabled.
+-- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
 NOTICE:  Values: (1, 1)
 RESET optimizer_enable_dml_triggers;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15235,8 +15235,6 @@ WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defu
 -- The next query should be processed by the Postgres planner
 -- because trigger execution in Orca was disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: UPDATE with triggers
 NOTICE:  Values: (1, 1)
 RESET optimizer_enable_dml_triggers;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15217,4 +15217,52 @@ WITH e AS (
 (65 rows)
 
 DROP TABLE d, r;
+-- Test disable optimizer_enable_dml_triggers GUC 
+CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+-- The next query should be processed by Orca
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
+QUERY PLAN
+___________
+ Insert (actual time=##.###..##.### rows=# loops=#)
+   ->  Result (actual time=##.###..##.### rows=# loops=#)
+         ->  Result (actual time=##.###..##.### rows=# loops=#)
+               ->  Result (actual time=##.###..##.### rows=# loops=#)
+                     ->  Result (actual time=##.###..##.### rows=# loops=#)
+ Planning time: ##.### ms
+   (slice0)    Executor Memory: 
+ Memory used:
+ Execution time: ##.### ms
+GP_IGNORE:(10 rows)
+
+CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
+AS $$
+BEGIN
+  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER d_upd AFTER UPDATE ON d
+FOR EACH ROW EXECUTE PROCEDURE trig_proc();
+SET optimizer_enable_dml_triggers = TRUE;
+WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+-- The next query should be processed by the Postgres planner
+-- because trigger execution in Orca was disabled.
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: UPDATE with triggers
+NOTICE:  Values: (1, 1, 1)
+QUERY PLAN
+___________
+ Update on d (actual time=##.###..##.### rows=# loops=#)
+   ->  Seq Scan on d (actual time=##.###..##.### rows=# loops=#)
+         Filter: (t1 = 1)
+ Planning time: ##.### ms
+   (slice0)    Executor Memory: 
+ Memory used:
+ Execution time: ##.### ms
+GP_IGNORE:(8 rows)
+
+RESET optimizer_enable_dml_triggers;
+WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+DROP TABLE d;
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15249,4 +15249,5 @@ SHOW optimizer_enable_dml_triggers;
 UPDATE d SET с2 = 2 WHERE с1 = 1;
 NOTICE:  Values: (1, 1)
 DROP TABLE d;
+DROP FUNCTION trig_proc();
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15219,7 +15219,6 @@ WITH e AS (
 DROP TABLE d, r;
 -- Test that optimizer_enable_dml_triggers GUC is defunct 
 CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
--- The next query should be processed by Orca
 INSERT INTO d VALUES (1, 1);
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
 AS $$
@@ -15230,7 +15229,7 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
--- GUC should be disabled by default and cannot be enabled
+-- The GUC should be disabled by default and cannot be enabled
 SHOW optimizer_enable_dml_triggers;
  optimizer_enable_dml_triggers 
 -------------------------------
@@ -15249,7 +15248,5 @@ SHOW optimizer_enable_dml_triggers;
 -- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
 NOTICE:  Values: (1, 1)
-RESET optimizer_enable_dml_triggers;
-WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 DROP TABLE d;
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -15218,26 +15218,13 @@ WITH e AS (
 
 DROP TABLE d, r;
 -- Test disable optimizer_enable_dml_triggers GUC 
-CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
 -- The next query should be processed by Orca
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
-QUERY PLAN
-___________
- Insert (actual time=##.###..##.### rows=# loops=#)
-   ->  Result (actual time=##.###..##.### rows=# loops=#)
-         ->  Result (actual time=##.###..##.### rows=# loops=#)
-               ->  Result (actual time=##.###..##.### rows=# loops=#)
-                     ->  Result (actual time=##.###..##.### rows=# loops=#)
- Planning time: ##.### ms
-   (slice0)    Executor Memory: 
- Memory used:
- Execution time: ##.### ms
-GP_IGNORE:(10 rows)
-
+INSERT INTO d VALUES (1, 1);
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
 AS $$
 BEGIN
-  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RAISE NOTICE 'Values: (%, %)', OLD.с1, OLD.с2;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -15247,21 +15234,10 @@ SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 -- The next query should be processed by the Postgres planner
 -- because trigger execution in Orca was disabled.
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+UPDATE d SET с2 = 2 WHERE с1 = 1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with triggers
-NOTICE:  Values: (1, 1, 1)
-QUERY PLAN
-___________
- Update on d (actual time=##.###..##.### rows=# loops=#)
-   ->  Seq Scan on d (actual time=##.###..##.### rows=# loops=#)
-         Filter: (t1 = 1)
- Planning time: ##.### ms
-   (slice0)    Executor Memory: 
- Memory used:
- Execution time: ##.### ms
-GP_IGNORE:(8 rows)
-
+NOTICE:  Values: (1, 1)
 RESET optimizer_enable_dml_triggers;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 DROP TABLE d;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15472,4 +15472,5 @@ INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with triggers
 NOTICE:  Values: (1, 1)
 DROP TABLE d;
+DROP FUNCTION trig_proc();
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15439,26 +15439,13 @@ WITH e AS (
 
 DROP TABLE d, r;
 -- Test disable optimizer_enable_dml_triggers GUC 
-CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
 -- The next query should be processed by Orca
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
-QUERY PLAN
-___________
- Insert (actual time=##.###..##.### rows=# loops=#)
-   ->  Result (actual time=##.###..##.### rows=# loops=#)
-         ->  Result (actual time=##.###..##.### rows=# loops=#)
-               ->  Result (actual time=##.###..##.### rows=# loops=#)
-                     ->  Result (actual time=##.###..##.### rows=# loops=#)
- Planning time: ##.### ms
-   (slice0)    Executor Memory: 
- Memory used:
- Execution time: ##.### ms
-GP_IGNORE:(10 rows)
-
+INSERT INTO d VALUES (1, 1);
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
 AS $$
 BEGIN
-  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RAISE NOTICE 'Values: (%, %)', OLD.с1, OLD.с2;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -15468,21 +15455,10 @@ SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 -- The next query should be processed by the Postgres planner
 -- because trigger execution in Orca was disabled.
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+UPDATE d SET с2 = 2 WHERE с1 = 1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with triggers
-NOTICE:  Values: (1, 1, 1)
-QUERY PLAN
-___________
- Update on d (actual time=##.###..##.### rows=# loops=#)
-   ->  Seq Scan on d (actual time=##.###..##.### rows=# loops=#)
-         Filter: (t1 = 1)
- Planning time: ##.### ms
-   (slice0)    Executor Memory: 
- Memory used:
- Execution time: ##.### ms
-GP_IGNORE:(8 rows)
-
+NOTICE:  Values: (1, 1)
 RESET optimizer_enable_dml_triggers;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 DROP TABLE d;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15438,7 +15438,7 @@ WITH e AS (
 (50 rows)
 
 DROP TABLE d, r;
--- Test disable optimizer_enable_dml_triggers GUC 
+-- Test that optimizer_enable_dml_triggers GUC is defunct 
 CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
 -- The next query should be processed by Orca
 INSERT INTO d VALUES (1, 1);
@@ -15451,10 +15451,19 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
+-- GUC should be disabled by default and cannot be enabled
+RESET optimizer_enable_dml_triggers;
+WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+SHOW optimizer_enable_dml_triggers;
+ optimizer_enable_dml_triggers 
+-------------------------------
+ off
+(1 row)
+
 SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 -- The next query should be processed by the Postgres planner
--- because trigger execution in Orca was disabled.
+-- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with triggers

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15438,4 +15438,52 @@ WITH e AS (
 (50 rows)
 
 DROP TABLE d, r;
+-- Test disable optimizer_enable_dml_triggers GUC 
+CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+-- The next query should be processed by Orca
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
+QUERY PLAN
+___________
+ Insert (actual time=##.###..##.### rows=# loops=#)
+   ->  Result (actual time=##.###..##.### rows=# loops=#)
+         ->  Result (actual time=##.###..##.### rows=# loops=#)
+               ->  Result (actual time=##.###..##.### rows=# loops=#)
+                     ->  Result (actual time=##.###..##.### rows=# loops=#)
+ Planning time: ##.### ms
+   (slice0)    Executor Memory: 
+ Memory used:
+ Execution time: ##.### ms
+GP_IGNORE:(10 rows)
+
+CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
+AS $$
+BEGIN
+  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER d_upd AFTER UPDATE ON d
+FOR EACH ROW EXECUTE PROCEDURE trig_proc();
+SET optimizer_enable_dml_triggers = TRUE;
+WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+-- The next query should be processed by the Postgres planner
+-- because trigger execution in Orca was disabled.
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: UPDATE with triggers
+NOTICE:  Values: (1, 1, 1)
+QUERY PLAN
+___________
+ Update on d (actual time=##.###..##.### rows=# loops=#)
+   ->  Seq Scan on d (actual time=##.###..##.### rows=# loops=#)
+         Filter: (t1 = 1)
+ Planning time: ##.### ms
+   (slice0)    Executor Memory: 
+ Memory used:
+ Execution time: ##.### ms
+GP_IGNORE:(8 rows)
+
+RESET optimizer_enable_dml_triggers;
+WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+DROP TABLE d;
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15440,7 +15440,6 @@ WITH e AS (
 DROP TABLE d, r;
 -- Test that optimizer_enable_dml_triggers GUC is defunct 
 CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
--- The next query should be processed by Orca
 INSERT INTO d VALUES (1, 1);
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
 AS $$
@@ -15451,7 +15450,7 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
--- GUC should be disabled by default and cannot be enabled
+-- The GUC should be disabled by default and cannot be enabled
 SHOW optimizer_enable_dml_triggers;
  optimizer_enable_dml_triggers 
 -------------------------------
@@ -15472,7 +15471,5 @@ UPDATE d SET с2 = 2 WHERE с1 = 1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: UPDATE with triggers
 NOTICE:  Values: (1, 1)
-RESET optimizer_enable_dml_triggers;
-WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 DROP TABLE d;
 reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15452,8 +15452,6 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
 -- GUC should be disabled by default and cannot be enabled
-RESET optimizer_enable_dml_triggers;
-WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
 SHOW optimizer_enable_dml_triggers;
  optimizer_enable_dml_triggers 
 -------------------------------
@@ -15462,6 +15460,12 @@ SHOW optimizer_enable_dml_triggers;
 
 SET optimizer_enable_dml_triggers = TRUE;
 WARNING:  "optimizer_enable_dml_triggers": setting is ignored because it is defunct
+SHOW optimizer_enable_dml_triggers;
+ optimizer_enable_dml_triggers 
+-------------------------------
+ off
+(1 row)
+
 -- The next query should be processed by the Postgres planner
 -- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3729,7 +3729,9 @@ SHOW optimizer_enable_dml_triggers;
 -- The next query should be processed by the Postgres planner
 -- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
+
 DROP TABLE d;
+DROP FUNCTION trig_proc();
 
 reset optimizer_trace_fallback;
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3708,7 +3708,6 @@ DROP TABLE d, r;
 
 -- Test that optimizer_enable_dml_triggers GUC is defunct 
 CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
--- The next query should be processed by Orca
 INSERT INTO d VALUES (1, 1);
 
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
@@ -3722,7 +3721,7 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
 
--- GUC should be disabled by default and cannot be enabled
+-- The GUC should be disabled by default and cannot be enabled
 SHOW optimizer_enable_dml_triggers;
 SET optimizer_enable_dml_triggers = TRUE;
 SHOW optimizer_enable_dml_triggers;
@@ -3730,7 +3729,6 @@ SHOW optimizer_enable_dml_triggers;
 -- The next query should be processed by the Postgres planner
 -- because trigger planning in Orca has been disabled.
 UPDATE d SET с2 = 2 WHERE с1 = 1;
-RESET optimizer_enable_dml_triggers;
 DROP TABLE d;
 
 reset optimizer_trace_fallback;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3707,13 +3707,13 @@ WITH e AS (
 DROP TABLE d, r;
 
 -- Test disable optimizer_enable_dml_triggers GUC 
-CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+CREATE TABLE d (с1 int, с2 int) DISTRIBUTED BY (с1);
 -- The next query should be processed by Orca
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
+INSERT INTO d VALUES (1, 1);
 CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
 AS $$
 BEGIN
-  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RAISE NOTICE 'Values: (%, %)', OLD.с1, OLD.с2;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -3723,7 +3723,7 @@ FOR EACH ROW EXECUTE PROCEDURE trig_proc();
 SET optimizer_enable_dml_triggers = TRUE;
 -- The next query should be processed by the Postgres planner
 -- because trigger execution in Orca was disabled.
-EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+UPDATE d SET с2 = 2 WHERE с1 = 1;
 RESET optimizer_enable_dml_triggers;
 DROP TABLE d;
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3723,9 +3723,9 @@ CREATE TRIGGER d_upd AFTER UPDATE ON d
 FOR EACH ROW EXECUTE PROCEDURE trig_proc();
 
 -- GUC should be disabled by default and cannot be enabled
-RESET optimizer_enable_dml_triggers;
 SHOW optimizer_enable_dml_triggers;
 SET optimizer_enable_dml_triggers = TRUE;
+SHOW optimizer_enable_dml_triggers;
 
 -- The next query should be processed by the Postgres planner
 -- because trigger planning in Orca has been disabled.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3706,6 +3706,27 @@ WITH e AS (
 
 DROP TABLE d, r;
 
+-- Test disable optimizer_enable_dml_triggers GUC 
+CREATE TABLE d (t1 int, t2 int, t3 int) DISTRIBUTED BY (t1);
+-- The next query should be processed by Orca
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) INSERT INTO d VALUES (1, 1, 1);
+CREATE OR REPLACE FUNCTION trig_proc() RETURNS TRIGGER
+AS $$
+BEGIN
+  RAISE NOTICE 'Values: (%, %, %)', OLD.t1, OLD.t2, OLD.t3;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER d_upd AFTER UPDATE ON d
+FOR EACH ROW EXECUTE PROCEDURE trig_proc();
+
+SET optimizer_enable_dml_triggers = TRUE;
+-- The next query should be processed by the Postgres planner
+-- because trigger execution in Orca was disabled.
+EXPLAIN (ANALYZE on, COSTS off, VERBOSE off) UPDATE d SET t2 = 2 WHERE t1 = 1;
+RESET optimizer_enable_dml_triggers;
+DROP TABLE d;
+
 reset optimizer_trace_fallback;
 
 -- start_ignore


### PR DESCRIPTION
Disable row trigger processing in Orca

Support for  triggers is limited due  to  the distributed nature of GPDB. Using
triggers  can lead to issues because of  unclear  support status and  bugs. For
example, `AFTER UPDATE` triggers are not supported in Orca, and using 
`BEFORE UPDATE` triggers with distributed keys can lead to unexpected errors.

Currently, DML triggers have been removed from Orca in GPDB 7. Orca doesn't plan
queries that fire DML triggers. These queries are planned with Postgres planner.

To prevent potential problems, the `optimizer_enable_dml_triggers` GUC has been
disabled. As  a result, row trigger  handling in GPDB 6 and GPDB 7 is consistent.
