### PR TITLE
ADBDEV-6047: Add OpenJDK 11 to Ubuntu image

### DIFF
--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -24,10 +24,13 @@ RUN set -eux; \
 # Alter precedence in favor of IPv4 during resolving
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
 # Packages for tests
-    DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip; \
+    DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip openjdk-11-jdk; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
-    pip2 cache purge
+    pip2 cache purge; \
+    echo '#!/bin/sh' >> /etc/profile.d/jdk_home.sh; \
+    echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/profile.d/jdk_home.sh; \
+    echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,7 +28,9 @@ RUN set -eux; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
     pip2 cache purge; \
-    echo '#!/bin/sh\nexport JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64\nexport PATH=$JAVA_HOME/bin:$PATH' > /etc/profile.d/jdk_home.sh
+    echo '#!/bin/sh' >> /etc/profile.d/jdk_home.sh; \
+    echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/profile.d/jdk_home.sh; \
+    echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,9 +28,7 @@ RUN set -eux; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
     pip2 cache purge; \
-    echo '#!/bin/sh' >> /etc/profile.d/jdk_home.sh; \
-    echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/profile.d/jdk_home.sh; \
-    echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
+    echo '#!/bin/sh\nexport JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64\nexport PATH=$JAVA_HOME/bin:$PATH' > /etc/profile.d/jdk_home.sh
 
 WORKDIR /home/gpadmin
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -28,7 +28,7 @@ RUN set -eux; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
     pip2 cache purge; \
-    echo '#!/bin/sh' >> /etc/profile.d/jdk_home.sh; \
+    echo '#!/bin/sh' > /etc/profile.d/jdk_home.sh; \
     echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/profile.d/jdk_home.sh; \
     echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
 

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -27,10 +27,7 @@ RUN set -eux; \
     DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip openjdk-11-jdk; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
-    pip2 cache purge; \
-    echo '#!/bin/sh' > /etc/profile.d/jdk_home.sh; \
-    echo 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /etc/profile.d/jdk_home.sh; \
-    echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/jdk_home.sh
+    pip2 cache purge
 
 WORKDIR /home/gpadmin
 


### PR DESCRIPTION
Add OpenJDK 11 to Ubuntu image

We need Java for PXF, ADBC etc, so this patch adds OpenJDK 11 to Ubuntu image,
as it did for CentOS 7 image.