### PR TITLE
ADBDEV-6348: Add signal handlers to FtsProbe and WalReceiver

### DIFF
--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -94,6 +94,13 @@ sigIntHandler(SIGNAL_ARGS)
 		SetLatch(MyLatch);
 }
 
+static void
+FtsProbeCrashHandler(SIGNAL_ARGS)
+{
+	StandardHandlerForSigillSigsegvSigbus_OnMainThread("ftsprobe",
+														PASS_SIGNAL_ARGS);
+}
+
 pid_t
 FtsProbePID(void)
 {
@@ -120,6 +127,16 @@ FtsProbeMain(Datum main_arg)
 	 */
 	pqsignal(SIGHUP, sigHupHandler);
 	pqsignal(SIGINT, sigIntHandler);
+
+	#ifdef SIGILL
+		pqsignal(SIGILL, FtsProbeCrashHandler);
+	#endif
+	#ifdef SIGSEGV
+		pqsignal(SIGSEGV, FtsProbeCrashHandler);
+	#endif
+	#ifdef SIGBUS
+		pqsignal(SIGBUS, FtsProbeCrashHandler);
+	#endif
 
 	/* We're now ready to receive signals */
 	BackgroundWorkerUnblockSignals();


### PR DESCRIPTION
Add signal handlers to FtsProbe and WalReceiver

Add signals handlers for SIGSEGV, SIGILL and SIGBUS to FtsProbe and
WalReceiver, similar to GPDB 6. The standard handler is used (the one that
logs a stacktrace) with corresponding process names.

Unlike GPDB 6, CdbProgramErrorHandler is not used for FtsProbe, because
FtsProbe does not use threads and therefore the standard handler is enough.

There are no tests added because testing for stacktraces appearing in logs is
complicated and unnecessary. To test this manually:
1. Run GPDB demo cluster with mirrors
2. Send a signal to FtsProbe or WalReceiver process with
`pkill -SIGSEGV -f ftsprobe` or `pkill -SIGSEGV -f walreceiver`.
4. Check GPDB logs for stacktraces