### PR TITLE
ADBDEV-6169: Fix allstat explain output in JSON format

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1873,7 +1873,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 								   "allstat: seg_firststart_total_ntuples");
 		}
 		else
-			ExplainOpenGroup("Allstat", "Allstat", true, es);
+			ExplainOpenGroup("Allstat", "Allstat", false, es);
 
 		for (i = 0; i < ns->ninst; i++)
 		{
@@ -1906,19 +1906,19 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 				cdbexplain_formatSeconds(totalbuf, sizeof(totalbuf),
 										 nsi->total, false);
 
-				ExplainOpenGroup("Segment", NULL, false, es);
+				ExplainOpenGroup("Segment", NULL, true, es);
 				ExplainPropertyInteger("Segment index", ns->segindex0 + i, es);
 				ExplainPropertyText("Time To First Result", startbuf, es);
 				ExplainPropertyText("Time To Total Result", totalbuf, es);
 				ExplainPropertyFloat("Tuples", nsi->ntuples, 1, es);
-				ExplainCloseGroup("Segment", NULL, false, es);
+				ExplainCloseGroup("Segment", NULL, true, es);
 			}
 		}
 
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 			appendStringInfoString(es->str, "//end\n");
 		else
-			ExplainCloseGroup("Allstat", "Allstat", true, es);
+			ExplainCloseGroup("Allstat", "Allstat", false, es);
 	}
 }								/* cdbexplain_showExecStats */
 

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -538,8 +538,8 @@ QUERY PLAN
 -- s/ "Average": \d+/ "Average": #####/
 -- m/ "Maximum Memory Used": \d+/
 -- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
--- m/ "Memory Used": \d+/
--- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/
 -- m/ "Execution Time": \d+.\d+/
 -- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
 -- end_matchsubs

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -514,6 +514,35 @@ QUERY PLAN
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
+-- m/ "Memory Used": \d+/
+-- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
+-- end_matchsubs
 CREATE SCHEMA explaintest;
 SET search_path=explaintest;
 CREATE TABLE SUBSELECT_TBL (
@@ -887,12 +916,105 @@ QUERY PLAN
   }
 ]
 (1 row)
+-- Test Allstats formatting
+create table allstat_test(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Startup Cost": 0.00,
+      "Total Cost": 1063.00,
+      "Plan Rows": 96300,
+      "Plan Width": 4,
+      "Actual Startup Time": 0.333,
+      "Actual Total Time": 0.333,
+      "Actual Rows": 0,
+      "Actual Loops": 1,
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Relation Name": "allstat_test",
+          "Alias": "allstat_test",
+          "Startup Cost": 0.00,
+          "Total Cost": 1063.00,
+          "Plan Rows": 96300,
+          "Plan Width": 4,
+          "Actual Startup Time": 0.000,
+          "Actual Total Time": 0.001,
+          "Actual Rows": 0,
+          "Actual Loops": 1,
+          "Allstat": [
+            {
+              "Segment index": 0,
+              "Time To First Result": "0.438",
+              "Time To Total Result": "0",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 1,
+              "Time To First Result": "0.436",
+              "Time To Total Result": "0.001",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 2,
+              "Time To First Result": "0.812",
+              "Time To Total Result": "0.001",
+              "Tuples": 0.0
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 0.310,
+    "Triggers": [
+    ],
+    "Slice statistics": [
+      {
+        "Slice": 0,
+        "Executor Memory": 42160
+      },
+      {
+        "Slice": 1,
+        "Executor Memory": {
+          "Average": 42160,
+          "Workers": 3,
+          "Maximum Memory Used": 42160
+        }
+      }
+    ],
+    "Statement statistics": {
+      "Memory used": 128000
+    },
+    "Settings": {
+      "Optimizer": "Postgres query optimizer"
+    },
+    "Execution Time": 1.026
+  }
+]
+(1 row)
+reset gp_enable_explain_allstat;
 -- Cleanup
 RESET search_path;
 DROP SCHEMA explaintest cascade;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table explaintest.subselect_tbl
 drop cascades to table explaintest.subselect_tbl_child
+drop cascades to table explaintest.allstat_test
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -517,8 +517,8 @@ QUERY PLAN
 -- s/ "Average": \d+/ "Average": #####/
 -- m/ "Maximum Memory Used": \d+/
 -- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
--- m/ "Memory Used": \d+/
--- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/
 -- m/ "Execution Time": \d+.\d+/
 -- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
 -- end_matchsubs

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -493,6 +493,35 @@ QUERY PLAN
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
+-- m/ "Memory Used": \d+/
+-- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
+-- end_matchsubs
 CREATE SCHEMA explaintest;
 SET search_path=explaintest;
 CREATE TABLE SUBSELECT_TBL (
@@ -884,12 +913,105 @@ QUERY PLAN
   }
 ]
 (1 row)
+-- Test Allstats formatting
+create table allstat_test(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Startup Cost": 0.00,
+      "Total Cost": 431.00,
+      "Plan Rows": 1,
+      "Plan Width": 4,
+      "Actual Startup Time": 0.776,
+      "Actual Total Time": 0.776,
+      "Actual Rows": 0,
+      "Actual Loops": 1,
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Relation Name": "allstat_test",
+          "Alias": "allstat_test",
+          "Startup Cost": 0.00,
+          "Total Cost": 431.00,
+          "Plan Rows": 1,
+          "Plan Width": 4,
+          "Actual Startup Time": 0.000,
+          "Actual Total Time": 0.001,
+          "Actual Rows": 0,
+          "Actual Loops": 1,
+          "Allstat": [
+            {
+              "Segment index": 0,
+              "Time To First Result": "0.937",
+              "Time To Total Result": "0",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 1,
+              "Time To First Result": "0.992",
+              "Time To Total Result": "0.001",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 2,
+              "Time To First Result": "1.197",
+              "Time To Total Result": "0",
+              "Tuples": 0.0
+            }
+          ]
+        }
+      ]
+    },
+    "Planning Time": 27.358,
+    "Triggers": [
+    ],
+    "Slice statistics": [
+      {
+        "Slice": 0,
+        "Executor Memory": 42160
+      },
+      {
+        "Slice": 1,
+        "Executor Memory": {
+          "Average": 42160,
+          "Workers": 3,
+          "Maximum Memory Used": 42160
+        }
+      }
+    ],
+    "Statement statistics": {
+      "Memory used": 128000
+    },
+    "Settings": {
+      "Optimizer": "Pivotal Optimizer (GPORCA)"
+    },
+    "Execution Time": 1.981
+  }
+]
+(1 row)
+reset gp_enable_explain_allstat;
 -- Cleanup
 RESET search_path;
 DROP SCHEMA explaintest cascade;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table explaintest.subselect_tbl
 drop cascades to table explaintest.subselect_tbl_child
+drop cascades to table explaintest.allstat_test
 DROP TABLE boxes;
 DROP TABLE apples;
 DROP TABLE box_locations;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -108,6 +108,36 @@ EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
 -- The plan contains an Agg and a Hash node on top of each other, neither of
 -- which have a plan->flow set. Explain should be able to dig the flow from
 -- the grandchild node then.
+
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
+-- m/ "Memory Used": \d+/
+-- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
+-- end_matchsubs
 CREATE SCHEMA explaintest;
 SET search_path=explaintest;
 CREATE TABLE SUBSELECT_TBL (
@@ -132,6 +162,12 @@ commit;
 -- Yet another variant, with missing flow in Append. (github issue #9819)
 create table subselect_tbl_child() INHERITS (subselect_tbl);
 explain (verbose, format json) select * from (select * from subselect_tbl) p where f1 in (select f1 from subselect_tbl where f2 >= 19);
+
+-- Test Allstats formatting
+create table allstat_test(a int);
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+reset gp_enable_explain_allstat;
 
 -- Cleanup
 RESET search_path;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -133,8 +133,8 @@ EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
 -- s/ "Average": \d+/ "Average": #####/
 -- m/ "Maximum Memory Used": \d+/
 -- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/
--- m/ "Memory Used": \d+/
--- s/ "Memory Used": \d+/ "Memory Used": #####/
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/
 -- m/ "Execution Time": \d+.\d+/
 -- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/
 -- end_matchsubs


### PR DESCRIPTION
Fix allstat explain output in JSON format

In `explain (format json)` a JSON object was used for "Allstat" although it
should be an array, and arrays were used for its elements instead of objects,
resulting in invalid JSON being generated. This patch fixes the types of
"Allstat" node and its elements to correct ones and adds a test for this
behavior.

Co-authored-by: Artem Vershinin <vav@arenadata.io>