### PR TITLE
ADBDEV-6497: Fallback to planner if a function in 'from' clause uses 'WITH ORDINALITY'

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3131,6 +3131,12 @@ CTranslatorQueryToDXL::TranslateFromClauseToDXL(Node *node)
 					   GPOS_WSZ_LIT("LATERAL"));
 		}
 
+		if (rte->funcordinality)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					   GPOS_WSZ_LIT("WITH ORDINALITY"));
+		}
+
 		static const SRTETranslator dxlop_translator_func_mapping_array[] = {
 			{RTE_RELATION, &CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet},
 			{RTE_VALUES, &CTranslatorQueryToDXL::TranslateValueScanRTEToDXL},

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -322,3 +322,11 @@ EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
 
 INSERT INTO partition_key_dropped VALUES(3);
 ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=13466)
+-- Orca should fallback if a function in 'from' clause uses 'WITH ORDINALITY'
+SELECT * FROM jsonb_array_elements('["b", "a"]'::jsonb) WITH ORDINALITY;
+ value | ordinality 
+-------+------------
+ "b"   |          1
+ "a"   |          2
+(2 rows)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -374,3 +374,13 @@ EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
 
 INSERT INTO partition_key_dropped VALUES(3);
 ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=12782)
+-- Orca should fallback if a function in 'from' clause uses 'WITH ORDINALITY'
+SELECT * FROM jsonb_array_elements('["b", "a"]'::jsonb) WITH ORDINALITY;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: WITH ORDINALITY
+ value | ordinality 
+-------+------------
+ "b"   |          1
+ "a"   |          2
+(2 rows)
+

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -123,3 +123,6 @@ UPDATE partition_key_dropped SET a=21 where a=2;
 
 EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
 INSERT INTO partition_key_dropped VALUES(3);
+
+-- Orca should fallback if a function in 'from' clause uses 'WITH ORDINALITY'
+SELECT * FROM jsonb_array_elements('["b", "a"]'::jsonb) WITH ORDINALITY;


### PR DESCRIPTION
Fallback to planner if a function in 'from' clause uses 'WITH ORDINALITY'

---

This is a cherry-pick of [99f0c82](https://github.com/arenadata/gpdb/commit/99f0c829398291e0026f1628c6732021f5b7e29b) with conflicts resolved and fallback message corrected for GPDB 6. This PR requires rebasing to preserve authorship.