### PR TITLE
Mark CurrentMemoryContext as volatile

### DIFF
--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -69,7 +69,7 @@ HTAB *chunks_htable = NULL;
  * CurrentMemoryContext
  *		Default memory context for allocations.
  */
-MemoryContext CurrentMemoryContext = NULL;
+volatile MemoryContext CurrentMemoryContext = NULL;
 
 /*
  * Standard top-level contexts. For a description of the purpose of each

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -123,7 +123,7 @@ typedef struct MemoryContextCallback
  * Avoid accessing it directly!  Instead, use MemoryContextSwitchTo()
  * to change the setting.
  */
-extern PGDLLIMPORT MemoryContext CurrentMemoryContext;
+extern volatile PGDLLIMPORT MemoryContext CurrentMemoryContext;
 
 extern bool gp_mp_inited;
 extern volatile OOMTimeType* segmentOOMTime;


### PR DESCRIPTION
Statement cancellation handler works in it’s own thread and perform memory
context switches. Main worker thread in error handling code also uses memory
contexts. Memory context switch is performed via global variable
CurrentMemoryContext which is not thread safe.

This patch marks CurrentMemoryContext as volatile to make it thread safe.
