### PR TITLE
Fix tests on Ubuntu docker image

### DIFF
--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -24,10 +24,10 @@ RUN set -eux; \
 # Alter precedence in favor of IPv4 during resolving
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
 # Packages for tests
-	DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip; \
+    DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip; \
 # Install allure-behave for behave tests
-	pip2 install allure-behave==2.4.0; \
-	pip2 cache purge
+    pip2 install allure-behave==2.4.0; \
+    pip2 cache purge
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -23,10 +23,11 @@ RUN set -eux; \
     mkdir /run/sshd; \
 # Alter precedence in favor of IPv4 during resolving
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
-# Install allure-behave for behave tests
-	curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python && pip install allure-behave==2.4.0; \
 # Packages for tests
-	DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo
+	DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip; \
+# Install allure-behave for behave tests
+	pip2 install allure-behave==2.4.0; \
+	pip2 cache purge
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -22,7 +22,11 @@ RUN set -eux; \
 # To run sshd directly, but not using `/etc/init.d/ssh start`
     mkdir /run/sshd; \
 # Alter precedence in favor of IPv4 during resolving
-    echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf
+    echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
+# Install allure-behave for behave tests
+	curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python && pip install allure-behave==2.4.0; \
+# Packages for tests
+	DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/docker-compose.yaml
+++ b/arenadata/docker-compose.yaml
@@ -16,8 +16,11 @@ services:
     privileged: true
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
+    ulimits:
+      nofile: 65535
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw1:
     image: "${IMAGE}"
     privileged: true
@@ -28,8 +31,11 @@ services:
       - "$PWD/logs_sdw1:/logs"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
+    ulimits:
+      nofile: 65535
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw2:
     image: "${IMAGE}"
     privileged: true
@@ -39,8 +45,11 @@ services:
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
+    ulimits:
+      nofile: 65535
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity
   sdw3:
     image: "${IMAGE}"
     privileged: true
@@ -50,5 +59,8 @@ services:
       - "$PWD/ssh_keys/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub"
     sysctls:
       kernel.sem: 500 1024000 200 4096
+    init: true
+    ulimits:
+      nofile: 65535
     entrypoint: >
-      bash -c "set -e && tail -f /home/gpadmin/gpdb_src/README.md"
+      sleep infinity


### PR DESCRIPTION
Add allure-behave, fakeroot and sudo to run behave tests. Add krb5-kdc and 
krb5-admin-server to run regression tests. 
Add "init: true" to kill postgres zombie processes. The pgrep utility found 
these processes and their existence was interpreted by behave tests as GPDB was 
running. 
Set the limit on the number of open files to 65535. Without this setting
the limit was 64000. It caused to warning in gpinitsystem, so behave tests did 
not pass. 
The entrypoint value is changed to "sleep infinity" for simplification and 
unification with GPDB 7.