### PR TITLE
ADBDEV-6214: Fix gpexpand error if partitioned table is spread across multiple schemas

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1782,7 +1782,7 @@ class gpexpand:
             FROM
                 pg_class c
                 JOIN pg_inherits a on (a.inhrelid = c.oid)
-                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.schemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
+                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.partitionschemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
                 JOIN pg_class d on (a.inhparent = d.oid)
                 JOIN pg_namespace n on (c.relnamespace = n.oid)
                 LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -643,6 +643,28 @@ Feature: expand the cluster by adding more segments
         Then the numsegments of table "partition_test" is 4
         Then distribution information from table "partition_test" with data in "gptest" is verified against saved data
 
+    @gpexpand_verify_partition_table_in_different_schemas
+    Scenario: Verify should succeed when expand partition table placed in different schemas
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "1" primaries only
+        And database "gptest" exists
+        And schema "schema1" exists
+        And schema "schema2" exists
+        And the user create a partition table with name "schema1.partition_test"
+        And the user sets schema of table "schema1.partition_test" to "schema2"
+        And distribution information from table "schema2.partition_test" with data in "gptest" is saved
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 3 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 3 new segments
+        When the user runs gpexpand to redistribute
+        Then the numsegments of table "schema2.partition_test" is 4
+        Then distribution information from table "schema2.partition_test" with data in "gptest" is verified against saved data
+
     @gpexpand_segment
     Scenario: on expand check if one or more cluster is down
         Given the database is not running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -225,6 +225,24 @@ def impl(conetxt, tabname):
         conn.commit()
 
 
+@given('schema "{schemaname}" exists')
+def impl(context, schemaname):
+    dbname = 'gptest'
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        sql = "CREATE SCHEMA IF NOT EXISTS {schemaname}".format(schemaname=schemaname)
+        dbconn.execSQL(conn, sql)
+        conn.commit()
+
+
+@given('the user sets schema of table "{tabname}" to "{schemaname}"')
+def impl(context, tabname, schemaname):
+    dbname = 'gptest'
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        sql = "ALTER TABLE {tabname} SET SCHEMA {schemaname}".format(tabname=tabname, schemaname=schemaname)
+        dbconn.execSQL(conn, sql)
+        conn.commit()
+
+
 @given('the user executes "{sql}" with named connection "{cname}"')
 def impl(context, cname, sql):
     conn = context.named_conns[cname]


### PR DESCRIPTION
Fix gpexpand error if partitioned table is spread across multiple schemas

If a partitioned table belongs to one schema and its partitions to another
schema, gpexpand would fail with "relation does not exist" error. This patch
fixes it by changing gpexpand's SQL query to use partition's schema instead of
parent's schema. Also added a behave test for this case.

Co-authored-by: Artem Vershinin <vav@arenadata.io>
Co-authored-by: Anton Vasiliev <a.vasiliev@arenadata.io>