### PR TITLE
ADBDEV-5465: Split temp tables storage from temp files storage  (#889)

### DIFF
--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-tablespace.html.md
@@ -54,6 +54,8 @@ CREATE TABLE foo(i int);
 
 There is also the `temp_tablespaces` configuration parameter, which determines the placement of temporary tables and indexes, as well as temporary files that are used for purposes such as sorting large data sets. This can be a comma-separate list of tablespace names, rather than only one, so that the load associated with temporary objects can be spread over multiple tablespaces. A random member of the list is picked each time a temporary object is to be created.
 
+If you need to separate temporary files from temporary tables, `temp_spill_files_tablespaces` configuration parameter allows to change their placement. If this parameter is empty, temporary files are created according to `temp_tablespaces`.
+
 The tablespace associated with a database stores that database's system catalogs, temporary files created by server processes using that database, and is the default tablespace selected for tables and indexes created within the database, if no `TABLESPACE` is specified when the objects are created. If you do not specify a tablespace when you create a database, the database uses the same tablespace used by its template database.
 
 You can use a tablespace from any database in the Greenplum Database system if you have appropriate privileges.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -3343,7 +3343,17 @@ When setting `temp_tablespaces` interactively, avoid specifying a nonexistent ta
 
 The default value is an empty string, which results in all temporary objects being created in the default tablespace of the current database.
 
-See also [default\_tablespace](#default_tablespace).
+See also [temp\_spill\_files\_tablespaces](#temp_spill_files_tablespaces), [default\_tablespace](#default_tablespace).
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|one or more tablespace names|unset|master, session, reload|
+
+## <a id="temp_spill_files_tablespaces"></a>temp\_spill\_files\_tablespaces
+
+Specifies tablespaces in which to create temporary files for purposes such as large data set sorting. This setting takes precedence over `temp_tablespaces` for temporary files.
+
+The value is a comma-separated list of tablespace names. When the list contains more than one tablespace name, Greenplum chooses a random list member each time it creates a temporary file. An exception applies within a transaction, where successively created temporary files are placed in successive tablespaces from the list. If the selected element of the list is an empty string, Greenplum automatically falls back to tablespaces specified in `temp_tablespaces`. If `temp_tablespaces` is empty, Greenplum uses the default tablespace of the current database instead.</p>
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -362,6 +362,7 @@ These configuration parameters set defaults that are used for client connections
 - [gin_pending_list_limit](guc-list.html#gin_pending_list_limit)
 - [statement_timeout](guc-list.html#statement_timeout)
 - [temp_tablespaces](guc-list.html#temp_tablespaces)
+- [temp_spill_files_tablespaces](guc-list.html#temp_spill_files_tablespaces)
 - [vacuum_cleanup_index_scale_factor](guc-list.html#vacuum_cleanup_index_scale_factor)
 - [vacuum_freeze_min_age](guc-list.html#vacuum_freeze_min_age)
 

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -111,6 +111,7 @@
 /* GUC variables */
 char	   *default_tablespace = NULL;
 char	   *temp_tablespaces = NULL;
+char	   *temp_spill_files_tablespaces = NULL;
 bool		allow_in_place_tablespaces = false;
 
 
@@ -1790,25 +1791,38 @@ assign_temp_tablespaces(const char *newval, void *extra)
 		SetTempTablespaces(NULL, 0);
 }
 
+/* assign_hook: do extra actions as needed */
+void
+assign_temp_spill_files_tablespaces(const char *newval, void *extra)
+{
+	temp_tablespaces_extra *myextra = (temp_tablespaces_extra *) extra;
+
+	/*
+	 * If check_temp_tablespaces was executed inside a transaction, then pass
+	 * the list it made to fd.c.  Otherwise, clear fd.c's list; we must be
+	 * still outside a transaction, or else restoring during transaction exit,
+	 * and in either case we can just let the next PrepareTempTablespaces call
+	 * make things sane.
+	 */
+	if (myextra)
+		SetTempFileTablespaces(myextra->tblSpcs, myextra->numSpcs);
+	else
+		SetTempFileTablespaces(NULL, 0);
+}
+
 /*
- * PrepareTempTablespaces -- prepare to use temp tablespaces
- *
  * If we have not already done so in the current transaction, parse the
  * temp_tablespaces GUC variable and tell fd.c which tablespace(s) to use
- * for temp files.
+ * for temporary files or tables.
  */
-void
-PrepareTempTablespaces(void)
+static void
+PrepareTempTablespacesImpl(char *gucstr, void (*setTablespacesFunc)(Oid *, int))
 {
 	char	   *rawname;
 	List	   *namelist;
 	Oid		   *tblSpcs;
 	int			numSpcs;
 	ListCell   *l;
-
-	/* No work if already done in current transaction */
-	if (TempTablespacesAreSet())
-		return;
 
 	/*
 	 * Can't do catalog access unless within a transaction.  This is just a
@@ -1821,13 +1835,13 @@ PrepareTempTablespaces(void)
 		return;
 
 	/* Need a modifiable copy of string */
-	rawname = pstrdup(temp_tablespaces);
+	rawname = pstrdup(gucstr);
 
 	/* Parse string into list of identifiers */
 	if (!SplitIdentifierString(rawname, ',', &namelist))
 	{
 		/* syntax error in name list */
-		SetTempTablespaces(NULL, 0);
+		setTablespacesFunc(NULL, 0);
 		pfree(rawname);
 		list_free(namelist);
 		return;
@@ -1879,12 +1893,26 @@ PrepareTempTablespaces(void)
 		tblSpcs[numSpcs++] = curoid;
 	}
 
-	SetTempTablespaces(tblSpcs, numSpcs);
+	setTablespacesFunc(tblSpcs, numSpcs);
 
 	pfree(rawname);
 	list_free(namelist);
 }
 
+/*
+ * PrepareTempTablespaces -- prepare to use tablespaces set in temp_tablespaces
+ * and temp_spill_files_tablespaces.  No work if already done in current
+ * transaction.
+ */
+void
+PrepareTempTablespaces(void)
+{
+	if (!TempTablespacesAreSet())
+		PrepareTempTablespacesImpl(temp_tablespaces, SetTempTablespaces);
+
+	if (!TempFileTablespacesAreSet())
+		PrepareTempTablespacesImpl(temp_spill_files_tablespaces, SetTempFileTablespaces);
+}
 
 /*
  * get_tablespace_oid - given a tablespace name, look up the OID

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -130,6 +130,7 @@ extern int	CommitDelay;
 extern int	CommitSiblings;
 extern char *default_tablespace;
 extern char *temp_tablespaces;
+extern char *temp_spill_files_tablespaces;
 extern bool ignore_checksum_failure;
 extern bool synchronize_seqscans;
 
@@ -3778,6 +3779,18 @@ static struct config_string ConfigureNamesString[] =
 		&temp_tablespaces,
 		"",
 		check_temp_tablespaces, assign_temp_tablespaces, NULL
+	},
+
+	{
+		{"temp_spill_files_tablespaces", PGC_USERSET, CLIENT_CONN_STATEMENT,
+			gettext_noop("Sets the tablespace(s) to use for temporary files."),
+			gettext_noop("This setting takes precedence over temp_tablespaces "
+						 "for temporary files."),
+			GUC_LIST_INPUT | GUC_LIST_QUOTE
+		},
+		&temp_spill_files_tablespaces,
+		"",
+		check_temp_tablespaces, assign_temp_spill_files_tablespaces, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5375,7 +5375,7 @@ dispatch_sync_pg_variable_internal(struct config_generic * gconfig, bool is_expl
 
 	initStringInfo( &buffer );
 
-	appendStringInfo(&buffer, "SET ");
+	appendStringInfo(&buffer, "SELECT pg_catalog.set_config(%s, ", quote_literal_cstr(gconfig->name));
 
 	switch (gconfig->vartype)
 	{
@@ -5383,21 +5383,21 @@ dispatch_sync_pg_variable_internal(struct config_generic * gconfig, bool is_expl
 		{
 			struct config_bool *bguc = (struct config_bool *) gconfig;
 
-			appendStringInfo(&buffer, "%s TO %s", gconfig->name, *(bguc->variable) ? "true" : "false");
+			appendStringInfoString(&buffer, *(bguc->variable) ? "'true'" : "'false'");
 			break;
 		}
 		case PGC_INT:
 		{
 			struct config_int *iguc = (struct config_int *) gconfig;
 
-			appendStringInfo(&buffer, "%s TO %d", gconfig->name, *iguc->variable);
+			appendStringInfo(&buffer, "'%d'", *iguc->variable);
 			break;
 		}
 		case PGC_REAL:
 		{
 			struct config_real *rguc = (struct config_real *) gconfig;
 
-			appendStringInfo(&buffer, " %s TO %f", gconfig->name, *rguc->variable);
+			appendStringInfo(&buffer, "'%f'", *rguc->variable);
 			break;
 		}
 		case PGC_STRING:
@@ -5405,40 +5405,7 @@ dispatch_sync_pg_variable_internal(struct config_generic * gconfig, bool is_expl
 			struct config_string *sguc = (struct config_string *) gconfig;
 			const char *str = *sguc->variable;
 
-			appendStringInfo(&buffer, "%s TO ", gconfig->name);
-
-			/*
-			 * If it's a list, we need to split the list into elements and
-			 * quote the elements individually.
-			 * else if it's empty or not a list, we should quote the whole src.
-			 *
-			 * This is the copied from pg_get_functiondef()'s handling of
-			 * proconfig options.
-			 * .
-			 */
-			if (sguc->gen.flags & GUC_LIST_QUOTE && str[0] != '\0')
-			{
-				List	   *namelist;
-				ListCell   *lc;
-
-				/* Parse string into list of identifiers */
-				if (!SplitGUCList((char *) pstrdup(str), ',', &namelist))
-				{
-					/* this shouldn't fail really */
-					elog(ERROR, "invalid list syntax in proconfig item");
-				}
-				foreach(lc, namelist)
-				{
-					char	   *curname = (char *) lfirst(lc);
-
-					appendStringInfoString(&buffer, quote_literal_cstr(curname));
-					if (lnext(lc))
-						appendStringInfoString(&buffer, ", ");
-				}
-			}
-			else
-				appendStringInfoString(&buffer, quote_literal_cstr(str));
-
+			appendStringInfoString(&buffer, quote_literal_cstr(str));
 			break;
 		}
 		case PGC_ENUM:
@@ -5446,25 +5413,13 @@ dispatch_sync_pg_variable_internal(struct config_generic * gconfig, bool is_expl
 			struct config_enum *eguc = (struct config_enum *) gconfig;
 			int			value = *eguc->variable;
 			const char *str = config_enum_lookup_by_value(eguc, value);
-			int			i;
 
-			appendStringInfo(&buffer, "%s TO ", gconfig->name);
-
-			/*
-			 * All whitespace characters must be escaped. See
-			 * pg_split_opts() in the backend. (Not sure if an enum value
-			 * can have whitespace, but let's be prepared.)
-			 */
-			for (i = 0; str[i] != '\0'; i++)
-			{
-				if (isspace((unsigned char) str[i]))
-					appendStringInfoChar(&buffer, '\\');
-
-				appendStringInfoChar(&buffer, str[i]);
-			}
+			appendStringInfoString(&buffer, quote_literal_cstr(str));
 			break;
 		}
 	}
+
+	appendStringInfo(&buffer, ", false)");
 
 	if (is_explicit)
 		CdbDispatchSetCommandForSync(buffer.data);

--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -731,6 +731,7 @@ bool
 variable_is_guc_list_quote(const char *name)
 {
 	if (pg_strcasecmp(name, "temp_tablespaces") == 0 ||
+		pg_strcasecmp(name, "temp_spill_files_tablespaces") == 0 ||
 		pg_strcasecmp(name, "session_preload_libraries") == 0 ||
 		pg_strcasecmp(name, "shared_preload_libraries") == 0 ||
 		pg_strcasecmp(name, "local_preload_libraries") == 0 ||

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -132,9 +132,12 @@ extern void InitFileAccess(void);
 extern void set_max_safe_fds(void);
 extern void closeAllVfds(void);
 extern void SetTempTablespaces(Oid *tableSpaces, int numSpaces);
+extern void SetTempFileTablespaces(Oid *tableSpaces, int numSpaces);
 extern bool TempTablespacesAreSet(void);
+extern bool TempFileTablespacesAreSet(void);
 extern int	GetTempTablespaces(Oid *tableSpaces, int numSpaces);
 extern Oid	GetNextTempTableSpace(void);
+extern Oid	GetNextTempFileTableSpace(void);
 extern void AtEOXact_Files(bool isCommit);
 extern void AtEOSubXact_Files(bool isCommit, SubTransactionId mySubid,
 							  SubTransactionId parentSubid);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -798,6 +798,7 @@ extern void GUC_check_errcode(int sqlerrcode);
 extern bool check_default_tablespace(char **newval, void **extra, GucSource source);
 extern bool check_temp_tablespaces(char **newval, void **extra, GucSource source);
 extern void assign_temp_tablespaces(const char *newval, void *extra);
+extern void assign_temp_spill_files_tablespaces(const char *newval, void *extra);
 
 /* in catalog/namespace.c */
 extern bool check_search_path(char **newval, void **extra, GucSource source);

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -158,6 +158,7 @@
 		"tcp_user_timeout",
 		"temp_buffers",
 		"temp_tablespaces",
+		"temp_spill_files_tablespaces",
 		"test_copy_qd_qe_split",
 		"TimeZone",
 		"timezone_abbreviations",

--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -53,6 +53,9 @@ pg_regress.o: override CPPFLAGS += -I$(top_builddir)/src/port $(EXTRADEFS)
 regress_gp.o: override CPPFLAGS += -I$(libpq_srcdir)
 regress_gp.o: override LDFLAGS += -L$(top_builddir)/src/interfaces/libpq
 
+file_monitor:
+	$(CC) $(CPPFLAGS) -I$(GPHOME)/include -o /tmp/file_monitor $(top_builddir)/src/test/regress/file_monitor.c -luv -L$(GPHOME)/lib
+
 twophase_pqexecparams: twophase_pqexecparams.c
 	$(CC) $(CPPFLAGS) -I$(top_builddir)/src/interfaces/libpq -L$(GPHOME)/lib -L$(top_builddir)/src/interfaces/libpq  -o $@ $< -lpq
 
@@ -170,7 +173,12 @@ tablespace-setup:
 	./testtablespace_mytempsp2 \
 	./testtablespace_mytempsp3 \
 	./testtablespace_mytempsp4 \
-	./testtablespace_database_tablespace
+	./testtablespace_database_tablespace \
+	./testtablespace_temp_tables \
+	./testtablespace_temp_files0 \
+	./testtablespace_temp_files1 \
+	./testtablespace_temp_files2 \
+	./testtablespace_temp_files3
 
 
 .PHONY: hooktest
@@ -200,7 +208,7 @@ installcheck: installcheck-good
 installcheck-small: all tablespace-setup
 	$(pg_regress_installcheck) $(REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule $(EXTRA_TESTS)
 
-installcheck-good: all tablespace-setup twophase_pqexecparams hooktest query_info_hook_test
+installcheck-good: all tablespace-setup twophase_pqexecparams hooktest query_info_hook_test file_monitor
 	$(pg_regress_installcheck) $(REGRESS_OPTS) --schedule=$(srcdir)/parallel_schedule --schedule=$(srcdir)/greenplum_schedule $(EXTRA_TESTS)
 
 installcheck-parallel: all tablespace-setup

--- a/src/test/regress/file_monitor.c
+++ b/src/test/regress/file_monitor.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <uv.h>
+
+static void fs_cb(uv_fs_event_t *handle, const char *filename, int events, int status)
+{
+  if (status != 0 || (events & UV_RENAME) == 0)
+    return;
+
+  printf("%s/%s\n", (char*)handle->data, filename);
+}
+
+static void signal_cb(uv_signal_t *handle, int signo)
+{
+  uv_signal_stop(handle);
+  uv_stop(uv_default_loop());
+  fflush(stdout);
+}
+
+int main(int ac, const char *av[])
+{
+  uv_loop_t *loop = uv_default_loop();
+  uv_fs_event_t fse[32];
+  uv_signal_t sig[2];
+  int i, n;
+  unsigned flags = 0;
+  n = ac - 1;
+  if (n > 32) {
+    fprintf(stderr, "Too many directories to monitor\n");
+    exit(1);
+  }
+  for (i = 0; i < n; i++) {
+    uv_fs_event_init(loop, &fse[i]);
+    fse[i].data = (void*)av[i+1];
+    uv_fs_event_start(&fse[i], fs_cb, av[i+1], flags);
+  }
+  uv_signal_init(loop, &sig[0]);
+  uv_signal_init(loop, &sig[1]);
+  uv_signal_start(&sig[0], signal_cb, SIGINT);
+  uv_signal_start(&sig[1], signal_cb, SIGTERM);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  fflush(stdout);
+  return 0;
+
+}

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -219,8 +219,8 @@ ANALYZE tts_jazz;
 
 CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
 CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
-CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
-CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE "temp_files1'" LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE "temp_files2""" LOCATION '@testtablespace@_temp_files2';
 CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 
 RESET temp_tablespaces;
@@ -243,6 +243,7 @@ DECLARE
     owo int;
     session_file_ts_name text;
     temp_table_ts_name text;
+    session_file_ts_filename text;
 BEGIN
     SET optimizer = off;
     SET statement_mem = '1MB';
@@ -262,7 +263,13 @@ BEGIN
     -- Find out the tablespace that will be used for files.
     -- N = gp_session_id % number of tablespaces in GUC.
     SELECT 'temp_files' || (current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces)
-        INTO session_file_ts_name;
+        INTO session_file_ts_filename;
+    SELECT CASE current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces
+        WHEN 0 THEN 'temp_files0'
+        WHEN 1 THEN 'temp_files1'''
+        WHEN 2 THEN 'temp_files2"'
+        WHEN 3 THEN 'temp_files3'
+    END INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (
@@ -278,7 +285,7 @@ BEGIN
     -- Start monitoring temporary tablespace usage.
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_filename, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
 
     -- Run the query again to create temporary hashjoin files in the tablespaces.
     WITH out11 AS (
@@ -299,7 +306,7 @@ BEGIN
         CASE
             WHEN gp_tablespace_watch_match(dbid, 'default', 'HashJoin') > 0 THEN 'default'
             WHEN gp_tablespace_watch_match(dbid, 'temp_tables', 'HashJoin') > 0 THEN 'temp_tables'
-            WHEN gp_tablespace_watch_match(dbid, session_file_ts_name, 'HashJoin') > 0 THEN 'temp_filesN'
+            WHEN gp_tablespace_watch_match(dbid, session_file_ts_filename, 'HashJoin') > 0 THEN 'temp_filesN'
         END
         FROM gp_segment_configuration
         WHERE role = 'p' AND content >= 0;
@@ -308,7 +315,6 @@ $$ LANGUAGE plpgsql;
 
 --
 -- Global GUC value tests:
--- FIXME: We shouldn't be forced to use \c to update GUCs on segments.
 --
 
 -- Both files and the table should be in the default tablespace.
@@ -316,7 +322,6 @@ $$ LANGUAGE plpgsql;
 \! gpconfig -r temp_tablespaces
 \! gpconfig -r temp_spill_files_tablespaces
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -325,7 +330,6 @@ SELECT * FROM gp_tablespace_file_report(1);
 \! gpconfig -c temp_tablespaces -v 'temp_tables'
 \! gpconfig -r temp_spill_files_tablespaces
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -334,7 +338,6 @@ SELECT * FROM gp_tablespace_file_report(1);
 \! gpconfig -r temp_tablespaces
 \! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -343,7 +346,6 @@ SELECT * FROM gp_tablespace_file_report(1);
 \! gpconfig -c temp_tablespaces -v 'temp_tables'
 \! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -351,9 +353,8 @@ SELECT * FROM gp_tablespace_file_report(1);
 -- in the default tablespace.
 -- start_ignore
 \! gpconfig -r 'temp_tablespaces'
-\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1','temp_files2','temp_files3'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1'\''','temp_files2"','temp_files3'
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(4);
 
@@ -362,7 +363,6 @@ SELECT * FROM gp_tablespace_file_report(4);
 \! gpconfig -c temp_tablespaces -v 'temp_tables'
 \! gpconfig -c temp_spill_files_tablespaces -v '""'
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -371,7 +371,6 @@ SELECT * FROM gp_tablespace_file_report(1);
 \! gpconfig -c temp_tablespaces -v 'temp_tables'
 \! gpconfig -c temp_spill_files_tablespaces -v 'pg_default'
 \! gpstop -u
-\c
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(1);
 
@@ -380,7 +379,6 @@ SELECT * FROM gp_tablespace_file_report(1);
 \! gpconfig -r temp_tablespaces
 \! gpconfig -r temp_spill_files_tablespaces
 \! gpstop -u
-\c
 -- end_ignore
 
 --
@@ -410,7 +408,7 @@ SELECT * FROM gp_tablespace_file_report(1);
 -- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
 -- in the default tablespace.
 RESET temp_tablespaces;
-SET temp_spill_files_tablespaces = 'temp_files0','temp_files1','temp_files2','temp_files3';
+SET temp_spill_files_tablespaces = 'temp_files0','temp_files1''','temp_files2"','temp_files3';
 SELECT * FROM gp_tablespace_file_report(4);
 
 -- Files should be in the default tablespace, table should be in temp_tables.
@@ -432,6 +430,6 @@ DROP TABLE tts_jazz;
 
 DROP TABLESPACE temp_tables;
 DROP TABLESPACE temp_files0;
-DROP TABLESPACE temp_files1;
-DROP TABLESPACE temp_files2;
+DROP TABLESPACE "temp_files1'";
+DROP TABLESPACE "temp_files2""";
 DROP TABLESPACE temp_files3;

--- a/src/test/regress/input/temp_tablespaces.source
+++ b/src/test/regress/input/temp_tablespaces.source
@@ -37,6 +37,57 @@ create tablespace mytempsp2 location '@testtablespace@_mytempsp2';
 create tablespace mytempsp3 location '@testtablespace@_mytempsp3';
 create tablespace mytempsp4 location '@testtablespace@_mytempsp4';
 
+--start_ignore
+CREATE EXTENSION IF NOT EXISTS plpython3u;
+--end_ignore
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_start(dbid int, name text, location text)
+    RETURNS SETOF void
+    EXECUTE ON ALL SEGMENTS
+AS $$
+import subprocess
+output = '/tmp/gp_temp_tablespaces_dbid%d_%s' % (dbid, name)
+cmd = "/tmp/file_monitor %s | tee -a /tmp/gp_temp_tablespaces_dbid%d.log > %s &" % (location, dbid, output)
+cmd = ["bash", "-c", cmd]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+rc = process.wait()
+if rc != 0:
+    output, error = process.communicate()
+    raise Exception("error=%s" % str(error))
+return []
+$$ LANGUAGE plpython3u;
+
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_stop()
+    RETURNS SETOF void
+    EXECUTE ON ALL SEGMENTS
+AS $$
+import subprocess
+cmd = "pkill file_monitor"
+cmd = ["bash", "-c", cmd]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+process.wait()
+return []
+$$ LANGUAGE plpython3u;
+
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_match(dbid int, name text, patstr text)
+    RETURNS int
+AS $$
+import subprocess
+script = '''grep "%s" '/tmp/gp_temp_tablespaces_dbid%d_%s' | wc -l''' % (patstr, dbid, name)
+cmd = ["bash", "-c", script]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+rc = process.wait()
+output, error = process.communicate()
+if rc != 0:
+    raise Exception("error=%s" % str(error))
+return int(str(output, encoding='utf-8').strip())
+$$ LANGUAGE plpython3u;
+
+
+CREATE OR REPLACE FUNCTION gp_temptablespace_path(tblspcOid Oid)
+    RETURNS text
+AS '@abs_builddir@/regress.so', 'gp_tablespace_tmppath'
+    LANGUAGE C;
+
 CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
@@ -138,3 +189,249 @@ drop tablespace mytempsp1;
 drop tablespace mytempsp2;
 drop tablespace mytempsp3;
 drop tablespace mytempsp4;
+
+--
+-- temp_spill_files_tablespaces:
+--
+
+-- start_ignore
+DROP TABLE IF EXISTS tts_foo;
+DROP TABLE IF EXISTS tts_bar;
+DROP TABLE IF EXISTS tts_jazz;
+DROP TABLESPACE IF EXISTS temp_tables;
+DROP TABLESPACE IF EXISTS temp_files0;
+DROP TABLESPACE IF EXISTS temp_files1;
+DROP TABLESPACE IF EXISTS temp_files2;
+DROP TABLESPACE IF EXISTS temp_files3;
+-- end_ignore
+
+CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
+CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
+
+INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
+INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
+
+ANALYZE tts_foo;
+ANALYZE tts_bar;
+ANALYZE tts_jazz;
+
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
+CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
+
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+
+-- Creates a temporary table and remembers the tablespace it was created in.
+-- Runs a query that creates some temporary files, calculates the tablespace for
+-- temporary files that will be used for current session, and checks if any
+-- files were created in that tablespace.
+--
+-- 'n_temp_spill_files_tablespaces' is the count of tablespaces specified in
+-- 'temp_spill_files_tablespaces', either global or session-wide.
+CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
+    n_temp_spill_files_tablespaces int
+) RETURNS TABLE (
+        temp_table_in text,
+        temp_files_in text
+    ) AS $$
+DECLARE
+    owo int;
+    session_file_ts_name text;
+    temp_table_ts_name text;
+BEGIN
+    SET optimizer = off;
+    SET statement_mem = '1MB';
+
+    CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+    -- See the tablespace where temporary table was created. If there is no
+    -- tablespace for this table, it's in default tablespace.
+    SELECT ts.spcname
+        FROM pg_tablespace ts
+        JOIN pg_class c ON ts.oid = c.reltablespace AND c.relname = 'tts_baz'
+        LIMIT 1
+        INTO temp_table_ts_name;
+
+    DROP TABLE tts_baz;
+
+    -- Find out the tablespace that will be used for files.
+    -- N = gp_session_id % number of tablespaces in GUC.
+    SELECT 'temp_files' || (current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces)
+        INTO session_file_ts_name;
+
+    -- Create the temporary directory.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    -- Start monitoring temporary tablespace usage.
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
+
+    -- Run the query again to create temporary hashjoin files in the tablespaces.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    PERFORM gp_tablespace_watch_stop();
+
+    -- Check the existence of temporary hashjoin files.
+    RETURN QUERY SELECT
+        coalesce(temp_table_ts_name, 'default'),
+        CASE
+            WHEN gp_tablespace_watch_match(dbid, 'default', 'HashJoin') > 0 THEN 'default'
+            WHEN gp_tablespace_watch_match(dbid, 'temp_tables', 'HashJoin') > 0 THEN 'temp_tables'
+            WHEN gp_tablespace_watch_match(dbid, session_file_ts_name, 'HashJoin') > 0 THEN 'temp_filesN'
+        END
+        FROM gp_segment_configuration
+        WHERE role = 'p' AND content >= 0;
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Global GUC value tests:
+-- FIXME: We shouldn't be forced to use \c to update GUCs on segments.
+--
+
+-- Both files and the table should be in the default tablespace.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Both files and the table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+-- start_ignore
+\! gpconfig -r 'temp_tablespaces'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1','temp_files2','temp_files3'
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(4);
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v '""'
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v 'pg_default'
+\! gpstop -u
+\c
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Reset the global config before testing session-only values.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+\c
+-- end_ignore
+
+--
+-- Session-only GUC value tests:
+--
+
+-- Both files and the table should be in the default tablespace.
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Both files and the table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+RESET temp_spill_files_tablespaces;
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+RESET temp_tablespaces;
+SET temp_spill_files_tablespaces = 'temp_files0';
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_files0, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = 'temp_files0';
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+RESET temp_tablespaces;
+SET temp_spill_files_tablespaces = 'temp_files0','temp_files1','temp_files2','temp_files3';
+SELECT * FROM gp_tablespace_file_report(4);
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = '';
+SELECT * FROM gp_tablespace_file_report(1);
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = 'pg_default';
+SELECT * FROM gp_tablespace_file_report(1);
+
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+
+DROP TABLE tts_foo;
+DROP TABLE tts_bar;
+DROP TABLE tts_jazz;
+
+DROP TABLESPACE temp_tables;
+DROP TABLESPACE temp_files0;
+DROP TABLESPACE temp_files1;
+DROP TABLESPACE temp_files2;
+DROP TABLESPACE temp_files3;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -284,8 +284,8 @@ ANALYZE tts_bar;
 ANALYZE tts_jazz;
 CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
 CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
-CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
-CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE "temp_files1'" LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE "temp_files2""" LOCATION '@testtablespace@_temp_files2';
 CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
 RESET temp_tablespaces;
 RESET temp_spill_files_tablespaces;
@@ -306,6 +306,7 @@ DECLARE
     owo int;
     session_file_ts_name text;
     temp_table_ts_name text;
+    session_file_ts_filename text;
 BEGIN
     SET optimizer = off;
     SET statement_mem = '1MB';
@@ -325,7 +326,13 @@ BEGIN
     -- Find out the tablespace that will be used for files.
     -- N = gp_session_id % number of tablespaces in GUC.
     SELECT 'temp_files' || (current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces)
-        INTO session_file_ts_name;
+        INTO session_file_ts_filename;
+    SELECT CASE current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces
+        WHEN 0 THEN 'temp_files0'
+        WHEN 1 THEN 'temp_files1'''
+        WHEN 2 THEN 'temp_files2"'
+        WHEN 3 THEN 'temp_files3'
+    END INTO session_file_ts_name;
 
     -- Create the temporary directory.
     WITH out11 AS (
@@ -341,7 +348,7 @@ BEGIN
     -- Start monitoring temporary tablespace usage.
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
     PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
-    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_filename, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
 
     -- Run the query again to create temporary hashjoin files in the tablespaces.
     WITH out11 AS (
@@ -362,7 +369,7 @@ BEGIN
         CASE
             WHEN gp_tablespace_watch_match(dbid, 'default', 'HashJoin') > 0 THEN 'default'
             WHEN gp_tablespace_watch_match(dbid, 'temp_tables', 'HashJoin') > 0 THEN 'temp_tables'
-            WHEN gp_tablespace_watch_match(dbid, session_file_ts_name, 'HashJoin') > 0 THEN 'temp_filesN'
+            WHEN gp_tablespace_watch_match(dbid, session_file_ts_filename, 'HashJoin') > 0 THEN 'temp_filesN'
         END
         FROM gp_segment_configuration
         WHERE role = 'p' AND content >= 0;
@@ -370,7 +377,6 @@ END;
 $$ LANGUAGE plpgsql;
 --
 -- Global GUC value tests:
--- FIXME: We shouldn't be forced to use \c to update GUCs on segments.
 --
 -- Both files and the table should be in the default tablespace.
 -- start_ignore
@@ -432,7 +438,7 @@ SELECT * FROM gp_tablespace_file_report(1);
 -- in the default tablespace.
 -- start_ignore
 \! gpconfig -r 'temp_tablespaces'
-\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1','temp_files2','temp_files3'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1'\''','temp_files2"','temp_files3'
 \! gpstop -u
 -- end_ignore
 SELECT * FROM gp_tablespace_file_report(4);
@@ -527,7 +533,7 @@ SELECT * FROM gp_tablespace_file_report(1);
 -- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
 -- in the default tablespace.
 RESET temp_tablespaces;
-SET temp_spill_files_tablespaces = 'temp_files0','temp_files1','temp_files2','temp_files3';
+SET temp_spill_files_tablespaces = 'temp_files0','temp_files1''','temp_files2"','temp_files3';
 SELECT * FROM gp_tablespace_file_report(4);
  temp_table_in | temp_files_in 
 ---------------+---------------
@@ -565,6 +571,6 @@ DROP TABLE tts_bar;
 DROP TABLE tts_jazz;
 DROP TABLESPACE temp_tables;
 DROP TABLESPACE temp_files0;
-DROP TABLESPACE temp_files1;
-DROP TABLESPACE temp_files2;
+DROP TABLESPACE "temp_files1'";
+DROP TABLESPACE "temp_files2""";
 DROP TABLESPACE temp_files3;

--- a/src/test/regress/output/temp_tablespaces.source
+++ b/src/test/regress/output/temp_tablespaces.source
@@ -48,6 +48,49 @@ create tablespace mytempsp1 location '@testtablespace@_mytempsp1';
 create tablespace mytempsp2 location '@testtablespace@_mytempsp2';
 create tablespace mytempsp3 location '@testtablespace@_mytempsp3';
 create tablespace mytempsp4 location '@testtablespace@_mytempsp4';
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_start(dbid int, name text, location text)
+    RETURNS SETOF void
+    EXECUTE ON ALL SEGMENTS
+AS $$
+import subprocess
+output = '/tmp/gp_temp_tablespaces_dbid%d_%s' % (dbid, name)
+cmd = "/tmp/file_monitor %s | tee -a /tmp/gp_temp_tablespaces_dbid%d.log > %s &" % (location, dbid, output)
+cmd = ["bash", "-c", cmd]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+rc = process.wait()
+if rc != 0:
+    output, error = process.communicate()
+    raise Exception("error=%s" % str(error))
+return []
+$$ LANGUAGE plpython3u;
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_stop()
+    RETURNS SETOF void
+    EXECUTE ON ALL SEGMENTS
+AS $$
+import subprocess
+cmd = "pkill file_monitor"
+cmd = ["bash", "-c", cmd]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+process.wait()
+return []
+$$ LANGUAGE plpython3u;
+CREATE OR REPLACE FUNCTION gp_tablespace_watch_match(dbid int, name text, patstr text)
+    RETURNS int
+AS $$
+import subprocess
+script = '''grep "%s" '/tmp/gp_temp_tablespaces_dbid%d_%s' | wc -l''' % (patstr, dbid, name)
+cmd = ["bash", "-c", script]
+process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+rc = process.wait()
+output, error = process.communicate()
+if rc != 0:
+    raise Exception("error=%s" % str(error))
+return int(str(output, encoding='utf-8').strip())
+$$ LANGUAGE plpython3u;
+CREATE OR REPLACE FUNCTION gp_temptablespace_path(tblspcOid Oid)
+    RETURNS text
+AS '@abs_builddir@/regress.so', 'gp_tablespace_tmppath'
+    LANGUAGE C;
 CREATE TABLE tts_foo (i int, j int) distributed by(i);
 insert into tts_foo select i, i from generate_series(1,80000)i;
 ANALYZE tts_foo;
@@ -227,3 +270,301 @@ drop tablespace mytempsp1;
 drop tablespace mytempsp2;
 drop tablespace mytempsp3;
 drop tablespace mytempsp4;
+--
+-- temp_spill_files_tablespaces:
+--
+CREATE TABLE tts_foo (a int, b int) DISTRIBUTED BY (a);
+CREATE TABLE tts_bar (c int, d int) DISTRIBUTED BY (d);
+CREATE TABLE tts_jazz (e int, f int) DISTRIBUTED BY (e);
+INSERT INTO tts_foo SELECT i, i FROM generate_series (1, 1000000) i;
+INSERT INTO tts_bar SELECT i, i FROM generate_series (6000, 120000) i;
+INSERT INTO tts_jazz SELECT i, i FROM generate_series (4000, 150000) i;
+ANALYZE tts_foo;
+ANALYZE tts_bar;
+ANALYZE tts_jazz;
+CREATE TABLESPACE temp_tables LOCATION '@testtablespace@_temp_tables';
+CREATE TABLESPACE temp_files0 LOCATION '@testtablespace@_temp_files0';
+CREATE TABLESPACE temp_files1 LOCATION '@testtablespace@_temp_files1';
+CREATE TABLESPACE temp_files2 LOCATION '@testtablespace@_temp_files2';
+CREATE TABLESPACE temp_files3 LOCATION '@testtablespace@_temp_files3';
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+-- Creates a temporary table and remembers the tablespace it was created in.
+-- Runs a query that creates some temporary files, calculates the tablespace for
+-- temporary files that will be used for current session, and checks if any
+-- files were created in that tablespace.
+--
+-- 'n_temp_spill_files_tablespaces' is the count of tablespaces specified in
+-- 'temp_spill_files_tablespaces', either global or session-wide.
+CREATE OR REPLACE FUNCTION gp_tablespace_file_report(
+    n_temp_spill_files_tablespaces int
+) RETURNS TABLE (
+        temp_table_in text,
+        temp_files_in text
+    ) AS $$
+DECLARE
+    owo int;
+    session_file_ts_name text;
+    temp_table_ts_name text;
+BEGIN
+    SET optimizer = off;
+    SET statement_mem = '1MB';
+
+    CREATE TEMPORARY TABLE tts_baz (a int) DISTRIBUTED BY (a);
+
+    -- See the tablespace where temporary table was created. If there is no
+    -- tablespace for this table, it's in default tablespace.
+    SELECT ts.spcname
+        FROM pg_tablespace ts
+        JOIN pg_class c ON ts.oid = c.reltablespace AND c.relname = 'tts_baz'
+        LIMIT 1
+        INTO temp_table_ts_name;
+
+    DROP TABLE tts_baz;
+
+    -- Find out the tablespace that will be used for files.
+    -- N = gp_session_id % number of tablespaces in GUC.
+    SELECT 'temp_files' || (current_setting('gp_session_id')::int % n_temp_spill_files_tablespaces)
+        INTO session_file_ts_name;
+
+    -- Create the temporary directory.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    -- Start monitoring temporary tablespace usage.
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'default', gp_temptablespace_path((SELECT dattablespace FROM pg_database WHERE datname = current_database() LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), 'temp_tables', gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = 'temp_tables' LIMIT 1)));
+    PERFORM gp_tablespace_watch_start(gp_execution_dbid(), session_file_ts_name, gp_temptablespace_path((SELECT oid FROM pg_tablespace WHERE spcname = session_file_ts_name LIMIT 1)));
+
+    -- Run the query again to create temporary hashjoin files in the tablespaces.
+    WITH out11 AS (
+        SELECT * FROM (
+            WITH cte(a,b) AS (SELECT a-1, b+1 FROM tts_foo)
+            SELECT * FROM (SELECT * FROM cte UNION ALL SELECT * FROM cte) AS X JOIN tts_bar ON b = c
+            UNION ALL SELECT *, 1, 2 FROM cte
+        ) AS XY
+        JOIN tts_jazz on c = e AND b = f
+    )
+    SELECT count(*) FROM out11 INTO owo;
+
+    PERFORM gp_tablespace_watch_stop();
+
+    -- Check the existence of temporary hashjoin files.
+    RETURN QUERY SELECT
+        coalesce(temp_table_ts_name, 'default'),
+        CASE
+            WHEN gp_tablespace_watch_match(dbid, 'default', 'HashJoin') > 0 THEN 'default'
+            WHEN gp_tablespace_watch_match(dbid, 'temp_tables', 'HashJoin') > 0 THEN 'temp_tables'
+            WHEN gp_tablespace_watch_match(dbid, session_file_ts_name, 'HashJoin') > 0 THEN 'temp_filesN'
+        END
+        FROM gp_segment_configuration
+        WHERE role = 'p' AND content >= 0;
+END;
+$$ LANGUAGE plpgsql;
+--
+-- Global GUC value tests:
+-- FIXME: We shouldn't be forced to use \c to update GUCs on segments.
+--
+-- Both files and the table should be in the default tablespace.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | default
+ default       | default
+ default       | default
+(3 rows)
+
+-- Both files and the table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | temp_tables
+ temp_tables   | temp_tables
+ temp_tables   | temp_tables
+(3 rows)
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | temp_filesN
+ default       | temp_filesN
+ default       | temp_filesN
+(3 rows)
+
+-- Files should be in temp_files0, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0'
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | temp_filesN
+ temp_tables   | temp_filesN
+ temp_tables   | temp_filesN
+(3 rows)
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+-- start_ignore
+\! gpconfig -r 'temp_tablespaces'
+\! gpconfig -c temp_spill_files_tablespaces -v 'temp_files0','temp_files1','temp_files2','temp_files3'
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(4);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | temp_filesN
+ default       | temp_filesN
+ default       | temp_filesN
+(3 rows)
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v '""'
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | default
+ temp_tables   | default
+ temp_tables   | default
+(3 rows)
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+-- start_ignore
+\! gpconfig -c temp_tablespaces -v 'temp_tables'
+\! gpconfig -c temp_spill_files_tablespaces -v 'pg_default'
+\! gpstop -u
+-- end_ignore
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | default
+ temp_tables   | default
+ temp_tables   | default
+(3 rows)
+
+-- Reset the global config before testing session-only values.
+-- start_ignore
+\! gpconfig -r temp_tablespaces
+\! gpconfig -r temp_spill_files_tablespaces
+\! gpstop -u
+-- end_ignore
+--
+-- Session-only GUC value tests:
+--
+-- Both files and the table should be in the default tablespace.
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | default
+ default       | default
+ default       | default
+(3 rows)
+
+-- Both files and the table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+RESET temp_spill_files_tablespaces;
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | temp_tables
+ temp_tables   | temp_tables
+ temp_tables   | temp_tables
+(3 rows)
+
+-- Files should be in temp_files0, table should be in the default tablespace.
+RESET temp_tablespaces;
+SET temp_spill_files_tablespaces = 'temp_files0';
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | temp_filesN
+ default       | temp_filesN
+ default       | temp_filesN
+(3 rows)
+
+-- Files should be in temp_files0, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = 'temp_files0';
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | temp_filesN
+ temp_tables   | temp_filesN
+ temp_tables   | temp_filesN
+(3 rows)
+
+-- Files should be in temp_filesN, where N = gp_session_id % 4, table should be
+-- in the default tablespace.
+RESET temp_tablespaces;
+SET temp_spill_files_tablespaces = 'temp_files0','temp_files1','temp_files2','temp_files3';
+SELECT * FROM gp_tablespace_file_report(4);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ default       | temp_filesN
+ default       | temp_filesN
+ default       | temp_filesN
+(3 rows)
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = '';
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | default
+ temp_tables   | default
+ temp_tables   | default
+(3 rows)
+
+-- Files should be in the default tablespace, table should be in temp_tables.
+SET temp_tablespaces = 'temp_tables';
+SET temp_spill_files_tablespaces = 'pg_default';
+SELECT * FROM gp_tablespace_file_report(1);
+ temp_table_in | temp_files_in 
+---------------+---------------
+ temp_tables   | default
+ temp_tables   | default
+ temp_tables   | default
+(3 rows)
+
+RESET temp_tablespaces;
+RESET temp_spill_files_tablespaces;
+DROP TABLE tts_foo;
+DROP TABLE tts_bar;
+DROP TABLE tts_jazz;
+DROP TABLESPACE temp_tables;
+DROP TABLESPACE temp_files0;
+DROP TABLESPACE temp_files1;
+DROP TABLESPACE temp_files2;
+DROP TABLESPACE temp_files3;


### PR DESCRIPTION
Split temp tables storage from temp files storage  (#889)

Some operations create temporary files on disk. The growth of temporary files in
conjunction with temporary tables can lead to 100% usage of the data directory
and an emergency stop of the DBMS.

Implement temp_spill_files_tablespaces GUC that controls tablespaces where
temporary files are stored. Temporary tables will still be stored in
temp_tablespaces.

In case temp_spill_files_tablespaces is not set: the behavior will remain the
same, and both files and tables will be stored in the specified table spaces
according to the list in temp_tablespaces, or if it's also empty, in system
table spaces.

If the temp_spill_files_tablespaces is not empty, but temp_tablespaces is empty,
only temporary files will be saved in the specified table spaces. Temporary
table files will still be stored in the system tablespace.

If temp_spill_files_tablespaces is set to the empty string ("") or 'pg_default',
it will not fall back to temp_tablespaces and will instead use the default
tablespace.

Changes from original commit:
1. Remove DITA format docs since they are missing in GPDB 7.
2. OpenNamedTemporaryFile is missing in GPDB 7, no fix needed.
3. Use GPDB 7 implementation of get_session_temp_tablespace instead of GPDB 6.
4. Additionally fix GetTempTablespaces (used by SharedFileSetInit) which now
   uses spill file tablespaces if there are any.
5. There is no GetSessionTempTableSpace, so call get_session_temp_tablespace
   directly from GetNextTempTableSpace.

Test-related changes:
1. Add file_monitor.c from GPDB 6.
2. Add GNUMakefile entry for file_monitor from GPDB 6.
3. Add gp_tablespace_tmppath function to regress.c from GPDB 6.
4. Add plpython functions from GPDB 6 with fixes for GPDB 7 (switch to
   plpython3, add SETOF, add utf-8 encoding).
5. Fix last query from gp_tablespace_file_report to execute on primary
   segments using gp_segment_configuration.

(cherry picked from commit 4bb482a12db5132bf94911b7c96b4ea0d2df3224)

---

Fix temp_spill_files_tablespaces GUC sync (#1074)

Previously GUC sync worked by sending SET commands to segments. However,
some values (for example the empty string for quoted GUCs) cannot be set this
way. This affects specifically temp_spill_files_tablespaces since "" and
"\\"\\"" have different semantic meaning for it.

This patch changes the way GUC sync works by using pg_catalog.set_config()
function instead of SET commands. This function sets the value of the GUC
directly without any quoting issues, and so now empty strings are handled
correctly.

(cherry picked from commit 993b6c4b24f3773762fe924851da9f6518cb002d)

---

Note: do not squash the commit to preserve authorship.