### PR TITLE
ADBDEV-6189: Fix source compatibility for MIN/MAX optimization patch

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1699,13 +1699,13 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		 * from a bunch of conditions that can cause motion in the plan,
 		 * we can only gather it to singleQE and materialize the data because we
 		 * cannot pass params across motion.
-		 * We also set can_have_dependencies to disable other related optimizations.
+		 * We also set is_under_lateral to disable other related optimizations.
 		 */
 		if ((!bms_is_empty(required_outer)) &&
 			check_query_for_possible_motion(subquery))
 		{
 			config->force_singleQE = true;
-			config->can_have_dependencies = true;
+			config->is_under_lateral = true;
 		}
 
 		rel->subplan = subquery_planner(root->glob, subquery,

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -1699,13 +1699,13 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 		 * from a bunch of conditions that can cause motion in the plan,
 		 * we can only gather it to singleQE and materialize the data because we
 		 * cannot pass params across motion.
-		 * We also set is_under_lateral to disable other related optimizations.
+		 * We also set is_under_subplan to disable other related optimizations.
 		 */
 		if ((!bms_is_empty(required_outer)) &&
 			check_query_for_possible_motion(subquery))
 		{
 			config->force_singleQE = true;
-			config->is_under_lateral = true;
+			config->is_under_subplan = true;
 		}
 
 		rel->subplan = subquery_planner(root->glob, subquery,

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -379,9 +379,11 @@ PlannerConfig *DefaultPlannerConfig(void)
 
 	c1->honor_order_by = true;
 
-	c1->can_have_dependencies = false;
+	c1->is_under_subplan = false;
 
 	c1->force_singleQE = false;
+	
+	c1->is_under_lateral = false;
 
 	return c1;
 }

--- a/src/backend/optimizer/plan/planmain.c
+++ b/src/backend/optimizer/plan/planmain.c
@@ -382,8 +382,6 @@ PlannerConfig *DefaultPlannerConfig(void)
 	c1->is_under_subplan = false;
 
 	c1->force_singleQE = false;
-	
-	c1->is_under_lateral = false;
 
 	return c1;
 }

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -634,9 +634,12 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	 * correlated, disable some optimizations that assume the subplan doesn't
 	 * have any dependencies on other parts of the plan.
 	 */
-	if ((parent_root && parent_root->is_correlated_subplan) ||
+	bool is_parent_correlated = parent_root && parent_root->is_correlated_subplan;
+	bool can_have_dependencies = root->config->is_under_subplan || root->config->is_under_lateral; 
+
+	if (is_parent_correlated ||
 		((Gp_role == GP_ROLE_DISPATCH) &&
-		root->config->can_have_dependencies &&
+		can_have_dependencies &&
 		IsSubqueryCorrelated(parse)))
 	{
 		root->is_correlated_subplan = true;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -634,12 +634,9 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	 * correlated, disable some optimizations that assume the subplan doesn't
 	 * have any dependencies on other parts of the plan.
 	 */
-	bool is_parent_correlated = parent_root && parent_root->is_correlated_subplan;
-	bool can_have_dependencies = root->config->is_under_subplan || root->config->is_under_lateral; 
-
-	if (is_parent_correlated ||
+	if ((parent_root && parent_root->is_correlated_subplan) ||
 		((Gp_role == GP_ROLE_DISPATCH) &&
-		can_have_dependencies &&
+		root->config->is_under_subplan &&
 		IsSubqueryCorrelated(parse)))
 	{
 		root->is_correlated_subplan = true;

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -635,6 +635,10 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		/*
+		 * This is a subquery, so it can possibly be correlated and depend
+		 * on other parts of the plan
+		 */
 		config->is_under_subplan = true;
 
 		/*

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -635,11 +635,7 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		/*
-		 * This is a subquery, so it can possibly be correlated and depend
-		 * on other parts of the plan
-		 */
-		config->can_have_dependencies = true;
+		config->is_under_subplan = true;
 
 		/*
 		 * Disable CTE sharing in subplan.

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -44,13 +44,20 @@ typedef struct PlannerConfig
 
 	bool		honor_order_by;
 
-	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
+	/*
+	 * True if it's possible for the plan to depend on external parameters,
+	 * for example if it is a correlated subquery or a clause in a lateral join.
+	 * Doesn't guarantee the subquery is actually correlated.
+	 * 
+	 * Despite its name, it is also true for lateral joins.
+	 * This should be named something like can_have_dependencies instead but
+	 * the name cannot be changed due to source compatibility.
+	 */
+	bool		is_under_subplan;
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
 	bool        force_singleQE; /* True means force gather base rel to singleQE  */
-
-	bool		is_under_lateral; /* True for plan rooted at a lateral join subexpression */
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);

--- a/src/include/nodes/plannerconfig.h
+++ b/src/include/nodes/plannerconfig.h
@@ -44,16 +44,13 @@ typedef struct PlannerConfig
 
 	bool		honor_order_by;
 
-	/*
-	 * True if it's possible for the plan to depend on external parameters,
-	 * for example if it is a clause in a lateral join or a correlated subquery.
-	 * Doesn't guarantee the subquery is actually correlated
-	 */
-	bool		can_have_dependencies;
+	bool		is_under_subplan; /* True for plan rooted at a subquery which is planned as a subplan */
 
 	/* These ones are tricky */
 	//GpRoleValue	Gp_role; // TODO: this one is tricky
 	bool        force_singleQE; /* True means force gather base rel to singleQE  */
+
+	bool		is_under_lateral; /* True for plan rooted at a lateral join subexpression */
 } PlannerConfig;
 
 extern PlannerConfig *DefaultPlannerConfig(void);


### PR DESCRIPTION
Fix source compatibility for MIN/MAX optimization patch

A previous patch (merged by 5fef7f52ad0b4447a3dbfa690f668d8202f31598) renamed
a struct field from `is_under_subplan` to `can_have_dependencies` which broke
source compatibility: if an extension used this field it would break if
recompiled with a new version. This was not detected by ABI tests previous
because they couldn't check for source compatibility (only binary
compatibility, which wasn't broken by the patch). Updated ABI tests were able
to detect this issue.

This patch fixes source compatibility by renaming the field back to
`is_under_subplan` and leaving a comment about its usage.