### PR TITLE
ADBDEV-6635: Align LIKE INCLUDE STORAGE docs with existing implementation

### DIFF
--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -443,7 +443,10 @@ Where column_reference_storage_directive is:
       default behavior is to exclude <literal>STORAGE</> settings, resulting
       in the copied columns in the new table having type-specific default
       settings.  For more on <literal>STORAGE</> settings, see
-      <xref linkend="storage-toast">.
+      <xref linkend="storage-toast">. <literal>ENCODING</> settings and
+      table-wide append-optimized options (such as such as
+      <literal>appendonly</>, <literal>orientation</>, <literal>checksum</>,
+      <literal>compresslevel</>, <literal>compresstype</>.)
      </para>
      <para>
       Comments for the copied columns, constraints, and indexes

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -443,10 +443,10 @@ Where column_reference_storage_directive is:
       default behavior is to exclude <literal>STORAGE</> settings, resulting
       in the copied columns in the new table having type-specific default
       settings.  For more on <literal>STORAGE</> settings, see
-      <xref linkend="storage-toast">. <literal>ENCODING</> settings and
-      table-wide append-optimized options (such as
-      <literal>appendonly</>, <literal>orientation</>, <literal>checksum</>,
-      <literal>compresslevel</>, <literal>compresstype</>.)
+      <xref linkend="storage-toast">. Copied options also include
+      <literal>ENCODING</> settings and table-wide append-optimized options
+      (such as <literal>appendonly</>, <literal>orientation</>,
+      <literal>checksum</>, <literal>compresslevel</>, <literal>compresstype</>.)
      </para>
      <para>
       Comments for the copied columns, constraints, and indexes

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -444,7 +444,7 @@ Where column_reference_storage_directive is:
       in the copied columns in the new table having type-specific default
       settings.  For more on <literal>STORAGE</> settings, see
       <xref linkend="storage-toast">. <literal>ENCODING</> settings and
-      table-wide append-optimized options (such as such as
+      table-wide append-optimized options (such as
       <literal>appendonly</>, <literal>orientation</>, <literal>checksum</>,
       <literal>compresslevel</>, <literal>compresstype</>.)
      </para>

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -343,8 +343,8 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
             distribution policy. Unlike <codeph>INHERITS</codeph>, the new table and original table
             are completely decoupled after creation is complete.</pd>
           <pd>
-            <note>Storage properties like append-optimized or partition structure are not
-              copied.</note>
+            <note>Partition structure is not copied. Storage properties like append-optimized are
+            only copied if <codeph>INCLUDING STORAGE</codeph> is specified.</note>
           </pd>
           <pd>Default expressions for the copied column definitions will only be copied if
               <codeph>INCLUDING DEFAULTS</codeph> is specified. The default behavior is to exclude
@@ -363,7 +363,14 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
           <pd><codeph>STORAGE</codeph> settings for the copied column definitions will be copied
             only if <codeph>INCLUDING STORAGE</codeph> is specified. The default behavior is to
             exclude <codeph>STORAGE</codeph> settings, resulting in the copied columns in the new
-            table having type-specific default settings. </pd>
+            table having type-specific default settings. Copied <codeph>STORAGE</codeph> settings
+            include: <ul>
+              <li>Table-wide append-optimized options such as <codeph>appendonly</codeph>,
+                <codeph>orientation</codeph>, <codeph>checksum</codeph>,
+                <codeph>compresslevel</codeph>, <codeph>compresstype</codeph>.</li>
+              <li>Column-specific <codeph>ENCODING</codeph> options.</li>
+              <li>Column-specific TOAST mode.</li>
+            </ul></pd>
           <pd> Comments for the copied columns, constraints, and indexes will be copied only if
               <codeph>INCLUDING COMMENTS</codeph> is specified. The default behavior is to exclude
             comments, resulting in the copied columns and constraints in the new table having no

--- a/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
+++ b/gpdb-doc/dita/ref_guide/sql_commands/CREATE_TABLE.xml
@@ -344,7 +344,8 @@ CREATE [ [GLOBAL | LOCAL] {TEMPORARY | TEMP} | UNLOGGED ] TABLE [IF NOT EXISTS]
             are completely decoupled after creation is complete.</pd>
           <pd>
             <note>Partition structure is not copied. Storage properties like append-optimized are
-            only copied if <codeph>INCLUDING STORAGE</codeph> is specified.</note>
+            only copied if <codeph>INCLUDING STORAGE</codeph> is specified. However, child
+            partitions inherit all the storage properties of the root partition.</note>
           </pd>
           <pd>Default expressions for the copied column definitions will only be copied if
               <codeph>INCLUDING DEFAULTS</codeph> is specified. The default behavior is to exclude

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
@@ -290,7 +290,7 @@ INHERITS \( parent\_table \[, …\]\)
 LIKE source\_table like\_option `...`\]
 :   The `LIKE` clause specifies a table from which the new table automatically copies all column names, their data types, not-null constraints, and distribution policy. Unlike `INHERITS`, the new table and original table are completely decoupled after creation is complete.
 
-:   > **Note** Partition structure is not copied. Storage properties like append-optimized are only copied if `INCLUDING STORAGE` is specified.
+:   > **Note** Partition structure is not copied. Storage properties like append-optimized are only copied if `INCLUDING STORAGE` is specified. However, child partitions inherit all the storage properties of the root partition.
 
 :   Default expressions for the copied column definitions will only be copied if `INCLUDING DEFAULTS` is specified. The default behavior is to exclude default expressions, resulting in the copied columns in the new table having null defaults.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
@@ -290,7 +290,7 @@ INHERITS \( parent\_table \[, …\]\)
 LIKE source\_table like\_option `...`\]
 :   The `LIKE` clause specifies a table from which the new table automatically copies all column names, their data types, not-null constraints, and distribution policy. Unlike `INHERITS`, the new table and original table are completely decoupled after creation is complete.
 
-:   > **Note** Storage properties like append-optimized or partition structure are not copied.
+:   > **Note** Partition structure is not copied. Storage properties like append-optimized are only copied if `INCLUDING STORAGE` is specified.
 
 :   Default expressions for the copied column definitions will only be copied if `INCLUDING DEFAULTS` is specified. The default behavior is to exclude default expressions, resulting in the copied columns in the new table having null defaults.
 
@@ -300,7 +300,11 @@ LIKE source\_table like\_option `...`\]
 
 :   Any indexes on the original table will not be created on the new table, unless the `INCLUDING INDEXES` clause is specified.
 
-:   `STORAGE` settings for the copied column definitions will be copied only if `INCLUDING STORAGE` is specified. The default behavior is to exclude `STORAGE` settings, resulting in the copied columns in the new table having type-specific default settings.
+:   `STORAGE` settings for the copied column definitions will be copied only if `INCLUDING STORAGE` is specified. The default behavior is to exclude `STORAGE` settings, resulting in the copied columns in the new table having type-specific default settings. Copied `STORAGE` settings include:
+
+    -   Table-wide append-optimized options such as `appendonly`, `orientation`, `checksum`, `compresslevel`, `compresstype`.
+    -   Column-specific `ENCODING` options.
+    -   Column-specific TOAST mode.
 
 :   Comments for the copied columns, constraints, and indexes will be copied only if `INCLUDING COMMENTS` is specified. The default behavior is to exclude comments, resulting in the copied columns and constraints in the new table having no comments.
 


### PR DESCRIPTION
Align LIKE INCLUDE STORAGE docs with existing implementation

Current documentation related to LIKE INCLUDE STORAGE is confusing and
incomplete. This patch adds details on which exact settings are copied if
INCLUDE STORAGE is specified.