### PR TITLE
ADBDEV-6173: Fix allstat explain output in JSON format (#1026)

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1756,7 +1756,7 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 								   "allstat: seg_firststart_total_ntuples");
 		}
 		else
-			ExplainOpenGroup("Allstat", "Allstat", true, es);
+			ExplainOpenGroup("Allstat", "Allstat", false, es);
 
 		for (i = 0; i < ns->ninst; i++)
 		{
@@ -1790,19 +1790,19 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 				cdbexplain_formatSeconds(totalbuf, sizeof(totalbuf),
 										 nsi->total, false);
 
-				ExplainOpenGroup("Segment", NULL, false, es);
+				ExplainOpenGroup("Segment", NULL, true, es);
 				ExplainPropertyInteger("Segment index", NULL, ns->segindexes[i], es);
 				ExplainPropertyText("Time To First Result", startbuf, es);
 				ExplainPropertyText("Time To Total Result", totalbuf, es);
 				ExplainPropertyFloat("Tuples", NULL, nsi->ntuples, 1, es);
-				ExplainCloseGroup("Segment", NULL, false, es);
+				ExplainCloseGroup("Segment", NULL, true, es);
 			}
 		}
 
 		if (es->format == EXPLAIN_FORMAT_TEXT)
 			appendStringInfoString(es->str, "//end\n");
 		else
-			ExplainCloseGroup("Allstat", "Allstat", true, es);
+			ExplainCloseGroup("Allstat", "Allstat", false, es);
 	}
 }								/* cdbexplain_showExecStats */
 

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -651,6 +651,35 @@ JIT:
 Execution Time: N.N ms
 (14 rows)
 -- Check explain analyze json format output with jit enable
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/g
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/g
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/g
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/g
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/g
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/g
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/g
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/g
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/g
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/g
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/g
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/g
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/g
+-- end_matchsubs
 select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
 explain_filter_to_json
 [{"JIT": {"slice": {"slice": 0, "Timing": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}, "Functions": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "Postgres-based planner", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
@@ -838,6 +867,106 @@ RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
+-- Test Allstats formatting
+create table allstat_test(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Parallel Aware": false,
+      "Startup Cost": 0.00,
+      "Total Cost": 1639.00,
+      "Plan Rows": 96300,
+      "Plan Width": 4,
+      "Actual Startup Time": 0.242,
+      "Actual Total Time": 0.242,
+      "Actual Rows": 0,
+      "Actual Loops": 1,
+      "Allstat": [
+        {
+          "Segment index": -1,
+          "Time To First Result": "0.109",
+          "Time To Total Result": "0.242",
+          "Tuples": 0.0
+        }
+      ],
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Parallel Aware": false,
+          "Relation Name": "allstat_test",
+          "Alias": "allstat_test",
+          "Startup Cost": 0.00,
+          "Total Cost": 355.00,
+          "Plan Rows": 32100,
+          "Plan Width": 4,
+          "Actual Startup Time": 0.000,
+          "Actual Total Time": 0.010,
+          "Actual Rows": 0,
+          "Actual Loops": 1,
+          "Allstat": [
+            {
+              "Segment index": 0,
+              "Time To First Result": "0.307",
+              "Time To Total Result": "0.010",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 1,
+              "Time To First Result": "0.304",
+              "Time To Total Result": "0.010",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 2,
+              "Time To First Result": "0.252",
+              "Time To Total Result": "0.008",
+              "Tuples": 0.0
+            }
+          ]
+        }
+      ]
+    },
+    "Optimizer": "Postgres-based planner",
+    "Planning Time": 0.179,
+    "Triggers": [
+    ],
+    "Slice statistics": [
+      {
+        "Slice": 0,
+        "Executor Memory": 36488
+      },
+      {
+        "Slice": 1,
+        "Executor Memory": {
+          "Average": 36360,
+          "Workers": 3,
+          "Maximum Memory Used": 36360
+        }
+      }
+    ],
+    "Statement statistics": {
+      "Memory used": 128000
+    },
+    "Execution Time": 0.489
+  }
+]
+(1 row)
+reset gp_enable_explain_allstat;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
@@ -848,3 +977,4 @@ DROP TABLE test_src_tbl;
 DROP TABLE test_hashagg_spill;
 DROP TABLE test_hashagg_groupingsets;
 DROP TABLE stat_io_timing;
+DROP TABLE allstat_test;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -596,6 +596,35 @@ JIT:
 Execution Time: N.N ms
 (12 rows)
 -- Check explain analyze json format output with jit enable
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/g
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/g
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/g
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/g
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/g
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/g
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/g
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/g
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/g
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/g
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/g
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/g
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/g
+-- end_matchsubs
 select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
 explain_filter_to_json
 [{"JIT": {"slice": {"slice": 0, "Timing": 0.0, "functions": 0.0}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "GPORCA", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
@@ -776,6 +805,106 @@ RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
+-- Test Allstats formatting
+create table allstat_test(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+QUERY PLAN
+[
+  {
+    "Plan": {
+      "Node Type": "Gather Motion",
+      "Senders": 3,
+      "Receivers": 1,
+      "Slice": 1,
+      "Segments": 3,
+      "Gang Type": "primary reader",
+      "Parallel Aware": false,
+      "Startup Cost": 0.00,
+      "Total Cost": 431.00,
+      "Plan Rows": 1,
+      "Plan Width": 4,
+      "Actual Startup Time": 0.304,
+      "Actual Total Time": 0.304,
+      "Actual Rows": 0,
+      "Actual Loops": 1,
+      "Allstat": [
+        {
+          "Segment index": -1,
+          "Time To First Result": "0.279",
+          "Time To Total Result": "0.304",
+          "Tuples": 0.0
+        }
+      ],
+      "Plans": [
+        {
+          "Node Type": "Seq Scan",
+          "Parent Relationship": "Outer",
+          "Slice": 1,
+          "Segments": 3,
+          "Gang Type": "primary reader",
+          "Parallel Aware": false,
+          "Relation Name": "allstat_test",
+          "Alias": "allstat_test",
+          "Startup Cost": 0.00,
+          "Total Cost": 431.00,
+          "Plan Rows": 1,
+          "Plan Width": 4,
+          "Actual Startup Time": 0.000,
+          "Actual Total Time": 0.018,
+          "Actual Rows": 0,
+          "Actual Loops": 1,
+          "Allstat": [
+            {
+              "Segment index": 0,
+              "Time To First Result": "0.493",
+              "Time To Total Result": "0.018",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 1,
+              "Time To First Result": "0.493",
+              "Time To Total Result": "0.018",
+              "Tuples": 0.0
+            },
+            {
+              "Segment index": 2,
+              "Time To First Result": "0.545",
+              "Time To Total Result": "0.013",
+              "Tuples": 0.0
+            }
+          ]
+        }
+      ]
+    },
+    "Optimizer": "GPORCA",
+    "Planning Time": 3.070,
+    "Triggers": [
+    ],
+    "Slice statistics": [
+      {
+        "Slice": 0,
+        "Executor Memory": 36488
+      },
+      {
+        "Slice": 1,
+        "Executor Memory": {
+          "Average": 36360,
+          "Workers": 3,
+          "Maximum Memory Used": 36360
+        }
+      }
+    ],
+    "Statement statistics": {
+      "Memory used": 128000
+    },
+    "Execution Time": 0.778
+  }
+]
+(1 row)
+reset gp_enable_explain_allstat;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
@@ -786,3 +915,4 @@ DROP TABLE test_src_tbl;
 DROP TABLE test_hashagg_spill;
 DROP TABLE test_hashagg_groupingsets;
 DROP TABLE stat_io_timing;
+DROP TABLE allstat_test;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -136,6 +136,35 @@ select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
 select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
 
 -- Check explain analyze json format output with jit enable
+-- JSON Required replaces for costs and time changes
+-- start_matchsubs
+-- m/ "Startup Cost": \d+.\d+/
+-- s/ "Startup Cost": \d+.\d+/ "Startup Cost": ##.###/g
+-- m/ "Total Cost": \d+.\d+/
+-- s/ "Total Cost": \d+.\d+/ "Total Cost": ##.###/g
+-- m/ "Plan Rows": \d+/
+-- s/ "Plan Rows": \d+/ "Plan Rows": #####/g
+-- m/ "Actual Startup Time": \d+.\d+/
+-- s/ "Actual Startup Time": \d+.\d+/ "Actual Startup Time": ##.###/g
+-- m/ "Actual Total Time": \d+.\d+/
+-- s/ "Actual Total Time": \d+.\d+/ "Actual Total Time": ##.###/g
+-- m/ "Time To First Result": "\d+(.\d+)?"/
+-- s/ "Time To First Result": "\d+(.\d+)?"/ "Time To First Result": "##.###"/g
+-- m/ "Time To Total Result": "\d+(.\d+)?"/
+-- s/ "Time To Total Result": "\d+(.\d+)?"/ "Time To Total Result": "##.###"/g
+-- m/ "Planning Time": \d+.\d+/
+-- s/ "Planning Time": \d+.\d+/ "Planning Time": ##.###/g
+-- m/ "Executor Memory": \d+/
+-- s/ "Executor Memory": \d+/ "Executor Memory": #####/g
+-- m/ "Average": \d+/
+-- s/ "Average": \d+/ "Average": #####/g
+-- m/ "Maximum Memory Used": \d+/
+-- s/ "Maximum Memory Used": \d+/ "Maximum Memory Used": #####/g
+-- m/ "Memory used": \d+/
+-- s/ "Memory used": \d+/ "Memory used": #####/g
+-- m/ "Execution Time": \d+.\d+/
+-- s/ "Execution Time": \d+.\d+/ "Execution Time": ##.###/g
+-- end_matchsubs
 select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
 
 RESET jit;
@@ -226,6 +255,12 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 
+-- Test Allstats formatting
+create table allstat_test(a int);
+set gp_enable_explain_allstat=true;
+explain (analyze, format json) select * from allstat_test;
+reset gp_enable_explain_allstat;
+
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;
@@ -236,3 +271,4 @@ DROP TABLE test_src_tbl;
 DROP TABLE test_hashagg_spill;
 DROP TABLE test_hashagg_groupingsets;
 DROP TABLE stat_io_timing;
+DROP TABLE allstat_test;


### PR DESCRIPTION
Fix allstat explain output in JSON format (#1026)

In explain (format json) a JSON object was used for "Allstat" although it
should be an array, and arrays were used for its elements instead of objects,
resulting in invalid JSON being generated. This patch fixes the types of
"Allstat" node and its elements to correct ones and adds a test for this
behavior.

Changes from original commit:
- Changed the expected plan in the test (changes due to GPDB 7).
- Moved matchsubs definition to other place in tests to cover JSON output.
- Added global flags to matchsubs to handle big JSON in one line.

Co-authored-by: Artem Vershinin <vav@arenadata.io>
(cherry picked from commit df9bcdd53ab62cb17b16eb2873fd05e7871caecd)
