### PR TITLE
Fix warning "The _posixsubprocess module is not being used"

### DIFF
--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -39,7 +39,8 @@ RUN mkdir /home/gpadmin/bin_gpdb
 
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend CFLAGS=-DPy_UNICODE_WIDE"
+# When there are both of python2 and python3 we should set UNICODE size for python2
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend CFLAGS=-DPy_UNICODE_SIZE=4"
 
 # Compile with running mocking tests
 RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -39,7 +39,7 @@ RUN mkdir /home/gpadmin/bin_gpdb
 
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend" 
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend CFLAGS=-DPy_UNICODE_WIDE"
 
 # Compile with running mocking tests
 RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -40,7 +40,8 @@ RUN mkdir /home/gpadmin/bin_gpdb
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
 # When there are both of python2 and python3 we should set UNICODE size for python2
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend CFLAGS=-DPy_UNICODE_SIZE=4"
+ENV CFLAGS="-DPy_UNICODE_SIZE=4"
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend CFLAGS=$CFLAGS"
 
 # Compile with running mocking tests
 RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash


### PR DESCRIPTION
Fix warning "The _posixsubprocess module is not being used"

When module subprocess32 tries to import the _posixsubprocess module it gets
error, which is masks by exception into message:
"RuntimeWarning: The _posixsubprocess module is not being used. Child process
reliability may suffer if your program uses threads. "program uses threads.",
RuntimeWarning".

Real reason of the error is "undefined symbol: PyUnicodeUCS2_EncodeUTF8".

Python2 at Ubuntu has Unicode with wide = 4 bytes. This patch add flag
"-DPy_UNICODE_SIZE=4" to CFLAGS to switch using Unicode 4 bytes instead of 2 bytes
in Python.
