### PR TITLE
ADBDEV-6368: Fix temporary schema cleanup after segment failure (#1022)

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -3926,6 +3926,28 @@ DropTempTableNamespaceForResetSession(Oid namespaceOid)
 }
 
 /*
+ * Remove temp namespace entry from pg_namespace.
+ */
+void
+DropTempTableNamespaceEntryForResetSession(Oid namespaceOid, Oid toastNamespaceOid)
+{
+	if (IsTransactionOrTransactionBlock())
+		elog(ERROR, "Called within a transaction");
+
+	StartTransactionCommand();
+
+	/* Make sure the temp namespace is valid. */
+	if (SearchSysCacheExists1(NAMESPACEOID,
+							  ObjectIdGetDatum(namespaceOid)))
+	{
+		RemoveSchemaById(namespaceOid);
+		RemoveSchemaById(toastNamespaceOid);
+	}
+
+	CommitTransactionCommand();
+}
+
+/*
  * Called by CreateSchemaCommand when creating a temporary schema 
  */
 void

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -987,14 +987,30 @@ rollbackDtxTransaction(void)
 			break;
 
 		case DTX_STATE_NOTIFYING_ABORT_NO_PREPARED:
-
-			/*
-			 * By deallocating the gang, we will force a new gang to connect
-			 * to all the segment instances.  And, we will abort the
-			 * transactions in the segments.
-			 */
-			elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
-			DisconnectAndDestroyAllGangs(true);
+			if (!proc_exit_inprogress)
+			{
+				/*
+				 * By deallocating the gang, we will force a new gang to connect
+				 * to all the segment instances.  And, we will abort the
+				 * transactions in the segments.
+				 *
+				 * Reset session ID and drop temp tables only when process does *not* exits,
+				 * because otherwise, proc_exit will do that eventually anyway.
+				 */
+				elog(NOTICE, "Releasing segworker groups to finish aborting the transaction.");
+				DisconnectAndDestroyAllGangs(true);
+			}
+			else
+			{
+				/*
+				 * Destroy all gangs early, so that they won't block any other QEs due to 2PC lock
+				 * when QD might be just retrying `rollbackDtxTransaction` for a prolonged time.
+				 *
+				 * Do not reset session just yet, because we want to keep myTempNamespace untouched
+				 * and let RemoveTempRelationsCallback() drops temp tables as part of proc_exit.
+				 */
+				DisconnectAndDestroyAllGangs(false);
+			}
 
 			/*
 			 * This call will at a minimum change the session id so we will
@@ -1059,18 +1075,13 @@ rollbackDtxTransaction(void)
 		Assert(MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_NO_PREPARED);
 
 		/*
-		 * By deallocating the gang, we will force a new gang to connect to
-		 * all the segment instances.  And, we will abort the transactions in
-		 * the segments.
+		 * Destroy all gangs early, so that they won't block any other QEs due to 2PC lock
+		 * when QD might be just retrying `rollbackDtxTransaction` for a prolonged time.
+		 *
+		 * Do not reset session just yet, because we want to keep myTempNamespace untouched
+		 * and let RemoveTempRelationsCallback() drops temp tables as part of proc_exit.
 		 */
-		DisconnectAndDestroyAllGangs(true);
-
-		/*
-		 * This call will at a minimum change the session id so we will not
-		 * have SharedSnapshotAdd colissions.
-		 */
-		CheckForResetSession();
-
+		DisconnectAndDestroyAllGangs(false);
 		clearAndResetGxact();
 		return;
 	}

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -773,8 +773,6 @@ void DisconnectAndDestroyUnusedQEs(void)
 /*
  * Drop any temporary tables associated with the current session and
  * use a new session id since we have effectively reset the session.
- *
- * Call this procedure outside of a transaction.
  */
 void
 CheckForResetSession(void)
@@ -783,33 +781,40 @@ CheckForResetSession(void)
 	int			newSessionId = 0;
 	Oid			dropTempNamespaceOid;
 
-	if (!NeedResetSession)
+	/* No need to reset session or drop temp tables */
+	if (!NeedResetSession && OldTempNamespace == InvalidOid)
 		return;
 
 	/* Do the session id change early. */
-
-	/* If we have gangs, we can't change our session ID. */
-	Assert(!cdbcomponent_qesExist());
-
-	oldSessionId = gp_session_id;
-	ProcNewMppSessionId(&newSessionId);
-
-	gp_session_id = newSessionId;
-	gp_command_count = 0;
-	MyProc->queryCommandId = 0;
-	pgstat_report_sessionid(newSessionId);
-
-	/* Update the slotid for our singleton reader. */
-	if (SharedLocalSnapshotSlot != NULL)
+	if (NeedResetSession)
 	{
-		LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
-		SharedLocalSnapshotSlot->slotid = gp_session_id;
-		LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+		/* If we have gangs, we can't change our session ID. */
+		Assert(!cdbcomponent_qesExist());
+
+		oldSessionId = gp_session_id;
+		ProcNewMppSessionId(&newSessionId);
+
+		gp_session_id = newSessionId;
+		gp_command_count = 0;
+		MyProc->queryCommandId = 0;
+		pgstat_report_sessionid(newSessionId);
+
+		/* Update the slotid for our singleton reader. */
+		if (SharedLocalSnapshotSlot != NULL)
+		{
+			LWLockAcquire(SharedLocalSnapshotSlot->slotLock, LW_EXCLUSIVE);
+			SharedLocalSnapshotSlot->slotid = gp_session_id;
+			LWLockRelease(SharedLocalSnapshotSlot->slotLock);
+		}
+
+		elog(LOG, "The previous session was reset because its gang was disconnected (session id = %d). "
+			 "The new session id = %d", oldSessionId, newSessionId);
 	}
 
-	elog(LOG, "The previous session was reset because its gang was disconnected (session id = %d). "
-		 "The new session id = %d", oldSessionId, newSessionId);
-
+	/*
+	 * When it's in transaction block, need to bump the session id, e.g. retry COMMIT PREPARED,
+	 * but defer drop temp table to the main loop in PostgresMain().
+	 */
 	if (IsTransactionOrTransactionBlock())
 	{
 		NeedResetSession = false;

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -778,14 +778,27 @@ void DisconnectAndDestroyUnusedQEs(void)
 void
 CheckForResetSession(void)
 {
+	GpResetSessionIfNeeded();
+	GpDropTempTables();
+}
+/*
+ * Check if there is a temporary namespace awaiting deletion.
+ */
+bool
+GpHasTempNamespaceForDeletion(void)
+{
+	return OidIsValid(OldTempNamespace);
+}
+
+/*
+ * Resets a session and starts a new one if the reset is needed.
+ * To be called before GpDropTempTables.
+ */
+void
+GpResetSessionIfNeeded(void)
+{
 	int			oldSessionId = 0;
 	int			newSessionId = 0;
-	Oid			dropTempNamespaceOid;
-	Oid			dropTempToastNamespaceOid;
-
-	/* No need to reset session or drop temp tables */
-	if (!NeedResetSession && OldTempNamespace == InvalidOid)
-		return;
 
 	/* Do the session id change early. */
 	if (NeedResetSession)
@@ -813,21 +826,31 @@ CheckForResetSession(void)
 			 "The new session id = %d", oldSessionId, newSessionId);
 	}
 
+	NeedResetSession = false;
+}
+
+/*
+ * Drop temporary tables if any are awaiting deletion.
+ * If called from within a transaction, does nothing and
+ * defers the deletion to the call from PostgresMain.
+ */
+void
+GpDropTempTables(void)
+{
+	Oid			dropTempNamespaceOid;
+	Oid			dropTempToastNamespaceOid;
+
 	/*
 	 * When it's in transaction block, need to bump the session id, e.g. retry COMMIT PREPARED,
 	 * but defer drop temp table to the main loop in PostgresMain().
 	 */
 	if (IsTransactionOrTransactionBlock())
-	{
-		NeedResetSession = false;
 		return;
-	}
 
 	dropTempNamespaceOid = OldTempNamespace;
 	dropTempToastNamespaceOid = OldTempToastNamespace;
 	OldTempNamespace = InvalidOid;
 	OldTempToastNamespace = InvalidOid;
-	NeedResetSession = false;
 
 	if (dropTempNamespaceOid != InvalidOid)
 	{
@@ -855,14 +878,16 @@ CheckForResetSession(void)
 			FlushErrorState();
 			AbortCurrentTransaction();
 		} PG_END_TRY();
+
+		CancelRemoveTempRelationsCallback();
 	}
 }
 
-void
-resetSessionForPrimaryGangLoss(void)
+static void
+GpScheduleSessionResetInternal(bool primaryGangLoss)
 {
 	/*
- 	 * resetSessionForPrimaryGangLoss could be called twice in a transacion,
+ 	 * GpScheduleSessionResetInternal could be called twice in a transacion,
  	 * we need to use NeedResetSession to double check if we should do the
  	 * real work to avoid that OldTempToastNamespace be makred invalid before
  	 * cleaning up the temp namespace.
@@ -870,7 +895,8 @@ resetSessionForPrimaryGangLoss(void)
 	if (ProcCanSetMppSessionId() && !NeedResetSession)
 	{
 		/*
-		 * Not too early.
+		 * Schedule this session for reset.
+		 * Reset will happen on the next GpResetSessionIfNeeded call.
 		 */
 		NeedResetSession = true;
 
@@ -891,8 +917,13 @@ resetSessionForPrimaryGangLoss(void)
 			 * inaccessible.  Later, when we can start a new transaction, we
 			 * will attempt to actually drop the old session tables to release
 			 * the disk space.
+			 * This will happen on the next GpDropTempTables call that isn't
+			 * inside a transaction.
 			 */
 			OldTempNamespace = ResetTempNamespace();
+
+			if (!primaryGangLoss)
+				return;
 
 			elog(WARNING,
 				 "Any temporary tables for this session have been dropped "
@@ -905,6 +936,32 @@ resetSessionForPrimaryGangLoss(void)
 			OldTempToastNamespace = InvalidOid;
 		}
 	}
+}
+
+/*
+ * Schedule this session for reset and register temporary tables for deletion.
+ * This function doesn't actually reset or delete anything by itself,
+ * the session will be reset on the next GpResetSessionIfNeeded call,
+ * and the temporary tables will be dropped by GpDropTempTables.
+ * Outputs a warning about dropping temporary tables.
+ */
+void
+resetSessionForPrimaryGangLoss(void)
+{
+	GpScheduleSessionResetInternal(true);
+}
+
+/*
+ * Schedule this session for reset and register temporary tables for deletion.
+ * This function doesn't actually reset or delete anything by itself,
+ * the session will be reset on the next GpResetSessionIfNeeded call,
+ * and the temporary tables will be dropped by GpDropTempTables.
+ * Does not output a warning about dropping temporary tables.
+ */
+void
+GpScheduleSessionReset(void)
+{
+	GpScheduleSessionResetInternal(false);
 }
 
 /*

--- a/src/backend/cdb/dispatcher/test/cdbgang_test.c
+++ b/src/backend/cdb/dispatcher/test/cdbgang_test.c
@@ -104,10 +104,13 @@ test__resetSessionForPrimaryGangLoss(void **state)
 
 	/* Assum we have created a temporary namespace. */
 	will_return(TempNamespaceOidIsValid, true);
+	will_return(GetTempToastNamespace, 9998);
 	will_return(ResetTempNamespace, 9999);
 	OldTempNamespace = InvalidOid;
+	OldTempToastNamespace = InvalidOid;
 
 	resetSessionForPrimaryGangLoss();
+	assert_int_equal(OldTempToastNamespace, 9998);
 	assert_int_equal(OldTempNamespace, 9999);
 }
 

--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -22,6 +22,7 @@
 
 #include "executor/executor.h"
 #include "miscadmin.h"
+#include "utils/faultinjector.h"
 #include "utils/memutils.h"
 
 
@@ -114,6 +115,8 @@ ExecScan(ScanState *node,
 	ExprContext *econtext;
 	List	   *qual;
 	ProjectionInfo *projInfo;
+
+	SIMPLE_FAULT_INJECTOR("before_exec_scan");
 
 	/*
 	 * Fetch data from node

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -114,6 +114,7 @@ extern Oid	LookupExplicitNamespace(const char *nspname, bool missing_ok);
 extern Oid	get_namespace_oid(const char *nspname, bool missing_ok);
 
 extern void DropTempTableNamespaceForResetSession(Oid namespaceOid);
+extern void DropTempTableNamespaceEntryForResetSession(Oid namespaceOid, Oid toastNamespaceOid);
 extern void SetTempNamespace(Oid namespaceOid, Oid toastNamespaceOid);
 extern Oid  ResetTempNamespace(void);
 extern bool TempNamespaceOidIsValid(void);  /* GPDB only:  used by cdbgang.c */

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -140,6 +140,7 @@ extern bool isOtherTempNamespace(Oid namespaceId);
 extern int	GetTempNamespaceBackendId(Oid namespaceId);
 extern Oid	GetTempToastNamespace(void);
 extern void ResetTempTableNamespace(void);
+extern void CancelRemoveTempRelationsCallback(void);
 
 extern OverrideSearchPath *GetOverrideSearchPath(MemoryContext context);
 extern OverrideSearchPath *CopyOverrideSearchPath(OverrideSearchPath *path);

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -77,6 +77,10 @@ extern void DisconnectAndDestroyAllGangs(bool resetSession);
 extern void DisconnectAndDestroyUnusedQEs(void);
 
 extern void CheckForResetSession(void);
+extern bool GpHasTempNamespaceForDeletion(void);
+extern void GpResetSessionIfNeeded(void);
+extern void GpDropTempTables(void);
+extern void ResetAllGangs(void);
 
 extern struct SegmentDatabaseDescriptor *getSegmentDescriptorFromGang(const Gang *gp, int seg);
 
@@ -102,6 +106,7 @@ extern bool segment_failure_due_to_fault_injector(const char *error_message);
  */
 extern void cdbgang_parse_gpqeid_params(struct Port *port, const char *gpqeid_value);
 
+extern void GpScheduleSessionReset(void);
 extern void resetSessionForPrimaryGangLoss(void);
 
 /*

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -21,6 +21,12 @@ ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0
  oid | relname | relnamespace 
 -----+---------+--------------
 (0 rows)
+-- we should not see the temp namespace on the coordinator
+1: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
+ count 
+-------
+ 0     
+(1 row)
 
 
 -- the temp table is left on segment 0, it should be dropped by gpcheckcat later

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -59,6 +59,9 @@ ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0
 (0 rows)
 
 -- case 2: Test if temp table will be left on the coordinator, when session exits in coordinator within a transaction block.
+2: CREATE FUNCTION wait_until_backend_exits(query_pattern text) RETURNS void AS $$ DECLARE count int; BEGIN loop PERFORM pg_stat_clear_snapshot(); SELECT count(*) FROM pg_stat_activity WHERE query = query_pattern INTO count; EXIT WHEN count = 0; PERFORM pg_sleep(0.1); end loop; END; $$ LANGUAGE plpgsql;
+CREATE
+
 2: CREATE TEMP TABLE test_temp_table_cleanup(a int);
 CREATE
 2: begin;
@@ -69,9 +72,71 @@ BEGIN
 (0 rows)
 2q: ... <quitting>
 
+-- wait until cleanup is complete
+3: select wait_until_backend_exits('select * from test_temp_table_cleanup;');
+ wait_until_backend_exits 
+--------------------------
+                          
+(1 row)
+
 3: select count(*) from pg_class where relname = 'test_temp_table_cleanup';
  count 
 -------
  0     
 (1 row)
+3: drop function wait_until_backend_exits(query_pattern text);
+DROP
 3q: ... <quitting>
+
+-- case 3: Test if temp namespace will be left if session exits during a long insert operation
+
+4: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+CREATE
+4: BEGIN;
+BEGIN
+-- simulate a long insert query
+4: SELECT gp_inject_fault('heap_insert', 'infinite_loop', '', '', 'test_temp_table_cleanup', 1, 1, 0, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+4&: INSERT INTO test_temp_table_cleanup SELECT generate_series(1, 100);  <waiting ...>
+
+-- trigger a panic on the segment
+5: SELECT gp_inject_fault('create_function_fail', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+5: CREATE FUNCTION my_function() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (seg0 127.0.0.1:7002 pid=1390184)
+
+-- the insert query should have failed
+4<:  <... completed>
+ERROR:  Error on receive from seg0 slice1 127.0.0.1:7002 pid=1390163: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+4q: ... <quitting>
+
+5: CREATE TABLE ensure_segment_is_up(a int);
+CREATE
+5: DROP TABLE ensure_segment_is_up;
+DROP
+
+5: SELECT gp_inject_fault('create_function_fail', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+5: SELECT gp_inject_fault('heap_insert', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- there shouldn't be any temporary namespaces left after the session quits
+5: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
+ count 
+-------
+ 0     
+(1 row)
+5q: ... <quitting>

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -1,0 +1,53 @@
+-- Test orphan temp table on coordinator.
+-- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
+
+-- create a temp table
+1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+CREATE
+
+-- panic on segment 0
+1: SELECT gp_inject_fault('before_exec_scan', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- trigger 'before_exec_scan' panic in ExecScan
+1: SELECT * FROM test_temp_table_cleanup;
+ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0 slice1 172.17.0.4:7002 pid=437900)
+
+-- we should not see the temp table on the coordinator
+1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+ oid | relname | relnamespace 
+-----+---------+--------------
+(0 rows)
+
+
+-- the temp table is left on segment 0, it should be dropped by gpcheckcat later
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+ relname                 
+-------------------------
+ test_temp_table_cleanup 
+(1 row)
+
+-- no temp table left on other segments
+1U: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+ oid | relname | relnamespace 
+-----+---------+--------------
+(0 rows)
+
+1: SELECT gp_inject_fault('before_exec_scan', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1q: ... <quitting>
+
+!\retcode gpcheckcat -O -R orphaned_toast_tables isolation2test;
+(exited with code 0)
+
+-- no temp table left
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+ relname 
+---------
+(0 rows)

--- a/src/test/isolation2/expected/orphan_temp_table.out
+++ b/src/test/isolation2/expected/orphan_temp_table.out
@@ -1,6 +1,6 @@
 -- Test orphan temp table on coordinator.
--- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
 
+-- case 1: Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
 -- create a temp table
 1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
 CREATE
@@ -57,3 +57,21 @@ ERROR:  fault triggered, fault name:'before_exec_scan' fault type:'panic'  (seg0
  relname 
 ---------
 (0 rows)
+
+-- case 2: Test if temp table will be left on the coordinator, when session exits in coordinator within a transaction block.
+2: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+CREATE
+2: begin;
+BEGIN
+2: select * from test_temp_table_cleanup;
+ a 
+---
+(0 rows)
+2q: ... <quitting>
+
+3: select count(*) from pg_class where relname = 'test_temp_table_cleanup';
+ count 
+-------
+ 0     
+(1 row)
+3q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -317,6 +317,9 @@ test: distributed_transactions
 # Test for distributed commit array overflow during replay on standby
 test: standby_replay_dtx_info
 
+# test the orphan temp table is dropped on the coordinator when panic happens on segment
+test: orphan_temp_table
+
 # Test for concurrent vacuum with delete
 test: concurrent_vacuum_with_delete
 

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -1,6 +1,6 @@
 -- Test orphan temp table on coordinator. 
--- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
 
+-- case 1: Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
 -- create a temp table
 1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
 
@@ -29,3 +29,12 @@
 
 -- no temp table left
 0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+
+-- case 2: Test if temp table will be left on the coordinator, when session exits in coordinator within a transaction block.
+2: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+2: begin;
+2: select * from test_temp_table_cleanup;
+2q:
+
+3: select count(*) from pg_class where relname = 'test_temp_table_cleanup';
+3q:

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -1,0 +1,29 @@
+-- Test orphan temp table on coordinator. 
+-- Before the fix, when backend process panic on the segment, the temp table will be left on the coordinator.
+
+-- create a temp table
+1: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+
+-- panic on segment 0
+1: SELECT gp_inject_fault('before_exec_scan', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+
+-- trigger 'before_exec_scan' panic in ExecScan
+1: SELECT * FROM test_temp_table_cleanup;
+
+-- we should not see the temp table on the coordinator
+1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+
+
+-- the temp table is left on segment 0, it should be dropped by gpcheckcat later
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
+
+-- no temp table left on other segments
+1U: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+
+1: SELECT gp_inject_fault('before_exec_scan', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+1q:
+
+!\retcode gpcheckcat -O -R orphaned_toast_tables isolation2test;
+
+-- no temp table left
+0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -31,10 +31,43 @@
 0U: SELECT relname FROM pg_class where relname = 'test_temp_table_cleanup';
 
 -- case 2: Test if temp table will be left on the coordinator, when session exits in coordinator within a transaction block.
+2: CREATE FUNCTION wait_until_backend_exits(query_pattern text) RETURNS void AS $$ DECLARE count int; BEGIN loop PERFORM pg_stat_clear_snapshot(); SELECT count(*) FROM pg_stat_activity WHERE query = query_pattern INTO count; EXIT WHEN count = 0; PERFORM pg_sleep(0.1); end loop; END; $$ LANGUAGE plpgsql;
+
 2: CREATE TEMP TABLE test_temp_table_cleanup(a int);
 2: begin;
 2: select * from test_temp_table_cleanup;
 2q:
 
+-- wait until cleanup is complete
+3: select wait_until_backend_exits('select * from test_temp_table_cleanup;');
+
 3: select count(*) from pg_class where relname = 'test_temp_table_cleanup';
+3: drop function wait_until_backend_exits(query_pattern text);
 3q:
+
+-- case 3: Test if temp namespace will be left if session exits during a long insert operation
+
+4: CREATE TEMP TABLE test_temp_table_cleanup(a int);
+4: BEGIN;
+-- simulate a long insert query
+4: SELECT gp_inject_fault('heap_insert', 'infinite_loop', '', '',
+   'test_temp_table_cleanup', 1, 1, 0, dbid) FROM gp_segment_configuration
+   WHERE content = 0 AND role = 'p';
+4&: INSERT INTO test_temp_table_cleanup SELECT generate_series(1, 100);
+
+-- trigger a panic on the segment
+5: SELECT gp_inject_fault('create_function_fail', 'panic', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+5: CREATE FUNCTION my_function() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql;
+
+-- the insert query should have failed
+4<:
+4q:
+
+5: CREATE TABLE ensure_segment_is_up(a int);
+5: DROP TABLE ensure_segment_is_up;
+
+5: SELECT gp_inject_fault('create_function_fail', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+5: SELECT gp_inject_fault('heap_insert', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 0;
+-- there shouldn't be any temporary namespaces left after the session quits
+5: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
+5q:

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -12,6 +12,8 @@
 
 -- we should not see the temp table on the coordinator
 1: SELECT oid, relname, relnamespace FROM pg_class where relname = 'test_temp_table_cleanup';
+-- we should not see the temp namespace on the coordinator
+1: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
 
 
 -- the temp table is left on segment 0, it should be dropped by gpcheckcat later


### PR DESCRIPTION
Fix orphan temp table on the coordinator (#11383)

When the backend process panics on the segment, temp tables should be dropped
on the coordinator. Before this, QD only resets the gang upon detecting the QE crash
but not dropping temp tables because it's still in a transaction block at that point.

Changes from original commit:
1. No renaming CheckForResetSession into GpDropTempTables due to ABI compatibility.
2. ResetAllGangs() is missing on GPDB 6, no changes necessary.
3. Fix autovacuum issue by using gpcheckcat instead.

Co-authored-by: Gang Xiong <gangx@vmware.com>
Co-authored-by: Adam Lee <adlee@vmware.com>

(cherry picked from commit https://github.com/arenadata/gpdb/commit/e88ceb8e399074189160a8a2a2eb906bdfebbb12)

---

Fix orphaned temp namespace catalog entry left on coordinator

Note that, commit e88ceb8e399074189160a8a2a2eb906bdfebbb12 fixed orphaned temp table left on
coordinator, but it did't handle orphaned namespace catalog
entry left on coordinator. This commit fix that.

(cherry picked from commit 0dcc97c76e9b7f54b1a5361fec970bd36a6e4743)

---

Fix orphaned temp table on coordinator

When session exits within a transaction block, temp table created
in this session will be left. This is because ResetAllGangs will
reset myTempNamespace, normal temp table catalog clean up won't be
called. More details could ref
https://github.com/greenplum-db/gpdb/issues/16506

Noted that, when a session is going to exit on coordinator, there
is no need to drop temp tables by calling GpDropTempTables, callback
function will do that at the end.

Changes from original commit:
1. ResetAllGangs() is missing, changed the logic to equivalent.
2. Fix test output (CREATE TABLE).

(cherry picked from commit c89fada973ee975efe8f56f543013ee5068fad8b)

---

After some segment failures (such as during long insert operations) temporary
schema wasn't deleted even after the session exits. This error was caused by a
complicated interaction between two places that delete temporary tables:
RemoveTempRelationsCallback and GpDropTempTables.

This patch refactors these two functions to make their actions more clear.
GpDropTempTables is split into two functions: GpResetSessionIfNeeded and
GpDropTempTables, and RemoveTempRelationsCallaback reuses GpDropTempTables.
There is also a new function GpHasTempRelationsForDeletion that is used to
check if any cleanup is necessary. Cancelling the RemoveTempRelationsCallback
is also moved from ResetTempNamespace (which doesn't fully delete it yet, so
the callback might still be needed) to GpDropTempTables. With this the issue
is now fixed.

Changes from original commit:
1. Function equivalent to GpDropTempTables in GPDB 7 was named
CheckForResetSession in GPDB 6. We keep it for backwards compatibility,
now calling GpResetSessionIfNeeded and GpDropTempTables in it
(same as in GPDB 7).
2. ResetAllGangs is missing in GPDB 6, no fix needed.
3. postgres.c already uses CheckForResetSession in GPDB 6, no fix needed.
4. Add a delay before checking whether the table was dropped.

(cherry picked from commit 465f4699b84930f439b75d1118657530e38414a1)

---
Note: do not squash the commit to preserve authorship.