### PR TITLE
ADBDEV-6534: Fix IPv6 checking in cdbsenddummypacket unit test

### DIFF
--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -313,8 +313,8 @@ static bool is_ipv6_supported(void) {
 	if (sockfd < 0 && errno == EAFNOSUPPORT)
 		return false;
 
-	struct sockaddr_in6 socket_struct = {.sin6_family = AF_INET6, .sin6_addr = in6addr_loopback};
-	int res = bind(sockfd, (struct sockaddr*) &socket_struct, sizeof(socket_struct));
+	const struct sockaddr_in6 socket_struct = {.sin6_family = AF_INET6, .sin6_addr = in6addr_loopback};
+	int res = bind(sockfd, (const struct sockaddr *) &socket_struct, sizeof(socket_struct));
 	if (res < 0 && errno == EADDRNOTAVAIL)
 		return false;
 

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -296,21 +296,46 @@ test_send_dummy_packet_ipv6_to_ipv6_wildcard(void **state)
 	wait_for_receiver(false);
 }
 
+
+/*
+ * Test if IPv6 is supported.
+ *
+ * Sometimes even if IPv6 socket is successfully created it is not possible
+ * to bind an address to it (if IPv6 is disabled).
+ * 
+ * Note: this is not a general solution and should only be used for this
+ * specific test. It is theoretically possible that loopback IPv6 address
+ * is available but real IPv6 addresses aren't. However, checking for that
+ * would be a lot more complicated
+ */
+static bool is_ipv6_supported(void) {
+	int sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
+	if (sockfd < 0 && errno == EAFNOSUPPORT)
+		return false;
+
+	struct sockaddr_in6 socket_struct;
+	socket_struct.sin6_family = AF_INET6;
+	socket_struct.sin6_addr = in6addr_loopback;
+	socket_struct.sin6_port = 0;
+	socket_struct.sin6_scope_id = 0;
+	int res = bind(sockfd, (struct sockaddr*) &socket_struct, sizeof(socket_struct));
+	if (res < 0 && errno == EADDRNOTAVAIL)
+		return false;
+
+	closesocket(sockfd);
+	return true;
+}
+
 int
 main(int argc, char* argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 
-	int is_ipv6_supported = true;
-	int sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
-	if (sockfd < 0 && errno == EAFNOSUPPORT)
-		is_ipv6_supported = false;
-
 	log_min_messages = DEBUG1;
 
 	start_receiver();
 
-	if (is_ipv6_supported)
+	if (is_ipv6_supported())
 	{
 		const UnitTest tests[] = {
 			unit_test(test_send_dummy_packet_ipv4_to_ipv4),

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -313,11 +313,7 @@ static bool is_ipv6_supported(void) {
 	if (sockfd < 0 && errno == EAFNOSUPPORT)
 		return false;
 
-	struct sockaddr_in6 socket_struct;
-	socket_struct.sin6_family = AF_INET6;
-	socket_struct.sin6_addr = in6addr_loopback;
-	socket_struct.sin6_port = 0;
-	socket_struct.sin6_scope_id = 0;
+	struct sockaddr_in6 socket_struct = {.sin6_family = AF_INET6, .sin6_addr = in6addr_loopback};
 	int res = bind(sockfd, (struct sockaddr*) &socket_struct, sizeof(socket_struct));
 	if (res < 0 && errno == EADDRNOTAVAIL)
 		return false;


### PR DESCRIPTION
Fix IPv6 checking in cdbsenddummypacket unit test

cdbsenddummypacket unit test checks for IPv6 availability to skip IPv6-related
tests. However, the checking was not sufficient since if IPv6 is present in
the system but disabled. In that case `socket()` succeeds, causing the test to
believe IPv6 is available, but later `bind()` fails with `errno =
EADDRNOTAVAIL` during test_send_dummy_packet_ipv6_to_ipv6 test.

This patch fixes the test_send_dummy_packet_ipv6_to_ipv6 test failing by
implementing a more detailed check for IPv6 availability. This is only
necessary for manual runs of this test since CI pipeline already has IPv6
enabled.

Note: commit b9cb5227ab9b43af28cdd0dbe1cc8f28e0e535ae is related, but the
complicated IPv6 check there is only necessary because it was used for regular
GPDB operation, requiring it to check non-loopback addresses too. This is not
necessary here because the tests only need loopback IPv6 address to pass, not
full IPv6 support.

---

To test manually, disable IPv6 on the host machine or run this inside a Docker container with IPv6 disabled. For example, on Ubuntu:
```
sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
```