### PR TITLE
ADBDEV-6344: Fix gpperfmon recording plpgsql queries with SPI cursors

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -117,7 +117,7 @@ Feature: gpperfmon
         SELECT test_sleep();
         """
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_sleep()%'" is "true"
-        And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%pg_sleep(80)%'" is "false"
+        And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%pg_sleep(80)%' AND query_text NOT LIKE '%queries_history%'" is "false"
 
     @gpperfmon_system_history
     Scenario: gpperfmon adds to system_history table

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -111,6 +111,9 @@ Feature: gpperfmon
         CREATE OR REPLACE FUNCTION test_sleep() RETURNS SETOF INT AS $$BEGIN
             RETURN QUERY SELECT 1 FROM pg_sleep(80);
         END$$ LANGUAGE plpgsql;
+        """
+        When below sql is executed in "gptest" db
+        """
         SELECT test_sleep();
         """
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_sleep()%'" is "true"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2513,6 +2513,18 @@ def impl(context, sql, boolean):
         if _str2bool(result) != _str2bool(boolean):
             raise Exception("sql output '%s' is not same as '%s'" % (result, boolean))
 
+@then('check that the result from boolean sql "{sql}" is "{boolean}"')
+def impl(context, sql, boolean):
+    cmd = Command(name='psql', cmdStr='psql --tuples-only -d gpperfmon -c "%s"' % sql)
+    cmd.run()
+    if cmd.get_return_code() != 0:
+        context.ret_code = cmd.get_return_code()
+        context.error_message = 'psql internal error: %s' % cmd.get_stderr()
+        check_return_code(context, 0)
+    else:
+        result = cmd.get_stdout()
+        if _str2bool(result) != _str2bool(boolean):
+            raise Exception("sql output '%s' is not same as '%s'" % (result, boolean))
 
 def _str2bool(string):
     return string.lower().strip() in ['t', 'true', '1', 'yes', 'y']

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1294,6 +1294,19 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	_SPI_current->processed = 0;
 	_SPI_current->tuptable = NULL;
 
+	bool orig_gp_enable_gpperfmon = gp_enable_gpperfmon;
+
+PG_TRY();
+{
+	/*
+	* Temporarily disable gpperfmon since we don't send information for internal queries in
+	* most cases, except when the debugging level is set to DEBUG4 or DEBUG5.
+	*/
+	if (log_min_messages > DEBUG4)
+	{
+		gp_enable_gpperfmon = false;
+	}
+
 	/* Create the portal */
 	if (name == NULL || name[0] == '\0')
 	{
@@ -1454,6 +1467,15 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	PortalStart(portal, paramLI, 0, snapshot, NULL);
 
 	Assert(portal->strategy != PORTAL_MULTI_QUERY);
+
+	gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
+}
+PG_CATCH();
+{
+	gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
+	PG_RE_THROW();
+}
+PG_END_TRY();
 
 	/* Pop the SPI stack */
 	_SPI_end_call(true);


### PR DESCRIPTION
Fix gpperfmon recording plpgsql queries with SPI cursors

Before this patch gpperfmon recorded plpgsql queries that used cursors (for
example FOR loops) even with log_min_messages < DEBUG 4. Logging for all the
other queries in plpgsql has been already disabled before by
cc2446b9333c52932c7a4ceeb522966d9cce31c3, this patch fixes the same issue for
SPI cursors.
Logging is enabled only for log_min_messages equal to DEBUG 5 or DEBUG 4.