### PR TITLE
ADBDEV-6588: Treat S3 errors as query errors

### DIFF
--- a/gpcontrib/gpcloud/src/gpcloud.cpp
+++ b/gpcontrib/gpcloud/src/gpcloud.cpp
@@ -222,13 +222,13 @@ static void destroyGpcloudResHandle(gpcloudResHandle *resHandle) {
 
     if (resHandle->gpreader != NULL) {
         if (!reader_cleanup(&resHandle->gpreader)) {
-            elog(WARNING, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
+            elog(ERROR, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 
     if (resHandle->gpwriter != NULL) {
         if (!writer_cleanup(&resHandle->gpwriter)) {
-            elog(WARNING, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
+            elog(ERROR, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 

--- a/gpcontrib/gpcloud/src/gpcloud.cpp
+++ b/gpcontrib/gpcloud/src/gpcloud.cpp
@@ -207,7 +207,7 @@ static gpcloudResHandle *createGpcloudResHandle(void) {
     return resHandle;
 }
 
-static void destroyGpcloudResHandle(gpcloudResHandle *resHandle) {
+static void destroyGpcloudResHandle(gpcloudResHandle *resHandle, int errorLevel) {
     if (resHandle == NULL) return;
 
     /* unlink from linked list first */
@@ -222,13 +222,13 @@ static void destroyGpcloudResHandle(gpcloudResHandle *resHandle) {
 
     if (resHandle->gpreader != NULL) {
         if (!reader_cleanup(&resHandle->gpreader)) {
-            elog(ERROR, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
+            elog(errorLevel, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 
     if (resHandle->gpwriter != NULL) {
         if (!writer_cleanup(&resHandle->gpwriter)) {
-            elog(ERROR, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
+            elog(errorLevel, "Failed to cleanup gpcloud extension: %s", s3extErrorMessage.c_str());
         }
     }
 
@@ -255,7 +255,7 @@ static void gpcloudAbortCallback(ResourceReleasePhase phase, bool isCommit, bool
             if (isCommit)
                 elog(WARNING, "gpcloud external table reference leak: %p still referenced", curr);
 
-            destroyGpcloudResHandle(curr);
+            destroyGpcloudResHandle(curr, WARNING);
         }
     }
 }
@@ -274,7 +274,7 @@ Datum s3_import(PG_FUNCTION_ARGS) {
 
     /* last call. destroy reader */
     if (EXTPROTOCOL_IS_LAST_CALL(fcinfo)) {
-        destroyGpcloudResHandle(resHandle);
+        destroyGpcloudResHandle(resHandle, ERROR);
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
         PG_RETURN_INT32(0);
@@ -331,7 +331,7 @@ Datum s3_export(PG_FUNCTION_ARGS) {
 
     /* last call. destroy writer */
     if (EXTPROTOCOL_IS_LAST_CALL(fcinfo)) {
-        destroyGpcloudResHandle(resHandle);
+        destroyGpcloudResHandle(resHandle, ERROR);
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
         PG_RETURN_INT32(0);


### PR DESCRIPTION
Treat S3 errors as query errors

It is possible for reader_cleanup and writer_cleanup to produce errors (via
S3Exception), resulting in incorrect query completion. Errors in these
functions should be treated as ERRORs, not WARNINGs.

However, we cannot throw ERRORs inside resource owner callbacks, so during an
actual abort we still use WARNINGs. This shouldn't be an issue because such an
abort should only occur in erroneous conditions anyway.

Tests are not presented, as there is no existing test infrastructure to make an
auto test with S3 storage.

---

To test manually, revert [this patch](https://github.com/arenadata/gpdb/pull/1092) and perform the scenario described in the corresponding [ticket](https://tracker.yandex.ru/ADBDEV-6543). With the new patch the scenario should produce 1 ERROR instead of 3 WARNINGs.