### PR TITLE
ADBDEV-6139 Fix clang compiler errors 

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,11 +1,11 @@
 FROM rockylinux:8.8 as base
 
-ARG USER_CC=clang
-ARG USER_CXX=clang++
+ARG CC=clang
+ARG CXX=clang++
 
 RUN /bin/bash -c $' \n\
-	if [ -z "${USER_CC}" ] || [ -z "${USER_CXX}" ]; then \n\
-		echo "User must provide USER_CC and USER_CXX" \n\
+	if [ -z "${CC}" ] || [ -z "${CXX}" ]; then \n\
+		echo "User must provide CC and CXX" \n\
 		exit 1 \n\
 	fi'
 

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,5 +1,14 @@
 FROM rockylinux:8.8 as base
 
+ARG USER_CC=clang
+ARG USER_CXX=clang++
+
+RUN /bin/bash -c $' \n\
+	if [ -z "${USER_CC}" ] || [ -z "${USER_CXX}" ]; then \n\
+		echo "User must provide USER_CC and USER_CXX" \n\
+		exit 1 \n\
+	fi'
+
 # Install some basic utilities and build tools
 RUN dnf -y install 'dnf-command(config-manager)' && dnf config-manager --set-enabled devel && dnf makecache && dnf update -y ca-certificates && \
     rpm --import https://mirror.yandex.ru/rockylinux/RPM-GPG-KEY-Rocky-8 && \

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -146,10 +146,15 @@ function configure() {
     # The full set of configure options which were used for building the
     # tree must be used here as well since the toplevel Makefile depends
     # on these options for deciding what to test. Since we don't ship
-	if [ -z "${USER_CC}" ] || [ -z "${USER_CXX}" ]; then
-		echo "USER_CC or USER_CXX not set"
+
+	# temp to run tests on ci
+	export CC=clang
+	export CXX=clang++
+	if [ -z "${CC}" ] || [ -z "${CXX}" ]; then
+		echo "User must provide CC and CXX"
+		exit 1
 	else
-    	./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpcloud --enable-orafce --enable-tap-tests --with-gssapi --with-libxml --with-openssl --with-perl --with-python --with-uuid=e2fs --with-llvm --with-zstd PYTHON=python3.11 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS} CC="${USER_CC}" CXX="${USER_CXX}"
+    	./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpcloud --enable-orafce --enable-tap-tests --with-gssapi --with-libxml --with-openssl --with-perl --with-python --with-uuid=e2fs --with-llvm --with-zstd PYTHON=python3.11 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
 	fi
 
     popd

--- a/concourse/scripts/common.bash
+++ b/concourse/scripts/common.bash
@@ -146,7 +146,11 @@ function configure() {
     # The full set of configure options which were used for building the
     # tree must be used here as well since the toplevel Makefile depends
     # on these options for deciding what to test. Since we don't ship
-    ./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpcloud --enable-orafce --enable-tap-tests --with-gssapi --with-libxml --with-openssl --with-perl --with-python --with-uuid=e2fs --with-llvm --with-zstd PYTHON=python3.11 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS}
+	if [ -z "${USER_CC}" ] || [ -z "${USER_CXX}" ]; then
+		echo "USER_CC or USER_CXX not set"
+	else
+    	./configure --prefix=/usr/local/greenplum-db-devel --disable-orca --enable-gpcloud --enable-orafce --enable-tap-tests --with-gssapi --with-libxml --with-openssl --with-perl --with-python --with-uuid=e2fs --with-llvm --with-zstd PYTHON=python3.11 PKG_CONFIG_PATH="${GPHOME}/lib/pkgconfig" ${CONFIGURE_FLAGS} CC="${USER_CC}" CXX="${USER_CXX}"
+	fi
 
     popd
 }

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -131,6 +131,7 @@ function export_gpdb_clients() {
 }
 
 function _main() {
+	echo "Using ${USER_CC} as C compiler and ${USER_CXX} as C++ compiler"
 
 	prep_env
 

--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -131,8 +131,6 @@ function export_gpdb_clients() {
 }
 
 function _main() {
-	echo "Using ${USER_CC} as C compiler and ${USER_CXX} as C++ compiler"
-
 	prep_env
 
 	## Add CCache Support (?)

--- a/contrib/btree_gin/btree_gin.c
+++ b/contrib/btree_gin/btree_gin.c
@@ -89,7 +89,7 @@ gin_btree_extract_query(FunctionCallInfo fcinfo,
 		case BTGreaterEqualStrategyNumber:
 		case BTGreaterStrategyNumber:
 			*ptr_partialmatch = true;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case BTEqualStrategyNumber:
 			entries[0] = datum;
 			break;

--- a/contrib/isn/isn.c
+++ b/contrib/isn/isn.c
@@ -852,6 +852,7 @@ string2ean(const char *str, bool errorOK, ean13 *result,
 		case UPC:
 			buf[2] = '0';
 			valid = (valid && ((rcheck = checkdig(buf + 2, 13)) == check || magic));
+			FALL_THROUGH
 		default:
 			break;
 	}

--- a/contrib/pg_trgm/trgm_gin.c
+++ b/contrib/pg_trgm/trgm_gin.c
@@ -97,7 +97,7 @@ gin_extract_query_trgm(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case LikeStrategyNumber:
 
 			/*
@@ -111,7 +111,7 @@ gin_extract_query_trgm(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case RegExpStrategyNumber:
 			trg = createTrgmNFA(val, PG_GET_COLLATION(),
 								&graph, CurrentMemoryContext);
@@ -221,7 +221,7 @@ gin_trgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case LikeStrategyNumber:
 			/* Check if all extracted trigrams are presented. */
 			res = true;
@@ -238,7 +238,7 @@ gin_trgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case RegExpStrategyNumber:
 			if (nkeys < 1)
 			{
@@ -306,7 +306,7 @@ gin_trgm_triconsistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case LikeStrategyNumber:
 			/* Check if all extracted trigrams are presented. */
 			res = GIN_MAYBE;
@@ -323,7 +323,7 @@ gin_trgm_triconsistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case RegExpStrategyNumber:
 			if (nkeys < 1)
 			{

--- a/contrib/pg_trgm/trgm_gist.c
+++ b/contrib/pg_trgm/trgm_gist.c
@@ -210,7 +210,7 @@ gtrgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 				elog(ERROR, "cannot handle ~~* with case-sensitive trigrams");
 #endif
-				/* FALL THRU */
+				FALL_THROUGH
 			case LikeStrategyNumber:
 				qtrg = generate_wildcard_trgm(VARDATA(query),
 											  querysize - VARHDRSZ);
@@ -219,7 +219,7 @@ gtrgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 				elog(ERROR, "cannot handle ~* with case-sensitive trigrams");
 #endif
-				/* FALL THRU */
+				FALL_THROUGH
 			case RegExpStrategyNumber:
 				qtrg = createTrgmNFA(query, PG_GET_COLLATION(),
 									 &graph, fcinfo->flinfo->fn_mcxt);
@@ -307,7 +307,7 @@ gtrgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case LikeStrategyNumber:
 			/* Wildcard search is inexact */
 			*recheck = true;
@@ -348,7 +348,7 @@ gtrgm_consistent(PG_FUNCTION_ARGS)
 #ifndef IGNORECASE
 			elog(ERROR, "cannot handle ~* with case-sensitive trigrams");
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case RegExpStrategyNumber:
 			/* Regexp search is inexact */
 			*recheck = true;

--- a/contrib/pgcrypto/imath.c
+++ b/contrib/pgcrypto/imath.c
@@ -1978,7 +1978,7 @@ mp_int_read_cstring(mp_int z, mp_size radix, const char *str,
 			++str;
 			break;
 		case '+':
-			++str;				/* fallthrough */
+			++str;				FALL_THROUGH
 		default:
 			z->sign = MP_ZPOS;
 			break;

--- a/contrib/pgcrypto/pgp-info.c
+++ b/contrib/pgcrypto/pgp-info.c
@@ -169,7 +169,7 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
 				break;
 			case PGP_PKT_SYMENCRYPTED_SESSKEY:
 				got_symenc_key++;
-				/* fallthru */
+				FALL_THROUGH
 			case PGP_PKT_SIGNATURE:
 			case PGP_PKT_MARKER:
 			case PGP_PKT_TRUST:

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -3101,13 +3101,13 @@ deparsePartialAggFunctionParamFilter(Aggref *node, deparse_expr_cxt *context,
 	{
 		case 2100:
 			/* int8 AVG */
-			/* Fall through */
+			FALL_THROUGH
 		case 2101:
 			/* int4 AVG function */
-			/* Fall through */
+			FALL_THROUGH
 		case 2102:
 			/* int2 AVG function */
-			/* Fall through */
+			FALL_THROUGH
 		case 2103:
 			/* numeric AVG function */
 			/* According to aggcombinefn, those aggregate functions need to fetch same columns from remote server. */
@@ -3116,7 +3116,7 @@ deparsePartialAggFunctionParamFilter(Aggref *node, deparse_expr_cxt *context,
 			break;
 		case 2104:
 			/* float4 AVG function */
-			/* Fall through */
+			FALL_THROUGH
 		case 2105:
 			/* float8 AVG function */
 			appendStringInfo(buf, "array[count(%s)%s, sum(%s)%s, count(%s)*var_pop(%s)%s]",

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -6350,7 +6350,7 @@ postgresGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 			/* It's unsafe to push having statements with partial aggregates */
 			if (((GroupPathExtraData *) extra)->havingQual)
 				return;
-			/* Fall through */
+			FALL_THROUGH
 			/* Partial agg push down path */
 		case UPPERREL_GROUP_AGG:
 			add_foreign_grouping_paths(root, input_rel, output_rel,

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -96,8 +96,14 @@ SERVER_PLATFORMS=rhel7_x86_64 rhel6_x86_64 rhel8_x86_64 rocky8_x86_64 ol8_x86_64
 # Compiler options
 #---------------------------------------------------------------------
 
-OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
-PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fargument-noalias-global -fno-omit-frame-pointer -g)"
+OPTFLAGS="$(strip $(BLD_CFLAGS) -O3 -fno-omit-frame-pointer -g)"
+PROFFLAGS="$(strip $(BLD_CFLAGS) -O3 -fno-omit-frame-pointer -g)"
+GCCFLAGS="-fargument-noalias-global"
+
+ifeq ($(firstword $(CC)), "gcc")
+OPTFLAGS=$(OPTFLAGS) $(GCCFLAGS)
+PROFFLAGS=$(PROFFLAGS) $(GCCFLAGS)
+endif
 
 ifeq (on, ${GPDBGOPT})
 CFLAGS_OPT=-O1 -fno-omit-frame-pointer

--- a/gpcontrib/gp_sparse_vector/operators.c
+++ b/gpcontrib/gp_sparse_vector/operators.c
@@ -411,7 +411,7 @@ svec_count(PG_FUNCTION_ARGS)
 			 * beginning of the accumulation of the correct dimension.
 			 */
 			left = makeSparseDataFromDouble(0.,right->total_value_count);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 
 		case 0: 		//neither arg is scalar
 		case 2:			//right arg is scalar

--- a/gpcontrib/gpcloud/include/s3common_headers.h
+++ b/gpcontrib/gpcloud/include/s3common_headers.h
@@ -26,6 +26,23 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
+#define DO_PRAGMA(x) _Pragma (#x)
+#if defined(__clang__)
+	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
+		_Pragma("clang diagnostic push") \
+		DO_PRAGMA(clang diagnostic ignored warning) \
+		expr; \
+		_Pragma("clang diagnostic pop") \
+	} while(0)
+#elif defined(__GNUC__)
+	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
+		_Pragma("GCC diagnostic push") \
+		_Pragma("clang diagnostic ignored \"" warning "\"") \
+		expr; \
+		_Pragma("GCC diagnostic pop") \
+	} while(0)
+#endif
+
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 

--- a/gpcontrib/gpcloud/include/s3common_headers.h
+++ b/gpcontrib/gpcloud/include/s3common_headers.h
@@ -37,7 +37,7 @@ using std::vector;
 #elif defined(__GNUC__)
 	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
 		_Pragma("GCC diagnostic push") \
-		_Pragma("clang diagnostic ignored \"" warning "\"") \
+		DO_PRAGMA(GCC diagnostic ignored warning) \
 		expr; \
 		_Pragma("GCC diagnostic pop") \
 	} while(0)

--- a/gpcontrib/gpcloud/src/s3utils.cpp
+++ b/gpcontrib/gpcloud/src/s3utils.cpp
@@ -105,16 +105,16 @@ size_t find_Nth(const string &str,  // where to work
 
 MD5Calc::MD5Calc() {
     memset(this->md5, 0, MD5_DIGEST_STRING_LENGTH);
-    MD5_Init(&this->c);
+    SUPPRESS_COMPILER_WARNING(MD5_Init(&this->c), "-Wdeprecated-declarations");
 }
 
 bool MD5Calc::Update(const char *data, int len) {
-    MD5_Update(&this->c, data, len);
+    SUPPRESS_COMPILER_WARNING(MD5_Update(&this->c, data, len), "-Wdeprecated-declarations");
     return true;
 }
 
 const char *MD5Calc::Get() {
-    MD5_Final(this->md5, &c);
+    SUPPRESS_COMPILER_WARNING(MD5_Final(this->md5, &c), "-Wdeprecated-declarations");
     std::stringstream ss;
     for (int i = 0; i < MD5_DIGEST_LENGTH; i++)
         ss << std::hex << std::setw(2) << std::setfill('0') << (int)this->md5[i];
@@ -122,7 +122,7 @@ const char *MD5Calc::Get() {
 
     // Reset MD5 context
     memset(this->md5, 0, MD5_DIGEST_STRING_LENGTH);
-    MD5_Init(&this->c);
+    SUPPRESS_COMPILER_WARNING(MD5_Init(&this->c), "-Wdeprecated-declarations");
     return this->result.c_str();
 }
 

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -688,7 +688,6 @@ AppendOptimizedDropDeadSegments(Relation aorel, Bitmapset *segnos, AOVacuumRelSt
 void
 AppendOptimizedTruncateToEOF(Relation aorel, AOVacuumRelStats *vacrelstats)
 {
-	const char *relname;
 	Relation	pg_aoseg_rel;
 	TupleDesc	pg_aoseg_dsc;
 	SysScanDesc aoscan;
@@ -697,8 +696,6 @@ AppendOptimizedTruncateToEOF(Relation aorel, AOVacuumRelStats *vacrelstats)
 	Oid			segrelid;
 
 	Assert(RelationStorageIsAO(aorel));
-
-	relname = RelationGetRelationName(aorel);
 
 	/*
 	 * The algorithm below for choosing a target segment is not concurrent-safe.
@@ -790,15 +787,12 @@ AppendOnlyCompact(Relation aorel,
 				  List *avoid_segnos,
 				  AOVacuumRelStats *vacrelstats)
 {
-	const char *relname;
 	AppendOnlyInsertDesc insertDesc = NULL;
 	FileSegInfo *fsinfo;
 	Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 
 	Assert(RelationStorageIsAoRows(aorel));
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
-
-	relname = RelationGetRelationName(aorel);
 
 	/* Fetch under the write lock to get latest committed eof. */
 	fsinfo = GetFileSegInfo(aorel, appendOnlyMetaDataSnapshot, compaction_segno, true);

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -144,7 +144,6 @@ void
 LockSegnoForWrite(Relation rel, int segno)
 {
 	Relation	pg_aoseg_rel;
-	TupleDesc	pg_aoseg_dsc;
 	SysScanDesc aoscan;
 	HeapTuple	tuple;
 	Snapshot	snapshot;
@@ -171,7 +170,6 @@ LockSegnoForWrite(Relation rel, int segno)
 	 * size threshold (90% full).
 	 */
 	pg_aoseg_rel = table_open(segrelid, AccessShareLock);
-	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	/*
 	 * Obtain the snapshot that is taken at the beginning of the transaction.
@@ -385,7 +383,6 @@ static int
 choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 {
 	Relation	pg_aoseg_rel;
-	TupleDesc	pg_aoseg_dsc;
 	int			i;
 	int32		chosen_segno = -1;
 	candidate_segment candidates[MAX_AOREL_CONCURRENCY];
@@ -443,7 +440,6 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	 * size threshold (90% full).
 	 */
 	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
-	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	/*
 	 * Scan through all the pg_aoseg (or pg_aocs) entries, and make note of

--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -121,7 +121,6 @@ bmbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	double      reltuples;
 	BMBuildState bmstate;
 	IndexBuildResult *result;
-	TupleDesc	tupDesc;
 
 	if (indexInfo->ii_Concurrent)
 		ereport(ERROR,
@@ -134,8 +133,6 @@ bmbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 				(errcode(ERRCODE_INDEX_CORRUPTED),
 				errmsg("index \"%s\" already contains data",
 				RelationGetRelationName(index))));
-
-	tupDesc = RelationGetDescr(index);
 
 	/* initialize the bitmap index for MAIN_FORKNUM. */
 	_bitmap_init(index, RelationNeedsWAL(index), false);

--- a/src/backend/access/bitmap/bitmaputil.c
+++ b/src/backend/access/bitmap/bitmaputil.c
@@ -1035,7 +1035,6 @@ _bitmap_log_bitmapwords(Relation rel,
 	xl_bm_bitmapwords xlBitmapWords;
 	ListCell   *lcp;
 	ListCell   *lcb;
-	bool		init_page;
 	int			num_bm_pages = list_length(xl_bm_bitmapword_pages);
 	int 		current_page = 0;
 
@@ -1064,7 +1063,6 @@ _bitmap_log_bitmapwords(Relation rel,
 	rdata_no = 1;
 
 	/* Write per-page structs */
-	init_page = init_first_page;
 	forboth(lcp, xl_bm_bitmapword_pages, lcb, bitmapBuffers)
 	{
 		xl_bm_bitmapwords_perpage *xlBitmapwordsPage = lfirst(lcp);

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -917,7 +917,7 @@ heapam_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 				break;
 			case HEAPTUPLE_RECENTLY_DEAD:
 				*tups_recently_dead += 1;
-				/* fall through */
+				FALL_THROUGH
 			case HEAPTUPLE_LIVE:
 				/* Live or recently dead, must copy it */
 				isdead = false;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -2155,7 +2155,9 @@ AdvanceXLInsertBuffer(XLogRecPtr upto, bool opportunistic)
 	XLogRecPtr	NewPageEndPtr = InvalidXLogRecPtr;
 	XLogRecPtr	NewPageBeginPtr;
 	XLogPageHeader NewPage;
+#ifdef WAL_DEBUG
 	int			npages = 0;
+#endif
 
 	LWLockAcquire(WALBufMappingLock, LW_EXCLUSIVE);
 
@@ -2310,7 +2312,9 @@ AdvanceXLInsertBuffer(XLogRecPtr upto, bool opportunistic)
 
 		XLogCtl->InitializedUpTo = NewPageEndPtr;
 
+#ifdef WAL_DEBUG
 		npages++;
+#endif
 	}
 	LWLockRelease(WALBufMappingLock);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7753,6 +7753,7 @@ StartupXLOG(void)
 						recoveryPausesHere();
 
 						/* drop into promote */
+						FALL_THROUGH
 
 					case RECOVERY_TARGET_ACTION_PROMOTE:
 						break;

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -639,7 +639,7 @@ findDependentObjects(const ObjectAddress *object,
 					break;
 
 				/* Otherwise, treat this like an internal dependency */
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case DEPENDENCY_INTERNAL:
 

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -2172,7 +2172,7 @@ pg_get_object_address(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("name list length must be at least %d", 3)));
 			/* fall through to check args length */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case OBJECT_OPERATOR:
 			if (list_length(args) != 2)
 				ereport(ERROR,

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -819,7 +819,7 @@ doNotifyingAbort(void)
 				setCurrentDtxState(DTX_STATE_RETRY_ABORT_PREPARED);
 				setDistributedTransactionContext(DTX_CONTEXT_QD_RETRY_PHASE_2);
 			}
-			/* FALL THRU */
+			FALL_THROUGH
 
 		case DTX_STATE_RETRY_ABORT_PREPARED:
 			retryAbortPrepared();

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2852,16 +2852,12 @@ CopyToDispatch(CopyState cstate)
 {
 	CopyStmt   *stmt = glob_copystmt;
 	TupleDesc	tupDesc;
-	int			num_phys_attrs;
-	int			attr_count;
 	FormData_pg_attribute *attr;
 	CdbCopy    *cdbCopy;
 	uint64		processed = 0;
 
 	tupDesc = cstate->rel->rd_att;
 	attr = tupDesc->attrs;
-	num_phys_attrs = tupDesc->natts;
-	attr_count = list_length(cstate->attnumlist);
 
 	/* We use fe_msgbuf as a per-row buffer regardless of copy_dest */
 	cstate->fe_msgbuf = makeStringInfo();
@@ -5738,8 +5734,7 @@ static bool
 NextCopyFromExecute(CopyState cstate, ExprContext *econtext, Datum *values, bool *nulls)
 {
 	TupleDesc	tupDesc;
-	AttrNumber	num_phys_attrs,
-				attr_count;
+	AttrNumber	num_phys_attrs;
 	FormData_pg_attribute *attr;
 	int			i;
 	copy_from_dispatch_row frame;
@@ -5748,7 +5743,6 @@ NextCopyFromExecute(CopyState cstate, ExprContext *econtext, Datum *values, bool
 
 	tupDesc = RelationGetDescr(cstate->rel);
 	num_phys_attrs = tupDesc->natts;
-	attr_count = list_length(cstate->attnumlist);
 
 	/*
 	 * The code below reads the 'copy_from_dispatch_row' struct, and only

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1487,7 +1487,6 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			ExplainState *es)
 {
 	Plan	   *plan = planstate->plan;
-	PlanState  *parentplanstate;
 	ExecSlice  *save_currentSlice = es->currentSlice;    /* save */
 	const char *pname;			/* node type name for text output */
 	const char *sname;			/* node type name for non-text output */
@@ -1504,7 +1503,6 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	ExecSlice  *parentSlice = NULL;
 
 	/* Remember who called us. */
-	parentplanstate = es->parentPlanState;
 	es->parentPlanState = planstate;
 
 	/*

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2354,7 +2354,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			show_tablesample(((SampleScan *) plan)->tablesample,
 							 planstate, ancestors, es);
 			/* fall through to print additional fields the same as SeqScan */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case T_SeqScan:
 		case T_DynamicSeqScan:
 		case T_ValuesScan:

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -171,7 +171,6 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	Oid			relowner;
 	Oid			OIDNewHeap;
 	DestReceiver *dest;
-	uint64		processed = 0;
 	bool		concurrent;
 	LOCKMODE	lockmode;
 	char		relpersistence;
@@ -352,7 +351,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	refreshClause = MakeRefreshClause(concurrent, stmt->skipData, stmt->relation);
 	dataQuery->intoPolicy = matviewRel->rd_cdbpolicy;
 
-	processed = refresh_matview_datafill(dest, dataQuery, queryString, refreshClause);
+	refresh_matview_datafill(dest, dataQuery, queryString, refreshClause);
 
 	/* Make the matview match the newly generated data. */
 	if (concurrent)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14587,7 +14587,7 @@ ATExecChangeOwner(Oid relationOid, Oid newOwnerId, bool recursing, LOCKMODE lock
 		case RELKIND_AOVISIMAP:
 			if (recursing)
 				break;
-			/* FALL THRU */
+			FALL_THROUGH
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -4381,7 +4381,7 @@ AfterTriggerExecute(EState *estate,
 											 trig_tuple_slot2))
 					elog(ERROR, "failed to fetch tuple2 for AFTER trigger");
 			}
-			/* fall through */
+			FALL_THROUGH
 		case AFTER_TRIGGER_FDW_REUSE:
 
 			/*

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1509,13 +1509,11 @@ getGpExecIdentity(QueryDesc *queryDesc,
 void mppExecutorFinishup(QueryDesc *queryDesc)
 {
 	EState	   *estate;
-	ExecSlice  *currentSlice;
 	int			primaryWriterSliceIndex;
 
 	/* caller must have switched into per-query memory context already */
 	estate = queryDesc->estate;
 
-	currentSlice = getCurrentSlice(estate, LocallyExecutingSliceIndex(estate));
 	primaryWriterSliceIndex = PrimaryWriterSliceIndex(estate);
 
 	/* Teardown the Interconnect */

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2326,7 +2326,7 @@ ExecAgg(PlanState *pstate)
 			case AGG_HASHED:
 				if (!node->table_filled)
 					agg_fill_hash_table(node);
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case AGG_MIXED:
 				result = agg_retrieve_hash_table(node);
 				break;

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -291,7 +291,7 @@ MultiExecParallelHash(HashState *node)
 			 * way, wait for everyone to arrive here so we can proceed.
 			 */
 			BarrierArriveAndWait(build_barrier, WAIT_EVENT_HASH_BUILD_ALLOCATING);
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_BUILD_HASHING_INNER:
 
@@ -1349,13 +1349,13 @@ ExecParallelHashIncreaseNumBatches(HashJoinTable hashtable)
 				/* All other participants just flush their tuples to disk. */
 				ExecParallelHashCloseBatchAccessors(hashtable);
 			}
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BATCHES_ALLOCATING:
 			/* Wait for the above to be finished. */
 			BarrierArriveAndWait(&pstate->grow_batches_barrier,
 								 WAIT_EVENT_HASH_GROW_BATCHES_ALLOCATING);
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BATCHES_REPARTITIONING:
 			/* Make sure that we have the current dimensions and buckets. */
@@ -1368,7 +1368,7 @@ ExecParallelHashIncreaseNumBatches(HashJoinTable hashtable)
 			/* Wait for the above to be finished. */
 			BarrierArriveAndWait(&pstate->grow_batches_barrier,
 								 WAIT_EVENT_HASH_GROW_BATCHES_REPARTITIONING);
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BATCHES_DECIDING:
 
@@ -1423,7 +1423,7 @@ ExecParallelHashIncreaseNumBatches(HashJoinTable hashtable)
 				dsa_free(hashtable->area, pstate->old_batches);
 				pstate->old_batches = InvalidDsaPointer;
 			}
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BATCHES_FINISHING:
 			/* Wait for the above to complete. */
@@ -1701,13 +1701,13 @@ ExecParallelHashIncreaseNumBuckets(HashJoinTable hashtable)
 				/* Clear the flag. */
 				pstate->growth = PHJ_GROWTH_OK;
 			}
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BUCKETS_ALLOCATING:
 			/* Wait for the above to complete. */
 			BarrierArriveAndWait(&pstate->grow_buckets_barrier,
 								 WAIT_EVENT_HASH_GROW_BUCKETS_ALLOCATING);
-			/* Fall through. */
+			FALL_THROUGH
 
 		case PHJ_GROW_BUCKETS_REINSERTING:
 			/* Reinsert all tuples into the hash table. */

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1814,7 +1814,6 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 	TupleTableSlot *slot;
 	uint32		hashvalue;
 	int			curbatch = hashtable->curbatch;
-	int			nmoved = 0;
 #if 0
 	int			orignbatch = hashtable->nbatch;
 #endif
@@ -1851,8 +1850,7 @@ ExecHashJoinReloadHashTable(HashJoinState *hjstate)
 			 * NOTE: some tuples may be sent to future batches.  Also, it is
 			 * possible for hashtable->nbatch to be increased here!
 			 */
-			if (!ExecHashTableInsert(hashState, hashtable, slot, hashvalue))
-				nmoved++;
+			ExecHashTableInsert(hashState, hashtable, slot, hashvalue);
 		}
 
 		/*

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -417,7 +417,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel)
 				else
 					node->hj_JoinState = HJ_NEED_NEW_OUTER;
 
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case HJ_NEED_NEW_OUTER:
 
@@ -511,7 +511,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel)
 				/* OK, let's scan the bucket for matches */
 				node->hj_JoinState = HJ_SCAN_BUCKET;
 
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case HJ_SCAN_BUCKET:
 
@@ -1389,13 +1389,13 @@ ExecParallelHashJoinNewBatch(HashJoinState *hjstate)
 					if (BarrierArriveAndWait(batch_barrier,
 											 WAIT_EVENT_HASH_BATCH_ELECTING))
 						ExecParallelHashTableAlloc(hashtable, batchno);
-					/* Fall through. */
+					FALL_THROUGH
 
 				case PHJ_BATCH_ALLOCATING:
 					/* Wait for allocation to complete. */
 					BarrierArriveAndWait(batch_barrier,
 										 WAIT_EVENT_HASH_BATCH_ALLOCATING);
-					/* Fall through. */
+					FALL_THROUGH
 
 				case PHJ_BATCH_LOADING:
 					/* Start (or join in) loading tuples. */
@@ -1415,7 +1415,7 @@ ExecParallelHashJoinNewBatch(HashJoinState *hjstate)
 					sts_end_parallel_scan(inner_tuples);
 					BarrierArriveAndWait(batch_barrier,
 										 WAIT_EVENT_HASH_BATCH_LOADING);
-					/* Fall through. */
+					FALL_THROUGH
 
 				case PHJ_BATCH_PROBING:
 

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -71,7 +71,7 @@ ExecLimit_guts(PlanState *pstate)
 			 */
 			recompute_limits(node);
 
-			/* FALL THRU */
+			FALL_THROUGH
 
 		case LIMIT_RESCAN:
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1766,7 +1766,6 @@ ExecSplitUpdate_Insert(ModifyTableState *mtstate,
 					   bool canSetTag)
 {
 	ResultRelInfo *resultRelInfo;
-	Relation	resultRelationDesc;
 	bool		partition_constraint_failed;
 	TupleConversionMap *saved_tcs_map = NULL;
 	PartitionTupleRouting *proute = mtstate->mt_partition_tuple_routing;
@@ -1777,7 +1776,6 @@ ExecSplitUpdate_Insert(ModifyTableState *mtstate,
 	 * get information on the (current) result relation
 	 */
 	resultRelInfo = estate->es_result_relation_info;
-	resultRelationDesc = resultRelInfo->ri_RelationDesc;
 
 	/* ensure slot is independent, consider e.g. EPQ */
 	ExecMaterializeSlot(slot);

--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -665,7 +665,6 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	ExecSlice  *sendSlice;
 	ExecSlice  *recvSlice;
 	SliceTable *sliceTable = estate->es_sliceTable;
-	PlanState  *outerPlan;
 	int			parentIndex;
 
 	/*
@@ -785,12 +784,6 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	{
 		outerPlanState(motionstate) = ExecInitNode(outerPlan(node), estate, eflags);
 	}
-
-	/*
-	 * initialize tuple type.  no need to initialize projection info because
-	 * this node doesn't do projections.
-	 */
-	outerPlan = outerPlanState(motionstate);
 
 	/*
 	 * Initialize result type and slot

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1117,7 +1117,6 @@ ExecSetParamPlan(SubPlanState *node, ExprContext *econtext, QueryDesc *queryDesc
 
 	bool		needDtx;
 	bool		shouldDispatch = false;
-	volatile bool explainRecvStats = false;
 
 	if (Gp_role == GP_ROLE_DISPATCH &&
 		planstate != NULL &&
@@ -1415,7 +1414,6 @@ PG_TRY();
 		if (planstate->instrument && planstate->instrument->need_cdb)
 		{
 			/* Jam stats into subplan's Instrumentation nodes. */
-			explainRecvStats = true;
 			cdbexplain_recvExecStats(planstate, ds->primaryResults,
 									 LocallyExecutingSliceIndex(queryDesc->estate),
 									 econtext->ecxt_estate->showstatctx);

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2738,7 +2738,6 @@ static int
 _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 {
 	int			operation = queryDesc->operation;
-	int			eflags;
 	int			res;
 
 	_SPI_assign_query_mem(queryDesc);
@@ -2817,12 +2816,6 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 	if (ShowExecutorStats)
 		ResetUsage();
 #endif
-
-	/* Select execution options */
-	if (fire_triggers)
-		eflags = 0;				/* default run-to-completion flags */
-	else
-		eflags = EXEC_FLAG_SKIP_TRIGGERS;
 
 	PG_TRY();
 	{

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -859,7 +859,7 @@ processRetry(fts_context *context)
 				if (!(ftsInfo->result.retryRequested && context->has_mirrors &&
 					  SEGMENT_IS_ALIVE(ftsInfo->mirror_cdbinfo)))
 					break;
-				/* else, fallthrough */
+				FALL_THROUGH
 			case FTS_PROBE_FAILED:
 			case FTS_SYNCREP_OFF_FAILED:
 			case FTS_PROMOTE_FAILED:

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -410,8 +410,8 @@ CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
 		arg_modes[arg_index++] = PROARGMODE_TABLE;
 	}
 
-	if (!gpdb::ResolvePolymorphicArgType(total_args, arg_types.data(), arg_modes.data(),
-										 funcexpr))
+	if (!gpdb::ResolvePolymorphicArgType(total_args, arg_types.data(),
+										 arg_modes.data(), funcexpr))
 	{
 		GPOS_RAISE(
 			gpdxl::ExmaDXL, gpdxl::ExmiDXLUnrecognizedType,

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -387,8 +387,8 @@ CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
 	const ULONG num_args = std::min(num_arg_types, num_args_from_query);
 	const ULONG total_args = num_args + num_return_args;
 
-	OID arg_types[total_args];
-	char arg_modes[total_args];
+	std::vector<OID> arg_types(total_args);
+	std::vector<char> arg_modes(total_args);
 
 	// copy the first 'num_args' function argument types
 	ListCell *arg_type = nullptr;
@@ -410,7 +410,7 @@ CTranslatorUtils::ResolvePolymorphicTypes(CMemoryPool *mp,
 		arg_modes[arg_index++] = PROARGMODE_TABLE;
 	}
 
-	if (!gpdb::ResolvePolymorphicArgType(total_args, arg_types, arg_modes,
+	if (!gpdb::ResolvePolymorphicArgType(total_args, arg_types.data(), arg_modes.data(),
 										 funcexpr))
 	{
 		GPOS_RAISE(

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -987,13 +987,13 @@ COptTasks::PrintMissingStatsWarning(CMemoryPool *mp, CMDAccessor *md_accessor,
 	if (0 < rel_stats->Size())
 	{
 		int length = NAMEDATALEN * rel_stats->Size() + 200;
-		char msgbuf[length];
+		std::vector<char> msgbuf(length);
 		snprintf(
-			msgbuf, sizeof(msgbuf),
+			msgbuf.data(), msgbuf.size() * sizeof(char),
 			"One or more columns in the following table(s) do not have statistics: %s",
 			CreateMultiByteCharStringFromWCString(wcstr.GetBuffer()));
 		GpdbEreport(
-			ERRCODE_SUCCESSFUL_COMPLETION, NOTICE, msgbuf,
+			ERRCODE_SUCCESSFUL_COMPLETION, NOTICE, msgbuf.data(),
 			"For non-partitioned tables, run analyze <table_name>(<column_list>)."
 			" For partitioned tables, run analyze rootpartition <table_name>(<column_list>)."
 			" See log for columns missing statistics.");

--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -664,7 +664,7 @@ llvm_compile_expr(ExprState *state)
 
 					LLVMPositionBuilderAtEnd(b, b_nonull);
 				}
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case EEOP_FUNCEXPR:
 				{
@@ -703,7 +703,7 @@ llvm_compile_expr(ExprState *state)
 					LLVMBuildStore(b, l_sbool_const(0), v_boolanynullp);
 
 				}
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 				/*
 				 * Treat them the same for now, optimizer can remove
@@ -804,7 +804,7 @@ llvm_compile_expr(ExprState *state)
 												 l_ptr(TypeStorageBool));
 					LLVMBuildStore(b, l_sbool_const(0), v_boolanynullp);
 				}
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 				/*
 				 * Treat them the same for now, optimizer can remove
@@ -2111,7 +2111,7 @@ llvm_compile_expr(ExprState *state)
 									b_deserialize);
 					LLVMPositionBuilderAtEnd(b, b_deserialize);
 				}
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case EEOP_AGG_DESERIALIZE:
 				{

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -2467,7 +2467,7 @@ pam_passwd_conv_proc(int num_msg, const struct pam_message **msg,
 				ereport(LOG,
 						(errmsg("error from underlying PAM layer: %s",
 								msg[i]->msg)));
-				/* FALL THROUGH */
+				FALL_THROUGH
 			case PAM_TEXT_INFO:
 				/* we don't bother to log TEXT_INFO messages */
 				if ((reply[i].resp = strdup("")) == NULL)

--- a/src/backend/libpq/be-secure-openssl.c
+++ b/src/backend/libpq/be-secure-openssl.c
@@ -831,6 +831,7 @@ load_dh_file(char *filename, bool isServerStart)
 	FILE	   *fp;
 	DH		   *dh = NULL;
 	int			codes;
+	int			result;
 
 	/* attempt to open file.  It's not an error if it doesn't exist. */
 	if ((fp = AllocateFile(filename, "r")) == NULL)
@@ -842,7 +843,7 @@ load_dh_file(char *filename, bool isServerStart)
 		return NULL;
 	}
 
-	dh = PEM_read_DHparams(fp, NULL, NULL, NULL);
+	SUPPRESS_COMPILER_WARNING(dh = PEM_read_DHparams(fp, NULL, NULL, NULL), "-Wdeprecated-declarations");
 	FreeFile(fp);
 
 	if (dh == NULL)
@@ -855,13 +856,14 @@ load_dh_file(char *filename, bool isServerStart)
 	}
 
 	/* make sure the DH parameters are usable */
-	if (DH_check(dh, &codes) == 0)
+	SUPPRESS_COMPILER_WARNING(result = DH_check(dh, &codes), "-Wdeprecated-declarations");
+	if (result == 0)
 	{
 		ereport(isServerStart ? FATAL : LOG,
 				(errcode(ERRCODE_CONFIG_FILE_ERROR),
 				 errmsg("invalid DH parameters: %s",
 						SSLerrmessage(ERR_get_error()))));
-		DH_free(dh);
+		SUPPRESS_COMPILER_WARNING(DH_free(dh), "-Wdeprecated-declarations");
 		return NULL;
 	}
 	if (codes & DH_CHECK_P_NOT_PRIME)
@@ -869,7 +871,7 @@ load_dh_file(char *filename, bool isServerStart)
 		ereport(isServerStart ? FATAL : LOG,
 				(errcode(ERRCODE_CONFIG_FILE_ERROR),
 				 errmsg("invalid DH parameters: p is not prime")));
-		DH_free(dh);
+		SUPPRESS_COMPILER_WARNING(DH_free(dh), "-Wdeprecated-declarations");
 		return NULL;
 	}
 	if ((codes & DH_NOT_SUITABLE_GENERATOR) &&
@@ -878,7 +880,7 @@ load_dh_file(char *filename, bool isServerStart)
 		ereport(isServerStart ? FATAL : LOG,
 				(errcode(ERRCODE_CONFIG_FILE_ERROR),
 				 errmsg("invalid DH parameters: neither suitable generator or safe prime")));
-		DH_free(dh);
+		SUPPRESS_COMPILER_WARNING(DH_free(dh), "-Wdeprecated-declarations");
 		return NULL;
 	}
 
@@ -900,7 +902,7 @@ load_dh_buffer(const char *buffer, size_t len)
 	bio = BIO_new_mem_buf(unconstify(char *, buffer), len);
 	if (bio == NULL)
 		return NULL;
-	dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+	SUPPRESS_COMPILER_WARNING(dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL), "-Wdeprecated-declarations");
 	if (dh == NULL)
 		ereport(DEBUG2,
 				(errmsg_internal("DH load buffer: %s",
@@ -1043,11 +1045,11 @@ initialize_dh(SSL_CTX *context, bool isServerStart)
 				(errcode(ERRCODE_CONFIG_FILE_ERROR),
 				 (errmsg("DH: could not set DH parameters: %s",
 						 SSLerrmessage(ERR_get_error())))));
-		DH_free(dh);
+		SUPPRESS_COMPILER_WARNING(DH_free(dh), "-Wdeprecated-declarations");
 		return false;
 	}
 
-	DH_free(dh);
+	SUPPRESS_COMPILER_WARNING(DH_free(dh), "-Wdeprecated-declarations");
 	return true;
 }
 
@@ -1072,7 +1074,7 @@ initialize_ecdh(SSL_CTX *context, bool isServerStart)
 		return false;
 	}
 
-	ecdh = EC_KEY_new_by_curve_name(nid);
+	SUPPRESS_COMPILER_WARNING(ecdh = EC_KEY_new_by_curve_name(nid), "-Wdeprecated-declarations");
 	if (!ecdh)
 	{
 		ereport(isServerStart ? FATAL : LOG,
@@ -1083,7 +1085,7 @@ initialize_ecdh(SSL_CTX *context, bool isServerStart)
 
 	SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
 	SSL_CTX_set_tmp_ecdh(context, ecdh);
-	EC_KEY_free(ecdh);
+	SUPPRESS_COMPILER_WARNING(EC_KEY_free(ecdh), "-Wdeprecated-declarations");
 #endif
 
 	return true;

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2851,7 +2851,6 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	CommonTableExpr *cte = NULL;
 	double		tuple_fraction = 0.0;
 	CtePlanInfo *cteplaninfo;
-	List	   *pathkeys = NULL;
 	PlannerInfo *subroot = NULL;
 	RelOptInfo *sub_final_rel;
 	Relids		required_outer;
@@ -3070,8 +3069,6 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		set_dummy_rel_pathlist(root, rel);
 		return;
 	}
-
-	pathkeys = subroot->query_pathkeys;
 
 	/* Mark rel with estimated output rows, width, etc */
 	{

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -5000,14 +5000,12 @@ adjust_selectivity_for_nulltest(Selectivity selec,
 
 			if (IsA(clause, NullTest))
 			{
-				int			nulltesttype;
 				Node	   *node;
 				Node	   *basenode;
 
 				/* extract information */
-				nulltesttype = ((NullTest *) clause)->nulltesttype;
 				node = (Node *) ((NullTest *) clause)->arg;
-	
+
 				/* CONSIDER: is this really necessary? */
 				if (IsA(node, RelabelType))
 					basenode = (Node *) ((RelabelType *) node)->arg;
@@ -5017,7 +5015,7 @@ adjust_selectivity_for_nulltest(Selectivity selec,
 				if (IsA(basenode, Var))
 				{
 					double	nullfrac = 1 - selec;
-	
+
 					/* adjust selectivity according to test */
 					switch (((NullTest *) clause)->nulltesttype)
 					{

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -2168,7 +2168,6 @@ select_cdb_redistribute_clauses(PlannerInfo *root,
 {
 	List	   *result_list = NIL;
 	bool		isouterjoin = IS_OUTER_JOIN(jointype);
-	bool		have_nonmergeable_joinclause = false;
 	ListCell   *l;
 
 	foreach(l, restrictlist)
@@ -2197,8 +2196,6 @@ select_cdb_redistribute_clauses(PlannerInfo *root,
 			 * reason to support constants is so we can do FULL JOIN ON
 			 * FALSE.)
 			 */
-			if (!restrictinfo->clause || !IsA(restrictinfo->clause, Const))
-				have_nonmergeable_joinclause = true;
 			continue;			/* not mergejoinable */
 		}
 
@@ -2207,7 +2204,6 @@ select_cdb_redistribute_clauses(PlannerInfo *root,
 		 */
 		if (!clause_sides_match_join(restrictinfo, outerrel, innerrel))
 		{
-			have_nonmergeable_joinclause = true;
 			continue;			/* no good for these input relations */
 		}
 
@@ -2236,7 +2232,6 @@ select_cdb_redistribute_clauses(PlannerInfo *root,
 		if (EC_MUST_BE_REDUNDANT(restrictinfo->left_ec) ||
 			EC_MUST_BE_REDUNDANT(restrictinfo->right_ec))
 		{
-			have_nonmergeable_joinclause = true;
 			continue;			/* can't handle redundant eclasses */
 		}
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -1714,7 +1714,7 @@ find_nonnullable_rels_walker(Node *node, bool top_level)
 				 * the intersection of the sets of nonnullable rels, just as
 				 * for OR.  Fall through to share code.
 				 */
-				/* FALL THRU */
+				FALL_THROUGH
 			case OR_EXPR:
 
 				/*
@@ -1939,7 +1939,7 @@ find_nonnullable_vars_walker(Node *node, bool top_level)
 				 * the intersection of the sets of nonnullable vars, just as
 				 * for OR.  Fall through to share code.
 				 */
-				/* FALL THRU */
+				FALL_THROUGH
 			case OR_EXPR:
 
 				/*

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -1628,7 +1628,6 @@ GetExtStatisticsName(Oid statOid)
 List *
 GetExtStatisticsKinds(Oid statOid)
 {
-	Form_pg_statistic_ext staForm;
 	HeapTuple	htup;
 	Datum		datum;
 	bool		isnull;
@@ -1641,8 +1640,6 @@ GetExtStatisticsKinds(Oid statOid)
 	htup = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(statOid));
 	if (!HeapTupleIsValid(htup))
 		elog(ERROR, "cache lookup failed for statistics object %u", statOid);
-
-	staForm = (Form_pg_statistic_ext) GETSTRUCT(htup);
 
 	datum = SysCacheGetAttr(STATEXTOID, htup,
 							Anum_pg_statistic_ext_stxkind, &isnull);

--- a/src/backend/optimizer/util/var.c
+++ b/src/backend/optimizer/util/var.c
@@ -947,16 +947,13 @@ flatten_join_alias_vars_mutator(Node *node,
 			RowExpr    *rowexpr;
 			List	   *fields = NIL;
 			List	   *colnames = NIL;
-			AttrNumber	attnum;
 			ListCell   *lv;
 			ListCell   *ln;
 
-			attnum = 0;
 			Assert(list_length(rte->joinaliasvars) == list_length(rte->eref->colnames));
 			forboth(lv, rte->joinaliasvars, ln, rte->eref->colnames)
 			{
 				newvar = (Node *) lfirst(lv);
-				attnum++;
 				/* Ignore dropped columns */
 				if (newvar == NULL)
 					continue;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2290,11 +2290,6 @@ transformSetOperationTree_internal(ParseState *pstate, SelectStmt *stmt,
 	{
 		/* Process an internal node (set operation node) */
 		SetOperationStmt *op = makeNode(SetOperationStmt);
-		const char *context;
-
-		context = (stmt->op == SETOP_UNION ? "UNION" :
-				   (stmt->op == SETOP_INTERSECT ? "INTERSECT" :
-					"EXCEPT"));
 
 		op->op = stmt->op;
 		op->all = stmt->all;

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2740,7 +2740,6 @@ transformDistributedBy(ParseState *pstate,
 
 		if (cxt->inhRelations)
 		{
-			bool		found = false;
 			/* try inherited tables */
 			ListCell   *inher;
 
@@ -2786,7 +2785,6 @@ transformDistributedBy(ParseState *pstate,
 										"table. ", inhname),
 								 errhint("The 'DISTRIBUTED BY' clause determines the distribution of data."
 								 		 " Make sure column(s) chosen are the optimal data distribution key to minimize skew.")));
-						found = true;
 						break;
 					}
 				}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -852,7 +852,7 @@ transformColumnDefinition(CreateStmtContext *cxt, ColumnDef *column)
 							 errmsg("primary key constraints are not supported on foreign tables"),
 							 parser_errposition(cxt->pstate,
 												constraint->location)));
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case CONSTR_UNIQUE:
 				if (cxt->isforeign)

--- a/src/backend/partitioning/partprune.c
+++ b/src/backend/partitioning/partprune.c
@@ -2712,7 +2712,7 @@ get_matching_list_bounds(PartitionPruneContext *context,
 
 		case BTGreaterEqualStrategyNumber:
 			inclusive = true;
-			/* fall through */
+			FALL_THROUGH
 		case BTGreaterStrategyNumber:
 			off = partition_list_bsearch(partsupfunc,
 										 partcollation,
@@ -2747,7 +2747,7 @@ get_matching_list_bounds(PartitionPruneContext *context,
 
 		case BTLessEqualStrategyNumber:
 			inclusive = true;
-			/* fall through */
+			FALL_THROUGH
 		case BTLessStrategyNumber:
 			off = partition_list_bsearch(partsupfunc,
 										 partcollation,
@@ -2994,7 +2994,7 @@ get_matching_range_bounds(PartitionPruneContext *context,
 
 		case BTGreaterEqualStrategyNumber:
 			inclusive = true;
-			/* fall through */
+			FALL_THROUGH
 		case BTGreaterStrategyNumber:
 
 			/*
@@ -3075,7 +3075,7 @@ get_matching_range_bounds(PartitionPruneContext *context,
 
 		case BTLessEqualStrategyNumber:
 			inclusive = true;
-			/* fall through */
+			FALL_THROUGH
 		case BTLessStrategyNumber:
 
 			/*

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -4820,17 +4820,11 @@ pgstat_combine_one_qe_result(List **oidList, struct pg_result *pgresult,
 {
 	int						arrayLen;
 	PgStatTabRecordFromQE  *records;
-	PgStat_SubXactStatus   *xact_state;
 	PgStat_TableStatus	   *pgstat_info;
 	PgStat_TableXactStatus *trans;
 
 	if (!pgresult || pgresult->extraslen < 1 || pgresult->extraType != PGExtraTypeTableStats)
 		return;
-	/*
-	* If this is the first rel to be modified at the current nest level,
-	* we first have to push a transaction stack entry.
-	*/
-	xact_state = get_tabstat_stack_level(nest_level);
 
 	arrayLen = pgresult->extraslen / sizeof(PgStatTabRecordFromQE);
 	records = (PgStatTabRecordFromQE *) pgresult->extras;

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -6426,19 +6426,21 @@ bgworker_should_start_now(BgWorkerStartTime start_time)
 				return true;
 			if (start_time == BgWorkerStart_RecoveryFinished)
 				return true;
-			/* fall through */
+			FALL_THROUGH
 
 		case PM_HOT_STANDBY:
 			if (start_time == BgWorkerStart_ConsistentState)
 				return true;
-			/* fall through */
+			FALL_THROUGH
 
 		case PM_RECOVERY:
 		case PM_STARTUP:
 		case PM_INIT:
 			if (start_time == BgWorkerStart_PostmasterStart)
 				return true;
-			/* fall through */
+			FALL_THROUGH
+		default:
+			break;
 
 	}
 

--- a/src/backend/regex/regc_lex.c
+++ b/src/backend/regex/regc_lex.c
@@ -875,7 +875,7 @@ lexescape(struct vars *v)
 			/* oops, doesn't look like it's a backref after all... */
 			v->now = save;
 			/* and fall through into octal number */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case CHR('0'):
 			NOTE(REG_UUNPORT);
 			v->now--;			/* put first digit back */

--- a/src/backend/regex/regc_pg_locale.c
+++ b/src/backend/regex/regc_pg_locale.c
@@ -303,7 +303,7 @@ pg_wc_isdigit(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswdigit((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isdigit((unsigned char) c));
@@ -312,7 +312,7 @@ pg_wc_isdigit(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswdigit_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -339,7 +339,7 @@ pg_wc_isalpha(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswalpha((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isalpha((unsigned char) c));
@@ -348,7 +348,7 @@ pg_wc_isalpha(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswalpha_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -375,7 +375,7 @@ pg_wc_isalnum(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswalnum((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isalnum((unsigned char) c));
@@ -384,7 +384,7 @@ pg_wc_isalnum(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswalnum_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -411,7 +411,7 @@ pg_wc_isupper(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswupper((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isupper((unsigned char) c));
@@ -420,7 +420,7 @@ pg_wc_isupper(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswupper_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -447,7 +447,7 @@ pg_wc_islower(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswlower((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					islower((unsigned char) c));
@@ -456,7 +456,7 @@ pg_wc_islower(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswlower_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -483,7 +483,7 @@ pg_wc_isgraph(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswgraph((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isgraph((unsigned char) c));
@@ -492,7 +492,7 @@ pg_wc_isgraph(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswgraph_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -519,7 +519,7 @@ pg_wc_isprint(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswprint((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isprint((unsigned char) c));
@@ -528,7 +528,7 @@ pg_wc_isprint(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswprint_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -555,7 +555,7 @@ pg_wc_ispunct(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswpunct((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					ispunct((unsigned char) c));
@@ -564,7 +564,7 @@ pg_wc_ispunct(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswpunct_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -591,7 +591,7 @@ pg_wc_isspace(pg_wchar c)
 		case PG_REGEX_LOCALE_WIDE:
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswspace((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			return (c <= (pg_wchar) UCHAR_MAX &&
 					isspace((unsigned char) c));
@@ -600,7 +600,7 @@ pg_wc_isspace(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return iswspace_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			return (c <= (pg_wchar) UCHAR_MAX &&
@@ -631,7 +631,7 @@ pg_wc_toupper(pg_wchar c)
 				return pg_ascii_toupper((unsigned char) c);
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return towupper((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			/* force C behavior for ASCII characters, per comments above */
 			if (c <= (pg_wchar) 127)
@@ -644,7 +644,7 @@ pg_wc_toupper(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return towupper_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			if (c <= (pg_wchar) UCHAR_MAX)
@@ -675,7 +675,7 @@ pg_wc_tolower(pg_wchar c)
 				return pg_ascii_tolower((unsigned char) c);
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return towlower((wint_t) c);
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE:
 			/* force C behavior for ASCII characters, per comments above */
 			if (c <= (pg_wchar) 127)
@@ -688,7 +688,7 @@ pg_wc_tolower(pg_wchar c)
 			if (sizeof(wchar_t) >= 4 || c <= (pg_wchar) 0xFFFF)
 				return towlower_l((wint_t) c, pg_regex_locale->info.lt);
 #endif
-			/* FALL THRU */
+			FALL_THROUGH
 		case PG_REGEX_LOCALE_1BYTE_L:
 #ifdef HAVE_LOCALE_T
 			if (c <= (pg_wchar) UCHAR_MAX)

--- a/src/backend/regex/regcomp.c
+++ b/src/backend/regex/regcomp.c
@@ -910,7 +910,7 @@ parseqatom(struct vars *v,
 			/* legal in EREs due to specification botch */
 			NOTE(REG_UPBOTCH);
 			/* fall through into case PLAIN */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case PLAIN:
 			onechr(v, v->nextvalue, lp, rp);
 			okcolors(v->nfa, v->cm);

--- a/src/backend/replication/logical/reorderbuffer.c
+++ b/src/backend/replication/logical/reorderbuffer.c
@@ -1540,7 +1540,7 @@ ReorderBufferCommit(ReorderBuffer *rb, TransactionId xid,
 					change = specinsert;
 					change->action = REORDER_BUFFER_CHANGE_INSERT;
 
-					/* intentionally fall through */
+					FALL_THROUGH
 				case REORDER_BUFFER_CHANGE_INSERT:
 				case REORDER_BUFFER_CHANGE_UPDATE:
 				case REORDER_BUFFER_CHANGE_DELETE:

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -206,7 +206,7 @@ WalReceiverMain(void)
 		case WALRCV_STOPPING:
 			/* If we've already been requested to stop, don't start up. */
 			walrcv->walRcvState = WALRCV_STOPPED;
-			/* fall through */
+			FALL_THROUGH
 
 		case WALRCV_STOPPED:
 			SpinLockRelease(&walrcv->mutex);

--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -201,7 +201,7 @@ ShutdownWalRcv(void)
 		case WALRCV_WAITING:
 		case WALRCV_RESTARTING:
 			walrcv->walRcvState = WALRCV_STOPPING;
-			/* fall through */
+			FALL_THROUGH
 		case WALRCV_STOPPING:
 			walrcvpid = walrcv->pid;
 			break;

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3691,7 +3691,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 					return;
 
 				/* Intentional fall through to check wait for pin */
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case PROCSIG_RECOVERY_CONFLICT_BUFFERPIN:
 
@@ -3717,7 +3717,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 				MyProc->recoveryConflictPending = true;
 
 				/* Intentional fall through to error handling */
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case PROCSIG_RECOVERY_CONFLICT_LOCK:
 			case PROCSIG_RECOVERY_CONFLICT_TABLESPACE:
@@ -3762,7 +3762,7 @@ RecoveryConflictInterrupt(ProcSignalReason reason)
 				}
 
 				/* Intentional fall through to session cancel */
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case PROCSIG_RECOVERY_CONFLICT_DATABASE:
 				RecoveryConflictPending = true;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2236,7 +2236,7 @@ ExecDropStmt(DropStmt *stmt, bool isTopLevel)
 			if (stmt->concurrent && Gp_role != GP_ROLE_EXECUTE)
 				PreventInTransactionBlock(isTopLevel,
 										  "DROP INDEX CONCURRENTLY");
-			/* fall through */
+			FALL_THROUGH
 
 		case OBJECT_TABLE:
 		case OBJECT_SEQUENCE:

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -1882,6 +1882,7 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						case DTK_DAY:
 							if (tzp == NULL)
 								return DTERR_BAD_FORMAT;
+							FALL_THROUGH
 						default:
 							break;
 					}
@@ -3141,7 +3142,7 @@ DecodeInterval(char **field, int *ftype, int nf, int range,
 				 * handle signed float numbers and signed year-month values.
 				 */
 
-				/* FALLTHROUGH */
+				FALL_THROUGH
 
 			case DTK_DATE:
 			case DTK_NUMBER:
@@ -3572,7 +3573,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
-					/* FALLTHROUGH */
+					FALL_THROUGH
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -3651,7 +3652,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
-					/* FALLTHROUGH */
+					FALL_THROUGH
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -3860,44 +3860,6 @@ EncodeTimezone(char *str, int tz, int style)
 }
 
 
-/* 
- * Convenience routine for encoding dates faster than sprintf does.
- * tm is the timestamp structure, str is the string, pos is position in
- * the string which we are at. Upon returning, it is set to the offset of the
- * last character we set in str.
- */
-inline static void
-fast_encode_date(struct pg_tm * tm, char *str, int *pos)
-{
-	/*
-	 * sprintf() is very slow so we just convert the numbers to
-	 * a string manually. Since we allow dates in the range
-	 * 4713 BC to 5874897 AD, we have to check for years
-	 * with 7, 6 and 5 digits, being careful to not add
-	 * leading zeros for those. We only zero pad to four digits.
-	 */
-	int y = (tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1);
-	
-	if (y >= 1000000)
-		str[(*pos)++] = y / 1000000 % 10 + '0';
-	if (y >= 100000)
-		str[(*pos)++] = y / 100000 % 10 + '0';
-	if (y >= 10000)
-		str[(*pos)++] = y / 10000 % 10 + '0';
-	
-	str[(*pos)++] = y/1000 % 10 + '0';
-	str[(*pos)++] = y/100 % 10 + '0';
-	str[(*pos)++] = y/10 % 10 + '0';
-	str[(*pos)++] = y % 10 + '0';
-	str[(*pos)++] = '-';
-	str[(*pos)++] = tm->tm_mon/10 + '0'; 
-	str[(*pos)++] = tm->tm_mon % 10 + '0';
-	str[(*pos)++] = '-';
-	str[(*pos)++] = tm->tm_mday/10 + '0';
-	str[(*pos)++] = tm->tm_mday % 10 + '0';
-	str[(*pos)] = '\0';
-}
-
 /* EncodeDateOnly()
  * Encode date as local time.
  */

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -1120,7 +1120,7 @@ NUMDesc_prepare(NUMDesc *num, FormatNode *n)
 		case NUM_D:
 			num->flag |= NUM_F_LDECIMAL;
 			num->need_locale = true;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case NUM_DEC:
 			if (IS_DECIMAL(num))
 				ereport(ERROR,
@@ -2973,7 +2973,7 @@ DCH_to_char(FormatNode *node, bool is_interval, TmToChar *in, char *out, Oid col
 				s += strlen(s);
 				break;
 			case DCH_RM:
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case DCH_rm:
 
 				/*

--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -595,7 +595,7 @@ pushJsonbValueScalar(JsonbParseState **pstate, JsonbIteratorToken seq,
 			break;
 		case WJB_END_OBJECT:
 			uniqueifyJsonbObject(&(*pstate)->contVal);
-			/* fall through! */
+			FALL_THROUGH
 		case WJB_END_ARRAY:
 			/* Steps here common to WJB_END_OBJECT case */
 			Assert(!scalarVal);

--- a/src/backend/utils/adt/jsonpath.c
+++ b/src/backend/utils/adt/jsonpath.c
@@ -331,7 +331,7 @@ flattenJsonPathParseItem(StringInfo buf, JsonPathParseItem *item,
 			break;
 		case jpiFilter:
 			argNestingLevel++;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case jpiIsUnknown:
 		case jpiNot:
 		case jpiPlus:
@@ -440,13 +440,13 @@ alignStringInfoInt(StringInfo buf)
 	{
 		case 3:
 			appendStringInfoCharMacro(buf, 0);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 2:
 			appendStringInfoCharMacro(buf, 0);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 1:
 			appendStringInfoCharMacro(buf, 0);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		default:
 			break;
 	}
@@ -855,7 +855,7 @@ jspInitByBuffer(JsonPathItem *v, char *base, int32 pos)
 		case jpiString:
 		case jpiVariable:
 			read_int32(v->content.value.datalen, base, pos);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case jpiNumeric:
 		case jpiBool:
 			v->content.value.data = base + pos;

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -1939,13 +1939,13 @@ numeric_abbrev_convert_var(const NumericVar *var, NumericSortSupport *nss)
 		{
 			default:
 				result |= ((int64) var->digits[3]);
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case 3:
 				result |= ((int64) var->digits[2]) << 14;
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case 2:
 				result |= ((int64) var->digits[1]) << 28;
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case 1:
 				result |= ((int64) var->digits[0]) << 42;
 				break;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -7810,7 +7810,7 @@ isSimpleNode(Node *node, Node *parentNode, int prettyFlags)
 				}
 				/* else do the same stuff as for T_SubLink et al. */
 			}
-			/* FALLTHROUGH */
+			FALL_THROUGH
 
 		case T_SubLink:
 		case T_NullTest:
@@ -10563,7 +10563,7 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 				break;
 			case RTE_TABLEFUNCTION:
 				/* Table Function RTE */
-				/* fallthrough */
+				FALL_THROUGH
 			case RTE_FUNCTION:
 				/* Function RTE */
 				rtfunc1 = (RangeTblFunction *) linitial(rte->functions);

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -4533,14 +4533,14 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					tm->tm_year = ((tm->tm_year + 999) / 1000) * 1000 - 999;
 				else
 					tm->tm_year = -((999 - (tm->tm_year - 1)) / 1000) * 1000 + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_CENTURY:
 				/* see comments in timestamptz_trunc */
 				if (tm->tm_year > 0)
 					tm->tm_year = ((tm->tm_year + 99) / 100) * 100 - 99;
 				else
 					tm->tm_year = -((99 - (tm->tm_year - 1)) / 100) * 100 + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_DECADE:
 				/* see comments in timestamptz_trunc */
 				if (val != DTK_MILLENNIUM && val != DTK_CENTURY)
@@ -4550,25 +4550,25 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 					else
 						tm->tm_year = -((8 - (tm->tm_year - 1)) / 10) * 10;
 				}
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_YEAR:
 				tm->tm_mon = 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_QUARTER:
 				tm->tm_mon = (3 * ((tm->tm_mon - 1) / 3)) + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_MONTH:
 				tm->tm_mday = 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_DAY:
 				tm->tm_hour = 0;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_HOUR:
 				tm->tm_min = 0;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_MINUTE:
 				tm->tm_sec = 0;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_SECOND:
 				fsec = 0;
 				break;
@@ -4674,14 +4674,14 @@ timestamptz_trunc_internal(text *units, TimestampTz timestamp, pg_tz *tzp)
 					tm->tm_year = ((tm->tm_year + 999) / 1000) * 1000 - 999;
 				else
 					tm->tm_year = -((999 - (tm->tm_year - 1)) / 1000) * 1000 + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_CENTURY:
 				/* truncating to the century? as above: -100, 1, 101... */
 				if (tm->tm_year > 0)
 					tm->tm_year = ((tm->tm_year + 99) / 100) * 100 - 99;
 				else
 					tm->tm_year = -((99 - (tm->tm_year - 1)) / 100) * 100 + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_DECADE:
 
 				/*
@@ -4695,26 +4695,26 @@ timestamptz_trunc_internal(text *units, TimestampTz timestamp, pg_tz *tzp)
 					else
 						tm->tm_year = -((8 - (tm->tm_year - 1)) / 10) * 10;
 				}
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_YEAR:
 				tm->tm_mon = 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_QUARTER:
 				tm->tm_mon = (3 * ((tm->tm_mon - 1) / 3)) + 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_MONTH:
 				tm->tm_mday = 1;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_DAY:
 				tm->tm_hour = 0;
 				redotz = true;	/* for all cases >= DAY */
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_HOUR:
 				tm->tm_min = 0;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_MINUTE:
 				tm->tm_sec = 0;
-				/* FALL THRU */
+				FALL_THROUGH
 			case DTK_SECOND:
 				fsec = 0;
 				break;
@@ -4862,33 +4862,33 @@ interval_trunc(PG_FUNCTION_ARGS)
 				case DTK_MILLENNIUM:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 1000) * 1000;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_CENTURY:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 100) * 100;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_DECADE:
 					/* caution: C division may have negative remainder */
 					tm->tm_year = (tm->tm_year / 10) * 10;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_YEAR:
 					tm->tm_mon = 0;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_QUARTER:
 					tm->tm_mon = 3 * (tm->tm_mon / 3);
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_MONTH:
 					tm->tm_mday = 0;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_DAY:
 					tm->tm_hour = 0;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_HOUR:
 					tm->tm_min = 0;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_MINUTE:
 					tm->tm_sec = 0;
-					/* FALL THRU */
+					FALL_THROUGH
 				case DTK_SECOND:
 					fsec = 0;
 					break;

--- a/src/backend/utils/adt/tsginidx.c
+++ b/src/backend/utils/adt/tsginidx.c
@@ -264,7 +264,7 @@ TS_execute_ternary(GinChkVal *gcv, QueryItem *curitem, bool in_phrase)
 			/* Pass down in_phrase == true in case there's a NOT below */
 			in_phrase = true;
 
-			/* FALL THRU */
+			FALL_THROUGH
 
 		case OP_AND:
 			val1 = TS_execute_ternary(gcv, curitem + curitem->qoperator.left,

--- a/src/backend/utils/cache/catcache.c
+++ b/src/backend/utils/cache/catcache.c
@@ -285,19 +285,19 @@ CatalogCacheComputeHashValue(CatCache *cache, int nkeys,
 
 			hashValue ^= oneHash << 24;
 			hashValue ^= oneHash >> 8;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 3:
 			oneHash = (cc_hashfunc[2]) (v3);
 
 			hashValue ^= oneHash << 16;
 			hashValue ^= oneHash >> 16;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 2:
 			oneHash = (cc_hashfunc[1]) (v2);
 
 			hashValue ^= oneHash << 8;
 			hashValue ^= oneHash >> 24;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 1:
 			oneHash = (cc_hashfunc[0]) (v1);
 
@@ -336,21 +336,21 @@ CatalogCacheComputeTupleHashValue(CatCache *cache, int nkeys, HeapTuple tuple)
 							 cc_tupdesc,
 							 &isNull);
 			Assert(!isNull);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 3:
 			v3 = fastgetattr(tuple,
 							 cc_keyno[2],
 							 cc_tupdesc,
 							 &isNull);
 			Assert(!isNull);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 2:
 			v2 = fastgetattr(tuple,
 							 cc_keyno[1],
 							 cc_tupdesc,
 							 &isNull);
 			Assert(!isNull);
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case 1:
 			v1 = fastgetattr(tuple,
 							 cc_keyno[0],

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -1714,7 +1714,7 @@ trigger_enabled(Oid triggerid)
 	switch (tgenabled)
 	{
 		case TRIGGER_FIRES_ON_ORIGIN:
-			/* fallthrough */
+			FALL_THROUGH
 			/*
 			 * FIXME: we should probably return false when
 			 * SessionReplicationRole isn't SESSION_REPLICATION_ROLE_ORIGIN,

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -178,7 +178,7 @@ datumstreamread_getlarge(DatumStreamRead * acc, Datum *datum, bool *null)
 			acc->largeObjectState = DatumStreamLargeObjectState_Consumed;
 
 			/* Fall below to ~_Consumed. */
-			/* fallthrough */
+			FALL_THROUGH
 
 		case DatumStreamLargeObjectState_Consumed:
 			{

--- a/src/backend/utils/datumstream/datumstreamblock.c
+++ b/src/backend/utils/datumstream/datumstreamblock.c
@@ -3476,7 +3476,6 @@ DatumStreamBlockWrite_PutDense(
 				return -1;
 			case DELTA_COMPRESSION_NOT_APPLIED:
 				break;
-				/* FALL through */
 		}
 	}
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -167,11 +167,11 @@ static void write_eventlog(int level, const char *line, int len);
  * It only works for x86 processors.
  */
 #if defined(__i386)
-#define ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
+#define ASMFP __asm__ volatile ("movl %%ebp, %0" : "=g" (ulp));
 #define GET_PTR_FROM_VALUE(value) ((uint32)value)
 #define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
 #elif defined(__x86_64__)
-#define ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
+#define ASMFP __asm__ volatile ("movq %%rbp, %0" : "=g" (ulp));
 #define GET_PTR_FROM_VALUE(value) (value)
 #define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
 #else

--- a/src/backend/utils/fmgr/funcapi.c
+++ b/src/backend/utils/fmgr/funcapi.c
@@ -1396,7 +1396,7 @@ build_function_result_tupdesc_d(char prokind,
 
 			/* input and output */
 			case PROARGMODE_INOUT:
-				/* fallthrough */
+				FALL_THROUGH
 
 			/* output modes */
 			case PROARGMODE_OUT:

--- a/src/backend/utils/hash/dynahash.c
+++ b/src/backend/utils/hash/dynahash.c
@@ -1039,7 +1039,7 @@ hash_search_with_hash_value(HTAB *hashp,
 			return NULL;
 
 		case HASH_ENTER_NULL:
-			/* FALL THRU */
+			FALL_THROUGH
 
 		case HASH_ENTER:
 			/* Return existing element if found, else create one */

--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -908,17 +908,17 @@ GpMurmurHash64A (const void * key, int len, unsigned int seed)
 
     switch(len & 7) {
         case 7: h ^= (uint64_t)data[6] << 48;
-		/* fallthrough */
+		FALL_THROUGH
         case 6: h ^= (uint64_t)data[5] << 40;
-		/* fallthrough */
+		FALL_THROUGH
         case 5: h ^= (uint64_t)data[4] << 32;
-		/* fallthrough */
+		FALL_THROUGH
         case 4: h ^= (uint64_t)data[3] << 24;
-		/* fallthrough */
+		FALL_THROUGH
         case 3: h ^= (uint64_t)data[2] << 16;
-		/* fallthrough */
+		FALL_THROUGH
         case 2: h ^= (uint64_t)data[1] << 8;
-		/* fallthrough */
+		FALL_THROUGH
         case 1: h ^= (uint64_t)data[0];
         h *= m;
     };

--- a/src/backend/utils/mb/conversion_procs/euc_tw_and_big5/big5.c
+++ b/src/backend/utils/mb/conversion_procs/euc_tw_and_big5/big5.c
@@ -370,6 +370,7 @@ CNStoBIG5(unsigned short cns, unsigned char lc)
 				if (b1c4[i][1] == cns)
 					return b1c4[i][0];
 			}
+			break;
 		default:
 			break;
 	}

--- a/src/backend/utils/mb/wchar.c
+++ b/src/backend/utils/mb/wchar.c
@@ -1516,12 +1516,12 @@ pg_utf8_islegal(const unsigned char *source, int length)
 			a = source[3];
 			if (a < 0x80 || a > 0xBF)
 				return false;
-			/* FALL THRU */
+			FALL_THROUGH
 		case 3:
 			a = source[2];
 			if (a < 0x80 || a > 0xBF)
 				return false;
-			/* FALL THRU */
+			FALL_THROUGH
 		case 2:
 			a = source[1];
 			switch (*source)
@@ -1547,7 +1547,7 @@ pg_utf8_islegal(const unsigned char *source, int length)
 						return false;
 					break;
 			}
-			/* FALL THRU */
+			FALL_THROUGH
 		case 1:
 			a = *source;
 			if (a >= 0x80 && a < 0xC2)
@@ -1623,7 +1623,7 @@ pg_utf8_increment(unsigned char *charptr, int length)
 				charptr[3]++;
 				break;
 			}
-			/* FALL THRU */
+			FALL_THROUGH
 		case 3:
 			a = charptr[2];
 			if (a < 0xBF)
@@ -1631,7 +1631,7 @@ pg_utf8_increment(unsigned char *charptr, int length)
 				charptr[2]++;
 				break;
 			}
-			/* FALL THRU */
+			FALL_THROUGH
 		case 2:
 			a = charptr[1];
 			switch (*charptr)
@@ -1651,7 +1651,7 @@ pg_utf8_increment(unsigned char *charptr, int length)
 				charptr[1]++;
 				break;
 			}
-			/* FALL THRU */
+			FALL_THROUGH
 		case 1:
 			a = *charptr;
 			if (a == 0x7F || a == 0xDF || a == 0xEF || a == 0xF4)

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7114,7 +7114,7 @@ set_config_option(const char *name, const char *value,
 				return 0;
 			}
 			/* fall through to process the same as PGC_BACKEND */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case PGC_BACKEND:
 			if (context == PGC_SIGHUP)
 			{
@@ -8546,7 +8546,7 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 		case VAR_SET_DEFAULT:
 			if (stmt->is_local)
 				WarnNoTransactionBlock(isTopLevel, "SET LOCAL");
-			/* fall through */
+			FALL_THROUGH
 		case VAR_RESET:
 			if (strcmp(stmt->name, "transaction_isolation") == 0 &&
 				Gp_role != GP_ROLE_EXECUTE)

--- a/src/backend/utils/resgroup/Makefile
+++ b/src/backend/utils/resgroup/Makefile
@@ -13,6 +13,8 @@ top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 
+CFLAGS=$(CFLAGS) -Wno-implicit-fallthrough
+
 OBJS = resgroup.o resgroup_helper.o
 
 ifeq ($(PORTNAME),linux)

--- a/src/backend/utils/resgroup/Makefile
+++ b/src/backend/utils/resgroup/Makefile
@@ -13,7 +13,7 @@ top_builddir = ../../../..
 include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 
-CFLAGS=$(CFLAGS) -Wno-implicit-fallthrough
+CFLAGS+=-Wno-implicit-fallthrough
 
 OBJS = resgroup.o resgroup_helper.o
 

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -579,7 +579,7 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 					break;
 				}
 			}
-			/* fallthrough */
+			FALL_THROUGH
 
 
 			case T_SelectStmt:

--- a/src/backend/utils/sort/tuplestore.c
+++ b/src/backend/utils/sort/tuplestore.c
@@ -1067,7 +1067,7 @@ tuplestore_gettuple(Tuplestorestate *state, bool forward,
 							(errcode_for_file_access(),
 							 errmsg("could not seek in tuplestore temporary file")));
 			state->status = TSS_READFILE;
-			/* FALLTHROUGH */
+			FALL_THROUGH
 
 		case TSS_READFILE:
 			*should_free = true;

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -889,7 +889,7 @@ syncTargetDirectory(void)
 				case FILE_ACTION_CREATE:
 					fsync_fname(entry->path,
 								entry->source_type == FILE_TYPE_DIRECTORY);
-					/* FALLTHROUGH */
+					FALL_THROUGH
 				case FILE_ACTION_REMOVE:
 					/*
 					 * Fsync the parent directory if we either create or delete

--- a/src/common/hashfn.c
+++ b/src/common/hashfn.c
@@ -194,13 +194,13 @@ hash_bytes(const unsigned char *k, int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ka[1];
@@ -208,22 +208,22 @@ hash_bytes(const unsigned char *k, int keylen)
 				break;
 			case 7:
 				b += ((uint32) k[6] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += ((uint32) k[4] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ka[0];
 				break;
 			case 3:
 				a += ((uint32) k[2] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += ((uint32) k[0] << 24);
 				/* case 0: nothing left to add */
@@ -233,13 +233,13 @@ hash_bytes(const unsigned char *k, int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ka[1];
@@ -247,22 +247,22 @@ hash_bytes(const unsigned char *k, int keylen)
 				break;
 			case 7:
 				b += ((uint32) k[6] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += k[4];
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ka[0];
 				break;
 			case 3:
 				a += ((uint32) k[2] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += k[0];
 				/* case 0: nothing left to add */
@@ -296,35 +296,35 @@ hash_bytes(const unsigned char *k, int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += k[7];
-				/* fall through */
+				FALL_THROUGH
 			case 7:
 				b += ((uint32) k[6] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += ((uint32) k[4] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += k[3];
-				/* fall through */
+				FALL_THROUGH
 			case 3:
 				a += ((uint32) k[2] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += ((uint32) k[0] << 24);
 				/* case 0: nothing left to add */
@@ -334,35 +334,35 @@ hash_bytes(const unsigned char *k, int keylen)
 		{
 			case 11:
 				c += ((uint32) k[10] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ((uint32) k[7] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 7:
 				b += ((uint32) k[6] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += k[4];
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ((uint32) k[3] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 3:
 				a += ((uint32) k[2] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += k[0];
 				/* case 0: nothing left to add */
@@ -433,13 +433,13 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 		{
 			case 11:
 				c += ((uint32) k[10] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ka[1];
@@ -447,22 +447,22 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 				break;
 			case 7:
 				b += ((uint32) k[6] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += ((uint32) k[4] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ka[0];
 				break;
 			case 3:
 				a += ((uint32) k[2] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += ((uint32) k[0] << 24);
 				/* case 0: nothing left to add */
@@ -472,13 +472,13 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 		{
 			case 11:
 				c += ((uint32) k[10] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ka[1];
@@ -486,22 +486,22 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 				break;
 			case 7:
 				b += ((uint32) k[6] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += k[4];
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ka[0];
 				break;
 			case 3:
 				a += ((uint32) k[2] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += k[0];
 				/* case 0: nothing left to add */
@@ -535,35 +535,35 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 		{
 			case 11:
 				c += ((uint32) k[10] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += k[7];
-				/* fall through */
+				FALL_THROUGH
 			case 7:
 				b += ((uint32) k[6] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += ((uint32) k[4] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += k[3];
-				/* fall through */
+				FALL_THROUGH
 			case 3:
 				a += ((uint32) k[2] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += ((uint32) k[0] << 24);
 				/* case 0: nothing left to add */
@@ -573,35 +573,35 @@ hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
 		{
 			case 11:
 				c += ((uint32) k[10] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 10:
 				c += ((uint32) k[9] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 9:
 				c += ((uint32) k[8] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 8:
 				/* the lowest byte of c is reserved for the length */
 				b += ((uint32) k[7] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 7:
 				b += ((uint32) k[6] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 6:
 				b += ((uint32) k[5] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 5:
 				b += k[4];
-				/* fall through */
+				FALL_THROUGH
 			case 4:
 				a += ((uint32) k[3] << 24);
-				/* fall through */
+				FALL_THROUGH
 			case 3:
 				a += ((uint32) k[2] << 16);
-				/* fall through */
+				FALL_THROUGH
 			case 2:
 				a += ((uint32) k[1] << 8);
-				/* fall through */
+				FALL_THROUGH
 			case 1:
 				a += k[0];
 				/* case 0: nothing left to add */

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -1211,6 +1211,14 @@ typedef union PGAlignedXLogBlock
 	((underlying_type) (expr))
 #endif
 
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7)
+	#define FALL_THROUGH __attribute__((fallthrough));
+#elif defined(__GNUC__)
+	#define FALL_THROUGH /* fall through */
+#elif defined(_MSC_VER)
+	#define FALL_THROUGH [[fallthrough]];
+#endif
+
 /* ----------------------------------------------------------------
  *				Section 9: system-specific hacks
  *

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -1230,7 +1230,7 @@ typedef union PGAlignedXLogBlock
 #elif defined(__GNUC__)
 	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
 		_Pragma("GCC diagnostic push") \
-		_Pragma("clang diagnostic ignored \"" warning "\"") \
+		DO_PRAGMA(GCC diagnostic ignored warning) \
 		expr; \
 		_Pragma("GCC diagnostic pop") \
 	} while(0)

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -1219,6 +1219,23 @@ typedef union PGAlignedXLogBlock
 	#define FALL_THROUGH [[fallthrough]];
 #endif
 
+#define DO_PRAGMA(x) _Pragma (#x)
+#if defined(__clang__)
+	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
+		_Pragma("clang diagnostic push") \
+		DO_PRAGMA(clang diagnostic ignored warning) \
+		expr; \
+		_Pragma("clang diagnostic pop") \
+	} while(0)
+#elif defined(__GNUC__)
+	#define SUPPRESS_COMPILER_WARNING(expr, warning) do { \
+		_Pragma("GCC diagnostic push") \
+		_Pragma("clang diagnostic ignored \"" warning "\"") \
+		expr; \
+		_Pragma("GCC diagnostic pop") \
+	} while(0)
+#endif
+
 /* ----------------------------------------------------------------
  *				Section 9: system-specific hacks
  *

--- a/src/interfaces/ecpg/pgtypeslib/interval.c
+++ b/src/interfaces/ecpg/pgtypeslib/interval.c
@@ -184,7 +184,7 @@ DecodeISO8601Interval(char *str,
 						continue;
 					}
 					/* Else fall through to extended alternative format */
-					/* FALLTHROUGH */
+					FALL_THROUGH
 				case '-':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -263,7 +263,7 @@ DecodeISO8601Interval(char *str,
 						return 0;
 					}
 					/* Else fall through to extended alternative format */
-					/* FALLTHROUGH */
+					FALL_THROUGH
 				case ':':		/* ISO 8601 4.4.3.3 Alternative Format,
 								 * Extended */
 					if (havefield)
@@ -391,7 +391,7 @@ DecodeInterval(char **field, int *ftype, int nf,	/* int range, */
 					tmask = DTK_M(TZ);
 					break;
 				}
-				/* FALL THROUGH */
+				FALL_THROUGH
 
 			case DTK_DATE:
 			case DTK_NUMBER:

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -190,7 +190,7 @@ main(int argc, char *const argv[])
 			case 'h':
 				header_mode = true;
 				/* this must include "-c" to make sense, so fall through */
-				/* FALLTHROUGH */
+				FALL_THROUGH
 			case 'c':
 				auto_create_c = true;
 				break;

--- a/src/interfaces/libpq/fe-secure-openssl.c
+++ b/src/interfaces/libpq/fe-secure-openssl.c
@@ -1025,6 +1025,7 @@ initialize_SSL(PGconn *conn)
 			/* Colon, but not in second character, treat as engine:key */
 			char	   *engine_str = strdup(conn->sslkey);
 			char	   *engine_colon;
+			int		   init_result;
 
 			if (engine_str == NULL)
 			{
@@ -1039,7 +1040,7 @@ initialize_SSL(PGconn *conn)
 			*engine_colon = '\0';	/* engine_str now has engine name */
 			engine_colon++;		/* engine_colon now has key name */
 
-			conn->engine = ENGINE_by_id(engine_str);
+			SUPPRESS_COMPILER_WARNING(conn->engine = ENGINE_by_id(engine_str), "-Wdeprecated-declarations");
 			if (conn->engine == NULL)
 			{
 				char	   *err = SSLerrmessage(ERR_get_error());
@@ -1052,7 +1053,8 @@ initialize_SSL(PGconn *conn)
 				return -1;
 			}
 
-			if (ENGINE_init(conn->engine) == 0)
+			SUPPRESS_COMPILER_WARNING(init_result = ENGINE_init(conn->engine), "-Wdeprecated-declarations");
+			if (init_result == 0)
 			{
 				char	   *err = SSLerrmessage(ERR_get_error());
 
@@ -1060,14 +1062,17 @@ initialize_SSL(PGconn *conn)
 								  libpq_gettext("could not initialize SSL engine \"%s\": %s\n"),
 								  engine_str, err);
 				SSLerrfree(err);
-				ENGINE_free(conn->engine);
+				SUPPRESS_COMPILER_WARNING(ENGINE_free(conn->engine), "-Wdeprecated-declarations");
 				conn->engine = NULL;
 				free(engine_str);
 				return -1;
 			}
 
-			pkey = ENGINE_load_private_key(conn->engine, engine_colon,
-										   NULL, NULL);
+			SUPPRESS_COMPILER_WARNING(
+				pkey = ENGINE_load_private_key(conn->engine, engine_colon,
+										   	   NULL, NULL),
+				"-Wdeprecated-declarations"
+			);
 			if (pkey == NULL)
 			{
 				char	   *err = SSLerrmessage(ERR_get_error());
@@ -1076,8 +1081,8 @@ initialize_SSL(PGconn *conn)
 								  libpq_gettext("could not read private SSL key \"%s\" from engine \"%s\": %s\n"),
 								  engine_colon, engine_str, err);
 				SSLerrfree(err);
-				ENGINE_finish(conn->engine);
-				ENGINE_free(conn->engine);
+				SUPPRESS_COMPILER_WARNING(ENGINE_finish(conn->engine), "-Wdeprecated-declarations");
+				SUPPRESS_COMPILER_WARNING(ENGINE_free(conn->engine), "-Wdeprecated-declarations");
 				conn->engine = NULL;
 				free(engine_str);
 				return -1;
@@ -1090,8 +1095,8 @@ initialize_SSL(PGconn *conn)
 								  libpq_gettext("could not load private SSL key \"%s\" from engine \"%s\": %s\n"),
 								  engine_colon, engine_str, err);
 				SSLerrfree(err);
-				ENGINE_finish(conn->engine);
-				ENGINE_free(conn->engine);
+				SUPPRESS_COMPILER_WARNING(ENGINE_finish(conn->engine), "-Wdeprecated-declarations");
+				SUPPRESS_COMPILER_WARNING(ENGINE_free(conn->engine), "-Wdeprecated-declarations");
 				conn->engine = NULL;
 				free(engine_str);
 				return -1;
@@ -1346,8 +1351,8 @@ pgtls_close(PGconn *conn)
 #ifdef USE_SSL_ENGINE
 	if (conn->engine)
 	{
-		ENGINE_finish(conn->engine);
-		ENGINE_free(conn->engine);
+		SUPPRESS_COMPILER_WARNING(ENGINE_finish(conn->engine), "-Wdeprecated-declarations");
+		SUPPRESS_COMPILER_WARNING(ENGINE_free(conn->engine), "-Wdeprecated-declarations");
 		conn->engine = NULL;
 	}
 #endif

--- a/src/interfaces/libpq/fe-secure.c
+++ b/src/interfaces/libpq/fe-secure.c
@@ -383,7 +383,7 @@ retry_masked:
 				REMEMBER_EPIPE(spinfo, true);
 
 #ifdef ECONNRESET
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case ECONNRESET:
 #endif

--- a/src/pl/plperl/plperl.h
+++ b/src/pl/plperl/plperl.h
@@ -82,7 +82,10 @@
  */
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
 #include "perl.h"
+#pragma clang diagnostic pop
 
 /*
  * We want to include XSUB.h only within .xs files, because on some platforms

--- a/src/pl/plperl/plperl.h
+++ b/src/pl/plperl/plperl.h
@@ -82,10 +82,17 @@
  */
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#include "perl.h"
-#pragma clang diagnostic pop
+#if defined(__clang__)
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+	#include "perl.h"
+	#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+	#include "perl.h"
+	#pragma GCC diagnostic pop
+#endif
 
 /*
  * We want to include XSUB.h only within .xs files, because on some platforms

--- a/src/pl/plpgsql/src/pl_comp.c
+++ b/src/pl/plpgsql/src/pl_comp.c
@@ -2425,7 +2425,7 @@ plpgsql_add_initdatums(int **varnos)
 					case PLPGSQL_DTYPE_VAR:
 					case PLPGSQL_DTYPE_REC:
 						(*varnos)[n++] = plpgsql_Datums[i]->dno;
-
+						break;
 					default:
 						break;
 				}

--- a/src/pl/plpgsql/src/pl_exec.c
+++ b/src/pl/plpgsql/src/pl_exec.c
@@ -3203,7 +3203,7 @@ exec_stmt_return(PLpgSQL_execstate *estate, PLpgSQL_stmt_return *stmt)
 				/* fulfill promise if needed, then handle like regular var */
 				plpgsql_fulfill_promise(estate, (PLpgSQL_var *) retvar);
 
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case PLPGSQL_DTYPE_VAR:
 				{
@@ -3349,7 +3349,7 @@ exec_stmt_return_next(PLpgSQL_execstate *estate,
 				/* fulfill promise if needed, then handle like regular var */
 				plpgsql_fulfill_promise(estate, (PLpgSQL_var *) retvar);
 
-				/* FALL THRU */
+				FALL_THROUGH
 
 			case PLPGSQL_DTYPE_VAR:
 				{
@@ -5463,7 +5463,7 @@ exec_eval_datum(PLpgSQL_execstate *estate,
 			/* fulfill promise if needed, then handle like regular var */
 			plpgsql_fulfill_promise(estate, (PLpgSQL_var *) datum);
 
-			/* FALL THRU */
+			FALL_THROUGH
 
 		case PLPGSQL_DTYPE_VAR:
 			{

--- a/src/pl/tcl/pltcl.c
+++ b/src/pl/tcl/pltcl.c
@@ -2454,7 +2454,7 @@ pltcl_process_SPI_result(Tcl_Interp *interp,
 				break;
 			}
 			/* fall through for utility returning tuples */
-			/* FALLTHROUGH */
+			FALL_THROUGH
 
 		case SPI_OK_SELECT:
 		case SPI_OK_INSERT_RETURNING:

--- a/src/port/glob.c
+++ b/src/port/glob.c
@@ -333,7 +333,7 @@ globexp2(ptr, pattern, pglob, rv)
 				i--;
 				break;
 			}
-			/* FALLTHROUGH */
+			FALL_THROUGH
 		case COMMA:
 			if (i && *pm == COMMA)
 				break;

--- a/src/port/snprintf.c
+++ b/src/port/snprintf.c
@@ -465,7 +465,7 @@ nextch2:
 				/* set zero padding if no nonzero digits yet */
 				if (accum == 0 && !pointflag)
 					zpad = '0';
-				/* FALL THRU */
+				FALL_THROUGH
 			case '1':
 			case '2':
 			case '3':

--- a/src/timezone/zic.c
+++ b/src/timezone/zic.c
@@ -1393,19 +1393,19 @@ gethms(char const *string, char const *errstring)
 			break;
 		case 8:
 			ok = '0' <= xr && xr <= '9';
-			/* fallthrough */
+			FALL_THROUGH
 		case 7:
 			ok &= ssx == '.';
 			if (ok && noise)
 				warning(_("fractional seconds rejected by"
 						  " pre-2018 versions of zic"));
-			/* fallthrough */
+			FALL_THROUGH
 		case 5:
 			ok &= mmx == ':';
-			/* fallthrough */
+			FALL_THROUGH
 		case 3:
 			ok &= hhx == ':';
-			/* fallthrough */
+			FALL_THROUGH
 		case 1:
 			break;
 	}


### PR DESCRIPTION
Fix clang compiler errors

This patch fixes multiple errors produced by clang:
1. -Wimplicit-fallthrough was fixed by adding generic macro
2. -Wunused-function
3. -Wunused-variable and -Wunused-but-set-variable
4. -Wvla-cxx-extension
5. Unknown "asm" keyword
6. -Wdeprecated-declarations in third party headers was fixed by disabling this error for particular headers

Also, this patch adds an ability to build gpdb in a docker container using clang