### PR TITLE
ADBDEV-6393: Fix explain analyze duplicate SubPlans handling

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -663,10 +663,8 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 	 * (see comment for cdbexplain_depositSliceStats)
 	 */
 	if (sliceIndex == 0 || !showstatctx->slices[sliceIndex].workers)
-	{
 		for (imsgptr = 0; imsgptr < ctx.nmsgptr; imsgptr++)
 			cdbexplain_depositSliceStats(ctx.msgptrs[imsgptr], &ctx);
-	}
 
 	/* Transfer worker counts to SliceSummary. */
 	showstatctx->slices[sliceIndex].dispatchSummary = ds;

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -657,9 +657,16 @@ cdbexplain_recvExecStats(struct PlanState *planstate,
 	/* Make sure we visited the right number of PlanState nodes. */
 	Assert(ctx.iStatInst == ctx.nStatInst);
 
-	/* Transfer per-slice stats from message headers to the SliceSummary. */
-	for (imsgptr = 0; imsgptr < ctx.nmsgptr; imsgptr++)
-		cdbexplain_depositSliceStats(ctx.msgptrs[imsgptr], &ctx);
+	/* Transfer per-slice stats from message headers to the SliceSummary.
+	 * Only do this if we haven't deposited stats for this slice before.
+	 * Slice 0 is allowed to be repeated.
+	 * (see comment for cdbexplain_depositSliceStats)
+	 */
+	if (sliceIndex == 0 || !showstatctx->slices[sliceIndex].workers)
+	{
+		for (imsgptr = 0; imsgptr < ctx.nmsgptr; imsgptr++)
+			cdbexplain_depositSliceStats(ctx.msgptrs[imsgptr], &ctx);
+	}
 
 	/* Transfer worker counts to SliceSummary. */
 	showstatctx->slices[sliceIndex].dispatchSummary = ds;

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -15,8 +15,10 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/g
--- s/\d+\w? bytes max/### bytes max/g
+-- m/\d+\w? bytes max \(seg\d+\)/
+-- s/\d+\w? bytes max \(seg\d+\)/### bytes max (seg#)/
+-- m/Work_mem: \d+\w? bytes max/
+-- s/Work_mem: \d+\w? bytes max/Work_mem: ### bytes max/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -99,7 +101,7 @@ insert into slice_test2 values (0, 1);
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test2 b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0 or b.i = 0)
     and a.i = a.j;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -108,9 +110,9 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
          Filter: ((j = (SubPlan 1)) AND ((SubPlan 1) = i))
          Rows Removed by Filter: 74
          SubPlan 1
-           ->  Result (actual rows=0 loops=78)
-                 One-Time Filter: (a.i = 0)
-                 ->  Materialize (actual rows=1 loops=6)
+           ->  Result (actual rows=1 loops=78)
+                 Filter: ((a.i = 0) OR (b.i = 0))
+                 ->  Materialize (actual rows=1 loops=80)
                        ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                              ->  Seq Scan on slice_test2 b (actual rows=1 loops=1)
  Optimizer: Postgres-based planner
@@ -124,14 +126,13 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
-  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+  select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a
     where a.j = (select round(random() / 5)::int where a.i = 0)
       and a.i = a.j;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Function Scan on round x (actual rows=0 loops=1)
-   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer + 1) = (SubPlan 1)))
-   Rows Removed by Filter: 1
+ Function Scan on round x (actual rows=1 loops=1)
+   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer / 5) = (SubPlan 1)))
    InitPlan 2 (returns $1)
      ->  Result (actual rows=1 loops=1)
    SubPlan 1

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -15,8 +15,8 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/
--- s/\d+\w? bytes max/### bytes max/
+-- m/\d+\w? bytes max/g
+-- s/\d+\w? bytes max/### bytes max/g
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -7,6 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning Time: [0-9.]+ ms/
+-- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
+-- m/Execution Time: [0-9.]+ ms/
+-- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -78,3 +82,57 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
 
 drop table sort_error_test1;
 drop table sort_error_test2;
+--
+-- Test correct slice stats reporting in case of duplicated subplans
+--
+create table slice_test(i int, j int) distributed by (i);
+-- explain_processing_off
+-- create duplicate subplan in QE slice
+explain (analyze, timing off, costs off) select a.i from slice_test a
+  where a.j = (select b.i from slice_test b where a.i = 0)
+    and a.i = a.j;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+   ->  Seq Scan on slice_test a (actual rows=0 loops=1)
+         Filter: ((j = (SubPlan 1)) AND ((SubPlan 1) = i))
+         SubPlan 1
+           ->  Result (never executed)
+                 One-Time Filter: (a.i = 0)
+                 ->  Materialize (actual rows=0 loops=2)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=0 loops=1)
+                             ->  Seq Scan on slice_test b (actual rows=0 loops=1)
+ Optimizer: Postgres-based planner
+ Planning Time: 0.497 ms
+   (slice0)    Executor memory: 38K bytes.
+   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).  Work_mem: 17K bytes max.
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 4.757 ms
+(16 rows)
+
+-- create multiple initplans in slice 0 (should be printed as two slices)
+explain (analyze, timing off, costs off)
+  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+    where a.j = (select round(random() / 5)::int where a.i = 0)
+      and a.i = a.j;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Function Scan on round x (actual rows=0 loops=1)
+   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer + 1) = (SubPlan 1)))
+   Rows Removed by Filter: 1
+   InitPlan 2 (returns $1)
+     ->  Result (actual rows=1 loops=1)
+   SubPlan 1
+     ->  Result (actual rows=1 loops=2)
+           One-Time Filter: ((x.x)::integer = 0)
+ Optimizer: Postgres-based planner
+ Planning Time: 0.245 ms
+   (slice0)    Executor memory: 19K bytes.
+   (slice1)    Executor memory: 36K bytes.  Work_mem: 17K bytes max.
+ Memory used:  128000kB
+ Execution Time: 0.082 ms
+(14 rows)
+
+-- explain_processing_on
+drop table slice_test;

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -11,6 +11,12 @@
 -- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
 -- m/Execution Time: [0-9.]+ ms/
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
+-- m/Executor memory: \d+\w? bytes/
+-- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
+-- m/Work_mem: \d+\w? bytes/
+-- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
+-- m/Memory used:\s+\d+\w?B/
+-- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -92,30 +92,35 @@ drop table sort_error_test2;
 -- Test correct slice stats reporting in case of duplicated subplans
 --
 create table slice_test(i int, j int) distributed by (i);
+create table slice_test2(i int, j int) distributed by (i);
+insert into slice_test select i, i from generate_series(0, 100) i;
+insert into slice_test select i, 2*i from generate_series(0, 100) i;
+insert into slice_test2 values (0, 1);
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0)
     and a.i = a.j;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-   ->  Seq Scan on slice_test a (actual rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   ->  Seq Scan on slice_test a (actual rows=2 loops=1)
          Filter: ((j = (SubPlan 1)) AND ((SubPlan 1) = i))
+         Rows Removed by Filter: 74
          SubPlan 1
-           ->  Result (never executed)
+           ->  Result (actual rows=0 loops=78)
                  One-Time Filter: (a.i = 0)
-                 ->  Materialize (actual rows=0 loops=2)
-                       ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=0 loops=1)
-                             ->  Seq Scan on slice_test b (actual rows=0 loops=1)
+                 ->  Materialize (actual rows=1 loops=6)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
+                             ->  Seq Scan on slice_test2 b (actual rows=1 loops=1)
  Optimizer: Postgres-based planner
- Planning Time: 0.497 ms
-   (slice0)    Executor memory: 38K bytes.
+ Planning Time: 0.662 ms
+   (slice0)    Executor memory: 47K bytes.
    (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).  Work_mem: 17K bytes max.
    (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 4.757 ms
-(16 rows)
+ Execution Time: 4.953 ms
+(17 rows)
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
@@ -142,3 +147,4 @@ explain (analyze, timing off, costs off)
 
 -- explain_processing_on
 drop table slice_test;
+drop table slice_test2;

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -124,6 +124,7 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
  Execution Time: 4.953 ms
 (17 rows)
 
+-- checking this didn't break previous behavior
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
   select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -13,10 +13,10 @@
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- m/Executor memory: \d+\w? bytes/
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
--- m/Work_mem: \d+\w? bytes/
--- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
+-- m/\d+\w? bytes max/
+-- s/\d+\w? bytes max/### bytes max/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -15,8 +15,8 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/
--- s/\d+\w? bytes max/### bytes max/
+-- m/\d+\w? bytes max/g
+-- s/\d+\w? bytes max/### bytes max/g
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -7,6 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning Time: [0-9.]+ ms/
+-- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
+-- m/Execution Time: [0-9.]+ ms/
+-- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -79,3 +83,59 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
 
 drop table sort_error_test1;
 drop table sort_error_test2;
+--
+-- Test correct slice stats reporting in case of duplicated subplans
+--
+create table slice_test(i int, j int) distributed by (i);
+-- explain_processing_off
+-- create duplicate subplan in QE slice
+explain (analyze, timing off, costs off) select a.i from slice_test a
+  where a.j = (select b.i from slice_test b where a.i = 0)
+    and a.i = a.j;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Result (actual rows=0 loops=1)
+   Filter: (a.j = (SubPlan 1))
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
+         ->  Seq Scan on slice_test a (actual rows=0 loops=1)
+               Filter: (i = j)
+   SubPlan 1
+     ->  Result (never executed)
+           One-Time Filter: (a.i = 0)
+           ->  Materialize (actual rows=0 loops=1)
+                 ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=0 loops=1)
+                       ->  Seq Scan on slice_test b (actual rows=0 loops=1)
+ Optimizer: GPORCA
+ Planning Time: 5.990 ms
+   (slice0)    Executor memory: 47K bytes.  Work_mem: 17K bytes max.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 4.098 ms
+(18 rows)
+
+-- create multiple initplans in slice 0 (should be printed as two slices)
+explain (analyze, timing off, costs off)
+  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+    where a.j = (select round(random() / 5)::int where a.i = 0)
+      and a.i = a.j;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Function Scan on round x (actual rows=0 loops=1)
+   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer + 1) = (SubPlan 1)))
+   Rows Removed by Filter: 1
+   InitPlan 2 (returns $1)
+     ->  Result (actual rows=1 loops=1)
+   SubPlan 1
+     ->  Result (actual rows=1 loops=2)
+           One-Time Filter: ((x.x)::integer = 0)
+ Optimizer: Postgres-based planner
+ Planning Time: 2.920 ms
+   (slice0)    Executor memory: 19K bytes.
+   (slice1)    Executor memory: 36K bytes.  Work_mem: 17K bytes max.
+ Memory used:  128000kB
+ Execution Time: 0.085 ms
+(14 rows)
+
+-- explain_processing_on
+drop table slice_test;

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -11,6 +11,12 @@
 -- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
 -- m/Execution Time: [0-9.]+ ms/
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
+-- m/Executor memory: \d+\w? bytes/
+-- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
+-- m/Work_mem: \d+\w? bytes/
+-- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
+-- m/Memory used:\s+\d+\w?B/
+-- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -15,8 +15,10 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/g
--- s/\d+\w? bytes max/### bytes max/g
+-- m/\d+\w? bytes max \(seg\d+\)/
+-- s/\d+\w? bytes max \(seg\d+\)/### bytes max (seg#)/
+-- m/Work_mem: \d+\w? bytes max/
+-- s/Work_mem: \d+\w? bytes max/Work_mem: ### bytes max/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -100,7 +102,7 @@ insert into slice_test2 values (0, 1);
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test2 b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0 or b.i = 0)
     and a.i = a.j;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
@@ -111,9 +113,9 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
                Filter: (i = j)
                Rows Removed by Filter: 37
    SubPlan 1
-     ->  Result (actual rows=0 loops=102)
-           One-Time Filter: (a.i = 0)
-           ->  Materialize (actual rows=1 loops=3)
+     ->  Result (actual rows=1 loops=102)
+           Filter: ((a.i = 0) OR (b.i = 0))
+           ->  Materialize (actual rows=1 loops=103)
                  ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=1 loops=1)
                        ->  Seq Scan on slice_test2 b (actual rows=1 loops=1)
  Optimizer: GPORCA
@@ -127,14 +129,13 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
-  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+  select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a
     where a.j = (select round(random() / 5)::int where a.i = 0)
       and a.i = a.j;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Function Scan on round x (actual rows=0 loops=1)
-   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer + 1) = (SubPlan 1)))
-   Rows Removed by Filter: 1
+ Function Scan on round x (actual rows=1 loops=1)
+   Filter: (((SubPlan 1) = (x)::integer) AND (((x)::integer / 5) = (SubPlan 1)))
    InitPlan 2 (returns $1)
      ->  Result (actual rows=1 loops=1)
    SubPlan 1

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -13,10 +13,10 @@
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- m/Executor memory: \d+\w? bytes/
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
--- m/Work_mem: \d+\w? bytes/
--- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
+-- m/\d+\w? bytes max/
+-- s/\d+\w? bytes max/### bytes max/
 -- end_matchsubs
 CREATE TEMP TABLE empty_table(a int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -93,32 +93,37 @@ drop table sort_error_test2;
 -- Test correct slice stats reporting in case of duplicated subplans
 --
 create table slice_test(i int, j int) distributed by (i);
+create table slice_test2(i int, j int) distributed by (i);
+insert into slice_test select i, i from generate_series(0, 100) i;
+insert into slice_test select i, 2*i from generate_series(0, 100) i;
+insert into slice_test2 values (0, 1);
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0)
     and a.i = a.j;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Result (actual rows=0 loops=1)
+ Result (actual rows=2 loops=1)
    Filter: (a.j = (SubPlan 1))
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
-         ->  Seq Scan on slice_test a (actual rows=0 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=102 loops=1)
+         ->  Seq Scan on slice_test a (actual rows=39 loops=1)
                Filter: (i = j)
+               Rows Removed by Filter: 37
    SubPlan 1
-     ->  Result (never executed)
+     ->  Result (actual rows=0 loops=102)
            One-Time Filter: (a.i = 0)
-           ->  Materialize (actual rows=0 loops=1)
-                 ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=0 loops=1)
-                       ->  Seq Scan on slice_test b (actual rows=0 loops=1)
+           ->  Materialize (actual rows=1 loops=3)
+                 ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=1 loops=1)
+                       ->  Seq Scan on slice_test2 b (actual rows=1 loops=1)
  Optimizer: GPORCA
- Planning Time: 5.990 ms
-   (slice0)    Executor memory: 47K bytes.  Work_mem: 17K bytes max.
+ Planning Time: 6.096 ms
+   (slice0)    Executor memory: 49K bytes.  Work_mem: 17K bytes max.
    (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
    (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 4.098 ms
-(18 rows)
+ Execution Time: 5.096 ms
+(19 rows)
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
@@ -145,3 +150,4 @@ explain (analyze, timing off, costs off)
 
 -- explain_processing_on
 drop table slice_test;
+drop table slice_test2;

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -127,6 +127,7 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
  Execution Time: 5.096 ms
 (19 rows)
 
+-- checking this didn't break previous behavior
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
   select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -13,10 +13,10 @@
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- m/Executor memory: \d+\w? bytes/
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
--- m/Work_mem: \d+\w? bytes/
--- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
+-- m/\d+\w? bytes max/
+-- s/\d+\w? bytes max/### bytes max/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int);

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -11,6 +11,12 @@
 -- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
 -- m/Execution Time: [0-9.]+ ms/
 -- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
+-- m/Executor memory: \d+\w? bytes/
+-- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
+-- m/Work_mem: \d+\w? bytes/
+-- s/Work_mem: \d+\w? bytes/Work_mem: ### bytes/
+-- m/Memory used:\s+\d+\w?B/
+-- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int);

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -66,6 +66,7 @@ explain (analyze, timing off, costs off) select a.i from slice_test a
   where a.j = (select b.i from slice_test2 b where a.i = 0 or b.i = 0)
     and a.i = a.j;
 
+-- checking this didn't break previous behavior
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
   select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -53,11 +53,15 @@ drop table sort_error_test2;
 --
 
 create table slice_test(i int, j int) distributed by (i);
+create table slice_test2(i int, j int) distributed by (i);
+insert into slice_test select i, i from generate_series(0, 100) i;
+insert into slice_test select i, 2*i from generate_series(0, 100) i;
+insert into slice_test2 values (0, 1);
 
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0)
     and a.i = a.j;
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
@@ -68,3 +72,4 @@ explain (analyze, timing off, costs off)
 -- explain_processing_on
 
 drop table slice_test;
+drop table slice_test2;

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -15,8 +15,10 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/g
--- s/\d+\w? bytes max/### bytes max/g
+-- m/\d+\w? bytes max \(seg\d+\)/
+-- s/\d+\w? bytes max \(seg\d+\)/### bytes max (seg#)/
+-- m/Work_mem: \d+\w? bytes max/
+-- s/Work_mem: \d+\w? bytes max/Work_mem: ### bytes max/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int);
@@ -61,12 +63,12 @@ insert into slice_test2 values (0, 1);
 -- explain_processing_off
 -- create duplicate subplan in QE slice
 explain (analyze, timing off, costs off) select a.i from slice_test a
-  where a.j = (select b.i from slice_test2 b where a.i = 0)
+  where a.j = (select b.i from slice_test2 b where a.i = 0 or b.i = 0)
     and a.i = a.j;
 
 -- create multiple initplans in slice 0 (should be printed as two slices)
 explain (analyze, timing off, costs off)
-  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+  select a.i from (select x::int as i, x::int / 5 as j from round(random() / 5) as x) a
     where a.j = (select round(random() / 5)::int where a.i = 0)
       and a.i = a.j;
 -- explain_processing_on

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -7,6 +7,10 @@
 -- s/Buckets: \d+/Buckets: ###/
 -- m/Batches: \d+/
 -- s/Batches: \d+/Batches: ###/
+-- m/Planning Time: [0-9.]+ ms/
+-- s/Planning Time: [0-9.]+ ms/Planning Time: #.### ms/
+-- m/Execution Time: [0-9.]+ ms/
+-- s/Execution Time: [0-9.]+ ms/Execution Time: #.### ms/
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int);
@@ -37,3 +41,24 @@ select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
     from gp_segment_configuration where role = 'p' and content > -1;
 drop table sort_error_test1;
 drop table sort_error_test2;
+
+--
+-- Test correct slice stats reporting in case of duplicated subplans
+--
+
+create table slice_test(i int, j int) distributed by (i);
+
+-- explain_processing_off
+-- create duplicate subplan in QE slice
+explain (analyze, timing off, costs off) select a.i from slice_test a
+  where a.j = (select b.i from slice_test b where a.i = 0)
+    and a.i = a.j;
+
+-- create multiple initplans in slice 0 (should be printed as two slices)
+explain (analyze, timing off, costs off)
+  select a.i from (select x::int as i, x::int + 1 as j from round(random() / 5) as x) a
+    where a.j = (select round(random() / 5)::int where a.i = 0)
+      and a.i = a.j;
+-- explain_processing_on
+
+drop table slice_test;

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -15,8 +15,8 @@
 -- s/Executor memory: \d+\w? bytes/Executor memory: ### bytes/
 -- m/Memory used:\s+\d+\w?B/
 -- s/Memory used:\s+\d+\w?B/Memory used:  ###B/
--- m/\d+\w? bytes max/
--- s/\d+\w? bytes max/### bytes max/
+-- m/\d+\w? bytes max/g
+-- s/\d+\w? bytes max/### bytes max/g
 -- end_matchsubs
 
 CREATE TEMP TABLE empty_table(a int);


### PR DESCRIPTION
Fix explain analyze duplicate subplans handling

Due to some optimizations in Postgres optimizer it is possible to have several
SubLinks using the same SubPlan. Because of how SubPlans are processed during
EXPLAIN ANALYZE statistics depositing, that caused each duplicated SubPlan to
be visited multiple times, triggering an assert. This patch fixes the issue by
skipping processing slices that have already been processed.

Because of an existing "kludge", it is expected for slice 0 to be visited
multiple times during some queries, creating new "slices" for each visit.
Therefore, slice deduplication should only be applied to non-zero slices.