### PR TITLE
ADBDEV-6573: Fix duplicated settings for LIKE INCLUDING STORAGE with partitioned table

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1177,7 +1177,7 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 	 * If STORAGE is included, we need to copy over the table storage params
 	 * as well as the attribute encodings.
 	 * 
-	 * We shouldn't copy them for child partitions since they are already
+	 * We shouldn't copy them for child partitions since they have already been
 	 * copied in make_child_node().
 	 */
 	if (stmt && table_like_clause->options & CREATE_TABLE_LIKE_STORAGE &&

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1176,8 +1176,12 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 	/*
 	 * If STORAGE is included, we need to copy over the table storage params
 	 * as well as the attribute encodings.
+	 * 
+	 * We shouldn't copy them for child partitions since they are already
+	 * copied in make_child_node().
 	 */
-	if (stmt && table_like_clause->options & CREATE_TABLE_LIKE_STORAGE)
+	if (stmt && table_like_clause->options & CREATE_TABLE_LIKE_STORAGE &&
+		!stmt->is_part_child)
 	{
 		/*
 		 * As we are modifying the utility statement we must make sure these

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -117,4 +117,33 @@ CREATE TABLE ctlt4_like (LIKE ctlt4 INCLUDING STORAGE)
 PARTITION BY RANGE(b) (
   DEFAULT PARTITION extra
 );
+\d+ ctlt4_like
+                          Append-Only Table "public.ctlt4_like"
+ Column |            Type             | Modifiers | Storage | Stats target | Description 
+--------+-----------------------------+-----------+---------+--------------+-------------
+ a      | numeric                     |           | main    |              | 
+ b      | timestamp without time zone |           | plain   |              | 
+Compression Type: zstd
+Compression Level: 1
+Block Size: 32768
+Checksum: t
+Child tables: ctlt4_like_1_prt_extra
+Distributed by: (a)
+Partition by: (b)
+Options: appendonly=true, checksum=true, compresslevel=1, compresstype=zstd
+
+\d+ ctlt4_like_1_prt_extra
+                    Append-Only Table "public.ctlt4_like_1_prt_extra"
+ Column |            Type             | Modifiers | Storage | Stats target | Description 
+--------+-----------------------------+-----------+---------+--------------+-------------
+ a      | numeric                     |           | main    |              | 
+ b      | timestamp without time zone |           | plain   |              | 
+Compression Type: zstd
+Compression Level: 1
+Block Size: 32768
+Checksum: t
+Inherits: ctlt4_like
+Distributed by: (a)
+Options: appendonly=true, checksum=true, compresslevel=1, compresstype=zstd
+
 DROP TABLE ctlt4, ctlt4_like;

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -109,3 +109,12 @@ WHERE c.table_name = 't_comments_b';
 
 DROP TABLE t_comments_a;
 DROP TABLE t_comments_b;
+-- Check including storage for partitioned table with storage attributes
+CREATE TABLE ctlt4 (a numeric, b timestamp)
+WITH (appendoptimized=true, orientation=row, compresstype=zstd);
+-- Should be created without errors
+CREATE TABLE ctlt4_like (LIKE ctlt4 INCLUDING STORAGE)
+PARTITION BY RANGE(b) (
+  DEFAULT PARTITION extra
+);
+DROP TABLE ctlt4, ctlt4_like;

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -80,3 +80,15 @@ WHERE c.table_name = 't_comments_b';
 
 DROP TABLE t_comments_a;
 DROP TABLE t_comments_b;
+
+-- Check including storage for partitioned table with storage attributes
+CREATE TABLE ctlt4 (a numeric, b timestamp)
+WITH (appendoptimized=true, orientation=row, compresstype=zstd);
+
+-- Should be created without errors
+CREATE TABLE ctlt4_like (LIKE ctlt4 INCLUDING STORAGE)
+PARTITION BY RANGE(b) (
+  DEFAULT PARTITION extra
+);
+
+DROP TABLE ctlt4, ctlt4_like;

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -91,4 +91,7 @@ PARTITION BY RANGE(b) (
   DEFAULT PARTITION extra
 );
 
+\d+ ctlt4_like
+\d+ ctlt4_like_1_prt_extra
+
 DROP TABLE ctlt4, ctlt4_like;


### PR DESCRIPTION
Fix duplicated settings for LIKE INCLUDING STORAGE with partitioned table

If a partitioned table was created with a LIKE INCLUDING STORAGE clause, the
storage settings for the child partition were applied twice: once from the
parent partition and second time from the LIKE. This caused an error when
trying to use INCLUDING STORAGE with partitioned tables. 

To fix it, this patch disables the INCLUDING STORAGE for the child partitions,
removing the duplicate settings.