### PR TITLE
Fix missing XML body in S3 CompleteMultipartUpload command

### DIFF
--- a/gpcontrib/gpcloud/src/s3restful_service.cpp
+++ b/gpcontrib/gpcloud/src/s3restful_service.cpp
@@ -237,7 +237,7 @@ Response S3RESTfulService::post(const string &url, HTTPHeaders &headers,
     UploadData uploadData(s3data);
     curl_easy_setopt(curl, CURLOPT_READDATA, (void *)&uploadData);
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, RESTfulServiceReadFuncCallback);
-    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)data.size());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)data.size());
 
     this->performCurl(curl, response);
 


### PR DESCRIPTION
Fix missing XML body in S3 CompleteMultipartUpload command

Problem:
Attempt to insert data into a writable external table with data file located on
S3 storage ended with warning "InvalidRequest : You must specify at least one 
part". Though GPDB reported that data was inserted, no file had been created in
the S3 bucket. So, actually the insert operation failed.

Cause:
Data insertion into S3 external table is done via S3 Multipart upload. This 
approach requires the following commands:
1. CreateMultipartUpload to start the process;
2. one or more UploadPart to pass the data itself;
3. CompleteMultipartUpload to finish the process.

CompleteMultipartUpload is a POST method request, that should have XML payload
with a list of all parts.
But the http analysis showed that actual POST request for
CompleteMultipartUpload didn't contain the payload. As a consequence, the S3
storage replied with an error.

The reason for missing payload is the following: according to the CURL
documentation, if data to POST is provided using the CURLOPT_READFUNCTION and
CURLOPT_READDATA options (which is our case), "you must set the size of the data
with the CURLOPT_POSTFIELDSIZE or CURLOPT_POSTFIELDSIZE_LARGE options". While
in the 'S3RESTfulService::post()' the size of the data was set via
CURLOPT_INFILESIZE_LARGE CURL option.

Fix:
CURL option CURLOPT_INFILESIZE_LARGE is replaced with
CURLOPT_POSTFIELDSIZE_LARGE.

Tests are not presented, as there is no existing test infrastructure to make an
auto test with S3 storage.