### PR TITLE
Keep original ccnt into query structure

### DIFF
--- a/.abi-check/7.2.0_arenadata5/postgres.types.ignore
+++ b/.abi-check/7.2.0_arenadata5/postgres.types.ignore
@@ -1,0 +1,1 @@
+struct QueryDesc

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -22,6 +22,7 @@
 #include "libpq/libpq-be.h"
 #include "miscadmin.h"
 #include "postmaster/postmaster.h"		/* postmaster port */
+#include "storage/proc.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
@@ -109,9 +110,9 @@ external_set_env_vars_ext(extvar_t *extvar, char *uri, bool csv, char *escape, c
 	 * "session id"-"command id" to identify the transaction.
 	 */
 	if (!getDistributedTransactionIdentifier(extvar->GP_XID))
-		sprintf(extvar->GP_XID, "%u-%.10u", gp_session_id, gp_command_count);
+		sprintf(extvar->GP_XID, "%u-%.10u", gp_session_id, MyProc->queryCommandId);
 
-	sprintf(extvar->GP_CID, "%x", gp_command_count);
+	sprintf(extvar->GP_CID, "%x", MyProc->queryCommandId);
 	sprintf(extvar->GP_SN, "%x", scancounter);
 	sprintf(extvar->GP_SEGMENT_ID, "%d", GpIdentity.segindex);
 	sprintf(extvar->GP_SEG_PORT, "%d", PostPortNumber);

--- a/src/backend/cdb/cdbdtxcontextinfo.c
+++ b/src/backend/cdb/cdbdtxcontextinfo.c
@@ -21,6 +21,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/cdbtm.h"
 #include "access/xact.h"
+#include "storage/proc.h"
 #include "utils/guc.h"
 #include "utils/session_state.h"
 
@@ -62,7 +63,7 @@ DtxContextInfo_CreateOnCoordinator(DtxContextInfo *dtxContextInfo, bool inCursor
 
 	AssertImply(inCursor,
 				dtxContextInfo->distributedXid != InvalidDistributedTransactionId &&
-				gp_command_count == MySessionState->latestCursorCommandId);
+				MyProc->queryCommandId == MySessionState->latestCursorCommandId);
 
 	dtxContextInfo->cursorContext = inCursor;
 	dtxContextInfo->nestingLevel = GetCurrentTransactionNestLevel();

--- a/src/backend/cdb/cdbthreadlog.c
+++ b/src/backend/cdb/cdbthreadlog.c
@@ -23,6 +23,7 @@
 #include "miscadmin.h"
 #include "pgtime.h"
 #include "postmaster/syslogger.h"
+#include "storage/proc.h"
 
 
 #ifndef _WIN32
@@ -166,7 +167,8 @@ write_log(const char *fmt,...)
 	sprintf(tempbuf, "%d", MyProcPid);
 	strcat(logprefix, tempbuf); /* pid */
 	strcat(logprefix, "|");
-	sprintf(tempbuf, "con%d cmd%d", gp_session_id, gp_command_count);
+	sprintf(tempbuf, "con%d cmd%d",
+			gp_session_id, MyProc != NULL ? MyProc->queryCommandId : 0);
 	strcat(logprefix, tempbuf);
 
 	strcat(logprefix, "|");

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -653,7 +653,7 @@ gpvars_check_rg_query_fixed_mem(int *newval, void **extra, GucSource source)
 /*
  * increment_command_count
  *	  Increment gp_command_count. If the new command count is 0 or a negative number, reset it to 1.
- *	  And keep MyProc->queryCommandId synced with gp_command_count.
+ *	  And update MyProc->queryCommandId.
  */
 void
 increment_command_count()
@@ -662,10 +662,6 @@ increment_command_count()
 	if (gp_command_count <= 0)
 		gp_command_count = 1;
 
-	/*
-	 * No need to maintain MyProc->queryCommandId elsewhere, we guarantee
-	 * they are always synced here.
-	 */
 	MyProc->queryCommandId = gp_command_count;
 }
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -808,6 +808,7 @@ GpResetSessionIfNeeded(void)
 
 		gp_session_id = newSessionId;
 		gp_command_count = 0;
+		MyProc->queryCommandId = 0;
 		pgstat_report_sessionid(newSessionId);
 
 		/* Update the slotid for our singleton reader. */

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -574,14 +574,14 @@ generate_endpoint_name(char *name, const char *cursorName)
 	len += ENDPOINT_NAME_SESSIONID_LEN;
 
 	/*
-	 * part3: gp_command_count In theory cursor name + gp_session_id is
+	 * part3: MyProc->queryCommandId. In theory cursor name + gp_session_id is
 	 * enough, but we'd keep this part to avoid confusion or potential issues
 	 * for the scenario that in the same session (thus same gp_session_id),
 	 * two endpoints with same cursor names (happens the cursor is
 	 * dropped/rollbacked and then recreated) and retrieve the endpoints would
 	 * be confusing for users that in the same retrieve connection.
 	 */
-	snprintf(name + len, ENDPOINT_NAME_COMMANDID_LEN + 1, "%08x", gp_command_count);
+	snprintf(name + len, ENDPOINT_NAME_COMMANDID_LEN + 1, "%08x", MyProc->queryCommandId);
 	len += ENDPOINT_NAME_COMMANDID_LEN;
 
 	name[len] = '\0';

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -34,6 +34,7 @@
 #include "cdb/cdbvars.h"
 #include "cdb/ml_ipc.h"
 #include "executor/execdesc.h"
+#include "storage/proc.h"
 #include "storage/shmem.h"
 
 #include "ic_proxy.h"
@@ -444,7 +445,7 @@ ic_proxy_backend_connect(ICProxyBackendContext *context, ChunkTransportStateEntr
 	/* message key for a HELLO message */
 	ic_proxy_key_init(&backend->key,					/* key itself */
 					  gp_session_id,					/* sessionId */
-					  gp_command_count,					/* commandId */
+					  MyProc->queryCommandId,			/* commandId */
 					  pEntry->sendSlice->sliceIndex,	/* sendSliceIndex */
 					  pEntry->recvSlice->sliceIndex,	/* recvSliceIndex */
 					  GpIdentity.segindex,				/* localContentId */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -45,6 +45,7 @@
 #include "postmaster/postmaster.h"
 #include "storage/latch.h"
 #include "storage/pmsignal.h"
+#include "storage/proc.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
@@ -3087,7 +3088,7 @@ SetupUDPIFCInterconnect_Internal(SliceTable *sliceTable)
 			}
 		}
 
-		addCursorIcEntry(ich_table, sliceTable->ic_instance_id, gp_command_count);
+		addCursorIcEntry(ich_table, sliceTable->ic_instance_id, MyProc->queryCommandId);
 		/* save the latest transaction id */
 		rx_control_info.lastDXatId = distTransId;
 	}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -113,6 +113,10 @@
 										queryDesc->ddesc->parallelCursorName &&	\
 										strlen(queryDesc->ddesc->parallelCursorName) > 0)
 
+#define UPDATE_COMMAND_ID_AT_START(queryDesc, prevCommandId) UpdateCommandId(queryDesc, prevCommandId, __FUNCTION__, true)
+#define UPDATE_COMMAND_ID(queryDesc, prevCommandId) UpdateCommandId(queryDesc, prevCommandId, __FUNCTION__, false)
+#define RESTORE_COMMAND_ID(queryDesc, prevCommandId) RestoreCommandId(queryDesc, prevCommandId, __FUNCTION__)
+
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
 ExecutorRun_hook_type ExecutorRun_hook = NULL;
@@ -183,8 +187,47 @@ static char *ExecBuildSlotValueDescription(Oid reloid,
 										   int maxfieldlen);
 static void EvalPlanQualStart(EPQState *epqstate, Plan *planTree);
 
+static inline void UpdateCommandId(QueryDesc *queryDesc, int *prevCommandId, const char *functionName, bool trackStart);
+static inline void RestoreCommandId(QueryDesc *queryDesc, int prevCommandId, const char *functionName);
+
 /* end of local decls */
 
+
+static inline void
+UpdateCommandId(QueryDesc *queryDesc, int *prevCommandId, const char *functionName, bool trackStart)
+{
+	if (Gp_role != GP_ROLE_EXECUTE)
+	{
+		*prevCommandId = MyProc->queryCommandId;
+		MyProc->queryCommandId = queryDesc->command_id;
+	}
+
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("track_query_command_id") == FaultInjectorTypeSkip ||
+		(trackStart && SIMPLE_FAULT_INJECTOR("track_query_command_id_at_start") == FaultInjectorTypeSkip))
+		elog(NOTICE,
+			"START %s | Q: %s | QUERY ID: %d",
+			functionName,
+			queryDesc->sourceText,
+			MyProc->queryCommandId);
+#endif
+}
+
+static inline void
+RestoreCommandId(QueryDesc *queryDesc, int prevCommandId, const char *functionName)
+{
+#ifdef FAULT_INJECTOR
+	if (SIMPLE_FAULT_INJECTOR("track_query_command_id") == FaultInjectorTypeSkip)
+		elog(NOTICE,
+			"END %s | Q: %s | QUERY ID: %d",
+			functionName,
+			queryDesc->sourceText,
+			MyProc->queryCommandId);
+#endif
+
+	if (Gp_role != GP_ROLE_EXECUTE)
+		MyProc->queryCommandId = prevCommandId;
+}
 
 /* ----------------------------------------------------------------
  *		ExecutorStart
@@ -216,10 +259,24 @@ static void EvalPlanQualStart(EPQState *epqstate, Plan *planTree);
 void
 ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
-	if (ExecutorStart_hook)
-		(*ExecutorStart_hook) (queryDesc, eflags);
-	else
-		standard_ExecutorStart(queryDesc, eflags);
+	int prevCommandId = 0;
+	UPDATE_COMMAND_ID_AT_START(queryDesc, &prevCommandId);
+
+	PG_TRY();
+	{
+		if (ExecutorStart_hook)
+			(*ExecutorStart_hook) (queryDesc, eflags);
+		else
+			standard_ExecutorStart(queryDesc, eflags);
+	}
+	PG_CATCH();
+	{
+		RESTORE_COMMAND_ID(queryDesc, prevCommandId);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	RESTORE_COMMAND_ID(queryDesc, prevCommandId);
 }
 
 void
@@ -784,6 +841,10 @@ ExecutorRun(QueryDesc *queryDesc,
 	 * at the definition of the static variable executor_run_nesting_level.
 	 */
 	executor_run_nesting_level++;
+
+	int prevCommandId = 0;
+	UPDATE_COMMAND_ID(queryDesc, &prevCommandId);
+
 	PG_TRY();
 	{
 		if (ExecutorRun_hook)
@@ -795,9 +856,12 @@ ExecutorRun(QueryDesc *queryDesc,
 	PG_CATCH();
 	{
 		executor_run_nesting_level--;
+		RESTORE_COMMAND_ID(queryDesc, prevCommandId);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	RESTORE_COMMAND_ID(queryDesc, prevCommandId);
 }
 
 void
@@ -1058,10 +1122,24 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 void
 ExecutorFinish(QueryDesc *queryDesc)
 {
-	if (ExecutorFinish_hook)
-		(*ExecutorFinish_hook) (queryDesc);
-	else
-		standard_ExecutorFinish(queryDesc);
+	int prevCommandId = 0;
+	UPDATE_COMMAND_ID(queryDesc, &prevCommandId);
+
+	PG_TRY();
+	{
+		if (ExecutorFinish_hook)
+			(*ExecutorFinish_hook) (queryDesc);
+		else
+			standard_ExecutorFinish(queryDesc);
+	}
+	PG_CATCH();
+	{
+		RESTORE_COMMAND_ID(queryDesc, prevCommandId);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	RESTORE_COMMAND_ID(queryDesc, prevCommandId);
 }
 
 void
@@ -1118,10 +1196,24 @@ standard_ExecutorFinish(QueryDesc *queryDesc)
 void
 ExecutorEnd(QueryDesc *queryDesc)
 {
-	if (ExecutorEnd_hook)
-		(*ExecutorEnd_hook) (queryDesc);
-	else
-		standard_ExecutorEnd(queryDesc);
+	int prevCommandId = 0;
+	UPDATE_COMMAND_ID(queryDesc, &prevCommandId);
+
+	PG_TRY();
+	{
+		if (ExecutorEnd_hook)
+			(*ExecutorEnd_hook) (queryDesc);
+		else
+			standard_ExecutorEnd(queryDesc);
+	}
+	PG_CATCH();
+	{
+		RESTORE_COMMAND_ID(queryDesc, prevCommandId);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	RESTORE_COMMAND_ID(queryDesc, prevCommandId);
 }
 
 void

--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -23,6 +23,7 @@
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 #include "miscadmin.h"
+#include "storage/proc.h"
 #include "storage/shmem.h"
 #include "cdb/cdbdtxcontextinfo.h"
 #include "cdb/cdbtm.h"
@@ -456,7 +457,7 @@ pickInstrFromShmem(const Plan *plan, int instrument_options)
 		slot->pid = MyProcPid;
 		gp_gettmid(&(slot->tmid));
 		slot->ssid = gp_session_id;
-		slot->ccnt = gp_command_count;
+		slot->ccnt = MyProc->queryCommandId;
 		slot->nid = (int16) plan->plan_node_id;
 
 		MemoryContext contextSave = MemoryContextSwitchTo(TopMemoryContext);

--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -688,7 +688,7 @@ void
 shareinput_create_bufname_prefix(char* p, int size, int share_id)
 {
 	snprintf(p, size, "SIRW_%d_%d_%d",
-			 gp_session_id, gp_command_count, share_id);
+			 gp_session_id, MyProc->queryCommandId, share_id);
 }
 
 /*
@@ -814,7 +814,7 @@ get_shareinput_reference(int share_id)
 	LWLockAcquire(ShareInputScanLock, LW_EXCLUSIVE);
 
 	tag.session_id = gp_session_id;
-	tag.command_count = gp_command_count;
+	tag.command_count = MyProc->queryCommandId;
 	tag.share_id = share_id;
 	xslice_state = hash_search(shareinput_Xslice_hash,
 							   &tag,

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "cdb/cdbvars.h"
 #include "optimizer/hints.h"
 #include "optimizer/orca.h"
+#include "storage/proc.h"
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 }
@@ -848,7 +849,7 @@ COptTasks::OptimizeTask(void *ptr)
 			plan_dxl = COptimizer::PdxlnOptimize(
 				mp, &mda, query_dxl, query_output_dxlnode_array,
 				cte_dxlnode_array, expr_evaluator, num_segments, gp_session_id,
-				gp_command_count, search_strategy_arr, optimizer_config);
+				MyProc->queryCommandId, search_strategy_arr, optimizer_config);
 
 			if (opt_ctxt->m_should_serialize_plan_dxl)
 			{

--- a/src/backend/postmaster/backoff.c
+++ b/src/backend/postmaster/backoff.c
@@ -612,7 +612,7 @@ BackoffBackendTickExpired(void)
 {
 	BackoffBackendLocalEntry *le;
 	BackoffBackendSharedEntry *se;
-	StatementId currentStatementId = {gp_session_id, gp_command_count};
+	StatementId currentStatementId = {gp_session_id, MyProc != NULL ? MyProc->queryCommandId : 0};
 
 	backoffTickCounter = 0;
 

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -576,7 +576,7 @@ InitProcess(void)
 	/* Set wait portal (do not check if resource scheduling is enabled) */
 	MyProc->waitPortalId = INVALID_PORTALID;
 
-	MyProc->queryCommandId = -1;
+	MyProc->queryCommandId = 0;
 
 	/* Init gxact */
 	MyTmGxact->gxid = InvalidDistributedTransactionId;
@@ -748,7 +748,7 @@ InitAuxiliaryProcess(void)
 	 */
 	PGSemaphoreReset(MyProc->sem);
 
-	MyProc->queryCommandId = -1;
+	MyProc->queryCommandId = 0;
 
 	/*
 	 * Arrange to clean up at process exit.

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5194,7 +5194,10 @@ PostgresMain(int argc, char *argv[],
         /* Reset elog globals */
         currentSliceId = UNSET_SLICE_ID;
         if (Gp_role == GP_ROLE_EXECUTE)
-            gp_command_count = 0;
+		{
+			gp_command_count = 0;
+			MyProc->queryCommandId = 0;
+		}
 
 		/*
 		 * Do deactiving and runaway detecting before ReadyForQuery(),
@@ -5477,8 +5480,12 @@ PostgresMain(int argc, char *argv[],
 					/* Set statement_timestamp() */
  					SetCurrentStatementStartTimestamp();
 
-					/* get the client command serial# */
-					gp_command_count = pq_getmsgint(&input_message, 4);
+					/*
+					 * Get the command id from the QD. gp_command_count on QE
+					 * is set to be the same as queryCommandId.
+					 */
+					MyProc->queryCommandId = pq_getmsgint(&input_message, 4);
+					gp_command_count = MyProc->queryCommandId;
 
 					elog(DEBUG1, "Message type %c received by from libpq, len = %d", firstchar, input_message.len); /* TODO: Remove this */
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3022,8 +3022,8 @@ log_line_prefix(StringInfo buf, ErrorData *edata)
 				int j = buf->len;
 				if (gp_session_id > 0)
 					appendStringInfo(buf, "con%d ", gp_session_id);
-				if (gp_command_count > 0)
-					appendStringInfo(buf, "cmd%d ", gp_command_count);
+				if (MyProc != NULL && MyProc->queryCommandId > 0)
+					appendStringInfo(buf, "cmd%d ", MyProc->queryCommandId);
 				if (Gp_role == GP_ROLE_EXECUTE)
 					appendStringInfo(buf, "seg%d ", GpIdentity.segindex);
 				if (currentSliceId > 0)
@@ -3769,7 +3769,7 @@ write_syslogger_in_csv(ErrorData *edata, bool amsyslogger)
 
 	/* GPDB specific options */
 	syslogger_write_int32(true, "con", gp_session_id, amsyslogger, true);
-	syslogger_write_int32(true, "cmd", gp_command_count, amsyslogger, true);
+	syslogger_write_int32(true, "cmd", MyProc != NULL ? MyProc->queryCommandId : 0, amsyslogger, true);
 	syslogger_write_int32(false, "seg", GpIdentity.segindex, amsyslogger, true);
 	syslogger_write_int32(true, "slice", currentSliceId, amsyslogger, true);
 	{
@@ -3908,7 +3908,7 @@ write_message_to_server_log(int elevel,
 	fix_fields.omit_location = omit_location ? 't' : 'f';
 	fix_fields.gp_is_primary = 't';
 	fix_fields.gp_session_id = gp_session_id;
-	fix_fields.gp_command_count = gp_command_count;
+	fix_fields.gp_command_count = MyProc != NULL ? MyProc->queryCommandId : 0;
 	fix_fields.gp_segment_id = GpIdentity.segindex;
 	fix_fields.slice_id = currentSliceId;
 	fix_fields.error_cursor_pos = cursorpos;
@@ -5020,7 +5020,7 @@ StandardHandlerForSigillSigsegvSigbus_OnMainThread(char *processName, SIGNAL_ARG
 	}
 
 	errorData->gp_session_id = gp_session_id;
-	errorData->gp_command_count = gp_command_count;
+	errorData->gp_command_count = MyProc != NULL ? MyProc->queryCommandId : 0;
 	errorData->gp_segment_id = GpIdentity.segindex;
 	errorData->slice_id = currentSliceId;
 	errorData->signal_num = (int32)postgres_signal_arg;

--- a/src/backend/utils/misc/ps_status.c
+++ b/src/backend/utils/misc/ps_status.c
@@ -34,6 +34,7 @@
 #include "utils/guc.h"
 
 #include "cdb/cdbvars.h"        /* Gp_role, GpIdentity.segindex, currentSliceId */
+#include "storage/proc.h"
 
 extern char **environ;
 extern int PostPortNumber; /* GPDB: Helps identify child processes */
@@ -380,8 +381,8 @@ set_ps_display(const char *activity, bool force)
 	}
 
 	/* Add count of commands received from client session. */
-	if (gp_command_count > 0 && ep - cp > 0)
-		cp += snprintf(cp, ep - cp, "cmd%d ", gp_command_count);
+	if (MyProc != NULL && MyProc->queryCommandId > 0 && ep - cp > 0)
+		cp += snprintf(cp, ep - cp, "cmd%d ", MyProc->queryCommandId);
 
 	/* Add slice number information */
 	if (currentSliceId > 0 && ep - cp > 0)

--- a/src/backend/utils/misc/test/ps_status_test.c
+++ b/src/backend/utils/misc/test/ps_status_test.c
@@ -21,7 +21,6 @@ test__set_ps_display(void **state)
 	gp_session_id = 1024;
 	Gp_role = GP_ROLE_DISPATCH;
 	GpIdentity.segindex = 24;
-	gp_command_count = 1024;
 	currentSliceId = 40;
 
 	set_ps_display("testing activity", true);
@@ -50,7 +49,6 @@ test__set_ps_display__real_act_prefix_size_overflow(void **state)
 	gp_session_id = 26351;
 	Gp_role = GP_ROLE_DISPATCH;
 	GpIdentity.segindex = -1;
-	gp_command_count = 964;
 	currentSliceId = -1;
 
 	set_ps_display("testing activity", true);
@@ -82,7 +80,6 @@ test__set_ps_display__real_act_prefix_size(void **state)
 	gp_session_id = 26351;
 	Gp_role = GP_ROLE_DISPATCH;
 	GpIdentity.segindex = -1;
-	gp_command_count = 964;
 	currentSliceId = -1;
 
 	set_ps_display(activity, true);

--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -83,6 +83,7 @@
 #include "storage/fd.h"
 #include "storage/ipc.h"
 #include "storage/lwlock.h"
+#include "storage/proc.h"
 #include "storage/shmem.h"
 #include "utils/builtins.h"
 #include "utils/faultinjector.h"
@@ -599,7 +600,7 @@ workfile_mgr_create_set_internal(const char *operator_name, const char *prefix)
 	 * Find our per-query entry (or allocate, on first use)
 	 */
 	key.session_id = gp_session_id;
-	key.command_count = gp_command_count;
+	key.command_count = MyProc->queryCommandId;
 	perquery = (WorkFileUsagePerQuery *) hash_search(workfile_shared->per_query_hash,
 													 &key,
 													 HASH_ENTER_NULL, &found);
@@ -632,7 +633,7 @@ workfile_mgr_create_set_internal(const char *operator_name, const char *prefix)
 	workfile_shared->num_active++;
 
 	work_set->session_id = gp_session_id;
-	work_set->command_count = gp_command_count;
+	work_set->command_count = MyProc->queryCommandId;
 	work_set->slice_id = currentSliceId;
 	work_set->perquery = perquery;
 	work_set->num_files = 0;

--- a/src/include/executor/execdesc.h
+++ b/src/include/executor/execdesc.h
@@ -289,6 +289,7 @@ typedef struct QueryDesc
 	CmdType		operation;		/* CMD_SELECT, CMD_UPDATE, etc. */
 	PlannedStmt *plannedstmt;	/* planner's output (could be utility, too) */
 	const char *sourceText;		/* source text of the query */
+	int		    command_id;		/* id of the query */
 	Snapshot	snapshot;		/* snapshot to use for query */
 	Snapshot	crosscheck_snapshot;	/* crosscheck for RI update/delete */
 	DestReceiver *dest;			/* the destination for tuple output */

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -209,8 +209,7 @@ struct PGPROC
 
 	/*
 	 * Current command_id for the running query
-	 * This counter is not dead code although there is no consumer in the gpdb
-	 * code tree, it is required by external monitoring infrastructure.
+	 * This counter can be used by external monitoring infrastructure.
 	 * As a monitoring approach, each query execution is assigned with a unique
 	 * ID. The queryCommandId is part of the ID. Monitoring extension with
 	 * shared memory access can use queryCommandId to map query execution with

--- a/src/include/utils/session_state.h
+++ b/src/include/utils/session_state.h
@@ -96,7 +96,7 @@ typedef struct SessionState
 	 */
 	void *resGroupSlot;
 
-	/* gp_command_count of the latest cursor command in this session */
+	/* MyProc->queryCommandId of the latest cursor command in this session */
 	int latestCursorCommandId;
 
 #ifdef USE_ASSERT_CHECKING

--- a/src/test/regress/expected/gp_query_id.out
+++ b/src/test/regress/expected/gp_query_id.out
@@ -1,0 +1,863 @@
+--
+-- Test the query command identification
+--
+set client_min_messages = notice;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+create or replace function sirv_function() returns int as $$
+declare
+    result int;
+begin
+    create table test_data (x int, y int) with (appendonly=true) distributed by (x);
+    insert into test_data values (1, 1);
+    select count(1) into result from test_data;
+    drop table test_data;
+    return result;
+end $$ language plpgsql;
+\c
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 5
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 5
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 8
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 8
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: select sirv_function(); | QUERY ID: 4
+ sirv_function 
+---------------
+             1
+(1 row)
+
+-- Test that the query command id is correct after execution of queries in the InitPlan
+create table t as select (select sirv_function()) as res distributed by (res);
+NOTICE:  START ProcessUtility | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 10
+NOTICE:  START ExecutorStart | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 12
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 12
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 15
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 15
+NOTICE:  END ExecutorStart | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorRun | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorRun | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorFinish | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorFinish | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorEnd | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorEnd | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ProcessUtility | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 10
+-- Test a simple query
+select * from t;
+NOTICE:  START ExecutorStart | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorStart | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorRun | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorRun | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorFinish | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorFinish | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorEnd | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorEnd | Q: select * from t; | QUERY ID: 17
+ res 
+-----
+   1
+(1 row)
+
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 19
+NOTICE:  END ProcessUtility | Q: drop table t; | QUERY ID: 19
+-- Test a cursor
+begin;
+NOTICE:  START ProcessUtility | Q: begin; | QUERY ID: 21
+NOTICE:  END ProcessUtility | Q: begin; | QUERY ID: 21
+declare cur1 cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 23
+NOTICE:  START ExecutorStart | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorStart | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 23
+fetch 1 from cur1;
+NOTICE:  START ProcessUtility | Q: fetch 1 from cur1; | QUERY ID: 26
+NOTICE:  START ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 27
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 27
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 30
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 30
+NOTICE:  END ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: fetch 1 from cur1; | QUERY ID: 26
+ res 
+-----
+   1
+(1 row)
+
+fetch all from cur1;
+NOTICE:  START ProcessUtility | Q: fetch all from cur1; | QUERY ID: 32
+NOTICE:  START ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: fetch all from cur1; | QUERY ID: 32
+ res 
+-----
+(0 rows)
+
+commit;
+NOTICE:  START ProcessUtility | Q: commit; | QUERY ID: 34
+NOTICE:  END ProcessUtility | Q: commit; | QUERY ID: 34
+NOTICE:  START ExecutorFinish | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorFinish | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  START ExecutorEnd | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorEnd | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+-- Test two cursors
+begin;
+NOTICE:  START ProcessUtility | Q: begin; | QUERY ID: 36
+NOTICE:  END ProcessUtility | Q: begin; | QUERY ID: 36
+declare cur1_a cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 38
+NOTICE:  START ExecutorStart | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorStart | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 38
+fetch 1 from cur1_a;
+NOTICE:  START ProcessUtility | Q: fetch 1 from cur1_a; | QUERY ID: 41
+NOTICE:  START ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 42
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 42
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 45
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 45
+NOTICE:  END ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: fetch 1 from cur1_a; | QUERY ID: 41
+ res 
+-----
+   1
+(1 row)
+
+declare cur2_b cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 47
+NOTICE:  START ExecutorStart | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorStart | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 47
+fetch 2 from cur2_b;
+NOTICE:  START ProcessUtility | Q: fetch 2 from cur2_b; | QUERY ID: 50
+NOTICE:  START ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 51
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 51
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 54
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 54
+NOTICE:  END ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: fetch 2 from cur2_b; | QUERY ID: 50
+ res 
+-----
+   1
+(1 row)
+
+fetch all from cur2_b;
+NOTICE:  START ProcessUtility | Q: fetch all from cur2_b; | QUERY ID: 56
+NOTICE:  START ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: fetch all from cur2_b; | QUERY ID: 56
+ res 
+-----
+(0 rows)
+
+fetch all from cur1_a;
+NOTICE:  START ProcessUtility | Q: fetch all from cur1_a; | QUERY ID: 58
+NOTICE:  START ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: fetch all from cur1_a; | QUERY ID: 58
+ res 
+-----
+(0 rows)
+
+commit;
+NOTICE:  START ProcessUtility | Q: commit; | QUERY ID: 60
+NOTICE:  END ProcessUtility | Q: commit; | QUERY ID: 60
+NOTICE:  START ExecutorFinish | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorFinish | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ExecutorEnd | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorEnd | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ExecutorFinish | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorFinish | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  START ExecutorEnd | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorEnd | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+-- Test partitioned tables
+create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra);
+NOTICE:  START ProcessUtility | Q: create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra); | QUERY ID: 62
+NOTICE:  END ProcessUtility | Q: create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra); | QUERY ID: 62
+alter table t rename to t1;
+NOTICE:  START ProcessUtility | Q: alter table t rename to t1; | QUERY ID: 64
+NOTICE:  END ProcessUtility | Q: alter table t rename to t1; | QUERY ID: 64
+drop table t1;
+NOTICE:  START ProcessUtility | Q: drop table t1; | QUERY ID: 66
+NOTICE:  END ProcessUtility | Q: drop table t1; | QUERY ID: 66
+-- Test a function written in sql language, that optimizers cannot inline
+create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql;
+NOTICE:  START ProcessUtility | Q: create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql; | QUERY ID: 68
+NOTICE:  END ProcessUtility | Q: create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql; | QUERY ID: 68
+select not_inlineable_sql_func(i) from generate_series(1, 10)i;
+NOTICE:  START ExecutorStart | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorStart | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorRun | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorRun | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorFinish | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorFinish | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorEnd | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorEnd | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+ not_inlineable_sql_func 
+-------------------------
+                       0
+                       0
+                       0
+                       0
+                       0
+                       1
+                       1
+                       1
+                       1
+                       1
+(10 rows)
+
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Test the query command ids dispatched to segments
+-- start_matchsubs
+-- m/select pg_catalog.pg_relation_size\(.*\)/
+-- s/select pg_catalog.pg_relation_size\(.*\)/select pg_catalog.pg_relation_size\(\)/
+-- m/select pg_catalog.gp_acquire_sample_rows\(.*\)/
+-- s/select pg_catalog.gp_acquire_sample_rows\(.*\)/select pg_catalog.gp_acquire_sample_rows\(\)/
+-- m/select pg_catalog.gp_acquire_correlations\(.*\)/
+-- s/select pg_catalog.gp_acquire_correlations\(.*\)/select pg_catalog.gp_acquire_correlations\(\)/
+-- end_matchsubs
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'skip', dbid) from gp_segment_configuration;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+create table t as select 1;
+NOTICE:  START ProcessUtility | Q: create table t as select 1; | QUERY ID: 86
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '?column?' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg0 slice1 127.0.1.1:7002 pid=1429677)
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg2 127.0.1.1:7004 pid=1429664)
+create table t (i int, j text) with (appendonly = true) distributed by (i);
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg2 127.0.1.1:7004 pid=1429664)
+insert into t select i, (i + 1)::text from generate_series(1, 100) i;
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg0 slice1 127.0.1.1:7002 pid=1429679)
+vacuum analyze t;
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(24939, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(24939, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(24939, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(24939, 10000, 'f'); | QUERY ID: 96
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(24939, 10000, 'f'); | QUERY ID: 96  (seg0 slice1 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(24939, 10000, 'f'); | QUERY ID: 96  (seg1 slice1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(24939, 10000, 'f'); | QUERY ID: 96  (seg2 slice1 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(24939, 'f'); | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(24939, 'f'); | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1429664)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(24939, 'f'); | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1429663)
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg0 127.0.1.1:7002 pid=1429663)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg1 127.0.1.1:7003 pid=1429662)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg2 127.0.1.1:7004 pid=1429664)
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id_at_start', 'reset', dbid) from gp_segment_configuration; | QUERY ID: 100
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+-- Test the query command id after an error has happened
+select gp_inject_fault('appendonly_insert', 'panic', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+WARNING:  consider disabling FTS probes while injecting a panic.
+HINT:  Inject an infinite 'skip' into the 'fts_probe' fault to disable FTS probing.
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- First query will fail with an error due to insert inside the function
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 107
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 107
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg1 127.0.1.1:7003 pid=1429662)
+CONTEXT:  SQL statement "insert into test_data values (1, 1)"
+PL/pgSQL function sirv_function() line 6 at SQL statement
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 3
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 3
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 6
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 6
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorFinish | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorFinish | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorEnd | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorEnd | Q: select sirv_function(); | QUERY ID: 2
+ sirv_function 
+---------------
+             1
+(1 row)
+
+select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+-- Test an exception caught inside the function
+\c
+create table t (i int);
+NOTICE:  START ProcessUtility | Q: create table t (i int); | QUERY ID: 2
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  END ProcessUtility | Q: create table t (i int); | QUERY ID: 2
+insert into t values(0);
+NOTICE:  START ExecutorStart | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorRun | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: insert into t values(0); | QUERY ID: 4
+do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$;
+NOTICE:  START ProcessUtility | Q: do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$; | QUERY ID: 6
+NOTICE:  START ExecutorStart | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  END ExecutorStart | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  START ExecutorRun | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  END ExecutorRun | Q: select 1 / i from t | QUERY ID: 7
+WARNING:  division by zero  (seg1 slice1 127.0.1.1:7003 pid=1429847)
+WARNING:  2
+WARNING:  3
+NOTICE:  END ProcessUtility | Q: do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$; | QUERY ID: 6
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+drop function sirv_function();
+drop function not_inlineable_sql_func(i int);
+reset client_min_messages;

--- a/src/test/regress/expected/gp_query_id_optimizer.out
+++ b/src/test/regress/expected/gp_query_id_optimizer.out
@@ -1,0 +1,863 @@
+--
+-- Test the query command identification
+--
+set client_min_messages = notice;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+create or replace function sirv_function() returns int as $$
+declare
+    result int;
+begin
+    create table test_data (x int, y int) with (appendonly=true) distributed by (x);
+    insert into test_data values (1, 1);
+    select count(1) into result from test_data;
+    drop table test_data;
+    return result;
+end $$ language plpgsql;
+\c
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 2
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 5
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 5
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 6
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 7
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 8
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 8
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: select sirv_function(); | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: select sirv_function(); | QUERY ID: 4
+ sirv_function 
+---------------
+             1
+(1 row)
+
+-- Test that the query command id is correct after execution of queries in the InitPlan
+create table t as select (select sirv_function()) as res distributed by (res);
+NOTICE:  START ProcessUtility | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 10
+NOTICE:  START ExecutorStart | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 12
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 12
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 13
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 14
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 15
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 15
+NOTICE:  END ExecutorStart | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorRun | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorRun | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorFinish | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorFinish | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  START ExecutorEnd | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ExecutorEnd | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 11
+NOTICE:  END ProcessUtility | Q: create table t as select (select sirv_function()) as res distributed by (res); | QUERY ID: 10
+-- Test a simple query
+select * from t;
+NOTICE:  START ExecutorStart | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorStart | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorRun | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorRun | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorFinish | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorFinish | Q: select * from t; | QUERY ID: 17
+NOTICE:  START ExecutorEnd | Q: select * from t; | QUERY ID: 17
+NOTICE:  END ExecutorEnd | Q: select * from t; | QUERY ID: 17
+ res 
+-----
+   1
+(1 row)
+
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 19
+NOTICE:  END ProcessUtility | Q: drop table t; | QUERY ID: 19
+-- Test a cursor
+begin;
+NOTICE:  START ProcessUtility | Q: begin; | QUERY ID: 21
+NOTICE:  END ProcessUtility | Q: begin; | QUERY ID: 21
+declare cur1 cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 23
+NOTICE:  START ExecutorStart | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorStart | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 23
+fetch 1 from cur1;
+NOTICE:  START ProcessUtility | Q: fetch 1 from cur1; | QUERY ID: 26
+NOTICE:  START ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 27
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 27
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 28
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 29
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 30
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 30
+NOTICE:  END ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: fetch 1 from cur1; | QUERY ID: 26
+ res 
+-----
+   1
+(1 row)
+
+fetch all from cur1;
+NOTICE:  START ProcessUtility | Q: fetch all from cur1; | QUERY ID: 32
+NOTICE:  START ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorRun | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ProcessUtility | Q: fetch all from cur1; | QUERY ID: 32
+ res 
+-----
+(0 rows)
+
+commit;
+NOTICE:  START ProcessUtility | Q: commit; | QUERY ID: 34
+NOTICE:  END ProcessUtility | Q: commit; | QUERY ID: 34
+NOTICE:  START ExecutorFinish | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorFinish | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  START ExecutorEnd | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+NOTICE:  END ExecutorEnd | Q: declare cur1 cursor for select sirv_function() as res; | QUERY ID: 24
+-- Test two cursors
+begin;
+NOTICE:  START ProcessUtility | Q: begin; | QUERY ID: 36
+NOTICE:  END ProcessUtility | Q: begin; | QUERY ID: 36
+declare cur1_a cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 38
+NOTICE:  START ExecutorStart | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorStart | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 38
+fetch 1 from cur1_a;
+NOTICE:  START ProcessUtility | Q: fetch 1 from cur1_a; | QUERY ID: 41
+NOTICE:  START ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 42
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 42
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 43
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 44
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 45
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 45
+NOTICE:  END ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: fetch 1 from cur1_a; | QUERY ID: 41
+ res 
+-----
+   1
+(1 row)
+
+declare cur2_b cursor for select sirv_function() as res;
+NOTICE:  START ProcessUtility | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 47
+NOTICE:  START ExecutorStart | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorStart | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 47
+fetch 2 from cur2_b;
+NOTICE:  START ProcessUtility | Q: fetch 2 from cur2_b; | QUERY ID: 50
+NOTICE:  START ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 51
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 51
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 52
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 53
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 54
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 54
+NOTICE:  END ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: fetch 2 from cur2_b; | QUERY ID: 50
+ res 
+-----
+   1
+(1 row)
+
+fetch all from cur2_b;
+NOTICE:  START ProcessUtility | Q: fetch all from cur2_b; | QUERY ID: 56
+NOTICE:  START ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorRun | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ProcessUtility | Q: fetch all from cur2_b; | QUERY ID: 56
+ res 
+-----
+(0 rows)
+
+fetch all from cur1_a;
+NOTICE:  START ProcessUtility | Q: fetch all from cur1_a; | QUERY ID: 58
+NOTICE:  START ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorRun | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ProcessUtility | Q: fetch all from cur1_a; | QUERY ID: 58
+ res 
+-----
+(0 rows)
+
+commit;
+NOTICE:  START ProcessUtility | Q: commit; | QUERY ID: 60
+NOTICE:  END ProcessUtility | Q: commit; | QUERY ID: 60
+NOTICE:  START ExecutorFinish | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorFinish | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ExecutorEnd | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  END ExecutorEnd | Q: declare cur2_b cursor for select sirv_function() as res; | QUERY ID: 48
+NOTICE:  START ExecutorFinish | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorFinish | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  START ExecutorEnd | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+NOTICE:  END ExecutorEnd | Q: declare cur1_a cursor for select sirv_function() as res; | QUERY ID: 39
+-- Test partitioned tables
+create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra);
+NOTICE:  START ProcessUtility | Q: create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra); | QUERY ID: 62
+NOTICE:  END ProcessUtility | Q: create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra); | QUERY ID: 62
+alter table t rename to t1;
+NOTICE:  START ProcessUtility | Q: alter table t rename to t1; | QUERY ID: 64
+NOTICE:  END ProcessUtility | Q: alter table t rename to t1; | QUERY ID: 64
+drop table t1;
+NOTICE:  START ProcessUtility | Q: drop table t1; | QUERY ID: 66
+NOTICE:  END ProcessUtility | Q: drop table t1; | QUERY ID: 66
+-- Test a function written in sql language, that optimizers cannot inline
+create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql;
+NOTICE:  START ProcessUtility | Q: create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql; | QUERY ID: 68
+NOTICE:  END ProcessUtility | Q: create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql; | QUERY ID: 68
+select not_inlineable_sql_func(i) from generate_series(1, 10)i;
+NOTICE:  START ExecutorStart | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorStart | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorRun | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 71
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 72
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 73
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 74
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 75
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 76
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 77
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 78
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 79
+NOTICE:  START ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorStart | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorRun | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorFinish | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  START ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorEnd | Q: 
+select case when i > 5 then 1 else 0 end;
+ | QUERY ID: 80
+NOTICE:  END ExecutorRun | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorFinish | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorFinish | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  START ExecutorEnd | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+NOTICE:  END ExecutorEnd | Q: select not_inlineable_sql_func(i) from generate_series(1, 10)i; | QUERY ID: 70
+ not_inlineable_sql_func 
+-------------------------
+                       0
+                       0
+                       0
+                       0
+                       0
+                       1
+                       1
+                       1
+                       1
+                       1
+(10 rows)
+
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 82
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Test the query command ids dispatched to segments
+-- start_matchsubs
+-- m/select pg_catalog.pg_relation_size\(.*\)/
+-- s/select pg_catalog.pg_relation_size\(.*\)/select pg_catalog.pg_relation_size\(\)/
+-- m/select pg_catalog.gp_acquire_sample_rows\(.*\)/
+-- s/select pg_catalog.gp_acquire_sample_rows\(.*\)/select pg_catalog.gp_acquire_sample_rows\(\)/
+-- m/select pg_catalog.gp_acquire_correlations\(.*\)/
+-- s/select pg_catalog.gp_acquire_correlations\(.*\)/select pg_catalog.gp_acquire_correlations\(\)/
+-- end_matchsubs
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'skip', dbid) from gp_segment_configuration;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+create table t as select 1;
+NOTICE:  START ProcessUtility | Q: create table t as select 1; | QUERY ID: 86
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_highest_oid() | QUERY ID: 87  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg0 slice1 127.0.1.1:7002 pid=1445897)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg1 slice1 127.0.1.1:7003 pid=1445898)
+NOTICE:  START ExecutorStart | Q: create table t as select 1; | QUERY ID: 87  (seg2 slice1 127.0.1.1:7004 pid=1445899)
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 89  (seg2 127.0.1.1:7004 pid=1445884)
+create table t (i int, j text) with (appendonly = true) distributed by (i);
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: create table t (i int, j text) with (appendonly = true) distributed by (i); | QUERY ID: 91  (seg0 127.0.1.1:7002 pid=1445882)
+insert into t select i, (i + 1)::text from generate_series(1, 100) i;
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ExecutorStart | Q: insert into t select i, (i + 1)::text from generate_series(1, 100) i; | QUERY ID: 93  (seg2 127.0.1.1:7004 pid=1445884)
+vacuum analyze t;
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ProcessUtility | Q: vacuum analyze t; | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(180587, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(180587, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.pg_relation_size(180587, /* include_ao_aux */ false, /* physical_ao_size */ false) | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(180587, 10000, 'f'); | QUERY ID: 96
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(180587, 10000, 'f'); | QUERY ID: 96  (seg0 slice1 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(180587, 10000, 'f'); | QUERY ID: 96  (seg1 slice1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_sample_rows(180587, 10000, 'f'); | QUERY ID: 96  (seg2 slice1 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(180587, 'f'); | QUERY ID: 95  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(180587, 'f'); | QUERY ID: 95  (seg2 127.0.1.1:7004 pid=1445884)
+NOTICE:  START ExecutorStart | Q: select pg_catalog.gp_acquire_correlations(180587, 'f'); | QUERY ID: 95  (seg0 127.0.1.1:7002 pid=1445882)
+drop table t;
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg0 127.0.1.1:7002 pid=1445882)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg1 127.0.1.1:7003 pid=1445883)
+NOTICE:  START ProcessUtility | Q: drop table t; | QUERY ID: 98  (seg2 127.0.1.1:7004 pid=1445884)
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'reset', dbid) from gp_segment_configuration;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id_at_start', 'reset', dbid) from gp_segment_configuration; | QUERY ID: 100
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+ Success:
+(8 rows)
+
+-- Test the query command id after an error has happened
+select gp_inject_fault('appendonly_insert', 'panic', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+WARNING:  consider disabling FTS probes while injecting a panic.
+HINT:  Inject an infinite 'skip' into the 'fts_probe' fault to disable FTS probing.
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 104
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- First query will fail with an error due to insert inside the function
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 107
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 107
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 108
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 106
+ERROR:  fault triggered, fault name:'appendonly_insert' fault type:'panic'  (seg1 127.0.1.1:7003 pid=1445883)
+CONTEXT:  SQL statement "insert into test_data values (1, 1)"
+PL/pgSQL function sirv_function() line 6 at SQL statement
+select sirv_function();
+NOTICE:  START ExecutorStart | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorStart | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorRun | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 3
+NOTICE:  END ProcessUtility | Q: create table test_data (x int, y int) with (appendonly=true) distributed by (x) | QUERY ID: 3
+NOTICE:  START ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorRun | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: insert into test_data values (1, 1) | QUERY ID: 4
+NOTICE:  START ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorStart | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorRun | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorFinish | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  END ExecutorEnd | Q: select count(1)             from test_data | QUERY ID: 5
+NOTICE:  START ProcessUtility | Q: drop table test_data | QUERY ID: 6
+NOTICE:  END ProcessUtility | Q: drop table test_data | QUERY ID: 6
+NOTICE:  END ExecutorRun | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorFinish | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorFinish | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  START ExecutorEnd | Q: select sirv_function(); | QUERY ID: 2
+NOTICE:  END ExecutorEnd | Q: select sirv_function(); | QUERY ID: 2
+ sirv_function 
+---------------
+             1
+(1 row)
+
+select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorRun | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorFinish | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorFinish | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  START ExecutorEnd | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+NOTICE:  END ExecutorEnd | Q: select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p'; | QUERY ID: 8
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+ Success:
+(4 rows)
+
+-- Test an exception caught inside the function
+\c
+create table t (i int);
+NOTICE:  START ProcessUtility | Q: create table t (i int); | QUERY ID: 2
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  END ProcessUtility | Q: create table t (i int); | QUERY ID: 2
+insert into t values(0);
+NOTICE:  START ExecutorStart | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorStart | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorRun | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorRun | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorFinish | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorFinish | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  START ExecutorEnd | Q: insert into t values(0); | QUERY ID: 4
+NOTICE:  END ExecutorEnd | Q: insert into t values(0); | QUERY ID: 4
+do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$;
+NOTICE:  START ProcessUtility | Q: do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$; | QUERY ID: 6
+NOTICE:  START ExecutorStart | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  END ExecutorStart | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  START ExecutorRun | Q: select 1 / i from t | QUERY ID: 7
+NOTICE:  END ExecutorRun | Q: select 1 / i from t | QUERY ID: 7
+WARNING:  division by zero  (seg1 slice1 127.0.1.1:7003 pid=1446046)
+WARNING:  2
+WARNING:  3
+NOTICE:  END ProcessUtility | Q: do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$; | QUERY ID: 6
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+NOTICE:  START ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+NOTICE:  END ExecutorStart | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+NOTICE:  START ExecutorRun | Q: select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1; | QUERY ID: 9
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+drop function sirv_function();
+drop function not_inlineable_sql_func(i int);
+reset client_min_messages;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -361,4 +361,6 @@ test: quicklz_fallback
 # run pg_hba raleted testing
 test: hba_conf
 
+test: gp_query_id
+
 # end of tests

--- a/src/test/regress/sql/gp_query_id.sql
+++ b/src/test/regress/sql/gp_query_id.sql
@@ -1,0 +1,137 @@
+--
+-- Test the query command identification
+--
+-- start_ignore
+create extension if not exists gp_inject_fault;
+drop function if exists sirv_function();
+drop function if exists not_inlineable_sql_func(i int);
+drop table if exists test_data;
+drop table if exists t;
+drop table if exists t1;
+-- end_ignore
+
+set client_min_messages = notice;
+select gp_inject_fault('all', 'reset', dbid) from gp_segment_configuration;
+
+create or replace function sirv_function() returns int as $$
+declare
+    result int;
+begin
+    create table test_data (x int, y int) with (appendonly=true) distributed by (x);
+    insert into test_data values (1, 1);
+    select count(1) into result from test_data;
+    drop table test_data;
+    return result;
+end $$ language plpgsql;
+
+\c
+
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+
+select sirv_function();
+
+-- Test that the query command id is correct after execution of queries in the InitPlan
+create table t as select (select sirv_function()) as res distributed by (res);
+
+-- Test a simple query
+select * from t;
+
+drop table t;
+
+-- Test a cursor
+begin;
+declare cur1 cursor for select sirv_function() as res;
+fetch 1 from cur1;
+fetch all from cur1;
+commit;
+
+-- Test two cursors
+begin;
+declare cur1_a cursor for select sirv_function() as res;
+fetch 1 from cur1_a;
+declare cur2_b cursor for select sirv_function() as res;
+fetch 2 from cur2_b;
+fetch all from cur2_b;
+fetch all from cur1_a;
+commit;
+
+-- Test partitioned tables
+create table t(i int) distributed by (i)
+partition by range (i) (start (1) end (10) every (1), default partition extra);
+
+alter table t rename to t1;
+
+drop table t1;
+
+-- Test a function written in sql language, that optimizers cannot inline
+create or replace function not_inlineable_sql_func(i int) returns int 
+immutable
+security definer
+as $$
+select case when i > 5 then 1 else 0 end;
+$$ language sql;
+
+select not_inlineable_sql_func(i) from generate_series(1, 10)i;
+
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+
+-- Test the query command ids dispatched to segments
+-- start_matchsubs
+-- m/select pg_catalog.pg_relation_size\(.*\)/
+-- s/select pg_catalog.pg_relation_size\(.*\)/select pg_catalog.pg_relation_size\(\)/
+-- m/select pg_catalog.gp_acquire_sample_rows\(.*\)/
+-- s/select pg_catalog.gp_acquire_sample_rows\(.*\)/select pg_catalog.gp_acquire_sample_rows\(\)/
+-- m/select pg_catalog.gp_acquire_correlations\(.*\)/
+-- s/select pg_catalog.gp_acquire_correlations\(.*\)/select pg_catalog.gp_acquire_correlations\(\)/
+-- end_matchsubs
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'skip', dbid) from gp_segment_configuration;
+
+create table t as select 1;
+drop table t;
+
+create table t (i int, j text) with (appendonly = true) distributed by (i);
+insert into t select i, (i + 1)::text from generate_series(1, 100) i;
+vacuum analyze t;
+drop table t;
+
+select gp_inject_fault_infinite('track_query_command_id_at_start', 'reset', dbid) from gp_segment_configuration;
+
+-- Test the query command id after an error has happened
+select gp_inject_fault('appendonly_insert', 'panic', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+
+select gp_inject_fault_infinite('track_query_command_id', 'skip', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+
+-- First query will fail with an error due to insert inside the function
+select sirv_function();
+
+select sirv_function();
+
+select gp_inject_fault('appendonly_insert', 'reset', '', '', 'test_data', 1, -1, 0, dbid) from gp_segment_configuration
+where role = 'p';
+
+-- Test an exception caught inside the function
+\c
+create table t (i int);
+insert into t values(0);
+
+do $$
+declare
+j int;
+begin
+    select 1 / i from t into strict j;
+    raise warning '%', j;
+    exception when others then raise warning '%', sqlerrm;
+    raise warning '%', 2;
+    raise warning '%', 3;
+end$$;
+
+select gp_inject_fault_infinite('track_query_command_id', 'reset', dbid) from gp_segment_configuration
+where role = 'p' and content = -1;
+
+drop function sirv_function();
+drop function not_inlineable_sql_func(i int);
+reset client_min_messages;


### PR DESCRIPTION
Keep original ccnt into query structure (#1064)

Problem:
Previous approach to identify a query that is currently being executed was based
on the global gp_command_count variable. Query identification is required by the
monitoring extensions to track the execution process. But gp_command_count is
incremented on each new query. So, in case of a complex query with initplans,
monitoring extensions were not able to track the execution of the query after
the initplan execution had been done, because gp_command_count was already
changed comparing to its value at the query start. To address this issue,
monitoring extensions hacked the gp_command_count value, which is dispatched
from the QD to the QEs (replaced it with the value stored before the init plan
execution). But it led to other problems, for ex. hanging of query execution if
IC proxy is enabled or if the plan had Shared Input scans, as these features
also relied on the gp_command_count value.

Fix:
This patch adds a support of a query monitoring into the GPDB core.
The approach uses already existing (but not previously used in the GPDB core)
field queryCommandId of PGPROC for command identification. The handling for
queryCommandId is reworked:

queryCommandId is set to gp_command_count every time gp_command_count is
incremented on the dispatcher (that’s old behavior, it is not changed).
QueryDesc now contains 1 new field (filled in CreateQueryDesc()) command_id -
the updated value of MyProc->queryCommandId after its increment.
At the Dispatcher side:
Executor switches MyProc->queryCommandId to the command_id of the QueryDesc at
the beginning of ExecutorStart(), ExecutorRun(), ExecutorFinish(),
ExecutorEnd(), and back to the preceding value at their end.
For utility commands, increment_command_count() is added in the
ProcessUtility(). At the end of ProcessUtility(), the value of
MyProc->queryCommandId is restored to preceding value.
MyProc->queryCommandId is added to the query message dispatched to the
executors (instead of gp_command_count). gp_command_count is not sent to
the QEs.
At the Executor side, backend acquires proper queryCommandId from the message
dispatched from the query dispatcher. On the QE the gp_command_count is set to
be equal to the queryCommandId.
Most parts of the code, that used gp_command_count, now use queryCommandId
(some places still use gp_command_count, like for ex. RunawayCleaner. They
require additional analysis and possibly would be updated later).
After this change, monitoring extension should use MyProc->queryCommandId as the
ccnt for the query identification instead of the gp_command_count.

gp_command_count still exists as a global counter at the QD, that is used to
assign a new value to the queryCommandId at the start of query execution.

Ticket: ADBDEV-6375
(cherry picked from commit 7ee713d)

Changes comparing to the original commit:
1. ABI check ignore file is moved to a folder with actual base version;
2. expected files for the test are updated because of GPDB 7 differences in some
queries execution;
3. matchsubs are updated in the test because of GPDB 7 differences;
4. gpperfmon is removed in GPDB 7, so changes in gpperfmon are omitted;
5. external_set_env_vars_ext() is now located in a different file, so the
respective change is done there;
6. sisc_lockname() doesn't exist anymore, so this change is omitted;
7. in get_shareinput_reference() gp_command_count is replaced with
MyProc->queryCommandId.
8. changes from CheckForResetSession() are now done in GpResetSessionIfNeeded(),
as CheckForResetSession() through the times was transormed into                 
GpDropTempTables(), which in turn was transformed into GpResetSessionIfNeeded().

----------------------------

Do not squash the commits.
