### PR TITLE
ADBDEV-6484: Fix assertion about exceeding maximum runs in mk-sorter

### DIFF
--- a/src/include/utils/tuplesort_mk_details.h
+++ b/src/include/utils/tuplesort_mk_details.h
@@ -132,7 +132,7 @@ static inline int32 mke_get_lv(MKEntry *e)
 }
 static inline void mke_set_lv(MKEntry *e, int32 lv)
 {
-    Assert(lv >= 0 && lv <= MKE_MAX_LV);
+    Assert(lv >= 0);
     /* If statement_mem is too small, we might end up generating 
        too many runs. */ 
     if (lv > MKE_MAX_LV) 

--- a/src/include/utils/tuplesort_mk_details.h
+++ b/src/include/utils/tuplesort_mk_details.h
@@ -115,6 +115,7 @@ static inline int32 mke_get_run(MKEntry *e)
 }
 static inline void mke_set_run(MKEntry *e, int32 run)
 {
+    Assert(run >= 0);
     /* If statement_mem is too small, we might end up generating 
        too many runs. */ 
     if (run > MKE_MAX_RUN)

--- a/src/include/utils/tuplesort_mk_details.h
+++ b/src/include/utils/tuplesort_mk_details.h
@@ -115,7 +115,6 @@ static inline int32 mke_get_run(MKEntry *e)
 }
 static inline void mke_set_run(MKEntry *e, int32 run)
 {
-    Assert(run >= 0 && run <= MKE_MAX_RUN);
     /* If statement_mem is too small, we might end up generating 
        too many runs. */ 
     if (run > MKE_MAX_RUN)


### PR DESCRIPTION
Fix assertion about exceeding maximum runs in mk-sorter

When there is insufficient memory, the mk-sorter uses a larger number of
sorting runs. And at some point it may exceed the maximum allowed number of
runs, which is 16383. This limitation is caused by 14-bit storage. The
mke_set_run and mke_set_lv functions use an assert that checks for going beyond
the maximum value. But this assert is redundant. Firstly, the release build
simply throws an error in this case. And secondly, increasing memory solves the
problem. Also, disabling the GUC gp_enable_mk_sort solves the problem. So we
can simply always throw an error and the user can solve it by increasing memory
or using another sorter.