### PR TITLE
ADBDEV-5310: Align fault injector behavior when target table provided

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -336,11 +336,23 @@ _bitmap_insert_lov(Relation lovHeap, Relation lovIndex, Datum *datum,
 	result = index_insert(lovIndex, indexDatum, indexNulls,
 					 	  &(tuple->t_self), lovHeap, true);
 
-	SIMPLE_FAULT_INJECTOR("insert_bmlov_before_freeze");
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+							"insert_bmlov_before_freeze",
+							DDLNotSpecified,
+							"", //databaseName
+							RelationGetRelationName(lovHeap));
+#endif
 	/* freeze the tuple */
 	heap_freeze_tuple_wal_logged(lovHeap, tuple);
 
-	SIMPLE_FAULT_INJECTOR("insert_bmlov_after_freeze");
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultIfSet(
+							"insert_bmlov_after_freeze",
+							DDLNotSpecified,
+							"", //databaseName
+							RelationGetRelationName(lovHeap));
+#endif
 	pfree(indexDatum);
 	pfree(indexNulls);
 	Assert(result);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -308,7 +308,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			/* fault injection is not set for the specified database name */
 			break;
 	
-		if (strcmp(entryShared->tableName, tableNameLocal) != 0)
+		if (strlen(entryShared->tableName) > 0 && strcmp(entryShared->tableName, tableNameLocal) != 0)
 			/* fault injection is not set for the specified table name */
 			break;
 


### PR DESCRIPTION
Align fault injector behavior when target table provided

Fixed injector behavior thanks to commit [9e73db3 ](https://github.com/arenadata/gpdb/commit/9e73db39861bb906234d9e23cdec4938433954a2)(cherry-picked) to better
handle tableName argument. The commit aligns the definition of
insert_bmlov_*_freeze fault injectors between 6X and 7X. Fixes the
replacement with SIMPLE_FAULT_INJECTOR in [1502bef](https://github.com/arenadata/gpdb/commit/1502befb5be3a511d287d9eff694bb1c0434156f)

----------

Commits in the PR shouldn't be squashed to preserve authorship.