### PR TITLE
Add gp_orca extension skeleton

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -36,6 +36,9 @@ endif
 ifeq "$(with_zstd)" "yes"
 	recurse_targets += zstd
 endif
+ifeq "$(enable_orca)" "yes"
+	recurse_targets += gp_orca
+endif
 $(call recurse,all install clean distclean, $(recurse_targets))
 
 all: gpcloud orafce

--- a/gpcontrib/gp_orca/Makefile
+++ b/gpcontrib/gp_orca/Makefile
@@ -1,0 +1,20 @@
+EXTENSION = gp_orca
+MODULE_big = gp_orca
+
+OBJS = gporca.o \
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_orca
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+install: install-gp-orca
+
+install-gp-orca: $(DESTDIR)$(datadir)/postgresql.conf.sample
+	sed -i "s/#shared_preload_libraries = ''	# (change requires restart)/shared_preload_libraries = 'gp_orca'/g" $(DESTDIR)$(datadir)/postgresql.conf.sample

--- a/gpcontrib/gp_orca/Makefile
+++ b/gpcontrib/gp_orca/Makefile
@@ -16,4 +16,4 @@ endif
 install: install-gp-orca
 
 install-gp-orca: $(DESTDIR)$(datadir)/postgresql.conf.sample
-	sed -i "s/#shared_preload_libraries = ''	# (change requires restart)/shared_preload_libraries = 'gp_orca'/g" $(DESTDIR)$(datadir)/postgresql.conf.sample
+	sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'gp_orca'/g" $(DESTDIR)$(datadir)/postgresql.conf.sample

--- a/gpcontrib/gp_orca/Makefile
+++ b/gpcontrib/gp_orca/Makefile
@@ -1,4 +1,3 @@
-EXTENSION = gp_orca
 MODULE_big = gp_orca
 
 OBJS = gporca.o \

--- a/gpcontrib/gp_orca/gp_orca.control
+++ b/gpcontrib/gp_orca/gp_orca.control
@@ -1,6 +1,0 @@
-# gp_orca extension
-
-comment = 'ORCA planner'
-default_version = '1.0'
-module_pathname = '$libdir/gp_orca'
-relocatable = false

--- a/gpcontrib/gp_orca/gp_orca.control
+++ b/gpcontrib/gp_orca/gp_orca.control
@@ -1,0 +1,6 @@
+# gp_orca extension
+
+comment = 'ORCA planner'
+default_version = '1.0'
+module_pathname = '$libdir/gp_orca'
+relocatable = false

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -1,5 +1,7 @@
 #include "postgres.h"
 
+#include "cdb/cdbvars.h"
+#include "miscadmin.h"
 #include "utils/builtins.h"
 
 PG_MODULE_MAGIC;
@@ -10,6 +12,13 @@ void		_PG_fini(void);
 void
 _PG_init(void)
 {
+	if (!process_shared_preload_libraries_in_progress)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("This module can only be loaded via shared_preload_libraries")));
+
+	if (!IS_QUERY_DISPATCHER())
+		return;
 }
 
 void

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -1,0 +1,19 @@
+#include "postgres.h"
+
+#include "utils/builtins.h"
+
+PG_MODULE_MAGIC;
+
+void		_PG_init(void);
+void		_PG_fini(void);
+
+void
+_PG_init(void)
+{
+}
+
+void
+_PG_fini(void)
+{
+}
+


### PR DESCRIPTION
Add gp_orca extension skeleton

This patch adds a skeleton for a new extension gpcontrib/gp_orca with empty 
_PG_init and _PG_fini. The extension will be filled in consequent commits.
Plus this patch updates 'shared_preload_libraries' value in the
postgresql.conf.sample file if ORCA is enabled.