### PR TITLE
ADBDEV-6041: Migrate ABI tests to Ubuntu 22

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Build libxerces 3.1.2
         run: |
           wget https://github.com/arenadata/gp-xerces/archive/refs/tags/v3.1.2-p1.tar.gz
-          tar -xzf xerces-c-3.1.2.tar.gz
-          pushd xerces-c-3.1.2
+          tar -xzf v3.1.2-p1.tar.gz
+          pushd v3.1.2-p1
           ./configure
           make -j`nproc` && sudo make install
           popd

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -64,7 +64,6 @@ jobs:
   abi-dump:
     needs: abi-dump-setup
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
     strategy:
       matrix:
         name:
@@ -79,20 +78,6 @@ jobs:
             ref: ${{ github.sha }}
 
     steps:
-      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
-      ## 'Exuberant Ctags'.
-      - name: Install universal-ctags.
-        run: |
-          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
-          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
-          cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
-          which ctags
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
-          yum install -y git
-
       - name: Download Greenplum source code
         uses: actions/checkout@v3
         with:
@@ -102,27 +87,35 @@ jobs:
           fetch-depth: 0 # Specify '0' to fetch all history for all branches and tags.
           path: gpdb_src
 
-      - name: Install abi-dumper
+      - name: Install dependencies and abi-dumper
         run: |
-          yum install -y epel-release
-          yum install -y abi-dumper
-          yum install -y libzstd-static
+          sudo gpdb_src/README.ubuntu.bash
+          sudo apt install -y libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
+          sudo ln -fs python2 /usr/bin/python
+
+      - name: Build libxerces 3.1.2
+        run: |
+          wget https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.2.tar.gz
+          tar -xzf xerces-c-3.1.2.tar.gz
+          pushd xerces-c-3.1.2
+          ./configure
+          make -j`nproc` && sudo make install
+          popd
 
       - name: Build Greenplum
         run: |
           ## TODO: Since abi-dumper requires debug info and it's hard to inject CFLAGS via the script for
           ## releasing Greenplum, we have to manually configure it here. Probably we can improve it in future.
-          export PATH=/opt/python-3.9.13/bin:/opt/python-2.7.18/bin:$PATH
           pushd gpdb_src
           CC='gcc -m64' \
-          CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
-          ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
+          CFLAGS='-Og -g3 -gdwarf-4 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
+          ./configure --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
                       --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
                       --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
                       --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
                       --mandir=/usr/local/greenplum-db-devel/man
-          make -j`nproc` && make install
+          make -j`nproc` && sudo make install
 
       - name: Dump ABI
         run: |
@@ -139,7 +132,6 @@ jobs:
       - abi-dump-setup
       - abi-dump
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v3
@@ -161,12 +153,7 @@ jobs:
 
       - name: Install abi-compliance-checker and report viewer (lynx)
         run: |
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          yum install -y epel-release
-          yum install -y abi-compliance-checker
-          yum install -y lynx
+          sudo apt install -y abi-compliance-checker lynx
 
       - name: Compare ABI
         run: |

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build libxerces 3.1.2
         run: |
-          wget https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.2.tar.gz
+          wget https://github.com/arenadata/gp-xerces/archive/refs/tags/v3.1.2-p1.tar.gz
           tar -xzf xerces-c-3.1.2.tar.gz
           pushd xerces-c-3.1.2
           ./configure

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           wget https://github.com/arenadata/gp-xerces/archive/refs/tags/v3.1.2-p1.tar.gz
           tar -xzf v3.1.2-p1.tar.gz
-          pushd v3.1.2-p1
+          pushd gp-xerces-3.1.2-p1
           ./configure
           make -j`nproc` && sudo make install
           popd


### PR DESCRIPTION
Migrate ABI tests to Ubuntu 22

Now ABI tests in Github Actions fully run on Ubuntu 22. Notable changes:
- Removed dependence on `gcr.io/data-gpdb-public-images/gpdb6-centos7-build`
image (likely maintained by upstream), now building on raw `ubuntu-latest`
from Github.
- Removed custom installation of Universal Ctags, now using package from
Ubuntu repo.
- Building libxerces here because our package is not available for GA.
- Added`-gdwarf-4` GCC flag (needed for abi-checker and GCC 11), which also
enabled source compatibility tests.
- Removed `--with-quicklz` flag since QuickLZ is deprecated and not available
in Ubuntu packages (adding it would require another build step).