### PR TITLE
Update yum repos for CentOS

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -87,9 +87,9 @@ jobs:
           tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
           cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
           which ctags
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
           yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
           yum install -y git
 
@@ -161,9 +161,9 @@ jobs:
 
       - name: Install abi-compliance-checker and report viewer (lynx)
         run: |
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
-          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=https://mirror.axelname.ru/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/os/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/updates/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
+          sed -i 's|mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra|baseurl=http://mirror.adsw.io/centos/$releasever/extras/$basearch|g' /etc/yum.repos.d/CentOS-Base.repo
           yum install -y epel-release
           yum install -y abi-compliance-checker
           yum install -y lynx

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -2,20 +2,14 @@ FROM centos:centos7 as base
 
 ARG sigar=https://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-1.6.5-1056.git2932df5.el7.x86_64.rpm
 ARG sigar_headers=http://downloads.adsw.io/ADB/6.22.0_arenadata38/centos/7/community/x86_64/sigar-headers-1.6.5-1056.git2932df5.el7.x86_64.rpm
-ARG CENTOS_REPOS_URL="https://mirror.axelname.ru/centos"
+ARG CENTOS_REPOS_URL="http://mirror.adsw.io"
 
 # Reinstall glibc-common. This is necessary to get langpacks in docker
 # because docker images don't contain them.
 # Change URL for repos, because Centos 7 EOL 30.06.2024
-RUN if [[ "x86_64" == "$(uname -i)" ]]; then \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-    else \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo; \
-    fi &&\
+RUN sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=os\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/centos/\$releasever/os/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=updates\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/centos/\$releasever/updates/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i "s|mirrorlist=http://mirrorlist.centos.org/?release=\$releasever\&arch=\$basearch\&repo=extras\&infra=\$infra|baseurl=$CENTOS_REPOS_URL/centos/\$releasever/extras/\$basearch|g" /etc/yum.repos.d/CentOS-Base.repo && \
     sed -i 's/\(override_install_langs*\)/# \1/' /etc/yum.conf && \
     yum -y reinstall glibc-common && \
 	yum clean all
@@ -62,13 +56,8 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
 
 # newer version of gcc and run environment for gpdb
 RUN yum -y install centos-release-scl && \
-    if [[ "x86_64" == "$(uname -i)" ]]; then \
-       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
-       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
-    else \
-       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/rh/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
-       sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-sclo|baseurl=$CENTOS_REPOS_URL/altarch/\$releasever/sclo/\$basearch/sclo/|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo; \
-    fi && \
+    sed -i "s|mirrorlist=http://mirrorlist.centos.org?arch=\$basearch\&release=7\&repo=sclo-rh|baseurl=$CENTOS_REPOS_URL/sc-lo/\$releasever/rh/\$basearch/|g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
+    sed -i "s|enabled=1|enabled=0|g" /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
     yum -y install --nogpgcheck devtoolset-7-gcc devtoolset-7-gcc-c++ && yum clean all && \
     pip --no-cache-dir install psi && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake && \


### PR DESCRIPTION
Update yum repos for CentOS

Servers, used for the yum repos, are not available now (connection fails with
'Peer's Certificate has expired' error). This patch changes URLs at yum's
configuration files to the working repositories.