### PR TITLE
ADBDEV-6111: Replace platform specific stack unwinding with the generic one

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -128,6 +128,7 @@ FtsProbeMain(Datum main_arg)
 	pqsignal(SIGHUP, sigHupHandler);
 	pqsignal(SIGINT, sigIntHandler);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 	#ifdef SIGILL
 		pqsignal(SIGILL, FtsProbeCrashHandler);
 	#endif

--- a/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
+++ b/src/backend/gporca/libgpos/src/common/CStackDescriptor.cpp
@@ -11,6 +11,8 @@
 
 #include "gpos/common/CStackDescriptor.h"
 
+#include <execinfo.h>
+
 #include "gpos/string/CWString.h"
 #include "gpos/task/IWorker.h"
 #include "gpos/utils.h"
@@ -30,53 +32,20 @@ using namespace gpos;
 void
 CStackDescriptor::BackTrace(ULONG top_frames_to_skip)
 {
-	// get base pointer of current frame
-	ULONG_PTR current_frame;
-	GPOS_GET_FRAME_POINTER(current_frame);
+	ULONG gpos_stack_trace_depth_actual;
+	void *raddrs[GPOS_STACK_TRACE_DEPTH];
+
+	// get the backtrace in platform-independent way
+	gpos_stack_trace_depth_actual = backtrace(raddrs, GPOS_STACK_TRACE_DEPTH);
 
 	// reset stack depth
 	Reset();
 
-	// pointer to next frame in stack
-	void **next_frame = (void **) current_frame;
-
-	// get stack start address
-	ULONG_PTR stack_start = 0;
-	IWorker *worker = IWorker::Self();
-	if (nullptr == worker)
+	// skip the first top_frames_to_skip
+	for (ULONG i = top_frames_to_skip; i < gpos_stack_trace_depth_actual; i++)
 	{
-		// no worker in stack, return immediately
-		return;
-	}
-
-	// get address from worker
-	stack_start = worker->GetStackStart();
-
-	// consider the first GPOS_STACK_TRACE_DEPTH frames below worker object
-	for (ULONG frame_counter = 0; frame_counter < GPOS_STACK_TRACE_DEPTH;
-		 frame_counter++)
-	{
-		// check if the frame pointer is after stack start and before previous frame
-		if ((ULONG_PTR) *next_frame > stack_start ||
-			(ULONG_PTR) *next_frame < (ULONG_PTR) next_frame)
-		{
-			break;
-		}
-
-		// skip top frames
-		if (0 < top_frames_to_skip)
-		{
-			top_frames_to_skip--;
-		}
-		else
-		{
-			// get return address (one above the base pointer)
-			ULONG_PTR *frame_address = (ULONG_PTR *) (next_frame + 1);
-			m_array_of_addresses[m_depth++] = (void *) *frame_address;
-		}
-
-		// move to next frame
-		next_frame = (void **) *next_frame;
+		// backtrace() produces pure return addresses, so just copy them
+		m_array_of_addresses[m_depth++] = raddrs[i];
 	}
 }
 

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -218,6 +218,7 @@ StartupProcessMain(void)
 	pqsignal(SIGUSR1, StartupProcSigUsr1Handler);
 	pqsignal(SIGUSR2, StartupProcTriggerHandler);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGBUS
 	pqsignal(SIGBUS, HandleCrash);
 #endif

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -266,6 +266,7 @@ WalReceiverMain(void)
 	/* Reset some signals that are accepted by postmaster but not here */
 	pqsignal(SIGCHLD, SIG_DFL);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 	#ifdef SIGILL
 		pqsignal(SIGILL, WalRcvCrashHandler);
 	#endif

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -3228,6 +3228,7 @@ WalSndSignals(void)
 	/* Reset some signals that are accepted by postmaster but not here */
 	pqsignal(SIGCHLD, SIG_DFL);
 
+	InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifdef SIGILL
 	pqsignal(SIGILL, WalSndCrashHandler);
 #endif

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4858,6 +4858,7 @@ PostgresMain(int argc, char *argv[],
 		 */
 		pqsignal(SIGCHLD, SIG_DFL); /* system() requires this on some
 									 * platforms */
+		InitStandardHandlerForSigillSigsegvSigbus_OnMainThread();
 #ifndef _WIN32
 #ifdef SIGILL
 		pqsignal(SIGILL, CdbProgramErrorHandler);

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -162,24 +162,6 @@ static void write_eventlog(int level, const char *line, int len);
 #define ADDRESS_SIZE     20
 #define STACK_DEPTH_MAX  100
 
-/*
- * Assembly code, gets the values of the frame pointer.
- * It only works for x86 processors.
- */
-#if defined(__i386)
-#define ASMFP asm volatile ("movl %%ebp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) ((uint32)value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#elif defined(__x86_64__)
-#define ASMFP asm volatile ("movq %%rbp, %0" : "=g" (ulp));
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x) do { uint64 ulp; ASMFP; x = ulp; } while (0)
-#else
-#define ASMFP
-#define GET_PTR_FROM_VALUE(value) (value)
-#define GET_FRAME_POINTER(x)
-#endif
-
 
 static ErrorData errordata[ERRORDATA_STACK_SIZE];
 
@@ -4905,63 +4887,9 @@ debug_backtrace(void)
  */
 uint32 gp_backtrace(void **stackAddresses, uint32 maxStackDepth)
 {
-#ifndef HAVE_BACKTRACE_SYMBOLS
+#ifdef WIN32
+	/* backtrace is not available for this platform */
 	return 0;
-#endif
-
-#if defined(__i386) || defined(__x86_64__)
-
-	/*
-	 * Stack base pointer has not been initialized by PostmasterMain,
-	 * or PostgresMain/AuxiliaryProcessMain is called directly by main
-	 * rather than forked by PostmasterMain (such as when initdb).
-	 *
-	 * In this case, just return depth as 0 to indicate that we have not
-	 * stored any frame addresses.
-	 */
-	if (stack_base_ptr == NULL)
-		return 0;
-
-	/* get base pointer of current frame */
-	uint64 framePtrValue = 0;
-	GET_FRAME_POINTER(framePtrValue);
-
-	uint32 depth = 0;
-	void **pFramePtr = (void**) GET_PTR_FROM_VALUE(framePtrValue);
-
-	/* check if the frame pointer is valid */
-	if (pFramePtr != NULL && (void *) &depth < (void *) pFramePtr)
-	{
-		/* consider the first maxStackDepth frames only, below the stack base pointer */
-		for (depth = 0; depth < maxStackDepth; depth++)
-		{
-			/* check if next frame is within stack */
-			if (pFramePtr == NULL ||
-				(void *) pFramePtr > *pFramePtr ||
-				(void *) stack_base_ptr < *pFramePtr)
-			{
-				break;
-			}
-
-			/* get return address (one above the frame pointer) */
-			const uintptr_t *returnAddr = (uintptr_t *)(pFramePtr + 1);
-
-			/* store return address */
-			stackAddresses[depth] = (void *) *returnAddr;
-
-			/* move to next frame */
-			pFramePtr = (void**)*pFramePtr;
-		}
-	}
-	else
-	{
-		depth  = backtrace(stackAddresses, maxStackDepth);
-	}
-
-	Assert(depth > 0);
-
-	return depth;
-
 #else
 	return backtrace(stackAddresses, maxStackDepth);
 #endif
@@ -5020,6 +4948,22 @@ SegvBusIllName(int signal)
 	}
 
 	return NULL;
+}
+
+/*
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread must be async-safe to be
+ * used as a signal handler. Under hood it calls backtrace() to collect frame
+ * addresses, that is known to be async-unsafe on the first run, while all the
+ * next runs are async-safe. This function must be called before setting
+ * StandardHandlerForSigillSigsegvSigbus_OnMainThread as a signal handler.
+ */
+void
+InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void)
+{
+	void *singleFrame[1];
+
+	/* Make gp_backtrace() async-safe */
+	gp_backtrace(singleFrame, 1);
 }
 
 /*

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -548,6 +548,7 @@ extern char *stack_base_ptr;
 extern bool gp_log_stack_trace_lines;   /* session GUC, controls line info in stack traces */
 
 extern const char *SegvBusIllName(int signal);
+extern void InitStandardHandlerForSigillSigsegvSigbus_OnMainThread(void);
 extern void StandardHandlerForSigillSigsegvSigbus_OnMainThread(char * processName, SIGNAL_ARGS);
 
 #endif							/* ELOG_H */


### PR DESCRIPTION
Refactor stack unwind in GPDB

ORCA and GPDB relied on frame registers to unwind the stack. This
approach required -fno-omit-frame-pointer during compilation.
Though it works faster than a backtrace(), the downside is reserving
a register by the compiler that affects the result code's performance.
Also, it is not an easy thing to port ORCA to other platforms (we
need to write assembly-specific code for that).

Besides, gp_backtrace() has some problems:

1. fallback to backtrace() from frame pointers was not SIGSEGV-safe
   for the builds without -fno-omit-frame-pointer.
2. backtrace() is known to be async-unsafe on the first run, while
   all the next runs are async-safe. For example on Linux backtrace()
   first run calls dlopen() to load libgcc that evaluates malloc().
   So we need to make an initial call of backtrace() before using it
   in a signal handler.

So, this commit removes the need to use -fno-omit-frame-pointer and
make all the code use backtrace() in a safe manner.

Changes to original commit:

1. Leave -fno-omit-frame-pointers in Makefiles since they are needed
   for debugging (see commit 16c441e9e88c8537179ec6e1895b56f636b551dc)
2. Since FtsProbe handles not only SIGSEGV, but also SIGILL and
   SIGBUS, move the initialization outside #ifdef SIGSEGV.

Co-authored-by: Ivan Leskin \<leskin.in@phystech.edu\>
(cherry picked from commit 2cfaa1b3984a21ebd399441087ff1a10c8bdd18d)

---
Note: do not squash the commit to preserve authorship.
