### PR TITLE
ADBDEV-6537 Fix -Wmissing-prototypes warning

### DIFF
--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -164,6 +164,11 @@ static void BufFileDumpCompressedBuffer(BufFile *file, const void *buffer, Size 
 static void BufFileEndCompression(BufFile *file);
 static int BufFileLoadCompressedBuffer(BufFile *file, void *buffer, size_t bufsize);
 
+#ifdef HAVE_LIBZSTD
+static void *customAlloc(void *opaque, size_t size);
+static void customFree(void *opaque, void *address);
+#endif
+
 
 /*
  * Create a BufFile given the first underlying physical file.

--- a/src/backend/storage/file/buffile.c
+++ b/src/backend/storage/file/buffile.c
@@ -1033,13 +1033,13 @@ BufFilePledgeSequential(BufFile *buffile)
 
 #define BUFFILE_ZSTD_COMPRESSION_LEVEL 1
 
-void *
+static void *
 customAlloc(void *opaque, size_t size)
 {
 	return MemoryContextAlloc(TopMemoryContext, size);
 }
 
-void
+static void
 customFree(void *opaque, void *address)
 {
 	pfree(address);


### PR DESCRIPTION
Fix -Wmissing-prototypes warning

Commit 7185bf8 introduced support for zstd memory control via callbacks, but
these callbacks neither were declared as static, nor had prototypes, which
resulted in -Wmissing-prototypes warning about them. This patch does both
things, eliminating the warning.