### PR TITLE
Fix segfault when copying dropped column ACLs to a new partition

### DIFF
--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6648,3 +6648,55 @@ PARTITION BY RANGE (year)
 ( START (2010) END (2012) EVERY (1),
   DEFAULT PARTITION outlying_years );
 drop table p3_sales;
+-- test copying ACLs on columns when adding a new partition if the table has
+-- dropped columns.
+-- start_ignore
+-- end_ignore
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE TABLE t_part_acl (b INT, c INT, d INT, e INT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON t_part_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_acl TO user_prt_acl;
+ALTER TABLE t_part_acl DROP COLUMN d;
+ALTER TABLE t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+-- check AO partition for a non-AO partitioned table
+-- (thus partition has less system columns comparing to the partitioned table).
+ALTER TABLE t_part_acl ADD PARTITION "40" START (31) INCLUSIVE END (40) EXCLUSIVE WITH (APPENDONLY = TRUE);
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_40'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+-- check non-AO partition for an AO partitioned table
+-- (thus partition has more system columns comparing to the partitioned table).
+CREATE TABLE t_part_ao_acl (b INT, c INT, d INT, e INT) WITH (APPENDONLY = TRUE) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+GRANT SELECT(d) ON t_part_ao_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_ao_acl TO user_prt_acl;
+ALTER TABLE t_part_ao_acl DROP COLUMN d;
+ALTER TABLE t_part_ao_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE WITH (APPENDONLY = FALSE);
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_ao_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+DROP TABLE t_part_acl;
+DROP TABLE t_part_ao_acl;
+DROP ROLE user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6619,3 +6619,55 @@ PARTITION BY RANGE (year)
 ( START (2010) END (2012) EVERY (1),
   DEFAULT PARTITION outlying_years );
 drop table p3_sales;
+-- test copying ACLs on columns when adding a new partition if the table has
+-- dropped columns.
+-- start_ignore
+-- end_ignore
+CREATE ROLE user_prt_acl;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE TABLE t_part_acl (b INT, c INT, d INT, e INT) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_10" for table "t_part_acl"
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_20" for table "t_part_acl"
+GRANT SELECT(d) ON t_part_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_acl TO user_prt_acl;
+ALTER TABLE t_part_acl DROP COLUMN d;
+ALTER TABLE t_part_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE;
+NOTICE:  CREATE TABLE will create partition "t_part_acl_1_prt_30" for table "t_part_acl"
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+-- check AO partition for a non-AO partitioned table
+-- (thus partition has less system columns comparing to the partitioned table).
+ALTER TABLE t_part_acl ADD PARTITION "40" START (31) INCLUSIVE END (40) EXCLUSIVE WITH (APPENDONLY = TRUE);
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_acl_1_prt_40'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+-- check non-AO partition for an AO partitioned table
+-- (thus partition has more system columns comparing to the partitioned table).
+CREATE TABLE t_part_ao_acl (b INT, c INT, d INT, e INT) WITH (APPENDONLY = TRUE) DISTRIBUTED BY (b) PARTITION BY RANGE (c)
+    (PARTITION "10" START ( 1) INCLUSIVE END (10) EXCLUSIVE,
+     PARTITION "20" START (11) INCLUSIVE END (20) EXCLUSIVE);
+GRANT SELECT(d) ON t_part_ao_acl TO user_prt_acl;
+GRANT UPDATE(e) ON t_part_ao_acl TO user_prt_acl;
+ALTER TABLE t_part_ao_acl DROP COLUMN d;
+ALTER TABLE t_part_ao_acl ADD PARTITION "30" START (21) INCLUSIVE END (30) EXCLUSIVE WITH (APPENDONLY = FALSE);
+-- checking that we have copied the correct ACL.
+SELECT attname, attacl FROM pg_attribute WHERE attrelid = 't_part_ao_acl_1_prt_30'::regclass AND attacl IS NOT NULL;
+ attname |          attacl          
+---------+--------------------------
+ e       | {user_prt_acl=w/gpadmin}
+(1 row)
+
+DROP TABLE t_part_acl;
+DROP TABLE t_part_ao_acl;
+DROP ROLE user_prt_acl;


### PR DESCRIPTION
Fix segfault when copying dropped column ACLs to a new partition

While copying columns ACLs when adding a new partition, we assumed that the
attribute numbers in the source and target relation would match, which is not
true in the case of the dropped columns in the original relation. In this case,
we would try to get an ACL for a non-existent column in the target table, which
would lead to a segfault.

This patch adds a separate iterator for the list of columns in the target
relation to obtain the correct skipping of dropped columns in the original
relation and obtain the correct attribute number for the target relation. We
assume that there are no dropped columns in the target relation, since this is a
newly created relation.

(cherry picked from commit https://github.com/arenadata/gpdb/commit/13482adee24069532915ce849ab2dc0019cf15e5)

Changes comparing to the original commit:

1. Additional cleanup is added before the test start, as the role used in the
test couldn't be dropped (and re-created later), because the same role was used
in the preceding test and there were some objects depending on this role. So we
remove these objects now before starting the test.

2. Now the partition table may have different number of system columns comparing
to the top level parent partitioned table. The original code didn't handle this
case, and it resulted in an assert when creating a partitioned table. The code
to handle different number of system columns is added.

3. Tests are updated to cover cases with different number of system columns

Co-authored-by: Roman Eskin <r.eskin@arenadata.io>

----------------------------

Commit shouldn't be squashed to preserve authorship