### PR TITLE
ADBDEV-6389: Fix CTAS from prepared statement which contains modifying DML

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -595,7 +595,7 @@ cdbllize_adjust_top_path(PlannerInfo *root, Path *best_path,
 			 query->commandType == CMD_UPDATE ||
 			 query->commandType == CMD_DELETE)
 	{
-		Assert(query->parentStmtType == PARENTSTMTTYPE_NONE);
+		Assert(query->parentStmtType == PARENTSTMTTYPE_NONE || query->parentStmtType == PARENTSTMTTYPE_CTAS);
 
 		if (query->commandType == CMD_SELECT || query->returningList)
 		{

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -528,7 +528,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(rowMarks);
 	WRITE_NODE_FIELD(setOperations);
 	WRITE_NODE_FIELD(constraintDeps);
-	WRITE_BOOL_FIELD(parentStmtType);
+	WRITE_ENUM_FIELD(parentStmtType, ParentStmtType);
 
 	/* Don't serialize policy */
 }

--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -65,6 +65,10 @@
 	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int8)); }
 
 /* Write an integer field  */
+#define WRITE_UINT8_FIELD(fldname) \
+	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(uint8)); }
+
+/* Write an integer field  */
 #define WRITE_INT16_FIELD(fldname) \
 	{ appendBinaryStringInfo(str, (const char *)&node->fldname, sizeof(int16)); }
 
@@ -528,7 +532,7 @@ _outQuery(StringInfo str, Query *node)
 	WRITE_NODE_FIELD(rowMarks);
 	WRITE_NODE_FIELD(setOperations);
 	WRITE_NODE_FIELD(constraintDeps);
-	WRITE_ENUM_FIELD(parentStmtType, ParentStmtType);
+	WRITE_UINT8_FIELD(parentStmtType);
 
 	/* Don't serialize policy */
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4402,7 +4402,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_NODE_FIELD(withCheckOptions);
 	WRITE_LOCATION_FIELD(stmt_location);
 	WRITE_LOCATION_FIELD(stmt_len);
-	WRITE_BOOL_FIELD(parentStmtType);
+	WRITE_ENUM_FIELD(parentStmtType, ParentStmtType);
 
 	/* Don't serialize policy */
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4402,7 +4402,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_NODE_FIELD(withCheckOptions);
 	WRITE_LOCATION_FIELD(stmt_location);
 	WRITE_LOCATION_FIELD(stmt_len);
-	WRITE_ENUM_FIELD(parentStmtType, ParentStmtType);
+	WRITE_UINT_FIELD(parentStmtType);
 
 	/* Don't serialize policy */
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -70,6 +70,10 @@
 #define READ_INT8_FIELD(fldname) \
 	memcpy(&local_node->fldname, read_str_ptr, sizeof(int8));  read_str_ptr+=sizeof(int8)
 
+/* Read an uint8 field  */
+#define READ_UINT8_FIELD(fldname) \
+	memcpy(&local_node->fldname, read_str_ptr, sizeof(uint8));  read_str_ptr+=sizeof(uint8)
+
 /* Read an int16 field  */
 #define READ_INT16_FIELD(fldname) \
 	memcpy(&local_node->fldname, read_str_ptr, sizeof(int16));  read_str_ptr+=sizeof(int16)
@@ -269,7 +273,7 @@ _readQuery(void)
 	READ_NODE_FIELD(rowMarks);
 	READ_NODE_FIELD(setOperations);
 	READ_NODE_FIELD(constraintDeps);
-	READ_ENUM_FIELD(parentStmtType, ParentStmtType);
+	READ_UINT8_FIELD(parentStmtType); Assert(local_node->parentStmtType <= PARENTSTMTTYPE_REFRESH_MATVIEW);
 
 	/* policy not serialized */
 

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -269,7 +269,7 @@ _readQuery(void)
 	READ_NODE_FIELD(rowMarks);
 	READ_NODE_FIELD(setOperations);
 	READ_NODE_FIELD(constraintDeps);
-	READ_BOOL_FIELD(parentStmtType);
+	READ_ENUM_FIELD(parentStmtType, ParentStmtType);
 
 	/* policy not serialized */
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -337,9 +337,9 @@ _readQuery(void)
 	READ_NODE_FIELD(constraintDeps);
     READ_NODE_FIELD(withCheckOptions);
     local_node->intoPolicy = NULL;
-    READ_UINT_FIELD(parentStmtType); Assert(local_node->parentStmtType <= PARENTSTMTTYPE_REFRESH_MATVIEW);
     READ_LOCATION_FIELD(stmt_location);
     READ_LOCATION_FIELD(stmt_len);
+    READ_UINT_FIELD(parentStmtType); Assert(local_node->parentStmtType <= PARENTSTMTTYPE_REFRESH_MATVIEW);
 
 	READ_DONE();
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -337,7 +337,7 @@ _readQuery(void)
 	READ_NODE_FIELD(constraintDeps);
     READ_NODE_FIELD(withCheckOptions);
     local_node->intoPolicy = NULL;
-    READ_ENUM_FIELD(parentStmtType, ParentStmtType);
+    READ_UINT_FIELD(parentStmtType); Assert(local_node->parentStmtType <= PARENTSTMTTYPE_REFRESH_MATVIEW);
     READ_LOCATION_FIELD(stmt_location);
     READ_LOCATION_FIELD(stmt_len);
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -337,7 +337,7 @@ _readQuery(void)
 	READ_NODE_FIELD(constraintDeps);
     READ_NODE_FIELD(withCheckOptions);
     local_node->intoPolicy = NULL;
-    READ_BOOL_FIELD(parentStmtType);
+    READ_ENUM_FIELD(parentStmtType, ParentStmtType);
     READ_LOCATION_FIELD(stmt_location);
     READ_LOCATION_FIELD(stmt_len);
 

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -178,6 +178,20 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |     SELECT * FROM road WHERE thepath = $1;                       | 
 (5 rows)
 
+-- create table as execute DML
+CREATE TABLE simple_table (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO simple_table VALUES (1, 1);
+PREPARE prepared_select AS SELECT * FROM simple_table;
+CREATE TEMPORARY TABLE simple_table_from_select AS EXECUTE prepared_select;
+PREPARE prepared_insert AS INSERT INTO simple_table VALUES (1, 1) RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_insert;
+ERROR:  prepared statement is not a SELECT
+PREPARE prepared_update AS UPDATE simple_table SET b = 2 WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_update;
+ERROR:  prepared statement is not a SELECT
+PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
+ERROR:  prepared statement is not a SELECT
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -180,6 +180,26 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |     SELECT * FROM road WHERE thepath = $1;                       | 
 (5 rows)
 
+-- create table as execute DML
+CREATE TABLE simple_table (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO simple_table VALUES (1, 1);
+PREPARE prepared_select AS SELECT * FROM simple_table;
+CREATE TEMPORARY TABLE simple_table_from_select AS EXECUTE prepared_select;
+PREPARE prepared_insert AS INSERT INTO simple_table VALUES (1, 1) RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_insert;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+ERROR:  prepared statement is not a SELECT
+PREPARE prepared_update AS UPDATE simple_table SET b = 2 WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_update;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+ERROR:  prepared statement is not a SELECT
+PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+ERROR:  prepared statement is not a SELECT
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -75,6 +75,22 @@ PREPARE q7(unknown) AS
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
+-- create table as execute DML
+CREATE TABLE simple_table (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO simple_table VALUES (1, 1);
+
+PREPARE prepared_select AS SELECT * FROM simple_table;
+CREATE TEMPORARY TABLE simple_table_from_select AS EXECUTE prepared_select;
+
+PREPARE prepared_insert AS INSERT INTO simple_table VALUES (1, 1) RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_insert;
+
+PREPARE prepared_update AS UPDATE simple_table SET b = 2 WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_update;
+
+PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
+CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements


### PR DESCRIPTION
Fix CTAS from prepared statement which contains modifying DML

The commit bad6ceb replaced the isCTAS boolean field in the Query structure
with a parentStmtType uint8, but forgot to change its read/write from
READ_BOOL_FIELD/WRITE_BOOL_FIELD to READ_UINT_FIELD/WRITE_UINT_FIELD and
READ_UINT8_FIELD/WRITE_UINT8_FIELD. This patch fixes that bug as well.

The commit 93abe74 added conditions on modifying DMLs, but left the previous
assert, which does not allow CTAS. At the same time, when executing CTAS from
prepared statements which containes modifying DML, this assert should allow
such case. This patch solves the problem.

The commit 19cd1cf introduced an incorrect field reading order in the
_readQuery function. This patch fixes that issue as well.