### PR TITLE
ADBDEV-5310: Revert merge commit

### DIFF
--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -336,23 +336,11 @@ _bitmap_insert_lov(Relation lovHeap, Relation lovIndex, Datum *datum,
 	result = index_insert(lovIndex, indexDatum, indexNulls,
 					 	  &(tuple->t_self), lovHeap, true);
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-							"insert_bmlov_before_freeze",
-							DDLNotSpecified,
-							"", //databaseName
-							RelationGetRelationName(lovHeap));
-#endif
+	SIMPLE_FAULT_INJECTOR("insert_bmlov_before_freeze");
 	/* freeze the tuple */
 	heap_freeze_tuple_wal_logged(lovHeap, tuple);
 
-#ifdef FAULT_INJECTOR
-	FaultInjector_InjectFaultIfSet(
-							"insert_bmlov_after_freeze",
-							DDLNotSpecified,
-							"", //databaseName
-							RelationGetRelationName(lovHeap));
-#endif
+	SIMPLE_FAULT_INJECTOR("insert_bmlov_after_freeze");
 	pfree(indexDatum);
 	pfree(indexNulls);
 	Assert(result);

--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -308,7 +308,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			/* fault injection is not set for the specified database name */
 			break;
 	
-		if (strlen(entryShared->tableName) > 0 && strcmp(entryShared->tableName, tableNameLocal) != 0)
+		if (strcmp(entryShared->tableName, tableNameLocal) != 0)
 			/* fault injection is not set for the specified table name */
 			break;
 


### PR DESCRIPTION
Revert merge commit ADBDEV-5310 branch

  Revert fea5f63 due to incorrect merge type and not enough interviewers.