### PR TITLE
Fix gpinitstandby does not modify pg_hba.conf for mirrors

### DIFF
--- a/gpMgmt/bin/gppylib/operations/update_pg_hba_on_segments.py
+++ b/gpMgmt/bin/gppylib/operations/update_pg_hba_on_segments.py
@@ -74,7 +74,7 @@ def update_on_segments(update_cmds, batch_size):
 
 def update_pg_hba_on_segments_for_standby(gpArray, standby_host, hba_hostnames,
                                           batch_size):
-    logger.info("Starting to create new pg_hba.conf on primary segments")
+    logger.info("Starting to create new pg_hba.conf on primary and mirror segments")
     update_cmds = []
     unreachable_seg_primary_hosts = []
     unreachable_seg_mirror_hosts = []

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -76,27 +76,6 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby coordinator
           And clean up and revert back to original coordinator
 
-    Scenario: gprecoverseg recoveries failed segment when standby works instead of coordinator
-        Given the database is running
-          And all the segments are running
-          And the segments are synchronized
-          And the standby is not initialized
-         When the user initializes a standby on the host "sdw3" and port 7001
-         Then gpinitstandby should return a return code of 0
-          And verify the standby coordinator entries in catalog
-          And verify that pg_hba.conf file has "standby" entries in each segment (primary and mirror) data directories
-          And the coordinator goes down
-          And the user runs gpactivatestandby with options "-f"
-         Then gpactivatestandby should return a return code of 0
-          And verify the standby coordinator is now acting as coordinator
-          And user restarts from standby all primary processes for content 0
-         When the user runs command "gprecoverseg -aF" from standby coordinator
-         Then gprecoverseg should return a return code of 0
-         When the user runs command "gprecoverseg -r" from standby coordinator
-         Then gprecoverseg should return a return code of 0
-          And the standby coordinator goes down
-          And revert back to original coordinator
-
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -94,7 +94,8 @@ Feature: gpactivatestandby
          Then gprecoverseg should return a return code of 0
          When the user runs command "gprecoverseg -r" from standby coordinator
          Then gprecoverseg should return a return code of 0
-          And clean up and revert back to original coordinator
+          And the standby coordinator goes down
+          And revert back to original coordinator
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -81,9 +81,10 @@ Feature: gpactivatestandby
           And all the segments are running
           And the segments are synchronized
           And the standby is not initialized
-          And the user runs gpinitstandby with options " "
+         When the user initializes a standby on the host "sdw3" and port 7001
          Then gpinitstandby should return a return code of 0
           And verify the standby coordinator entries in catalog
+          And verify that pg_hba.conf file has "standby" entries in each segment (primary and mirror) data directories
           And the coordinator goes down
           And the user runs gpactivatestandby with options "-f"
          Then gpactivatestandby should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpactivatestandby.feature
@@ -76,6 +76,25 @@ Feature: gpactivatestandby
           And the tablespace is valid on the standby coordinator
           And clean up and revert back to original coordinator
 
+    Scenario: gprecoverseg recoveries failed segment when standby works instead of coordinator
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the standby is not initialized
+          And the user runs gpinitstandby with options " "
+         Then gpinitstandby should return a return code of 0
+          And verify the standby coordinator entries in catalog
+          And the coordinator goes down
+          And the user runs gpactivatestandby with options "-f"
+         Then gpactivatestandby should return a return code of 0
+          And verify the standby coordinator is now acting as coordinator
+          And user restarts from standby all primary processes for content 0
+         When the user runs command "gprecoverseg -aF" from standby coordinator
+         Then gprecoverseg should return a return code of 0
+         When the user runs command "gprecoverseg -r" from standby coordinator
+         Then gprecoverseg should return a return code of 0
+          And clean up and revert back to original coordinator
+
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster
 

--- a/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitstandby.feature
@@ -133,6 +133,13 @@ Feature: Tests for gpinitstandby feature
         Then gpinitstandby should return a return code of 0
         And verify that the file "pg_hba.conf" in the coordinator data directory has "no" line starting with "host.*replication.*(127.0.0.1|::1).*trust"
 
+    Scenario: gpinitstandby should create pg_hba standby entry to segment primary and mirror
+        Given the database is running
+        And the standby is not initialized
+        When the user initializes a standby on the host "sdw3" and port 7001
+        Then gpinitstandby should return a return code of 0
+        And verify that pg_hba.conf file has "standby" entries in each segment (primary and mirror) data directories
+
     @backup_restore_bashrc
     Scenario: gpinitstandby should not throw error when banner exists on the host
         Given the database is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1289,7 +1289,6 @@ def impl(context):
     coordinator.run()
 
 @when('the standby coordinator goes down')
-@then('the standby coordinator goes down')
 def impl(context):
     coordinator = CoordinatorStop("Stopping Coordinator Standby", context.standby_data_dir, mode='immediate', ctxt=REMOTE,
                         remoteHost=context.standby_hostname)
@@ -1446,6 +1445,7 @@ def stop_all_primary_or_mirror_segments(context, segment_type, content):
     content_ids = [int(i) for i in content.split(',')]
     role = ROLE_PRIMARY if segment_type == 'primary' else ROLE_MIRROR
     stop_segments_immediate(context, lambda seg: seg.getSegmentRole() == role and seg.content in content_ids)
+
 
 @given('user immediately stops all {segment_type} processes')
 @when('user immediately stops all {segment_type} processes')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1098,7 +1098,7 @@ def run_gpinitstandby(context, hostname, port, standby_data_dir, options='', rem
         # create the data dir on $hostname
         create_dir(hostname, os.path.dirname(standby_data_dir))
         # We do not set port nor data dir here to test gpinitstandby's ability to autogather that info
-        cmd = "gpinitstandby -a -s %s" % hostname
+        cmd = "gpinitstandby -a -s %s -P %s -S %s" % (hostname, port, standby_data_dir)
     else:
         cmd = "gpinitstandby -a -s %s -P %s -S %s" % (hostname, port, standby_data_dir)
 
@@ -1110,6 +1110,14 @@ def impl(context):
     hostname = get_coordinator_hostname('postgres')[0][0]
     temp_data_dir = tempfile.mkdtemp() + "/standby_datadir"
     run_gpinitstandby(context, hostname, os.environ.get("PGPORT"), temp_data_dir)
+
+@when('the user initializes a standby on the host "{host}" and port {port}')
+def impl(context, host, port):
+    temp_data_dir = tempfile.mkdtemp() + "/standby_datadir"
+    run_gpinitstandby(context, host, port, temp_data_dir, "", True)
+    context.standby_hostname = host
+    context.standby_port = port
+    context.standby_data_dir = temp_data_dir
 
 @when('the user initializes a standby on the same host as coordinator and the same data directory')
 def impl(context):
@@ -2053,13 +2061,25 @@ def impl(context, filename, some, output):
         err_str = "xx Expected stdout string '%s' and found: '%s'" % (regexStr, contents)
         raise Exception(err_str)
 
+@given('verify that pg_hba.conf file has "{type}" entries in each segment (primary and mirror) data directories')
+@then('verify that pg_hba.conf file has "{type}" entries in each segment (primary and mirror) data directories')
+def impl(context, type):
+    verify_pg_hba_in_each_segment_data_directories(context, type, False)
+
 @given('verify that pg_hba.conf file has "{type}" entries in each segment data directories')
 @then('verify that pg_hba.conf file has "{type}" entries in each segment data directories')
 def impl(context, type):
+    verify_pg_hba_in_each_segment_data_directories(context, type)
+
+def verify_pg_hba_in_each_segment_data_directories(context, type, check_only_primary=True):
+    if check_only_primary:
+        query = "SELECT hostname, datadir FROM gp_segment_configuration WHERE role='p' AND content > -1;"
+    else:
+        query = "SELECT hostname, datadir FROM gp_segment_configuration WHERE content > -1;"
+
     conn = dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False)
     try:
-        curs = dbconn.query(conn,
-                            "SELECT hostname, datadir FROM gp_segment_configuration WHERE role='p' AND content > -1;")
+        curs = dbconn.query(conn, query)
         result = curs.fetchall()
         segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1288,6 +1288,7 @@ def impl(context):
     coordinator.run()
 
 @when('the standby coordinator goes down')
+@then('the standby coordinator goes down')
 def impl(context):
     coordinator = CoordinatorStop("Stopping Coordinator Standby", context.standby_data_dir, mode='immediate', ctxt=REMOTE,
                         remoteHost=context.standby_hostname)
@@ -1317,6 +1318,11 @@ def impl(context):
     coordinator.run()
 
     cmd = "gpactivatestandby -a -d %s" % coordinator_data_dir
+    run_gpcommand(context, cmd)
+
+@then('revert back to original coordinator')
+def impl(context):
+    cmd = "gpactivatestandby -a -f -d %s" % coordinator_data_dir
     run_gpcommand(context, cmd)
 
 # from https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309


### PR DESCRIPTION
Fix gpinitstandby does not modify pg_hba.conf for mirrors

When standby is added by gpinitstanby, pg_hba.conf must be update on all
segments: both of primary an mirrors.
But commit 84cc8061755507d86ca527dba5ee7cf2377f55ce modifies pg_hba.conf in data
directories only for primary segments.

This patch adds modifying pg_hba.conf in data directories for mirror segments.
