### PR TITLE
ADBDEV-6278: pg_dump incorrectly generate cleanup for external tables (#1045)

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16431,7 +16431,7 @@ dumpExternal(Archive *fout, const TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer 
 		 * DROP must be fully qualified in case same name appears in
 		 * pg_catalog
 		 */
-		appendPQExpBuffer(delq, "DROP EXTERNAL TABLE %s.",
+		appendPQExpBuffer(delq, "DROP EXTERNAL TABLE %s;\n",
 						  qualrelname);
 
 		/* Now get required information from pg_exttable */


### PR DESCRIPTION
pg_dump incorrectly generate cleanup for external tables (#1045)

Fixes issue #1025. DROP EXTERNAL TABLE in pg_dump output had incorrect syntax,
this patch fixes the typo.

Ticket: ADBDEV-6257

Changes from original commit:
1. Removed tests since this code only affects GPDB 6 compatibility, there is
no way to reach this line using only GPDB 7. This is because GPDB 7 uses
FOREIGN TABLE instead of EXTERNAL TABLE, so EXTERNAL TABLE cannot appear in
GPDB 7 database.

Co-authored-by: eshkinkot \<eshkinkot@gmail.com\>
(cherry picked from commit eaafa97a524e34f6533b5b5ee406fce5bf430d94)

---

To test this manually, connect to a working GPDB 6's cluster using pg_dump taken from GPDB 7 (GPDB 7 cluster is not necessary).

Note: Do not squash to preserve authorship