### PR TITLE
Ensure proper order of statements in fts_segment_reset test

### DIFF
--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -283,6 +283,8 @@ checkIfFailedDueToNormalRestart(fts_segment_info *ftsInfo)
 				   ftsInfo->primary_cdbinfo->config->segindex,
 				   ftsInfo->primary_cdbinfo->config->dbid,
 				   ftsInfo->mirror_cdbinfo->config->dbid);
+
+		SIMPLE_FAULT_INJECTOR("fts_segment_in_reset_mode");
 	}
 }
 

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -38,6 +38,15 @@ select gp_inject_fault_infinite('postmaster_delay_termination_bg_writer', 'skip'
 (1 row)
 1&:create table fts_reset_t(a int);  <waiting ...>
 
+-- Make sure that fault is processed and the following query started after seg0 has actually gone
+-- Of course, sleeping is not the best solution, but wait_until_triggered_fault won't work here
+-- because seg0 process with faults hash table has gone.
+select pg_sleep(0.5);
+ pg_sleep 
+----------
+          
+(1 row)
+
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);  <waiting ...>
 

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -29,6 +29,13 @@ select gp_inject_fault_infinite('postmaster_delay_termination_bg_writer', 'skip'
  Success:                 
 (1 row)
 
+-- prepare wait on QD for segment is in reset mode
+select gp_inject_fault('fts_segment_in_reset_mode', 'suspend', dbid) from gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
 -- Now bring down primary of seg0. There're a lot of ways to do that, in order
 -- to better emulate a real-world scnarios we're injecting a PANIC to do that.
 1:select gp_inject_fault('start_prepare', 'panic', dbid) from gp_segment_configuration where role = 'p' AND content = 0;
@@ -38,13 +45,17 @@ select gp_inject_fault_infinite('postmaster_delay_termination_bg_writer', 'skip'
 (1 row)
 1&:create table fts_reset_t(a int);  <waiting ...>
 
--- Make sure that fault is processed and the following query started after seg0 has actually gone
--- Of course, sleeping is not the best solution, but wait_until_triggered_fault won't work here
--- because seg0 process with faults hash table has gone.
-select pg_sleep(0.5);
- pg_sleep 
-----------
-          
+-- Now wait for segment in reset mode
+select gp_wait_until_triggered_fault('fts_segment_in_reset_mode', 1, dbid) from gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+select gp_inject_fault('fts_segment_in_reset_mode', 'reset', dbid) from gp_segment_configuration WHERE content = -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
 (1 row)
 
 -- This should fail due to the seg0 in reset mode
@@ -84,7 +95,7 @@ select gp_inject_fault('postmaster_delay_termination_bg_writer', 'reset', dbid) 
 (1 row)
 
 -- The only table that should have been created successfully
-drop table fts_reset_t3;
+3:drop table fts_reset_t3;
 DROP TABLE
 
 -- In case anything goes wrong, we don't want to affect other tests. So rebalance the cluster anyway.

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -23,16 +23,22 @@
 select gp_inject_fault_infinite('postmaster_delay_termination_bg_writer', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
 
+-- prepare wait on QD for segment is in reset mode
+select gp_inject_fault('fts_segment_in_reset_mode', 'suspend', dbid) 
+from gp_segment_configuration WHERE content = -1 AND role = 'p';
+
 -- Now bring down primary of seg0. There're a lot of ways to do that, in order
 -- to better emulate a real-world scnarios we're injecting a PANIC to do that.
 1:select gp_inject_fault('start_prepare', 'panic', dbid) 
 from gp_segment_configuration where role = 'p' AND content = 0;
 1&:create table fts_reset_t(a int);
 
--- Make sure that fault is processed and the following query started after seg0 has actually gone
--- Of course, sleeping is not the best solution, but wait_until_triggered_fault won't work here 
--- because seg0 process with faults hash table has gone.
-select pg_sleep(0.5);
+-- Now wait for segment in reset mode
+select gp_wait_until_triggered_fault('fts_segment_in_reset_mode', 1, dbid) 
+from gp_segment_configuration WHERE content = -1 AND role = 'p';
+
+select gp_inject_fault('fts_segment_in_reset_mode', 'reset', dbid)
+from gp_segment_configuration WHERE content = -1 AND role = 'p';
 
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);
@@ -53,7 +59,7 @@ select dbid, role, preferred_role, status from gp_segment_configuration where co
 select gp_inject_fault('postmaster_delay_termination_bg_writer', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 
 -- The only table that should have been created successfully
-drop table fts_reset_t3;
+3:drop table fts_reset_t3;
 
 -- In case anything goes wrong, we don't want to affect other tests. So rebalance the cluster anyway.
 !\retcode gprecoverseg -aF

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -29,6 +29,11 @@ from gp_segment_configuration where role = 'p' and content = 0;
 from gp_segment_configuration where role = 'p' AND content = 0;
 1&:create table fts_reset_t(a int);
 
+-- Make sure that fault is processed and the following query started after seg0 has actually gone
+-- Of course, sleeping is not the best solution, but wait_until_triggered_fault won't work here 
+-- because seg0 process with faults hash table has gone.
+select pg_sleep(0.5);
+
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);
 


### PR DESCRIPTION
Ensure proper order of statements in the test fts_segment_reset.

The aforementioned isolation test contains statements that are started in
parallel at the same time. Under some circumstances, e.g., when using a Docker
container based on Ubuntu 22.04, these statements are executed in an unexpected
order, causing the test to fail.

This commit adds a fault injector to enforce the order of statements by
introducing a dependency between getting segment master into reset and 
the start of next command.