### PR TITLE
Remove an assert when WAL sender tries to update a cleared replication slot.

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -181,7 +181,7 @@ FTSReplicationStatusDrop(const char* app_name)
  * FTSReplicationStatusLock should be held before call this function.
  */
 FTSReplicationStatus *
-RetrieveFTSReplicationStatus(const char *app_name, bool skip_err)
+RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn)
 {
 	/* FTSRepStatusCtl should be set already. */
 	Assert(FTSRepStatusCtl != NULL);
@@ -196,8 +196,8 @@ RetrieveFTSReplicationStatus(const char *app_name, bool skip_err)
 			return slot;
 	}
 
-	if (!skip_err)
-		ereport(ERROR,
+	if (!skip_warn)
+		ereport(WARNING,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("FTSReplicationStatus \"%s\" does not exist", app_name)));
 	return NULL;
@@ -249,9 +249,18 @@ FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state)
 
 	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
 
-	replication_status = RetrieveFTSReplicationStatus(app_name, false /*skip_err*/);
+	replication_status = RetrieveFTSReplicationStatus(app_name, false /*skip_warn*/);
 
-	Assert(replication_status);
+	/*
+	 * FTS and WAL working independently, it's still possible a condition when
+	 * FTS command to stop replication comes after replica starts. In this
+	 * case replication status slot can be already empty.
+	 */
+	if (replication_status == NULL)
+	{
+		LWLockRelease(FTSReplicationStatusLock);
+		return;
+	}
 
 	bool is_up;
 	SpinLockAcquire(&MyWalSnd->mutex);
@@ -303,7 +312,7 @@ FTSReplicationStatusMarkDisconnectForReplication(const char *app_name)
 	 * FTS may already mark the mirror down and free the replication status.
 	 * For this case, a NULL pointer will return.
 	 */
-	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_err */);
+	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_warn */);
 
 	/* if replication_status is NULL, do nothing */
 	FTSReplicationStatusMarkDisconnect(replication_status);
@@ -454,7 +463,7 @@ FTSGetReplicationDisconnectTime(const char *app_name)
 	FTSReplicationStatus	   *replication_status = NULL;
 
 	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
-	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_err */);
+	replication_status = RetrieveFTSReplicationStatus(app_name, true /* skip_warn */);
 	if (replication_status)
 	{
 		attempt_replication_times = FTSReplicationStatusRetrieveAttempts(replication_status);

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -250,8 +250,11 @@ FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state)
 	LWLockAcquire(FTSReplicationStatusLock, LW_SHARED);
 
 	replication_status = RetrieveFTSReplicationStatus(app_name, false /*skip_warn*/);
-	/* replication_status must exist */
-	Assert(replication_status);
+
+	if (replication_status == NULL) {
+		LWLockRelease(FTSReplicationStatusLock);
+		return;
+	}
 
 	bool is_up;
 	SpinLockAcquire(&MyWalSnd->mutex);

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -68,7 +68,7 @@ extern void FTSReplicationStatusShmemInit(void);
 extern void FTSReplicationStatusCreateIfNotExist(const char *app_name);
 extern void FTSReplicationStatusDrop(const char* app_name);
 
-extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn);
+extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_err);
 extern void FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state);
 extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_name);
 extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);

--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -68,7 +68,7 @@ extern void FTSReplicationStatusShmemInit(void);
 extern void FTSReplicationStatusCreateIfNotExist(const char *app_name);
 extern void FTSReplicationStatusDrop(const char* app_name);
 
-extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_err);
+extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn);
 extern void FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state);
 extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_name);
 extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);


### PR DESCRIPTION
Remove an assert when WAL sender tries to update a cleared replication slot.

Due to the asynchronous nature of FTS and WAL communications, there is a
possible situation where the mirror goes down, FTS sends a command to turn off
replication, but the mirror and WAL sender restart before the command from FTS
reaches the segment master. In this case, FTS removes the replication slot on
the master, but the WAL sender tries to update the slot. In this situation,
replication is useless, and WAL sender will exit. 
Assert for this condition looks to be unwanted.

The test max_slot_wal_keep_size.sql hit this rare condition with the Ubuntu
container. This commit removes the assert in 
FTSReplicationStatusUpdateForWalState() making the test more reliable.