### PR TITLE
ADBDEV-6369: Unify gpperfmon logging behavior

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -111,12 +111,14 @@ Feature: gpperfmon
             RETURN QUERY SELECT 1 FROM pg_sleep(30);
         END$$ LANGUAGE plpgsql;
         """
-        When below sql is executed in "gptest" db line by line as a transaction
+        When the user runs psql with following arguments against database "gptest"
         """
+        -1 <<EOF
         SET log_min_messages = "<log_level>";
         DECLARE test_cursor CURSOR FOR SELECT * FROM generate_series(1,100);
         FETCH FORWARD 10 FROM test_cursor;
         SELECT test_sleep();
+        EOF
         """
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_sleep()%' AND query_text NOT LIKE '%queries_history%'" is "true"
         And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_cursor%' AND query_text NOT LIKE '%queries_history%'" is "true"

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -102,7 +102,7 @@ Feature: gpperfmon
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text = 'SELECT pg_sleep(80)'" is "true"
 
     @gpperfmon_query_history
-    Scenario Outline: gpperfmon does not log nested statements with log_min_messages < debug4
+    Scenario Outline: gpperfmon only logs nested statements if log_min_messages is set to debug4 or debug5
         Given gpperfmon is configured and running in qamode
         When the user truncates "queries_history" tables in "gpperfmon"
         When below sql is executed in "gptest" db

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -101,6 +101,24 @@ Feature: gpperfmon
         """
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text = 'SELECT pg_sleep(80)'" is "true"
 
+    @gpperfmon_query_history
+    Scenario: gpperfmon does not log PL/pgSQL statements with log_min_messages < debug4
+        Given gpperfmon is configured and running in qamode
+        When the user truncates "queries_history" tables in "gpperfmon"
+        When below sql is executed in "gptest" db
+        """
+        SET log_min_messages = "warning";
+        CREATE OR REPLACE FUNCTION test_sleep() RETURNS SETOF INT AS $$BEGIN
+            RETURN QUERY SELECT 1 FROM pg_sleep(80);
+        END$$ LANGUAGE plpgsql;
+        """
+        When below sql is executed in "gptest" db
+        """
+        SELECT test_sleep();
+        """
+        Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_sleep()%'" is "true"
+        And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%pg_sleep(80)%' AND query_text NOT LIKE '%queries_history%'" is "false"
+
     @gpperfmon_system_history
     Scenario: gpperfmon adds to system_history table
         Given gpperfmon is configured and running in qamode

--- a/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpperfmon.feature
@@ -111,15 +111,7 @@ Feature: gpperfmon
             RETURN QUERY SELECT 1 FROM pg_sleep(30);
         END$$ LANGUAGE plpgsql;
         """
-        When the user runs psql with following arguments against database "gptest"
-        """
-        -1 <<EOF
-        SET log_min_messages = "<log_level>";
-        DECLARE test_cursor CURSOR FOR SELECT * FROM generate_series(1,100);
-        FETCH FORWARD 10 FROM test_cursor;
-        SELECT test_sleep();
-        EOF
-        """
+        When the user runs psql with "-1c 'SET log_min_messages = "<log_level>"; DECLARE test_cursor CURSOR FOR SELECT * FROM generate_series(1,100); FETCH FORWARD 10 FROM test_cursor; SELECT test_sleep();'" against database "gptest"
         Then wait until the results from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_sleep()%' AND query_text NOT LIKE '%queries_history%'" is "true"
         And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%test_cursor%' AND query_text NOT LIKE '%queries_history%'" is "true"
         And check that the result from boolean sql "SELECT count(*) > 0 FROM queries_history WHERE query_text LIKE '%pg_sleep(30)%' AND query_text NOT LIKE '%queries_history%'" is "<inner_query_present>"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2513,6 +2513,19 @@ def impl(context, sql, boolean):
         if _str2bool(result) != _str2bool(boolean):
             raise Exception("sql output '%s' is not same as '%s'" % (result, boolean))
 
+@then('check that the result from boolean sql "{sql}" is "{boolean}"')
+def impl(context, sql, boolean):
+    cmd = Command(name='psql', cmdStr='psql --tuples-only -d gpperfmon -c "%s"' % sql)
+    cmd.run()
+    if cmd.get_return_code() != 0:
+        context.ret_code = cmd.get_return_code()
+        context.error_message = 'psql internal error: %s' % cmd.get_stderr()
+        check_return_code(context, 0)
+    else:
+        result = cmd.get_stdout()
+        if _str2bool(result) != _str2bool(boolean):
+            raise Exception("sql output '%s' is not same as '%s'" % (result, boolean))
+
 
 def _str2bool(string):
     return string.lower().strip() in ['t', 'true', '1', 'yes', 'y']

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -170,17 +170,6 @@ def impl(context, dbname, psql_cmd):
     if context.ret_code != 0:
         raise Exception('%s' % context.error_message)
 
-@given('the user runs psql with following arguments against database "{dbname}"')
-@when('the user runs psql with following arguments against database "{dbname}"')
-@then('the user runs psql with following arguments against database "{dbname}"')
-def impl(context, dbname):
-    psql_cmd = context.text
-    cmd = "psql -d %s %s" % (dbname, psql_cmd)
-
-    run_command(context, cmd)
-
-    if context.ret_code != 0:
-        raise Exception('%s' % context.error_message)
 
 @given('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
 @when('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1481,6 +1481,14 @@ def impl(context, dbname):
 def impl(context, sql, dbname):
     execute_sql(dbname, sql)
 
+@given('below sql is executed in "{dbname}" db line by line as a transaction')
+@when('below sql is executed in "{dbname}" db line by line as a transaction')
+def impl(context, dbname):
+    sql = context.text
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        for line in sql.splitlines():
+            dbconn.execSQL(conn, line)
+        conn.commit()
 
 @when('execute following sql in db "{dbname}" and store result in the context')
 def impl(context, dbname):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -170,7 +170,6 @@ def impl(context, dbname, psql_cmd):
     if context.ret_code != 0:
         raise Exception('%s' % context.error_message)
 
-
 @given('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
 @when('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
 @then('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
@@ -182,6 +181,7 @@ def impl(context, query, db, contentids):
         psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_session_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
             db, host, port, query)
         Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
+
 
 @given('the user connects to "{dbname}" with named connection "{cname}"')
 def impl(context, dbname, cname):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -1481,6 +1481,7 @@ def impl(context, dbname):
 def impl(context, sql, dbname):
     execute_sql(dbname, sql)
 
+
 @when('execute following sql in db "{dbname}" and store result in the context')
 def impl(context, dbname):
     context.stored_rows = []

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -170,6 +170,18 @@ def impl(context, dbname, psql_cmd):
     if context.ret_code != 0:
         raise Exception('%s' % context.error_message)
 
+@given('the user runs psql with following arguments against database "{dbname}"')
+@when('the user runs psql with following arguments against database "{dbname}"')
+@then('the user runs psql with following arguments against database "{dbname}"')
+def impl(context, dbname):
+    psql_cmd = context.text
+    cmd = "psql -d %s %s" % (dbname, psql_cmd)
+
+    run_command(context, cmd)
+
+    if context.ret_code != 0:
+        raise Exception('%s' % context.error_message)
+
 @given('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
 @when('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
 @then('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
@@ -1480,15 +1492,6 @@ def impl(context, dbname):
 @then('sql "{sql}" is executed in "{dbname}" db')
 def impl(context, sql, dbname):
     execute_sql(dbname, sql)
-
-@given('below sql is executed in "{dbname}" db line by line as a transaction')
-@when('below sql is executed in "{dbname}" db line by line as a transaction')
-def impl(context, dbname):
-    sql = context.text
-    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
-        for line in sql.splitlines():
-            dbconn.execSQL(conn, line)
-        conn.commit()
 
 @when('execute following sql in db "{dbname}" and store result in the context')
 def impl(context, dbname):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -183,7 +183,6 @@ def impl(context, query, db, contentids):
             db, host, port, query)
         Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
 
-
 @given('the user connects to "{dbname}" with named connection "{cname}"')
 def impl(context, dbname, cname):
     if not hasattr(context, 'named_conns'):

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2274,19 +2274,6 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 
 			dest = CreateDestReceiver(canSetTag ? DestSPI : DestNone);
 
-			bool orig_gp_enable_gpperfmon = gp_enable_gpperfmon;
-			
-PG_TRY();
-{
-			/*
-			* Temporarily disable gpperfmon since we don't send information for internal queries in
-			* most cases, except when the debugging level is set to DEBUG4 or DEBUG5.
-			*/
-			if (log_min_messages > DEBUG4)
-			{
-				gp_enable_gpperfmon = false;
-			}
-
 			if (IsA(stmt, PlannedStmt) &&
 				((PlannedStmt *) stmt)->utilityStmt == NULL)
 			{
@@ -2383,15 +2370,6 @@ PG_TRY();
 													  NULL, 10);
 				}
 			}
-
-			gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-}
-PG_CATCH();
-{
-			gp_enable_gpperfmon = orig_gp_enable_gpperfmon;
-			PG_RE_THROW();
-}
-PG_END_TRY();
 
 			/*
 			 * The last canSetTag query sets the status values returned to the

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -124,6 +124,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 	{
 		qd->gpmon_pkt = (gpmon_packet_t *) palloc0(sizeof(gpmon_packet_t));
 		gpmon_qlog_packet_init(qd->gpmon_pkt);
+		gpmon_qlog_set_top_level(qd->gpmon_pkt, qd->plannedstmt->metricsQueryType == TOP_LEVEL_QUERY);
 	}
 
 	return qd;

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -210,12 +210,9 @@ void gpmon_qlog_set_top_level(gpmon_packet_t *gpmonPacket, bool isTopLevel)
 	gpmonPacket->u.qlog.istoplevel = isTopLevel;
 }
 
-static bool gpmon_qlog_should_send(gpmon_packet_t *gpmonPacket)
-{
-	bool top_level = gpmonPacket->u.qlog.istoplevel;
-	bool debug = log_min_messages <= DEBUG4;
-	return top_level || debug;
-}
+#define GPMON_QLOG_SHOULD_SEND(gpmonPacket) \
+	if (!gpmonPacket->u.qlog.istoplevel && log_min_messages > DEBUG4) \
+		return
 
 /**
  * To be used when gpmon packet has not been inited already.
@@ -259,12 +256,10 @@ void gpmon_qlog_packet_init(gpmon_packet_t *gpmonPacket)
  */
 void gpmon_qlog_query_submit(gpmon_packet_t *gpmonPacket)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 
 	gettimeofday(&tv, 0);
 	
@@ -300,10 +295,8 @@ void gpmon_qlog_query_text(const gpmon_packet_t *gpmonPacket,
 		const char *resqName,
 		const char *resqPriority)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 
 	queryText = gpmon_null_subst(queryText);
 	appName = gpmon_null_subst(appName);
@@ -347,12 +340,10 @@ void gpmon_qlog_query_text(const gpmon_packet_t *gpmonPacket,
  */
 void gpmon_qlog_query_start(gpmon_packet_t *gpmonPacket)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 
 	gettimeofday(&tv, 0);
 	
@@ -372,12 +363,10 @@ void gpmon_qlog_query_start(gpmon_packet_t *gpmonPacket)
  */
 void gpmon_qlog_query_end(gpmon_packet_t *gpmonPacket)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START);
 	gettimeofday(&tv, 0);
 	
@@ -397,12 +386,10 @@ void gpmon_qlog_query_end(gpmon_packet_t *gpmonPacket)
  */
 void gpmon_qlog_query_error(gpmon_packet_t *gpmonPacket)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_SUBMIT ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_CANCELING);
@@ -427,10 +414,8 @@ void gpmon_qlog_query_error(gpmon_packet_t *gpmonPacket)
 void
 gpmon_qlog_query_canceling(gpmon_packet_t *gpmonPacket)
 {
-	if (!gpmon_qlog_should_send(gpmonPacket))
-		return;
-
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
+	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_SUBMIT);
 

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -210,7 +210,7 @@ void gpmon_qlog_set_top_level(gpmon_packet_t *gpmonPacket, bool isTopLevel)
 	gpmonPacket->u.qlog.istoplevel = isTopLevel;
 }
 
-#define GPMON_QLOG_SHOULD_SEND(gpmonPacket) \
+#define GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket) \
 	if (!gpmonPacket->u.qlog.istoplevel && log_min_messages > DEBUG4) \
 		return
 
@@ -259,7 +259,7 @@ void gpmon_qlog_query_submit(gpmon_packet_t *gpmonPacket)
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 
 	gettimeofday(&tv, 0);
 	
@@ -296,7 +296,7 @@ void gpmon_qlog_query_text(const gpmon_packet_t *gpmonPacket,
 		const char *resqPriority)
 {
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 
 	queryText = gpmon_null_subst(queryText);
 	appName = gpmon_null_subst(appName);
@@ -343,7 +343,7 @@ void gpmon_qlog_query_start(gpmon_packet_t *gpmonPacket)
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 
 	gettimeofday(&tv, 0);
 	
@@ -366,7 +366,7 @@ void gpmon_qlog_query_end(gpmon_packet_t *gpmonPacket)
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START);
 	gettimeofday(&tv, 0);
 	
@@ -389,7 +389,7 @@ void gpmon_qlog_query_error(gpmon_packet_t *gpmonPacket)
 	struct timeval tv;
 
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_SUBMIT ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_CANCELING);
@@ -415,7 +415,7 @@ void
 gpmon_qlog_query_canceling(gpmon_packet_t *gpmonPacket)
 {
 	GPMON_QLOG_PACKET_ASSERTS(gpmonPacket);
-	GPMON_QLOG_SHOULD_SEND(gpmonPacket);
+	GPMON_QLOG_PACKET_SHOULD_SEND(gpmonPacket);
 	Assert(gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_START ||
 		   gpmonPacket->u.qlog.status == GPMON_QLOG_STATUS_SUBMIT);
 

--- a/src/include/gpmon/gpmon.h
+++ b/src/include/gpmon/gpmon.h
@@ -41,6 +41,7 @@ for example SCHEMA.RELATION\0
    ------------------------------------------------------------------ */
 
 extern void gpmon_qlog_packet_init(gpmon_packet_t *gpmonPacket);
+extern void gpmon_qlog_set_top_level(gpmon_packet_t *gpmonPacket, bool isTopLevel);
 extern void gpmon_qlog_query_submit(gpmon_packet_t *gpmonPacket);
 extern void gpmon_qlog_query_text(const gpmon_packet_t *gpmonPacket,
 		const char *queryText,
@@ -173,6 +174,7 @@ struct gpmon_qlog_t
 	int32 cost;
 	int64 cpu_elapsed; /* CPU elapsed for query */
 	gpmon_proc_metrics_t p_metrics;
+	bool istoplevel;
 };
 
 


### PR DESCRIPTION
Unify gpperfmon logging behavior

Gpperfmon should only process nested queries if `log_min_messages` level is
`DEBUG4` or `DEBUG5`. Before there were multiple separate conditions that
checked this, one of them were incorrect (in functions.c, only handled
`DEBUG5` previously), and not all cases were covered (for example, cursors
opened through SPI).

Now all this logic is moved to `gpmon.c` file. Nested query checking is
implemented by checking `plannedstmt->metricsQueryType` into `gpmon_packet_t`
during `CreateQueryDesc`. Queries are only sent to gpperfmon if `istoplevel`
flag is set or if `log_min_messages` level is `DEBUG4` or `DEBUG5`. This
allows removing all of the separate conditions since they are now unnecessary.