### PR TITLE
Align compilation flags for gpopt with gporca

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -13,8 +13,9 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/config/CConfigParamMapping.h"
+
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/xforms/CXform.h"
 
 using namespace gpos;

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -13,12 +13,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "utils/guc.h"
-}
-
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/config/CConfigParamMapping.h"
 #include "gpopt/xforms/CXform.h"
 

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2513,6 +2513,8 @@ gpdb::GPDBMemoryContextDelete(MemoryContext context)
 	GP_WRAP_END;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 MemoryContext
 gpdb::GPDBAllocSetContextCreate()
 {
@@ -2534,6 +2536,7 @@ gpdb::GPDBAllocSetContextCreate()
 	GP_WRAP_END;
 	return nullptr;
 }
+#pragma GCC diagnostic pop
 
 bool
 gpdb::ExpressionReturnsSet(Node *clause)

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -24,6 +24,7 @@
 
 #include <limits>  // std::numeric_limits
 
+#include "gpos/attributes.h"
 #include "gpos/base.h"
 #include "gpos/error/CAutoExceptionStack.h"
 #include "gpos/error/CException.h"
@@ -2301,17 +2302,16 @@ static int64 mdcache_invalidation_counter = 0;
 static int64 last_mdcache_invalidation_counter = 0;
 
 static void
-mdsyscache_invalidation_counter_callback(Datum arg __attribute__((unused)),
-										 int cacheid __attribute__((unused)),
-										 uint32 hashvalue
-										 __attribute__((unused)))
+mdsyscache_invalidation_counter_callback(Datum arg GPOS_UNUSED,
+										 int cacheid GPOS_UNUSED,
+										 uint32 hashvalue GPOS_UNUSED)
 {
 	mdcache_invalidation_counter++;
 }
 
 static void
-mdrelcache_invalidation_counter_callback(Datum arg __attribute__((unused)),
-										 Oid relid __attribute__((unused)))
+mdrelcache_invalidation_counter_callback(Datum arg GPOS_UNUSED,
+										 Oid relid GPOS_UNUSED)
 {
 	mdcache_invalidation_counter++;
 }

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2301,16 +2301,17 @@ static int64 mdcache_invalidation_counter = 0;
 static int64 last_mdcache_invalidation_counter = 0;
 
 static void
-mdsyscache_invalidation_counter_callback(Datum arg __attribute__ ((unused)),
-										 int cacheid __attribute__ ((unused)),
-										 uint32 hashvalue __attribute__ ((unused)))
+mdsyscache_invalidation_counter_callback(Datum arg __attribute__((unused)),
+										 int cacheid __attribute__((unused)),
+										 uint32 hashvalue
+										 __attribute__((unused)))
 {
 	mdcache_invalidation_counter++;
 }
 
 static void
-mdrelcache_invalidation_counter_callback(Datum arg __attribute__ ((unused)),
-										 Oid relid __attribute__ ((unused)))
+mdrelcache_invalidation_counter_callback(Datum arg __attribute__((unused)),
+										 Oid relid __attribute__((unused)))
 {
 	mdcache_invalidation_counter++;
 }

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -28,28 +28,22 @@
 #include "gpos/error/CAutoExceptionStack.h"
 #include "gpos/error/CException.h"
 
-#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/exception.h"
 
-#include "catalog/pg_collation.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 extern "C" {
-#include "access/amapi.h"
-#include "access/external.h"
-#include "access/genam.h"
+#include "catalog/pg_collation.h"
 #include "catalog/pg_inherits.h"
 #include "foreign/fdwapi.h"
-#include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
-#include "optimizer/plancat.h"
 #include "optimizer/subselect.h"
 #include "parser/parse_agg.h"
-#include "partitioning/partdesc.h"
 #include "storage/lmgr.h"
-#include "utils/fmgroids.h"
-#include "utils/memutils.h"
-#include "utils/partcache.h"
 }
+#pragma GCC diagnostic pop
+
 #define GP_WRAP_START                                            \
 	sigjmp_buf local_sigjmp_buf;                                 \
 	{                                                            \
@@ -2307,14 +2301,16 @@ static int64 mdcache_invalidation_counter = 0;
 static int64 last_mdcache_invalidation_counter = 0;
 
 static void
-mdsyscache_invalidation_counter_callback(Datum arg, int cacheid,
-										 uint32 hashvalue)
+mdsyscache_invalidation_counter_callback(Datum arg __attribute__ ((unused)),
+										 int cacheid __attribute__ ((unused)),
+										 uint32 hashvalue __attribute__ ((unused)))
 {
 	mdcache_invalidation_counter++;
 }
 
 static void
-mdrelcache_invalidation_counter_callback(Datum arg, Oid relid)
+mdrelcache_invalidation_counter_callback(Datum arg __attribute__ ((unused)),
+										 Oid relid __attribute__ ((unused)))
 {
 	mdcache_invalidation_counter++;
 }

--- a/src/backend/gpopt/gpopt.mk
+++ b/src/backend/gpopt/gpopt.mk
@@ -3,6 +3,8 @@ override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpopt/include $(CPPFL
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
 override CPPFLAGS := -I$(top_srcdir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
 
+override CXXFLAGS := -Werror -Wextra -Wpedantic -fno-omit-frame-pointer $(CXXFLAGS)
+
 # orca is not accessed in JIT (executor stage), avoid the generation of .bc here
 # NOTE: accordingly we MUST avoid them in install step (install-postgres-bitcode
 # in src/backend/Makefile)

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -13,10 +13,11 @@
 //
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
-#include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/relcache/CMDProviderRelcache.h"
+
+#include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/exception.h"
 
@@ -25,9 +26,10 @@ using namespace gpdxl;
 using namespace gpmd;
 
 CWStringBase *
-CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp __attribute__ ((unused)),
-									CMDAccessor *md_accessor __attribute__ ((unused)),
-									IMDId *md_id __attribute__ ((unused))) const
+CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp __attribute__((unused)),
+									CMDAccessor *md_accessor
+									__attribute__((unused)),
+									IMDId *md_id __attribute__((unused))) const
 {
 	// not used
 	return nullptr;

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -26,10 +26,9 @@ using namespace gpdxl;
 using namespace gpmd;
 
 CWStringBase *
-CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp __attribute__((unused)),
-									CMDAccessor *md_accessor
-									__attribute__((unused)),
-									IMDId *md_id __attribute__((unused))) const
+CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp GPOS_UNUSED,
+									CMDAccessor *md_accessor GPOS_UNUSED,
+									IMDId *md_id GPOS_UNUSED) const
 {
 	// not used
 	return nullptr;

--- a/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
+++ b/src/backend/gpopt/relcache/CMDProviderRelcache.cpp
@@ -13,10 +13,7 @@
 //
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include "postgres.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/relcache/CMDProviderRelcache.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
@@ -28,8 +25,9 @@ using namespace gpdxl;
 using namespace gpmd;
 
 CWStringBase *
-CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp, CMDAccessor *md_accessor,
-									IMDId *md_id) const
+CMDProviderRelcache::GetMDObjDXLStr(CMemoryPool *mp __attribute__ ((unused)),
+									CMDAccessor *md_accessor __attribute__ ((unused)),
+									IMDId *md_id __attribute__ ((unused))) const
 {
 	// not used
 	return nullptr;

--- a/src/backend/gpopt/translate/CCTEListEntry.cpp
+++ b/src/backend/gpopt/translate/CCTEListEntry.cpp
@@ -13,11 +13,12 @@
 //
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CCTEListEntry.h"
+
 #include "gpos/base.h"
 
 #include "gpopt/gpdbwrappers.h"
-#include "gpopt/translate/CCTEListEntry.h"
+#include "gpopt/utils/gpdbdefs.h"
 using namespace gpdxl;
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CCTEListEntry.cpp
+++ b/src/backend/gpopt/translate/CCTEListEntry.cpp
@@ -13,12 +13,7 @@
 //
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/parsenodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpos/base.h"
 
 #include "gpopt/gpdbwrappers.h"

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -15,14 +15,7 @@
 //
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "utils/rel.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -15,12 +15,12 @@
 //
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CContextDXLToPlStmt.h"
 
 #include "gpos/base.h"
 
 #include "gpopt/gpdbwrappers.h"
-#include "gpopt/translate/CContextDXLToPlStmt.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/exception.h"
 
 using namespace gpdxl;

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -12,9 +12,7 @@
 //		and the caller is responsible for freeing it
 //
 //---------------------------------------------------------------------------
-extern "C" {
-#include "postgres.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/translate/CContextQueryToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -12,10 +12,10 @@
 //		and the caller is responsible for freeing it
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
-
 #include "gpopt/translate/CContextQueryToDXL.h"
+
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CIdGenerator.h"
 
 using namespace gpdxl;

--- a/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
+++ b/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
@@ -13,8 +13,9 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/translate/CDXLTranslateContextBaseTable.h"
+
+#include "gpopt/utils/gpdbdefs.h"
 
 using namespace gpdxl;
 using namespace gpos;

--- a/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
+++ b/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
@@ -15,8 +15,6 @@
 
 #include "gpopt/translate/CDXLTranslateContextBaseTable.h"
 
-#include "gpopt/utils/gpdbdefs.h"
-
 using namespace gpdxl;
 using namespace gpos;
 

--- a/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
+++ b/src/backend/gpopt/translate/CDXLTranslateContextBaseTable.cpp
@@ -13,9 +13,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpopt/translate/CDXLTranslateContextBaseTable.h"
 
 using namespace gpdxl;

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -14,11 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/primnodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoP.h"

--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -14,14 +14,14 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CMappingColIdVarPlStmt.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoP.h"
 
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/translate/CDXLTranslateContextBaseTable.h"
-#include "gpopt/translate/CMappingColIdVarPlStmt.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/operators/CDXLScalarIdent.h"
 #include "naucrates/exception.h"
 #include "naucrates/md/CMDIdGPDB.h"

--- a/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
@@ -14,9 +14,9 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
-
 #include "gpopt/translate/CMappingElementColIdParamId.h"
+
+#include "gpopt/utils/gpdbdefs.h"
 
 using namespace gpdxl;
 using namespace gpos;

--- a/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
+++ b/src/backend/gpopt/translate/CMappingElementColIdParamId.cpp
@@ -14,12 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/makefuncs.h"
-#include "nodes/primnodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/translate/CMappingElementColIdParamId.h"
 

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -12,12 +12,8 @@
 //
 //
 //---------------------------------------------------------------------------
-extern "C" {
-#include "postgres.h"
+#include "gpopt/utils/gpdbdefs.h"
 
-#include "nodes/primnodes.h"
-#include "nodes/value.h"
-}
 #include "gpos/error/CAutoTrace.h"
 
 #include "gpopt/gpdbwrappers.h"

--- a/src/backend/gpopt/translate/CMappingVarColId.cpp
+++ b/src/backend/gpopt/translate/CMappingVarColId.cpp
@@ -12,13 +12,13 @@
 //
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CMappingVarColId.h"
 
 #include "gpos/error/CAutoTrace.h"
 
 #include "gpopt/gpdbwrappers.h"
-#include "gpopt/translate/CMappingVarColId.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/CDXLScalarIdent.h"
 #include "naucrates/dxl/operators/CDXLScalarProjElem.h"

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -10,14 +10,7 @@
 // 		PartPruningSteps from partitioning filter expressions
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/parsenodes.h"
-#include "partitioning/partdesc.h"
-#include "utils/partcache.h"
-#include "utils/rel.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/translate/CPartPruneStepsBuilder.h"

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -10,10 +10,10 @@
 // 		PartPruningSteps from partitioning filter expressions
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CPartPruneStepsBuilder.h"
 
 #include "gpopt/gpdbwrappers.h"
-#include "gpopt/translate/CPartPruneStepsBuilder.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/operators/CDXLScalarBoolExpr.h"
 #include "naucrates/dxl/operators/CDXLScalarCast.h"
 #include "naucrates/dxl/operators/CDXLScalarComp.h"

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -13,14 +13,9 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/makefuncs.h"
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "optimizer/walkers.h"
-}
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/base/CUtils.h"
 #include "gpopt/gpdbwrappers.h"
@@ -1160,7 +1155,7 @@ CQueryMutators::MakeTopLevelTargetEntry(TargetEntry *old_target_entry,
 //		Return the column name of the target list entry
 //---------------------------------------------------------------------------
 CHAR *
-CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry, Query *query)
+CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry, Query *query __attribute__ ((unused)))
 {
 	if (nullptr != target_entry->resname)
 	{
@@ -1696,5 +1691,7 @@ CQueryMutators::ReassignSortClause(Query *top_level_query,
 	derived_table_query->limitOffset = nullptr;
 	derived_table_query->limitCount = nullptr;
 }
+
+#pragma GCC diagnostic pop
 
 // EOF

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -1156,7 +1156,7 @@ CQueryMutators::MakeTopLevelTargetEntry(TargetEntry *old_target_entry,
 //---------------------------------------------------------------------------
 CHAR *
 CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry,
-									  Query *query __attribute__((unused)))
+									  Query *query GPOS_UNUSED)
 {
 	if (nullptr != target_entry->resname)
 	{

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -13,7 +13,6 @@
 //
 //---------------------------------------------------------------------------
 
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #include "gpopt/translate/CQueryMutators.h"
 
@@ -1689,7 +1688,5 @@ CQueryMutators::ReassignSortClause(Query *top_level_query,
 	derived_table_query->limitOffset = nullptr;
 	derived_table_query->limitCount = nullptr;
 }
-
-#pragma GCC diagnostic pop
 
 // EOF

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -524,8 +524,7 @@ CQueryMutators::FixGroupingCols(Node *node, TargetEntry *orginal_target_entry,
 	// fix any outer references in the grouping column expression
 	Node *expr = (Node *) RunGroupingColMutator(node, context);
 
-	CHAR *name = CQueryMutators::GetTargetEntryColName(orginal_target_entry,
-													   context->m_query);
+	CHAR *name = CQueryMutators::GetTargetEntryColName(orginal_target_entry);
 	TargetEntry *new_target_entry = gpdb::MakeTargetEntry(
 		(Expr *) expr, (AttrNumber) arity, name, false /*resjunk */);
 
@@ -1020,8 +1019,7 @@ CQueryMutators::NormalizeHaving(CMemoryPool *mp, CMDAccessor *md_accessor,
 				gpdb::LAppend(new_query->targetList, new_target_entry);
 			// Ensure that such target entries is not suppressed in the target list of the RTE
 			// and has a name
-			target_entry->resname =
-				GetTargetEntryColName(target_entry, derived_table_query);
+			target_entry->resname = GetTargetEntryColName(target_entry);
 			target_entry->resjunk = false;
 			new_target_entry->ressortgroupref = target_entry->ressortgroupref;
 
@@ -1155,8 +1153,7 @@ CQueryMutators::MakeTopLevelTargetEntry(TargetEntry *old_target_entry,
 //		Return the column name of the target list entry
 //---------------------------------------------------------------------------
 CHAR *
-CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry,
-									  Query *query GPOS_UNUSED)
+CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry)
 {
 	if (nullptr != target_entry->resname)
 	{

--- a/src/backend/gpopt/translate/CQueryMutators.cpp
+++ b/src/backend/gpopt/translate/CQueryMutators.cpp
@@ -15,14 +15,14 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CQueryMutators.h"
 
 #include "gpopt/base/CUtils.h"
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/mdcache/CMDAccessorUtils.h"
-#include "gpopt/translate/CQueryMutators.h"
 #include "gpopt/translate/CTranslatorDXLToPlStmt.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/exception.h"
 #include "naucrates/md/IMDAggregate.h"
 #include "naucrates/md/IMDScalarOp.h"
@@ -1155,7 +1155,8 @@ CQueryMutators::MakeTopLevelTargetEntry(TargetEntry *old_target_entry,
 //		Return the column name of the target list entry
 //---------------------------------------------------------------------------
 CHAR *
-CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry, Query *query __attribute__ ((unused)))
+CQueryMutators::GetTargetEntryColName(TargetEntry *target_entry,
+									  Query *query __attribute__((unused)))
 {
 	if (nullptr != target_entry->resname)
 	{

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -14,27 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "catalog/gp_distribution_policy.h"
-#include "catalog/pg_collation.h"
-#include "cdb/cdbutil.h"
-#include "cdb/cdbvars.h"
-#include "executor/execPartition.h"
-#include "executor/executor.h"
-#include "nodes/nodes.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "partitioning/partdesc.h"
-#include "storage/lmgr.h"
-#include "utils/guc.h"
-#include "utils/lsyscache.h"
-#include "utils/partcache.h"
-#include "utils/rel.h"
-#include "utils/typcache.h"
-#include "utils/uri.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include <algorithm>
 #include <limits>  // std::numeric_limits
@@ -104,7 +84,8 @@ extern "C" {
 #include "naucrates/md/IMDTypeInt4.h"
 #include "naucrates/traceflags/traceflags.h"
 
-#include "nodes/nodeFuncs.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 
 using namespace gpdxl;
 using namespace gpos;
@@ -612,7 +593,7 @@ CTranslatorDXLToPlStmt::TranslateJoinPruneParamids(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTblScan(
 	const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalTableScan *phy_tbl_scan_dxlop =
@@ -1110,7 +1091,8 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexFilter(
 //---------------------------------------------------------------------------
 void
 CTranslatorDXLToPlStmt::TranslateIndexConditions(
-	CDXLNode *index_cond_list_dxlnode, const CDXLTableDescr *dxl_tbl_descr,
+	CDXLNode *index_cond_list_dxlnode,
+	const CDXLTableDescr *dxl_tbl_descr __attribute__ ((unused)),
 	BOOL is_bitmap_index_probe, const IMDIndex *index,
 	const IMDRelation *md_rel, CDXLTranslateContext *output_context,
 	CDXLTranslateContextBaseTable *base_table_context,
@@ -1637,7 +1619,7 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTvf(
 	const CDXLNode *tvf_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
@@ -3409,7 +3391,7 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(const CDXLNode *result_dxlnode)
 Plan *
 CTranslatorDXLToPlStmt::CreateProjectSetNodeTree(const CDXLNode *result_dxlnode,
 												 Plan *result_node_plan,
-												 Plan *child_plan,
+												 Plan *child_plan __attribute__ ((unused)),
 												 Plan *&project_set_child_plan,
 												 BOOL &will_require_result_node)
 {
@@ -4100,7 +4082,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
 	const CDXLNode *cte_consumer_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	CDXLPhysicalCTEConsumer *cte_consumer_dxlop =
 		CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
@@ -4231,7 +4213,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	const CDXLNode *dyn_tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop =
@@ -4516,7 +4498,7 @@ Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynForeignScan(
 	const CDXLNode *dyn_foreign_scan_dxlnode,
 	CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicForeignScan *dyn_foreign_scan_dxlop =
@@ -5199,8 +5181,7 @@ CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
 	}
 
 	ULONG acl_mode = table_descr->GetAclMode();
-	GPOS_ASSERT(acl_mode >= 0 &&
-				acl_mode <= std::numeric_limits<AclMode>::max());
+	GPOS_ASSERT(acl_mode <= std::numeric_limits<AclMode>::max());
 	AclMode required_perms = static_cast<AclMode>(acl_mode);
 
 	// descriptor was already processed, and translated RTE is stored at
@@ -6327,7 +6308,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause(
 //---------------------------------------------------------------------------
 GpPolicy *
 CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy(
-	const CDXLPhysicalCTAS *dxlop, List *target_list)
+	const CDXLPhysicalCTAS *dxlop, List *target_list __attribute__ ((unused)))
 {
 	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
@@ -6723,7 +6704,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLValueScan(
 	const CDXLNode *value_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
@@ -6826,4 +6807,7 @@ CTranslatorDXLToPlStmt::IsIndexForOrderBy(
 	}
 	return false;
 }
+
+#pragma GCC diagnostic pop
+
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -83,7 +83,6 @@
 #include "naucrates/md/IMDTypeInt4.h"
 #include "naucrates/traceflags/traceflags.h"
 
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 
 using namespace gpdxl;
@@ -6786,7 +6785,5 @@ CTranslatorDXLToPlStmt::IsIndexForOrderBy(
 	}
 	return false;
 }
-
-#pragma GCC diagnostic pop
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -14,7 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorDXLToPlStmt.h"
 
 #include <algorithm>
 #include <limits>  // std::numeric_limits
@@ -30,8 +30,8 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/translate/CIndexQualInfo.h"
 #include "gpopt/translate/CPartPruneStepsBuilder.h"
-#include "gpopt/translate/CTranslatorDXLToPlStmt.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/operators/CDXLDatumGeneric.h"
 #include "naucrates/dxl/operators/CDXLDirectDispatchInfo.h"
 #include "naucrates/dxl/operators/CDXLNode.h"
@@ -593,7 +593,8 @@ CTranslatorDXLToPlStmt::TranslateJoinPruneParamids(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTblScan(
 	const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalTableScan *phy_tbl_scan_dxlop =
@@ -1092,7 +1093,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexFilter(
 void
 CTranslatorDXLToPlStmt::TranslateIndexConditions(
 	CDXLNode *index_cond_list_dxlnode,
-	const CDXLTableDescr *dxl_tbl_descr __attribute__ ((unused)),
+	const CDXLTableDescr *dxl_tbl_descr __attribute__((unused)),
 	BOOL is_bitmap_index_probe, const IMDIndex *index,
 	const IMDRelation *md_rel, CDXLTranslateContext *output_context,
 	CDXLTranslateContextBaseTable *base_table_context,
@@ -1619,7 +1620,8 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTvf(
 	const CDXLNode *tvf_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
@@ -3391,7 +3393,8 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(const CDXLNode *result_dxlnode)
 Plan *
 CTranslatorDXLToPlStmt::CreateProjectSetNodeTree(const CDXLNode *result_dxlnode,
 												 Plan *result_node_plan,
-												 Plan *child_plan __attribute__ ((unused)),
+												 Plan *child_plan
+												 __attribute__((unused)),
 												 Plan *&project_set_child_plan,
 												 BOOL &will_require_result_node)
 {
@@ -4082,7 +4085,8 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
 	const CDXLNode *cte_consumer_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	CDXLPhysicalCTEConsumer *cte_consumer_dxlop =
 		CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
@@ -4213,7 +4217,8 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	const CDXLNode *dyn_tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop =
@@ -4498,7 +4503,8 @@ Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynForeignScan(
 	const CDXLNode *dyn_foreign_scan_dxlnode,
 	CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicForeignScan *dyn_foreign_scan_dxlop =
@@ -5363,7 +5369,7 @@ CTranslatorDXLToPlStmt::TranslateDXLProjList(
 		target_entry->resname =
 			CTranslatorUtils::CreateMultiByteCharStringFromWCString(
 				sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
-		target_entry->resno = (AttrNumber)(ul + 1);
+		target_entry->resno = (AttrNumber) (ul + 1);
 
 		if (IsA(expr, Var))
 		{
@@ -6308,7 +6314,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause(
 //---------------------------------------------------------------------------
 GpPolicy *
 CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy(
-	const CDXLPhysicalCTAS *dxlop, List *target_list __attribute__ ((unused)))
+	const CDXLPhysicalCTAS *dxlop, List *target_list __attribute__((unused)))
 {
 	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
@@ -6704,7 +6710,8 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLValueScan(
 	const CDXLNode *value_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings __attribute__ ((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings
+	__attribute__((unused)))
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -327,8 +327,7 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 		case EdxlopPhysicalTableScan:
 		case EdxlopPhysicalForeignScan:
 		{
-			plan = TranslateDXLTblScan(dxlnode, output_context,
-									   ctxt_translation_prev_siblings);
+			plan = TranslateDXLTblScan(dxlnode, output_context);
 			break;
 		}
 		case EdxlopPhysicalIndexScan:
@@ -426,8 +425,7 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 		}
 		case EdxlopPhysicalDynamicTableScan:
 		{
-			plan = TranslateDXLDynTblScan(dxlnode, output_context,
-										  ctxt_translation_prev_siblings);
+			plan = TranslateDXLDynTblScan(dxlnode, output_context);
 			break;
 		}
 		case EdxlopPhysicalDynamicIndexScan:
@@ -444,14 +442,12 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 		}
 		case EdxlopPhysicalDynamicForeignScan:
 		{
-			plan = TranslateDXLDynForeignScan(dxlnode, output_context,
-											  ctxt_translation_prev_siblings);
+			plan = TranslateDXLDynForeignScan(dxlnode, output_context);
 			break;
 		}
 		case EdxlopPhysicalTVF:
 		{
-			plan = TranslateDXLTvf(dxlnode, output_context,
-								   ctxt_translation_prev_siblings);
+			plan = TranslateDXLTvf(dxlnode, output_context);
 			break;
 		}
 		case EdxlopPhysicalDML:
@@ -480,8 +476,7 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 		}
 		case EdxlopPhysicalCTEConsumer:
 		{
-			plan = TranslateDXLCTEConsumerToSharedScan(
-				dxlnode, output_context, ctxt_translation_prev_siblings);
+			plan = TranslateDXLCTEConsumerToSharedScan(dxlnode, output_context);
 			break;
 		}
 		case EdxlopPhysicalBitmapTableScan:
@@ -505,8 +500,7 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 		}
 		case EdxlopPhysicalValuesScan:
 		{
-			plan = TranslateDXLValueScan(dxlnode, output_context,
-										 ctxt_translation_prev_siblings);
+			plan = TranslateDXLValueScan(dxlnode, output_context);
 			break;
 		}
 	}
@@ -591,8 +585,7 @@ CTranslatorDXLToPlStmt::TranslateJoinPruneParamids(
 //---------------------------------------------------------------------------
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTblScan(
-	const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+	const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalTableScan *phy_tbl_scan_dxlop =
@@ -882,7 +875,6 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan(
 	{
 		TranslateIndexConditions(
 			(*index_scan_dxlnode)[EdxlisIndexCondition],
-			physical_idx_scan_dxlop->GetDXLTableDescr(),
 			false,	// is_bitmap_index_probe
 			md_index, md_rel, output_context, &base_table_context,
 			ctxt_translation_prev_siblings, &index_cond, &index_orig_cond);
@@ -1033,7 +1025,6 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan(
 	{
 		TranslateIndexConditions(
 			(*index_scan_dxlnode)[EdxlisIndexCondition],
-			physical_idx_scan_dxlop->GetDXLTableDescr(),
 			false,	// is_bitmap_index_probe
 			md_index, md_rel, output_context, &base_table_context,
 			ctxt_translation_prev_siblings, &index_cond, &index_orig_cond);
@@ -1090,8 +1081,7 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexFilter(
 //---------------------------------------------------------------------------
 void
 CTranslatorDXLToPlStmt::TranslateIndexConditions(
-	CDXLNode *index_cond_list_dxlnode,
-	const CDXLTableDescr *dxl_tbl_descr GPOS_UNUSED, BOOL is_bitmap_index_probe,
+	CDXLNode *index_cond_list_dxlnode, BOOL is_bitmap_index_probe,
 	const IMDIndex *index, const IMDRelation *md_rel,
 	CDXLTranslateContext *output_context,
 	CDXLTranslateContextBaseTable *base_table_context,
@@ -1616,9 +1606,8 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin(
 //
 //---------------------------------------------------------------------------
 Plan *
-CTranslatorDXLToPlStmt::TranslateDXLTvf(
-	const CDXLNode *tvf_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+CTranslatorDXLToPlStmt::TranslateDXLTvf(const CDXLNode *tvf_dxlnode,
+										CDXLTranslateContext *output_context)
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
@@ -3390,7 +3379,6 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(const CDXLNode *result_dxlnode)
 Plan *
 CTranslatorDXLToPlStmt::CreateProjectSetNodeTree(const CDXLNode *result_dxlnode,
 												 Plan *result_node_plan,
-												 Plan *child_plan GPOS_UNUSED,
 												 Plan *&project_set_child_plan,
 												 BOOL &will_require_result_node)
 {
@@ -3680,8 +3668,7 @@ CTranslatorDXLToPlStmt::TranslateDXLResult(
 
 	// Creating project set nodes plan tree
 	Plan *project_set_parent_plan = CreateProjectSetNodeTree(
-		result_dxlnode, plan, child_plan, project_set_child_plan,
-		will_require_result_node);
+		result_dxlnode, plan, project_set_child_plan, will_require_result_node);
 
 	// If Project Set plan nodes are not required return the result plan node
 	// created
@@ -4080,8 +4067,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 //---------------------------------------------------------------------------
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
-	const CDXLNode *cte_consumer_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+	const CDXLNode *cte_consumer_dxlnode, CDXLTranslateContext *output_context)
 {
 	CDXLPhysicalCTEConsumer *cte_consumer_dxlop =
 		CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
@@ -4211,8 +4197,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence(
 //---------------------------------------------------------------------------
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
-	const CDXLNode *dyn_tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+	const CDXLNode *dyn_tbl_scan_dxlnode, CDXLTranslateContext *output_context)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop =
@@ -4365,7 +4350,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxOnlyScan(
 	TranslateIndexConditions(
 		(*dyn_idx_only_scan_dxlnode)
 			[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition],
-		dyn_index_only_scan_dxlop->GetDXLTableDescr(),
 		false,	// is_bitmap_index_probe
 		md_index, md_rel, output_context, &base_table_context,
 		ctxt_translation_prev_siblings, &index_cond, &index_orig_cond);
@@ -4445,7 +4429,6 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 	TranslateIndexConditions(
 		(*dyn_idx_only_scan_dxlnode)
 			[CDXLPhysicalDynamicIndexScan::EdxldisIndexCondition],
-		dyn_index_scan_dxlop->GetDXLTableDescr(),
 		false,	// is_bitmap_index_probe
 		md_index, md_rel, output_context, &base_table_context,
 		ctxt_translation_prev_siblings, &index_cond, &index_orig_cond);
@@ -4496,8 +4479,7 @@ RemapAttrsFromTupDesc(TupleDesc fromDesc, TupleDesc toDesc, Index index,
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynForeignScan(
 	const CDXLNode *dyn_foreign_scan_dxlnode,
-	CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+	CDXLTranslateContext *output_context)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicForeignScan *dyn_foreign_scan_dxlop =
@@ -6201,8 +6183,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCtas(
 
 	//IntoClause *into_clause = TranslateDXLPhyCtasToIntoClause(phy_ctas_dxlop);
 	IntoClause *into_clause = nullptr;
-	GpPolicy *distr_policy =
-		TranslateDXLPhyCtasToDistrPolicy(phy_ctas_dxlop, target_list);
+	GpPolicy *distr_policy = TranslateDXLPhyCtasToDistrPolicy(phy_ctas_dxlop);
 	m_dxl_to_plstmt_context->AddCtasInfo(into_clause, distr_policy);
 
 	GPOS_ASSERT(IMDRelation::EreldistrCoordinatorOnly !=
@@ -6307,7 +6288,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause(
 //---------------------------------------------------------------------------
 GpPolicy *
 CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy(
-	const CDXLPhysicalCTAS *dxlop, List *target_list GPOS_UNUSED)
+	const CDXLPhysicalCTAS *dxlop)
 {
 	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
@@ -6684,9 +6665,9 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe(
 	List *index_orig_cond = NIL;
 
 	TranslateIndexConditions(
-		index_cond_list_dxlnode, table_descr, true /*is_bitmap_index_probe*/,
-		index, md_rel, output_context, base_table_context,
-		ctxt_translation_prev_siblings, &index_cond, &index_orig_cond);
+		index_cond_list_dxlnode, true /*is_bitmap_index_probe*/, index, md_rel,
+		output_context, base_table_context, ctxt_translation_prev_siblings,
+		&index_cond, &index_orig_cond);
 
 	bitmap_idx_scan->indexqual = index_cond;
 	bitmap_idx_scan->indexqualorig = index_orig_cond;
@@ -6702,8 +6683,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe(
 // translates a DXL Value Scan node into a GPDB Value scan node
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLValueScan(
-	const CDXLNode *value_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
+	const CDXLNode *value_scan_dxlnode, CDXLTranslateContext *output_context)
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -592,8 +592,7 @@ CTranslatorDXLToPlStmt::TranslateJoinPruneParamids(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTblScan(
 	const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalTableScan *phy_tbl_scan_dxlop =
@@ -1092,9 +1091,9 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexFilter(
 void
 CTranslatorDXLToPlStmt::TranslateIndexConditions(
 	CDXLNode *index_cond_list_dxlnode,
-	const CDXLTableDescr *dxl_tbl_descr __attribute__((unused)),
-	BOOL is_bitmap_index_probe, const IMDIndex *index,
-	const IMDRelation *md_rel, CDXLTranslateContext *output_context,
+	const CDXLTableDescr *dxl_tbl_descr GPOS_UNUSED, BOOL is_bitmap_index_probe,
+	const IMDIndex *index, const IMDRelation *md_rel,
+	CDXLTranslateContext *output_context,
 	CDXLTranslateContextBaseTable *base_table_context,
 	CDXLTranslationContextArray *ctxt_translation_prev_siblings,
 	List **index_cond, List **index_orig_cond)
@@ -1619,8 +1618,7 @@ CTranslatorDXLToPlStmt::TranslateDXLHashJoin(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLTvf(
 	const CDXLNode *tvf_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
@@ -3392,8 +3390,7 @@ CTranslatorDXLToPlStmt::TranslateDXLProjectSet(const CDXLNode *result_dxlnode)
 Plan *
 CTranslatorDXLToPlStmt::CreateProjectSetNodeTree(const CDXLNode *result_dxlnode,
 												 Plan *result_node_plan,
-												 Plan *child_plan
-												 __attribute__((unused)),
+												 Plan *child_plan GPOS_UNUSED,
 												 Plan *&project_set_child_plan,
 												 BOOL &will_require_result_node)
 {
@@ -4084,8 +4081,7 @@ CTranslatorDXLToPlStmt::TranslateDXLCTEProducerToSharedScan(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLCTEConsumerToSharedScan(
 	const CDXLNode *cte_consumer_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	CDXLPhysicalCTEConsumer *cte_consumer_dxlop =
 		CDXLPhysicalCTEConsumer::Cast(cte_consumer_dxlnode->GetOperator());
@@ -4216,8 +4212,7 @@ CTranslatorDXLToPlStmt::TranslateDXLSequence(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	const CDXLNode *dyn_tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicTableScan *dyn_tbl_scan_dxlop =
@@ -4502,8 +4497,7 @@ Plan *
 CTranslatorDXLToPlStmt::TranslateDXLDynForeignScan(
 	const CDXLNode *dyn_foreign_scan_dxlnode,
 	CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	// translate table descriptor into a range table entry
 	CDXLPhysicalDynamicForeignScan *dyn_foreign_scan_dxlop =
@@ -6313,7 +6307,7 @@ CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToIntoClause(
 //---------------------------------------------------------------------------
 GpPolicy *
 CTranslatorDXLToPlStmt::TranslateDXLPhyCtasToDistrPolicy(
-	const CDXLPhysicalCTAS *dxlop, List *target_list __attribute__((unused)))
+	const CDXLPhysicalCTAS *dxlop, List *target_list GPOS_UNUSED)
 {
 	ULongPtrArray *distr_col_pos_array = dxlop->GetDistrColPosArray();
 
@@ -6709,8 +6703,7 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapIndexProbe(
 Plan *
 CTranslatorDXLToPlStmt::TranslateDXLValueScan(
 	const CDXLNode *value_scan_dxlnode, CDXLTranslateContext *output_context,
-	CDXLTranslationContextArray *ctxt_translation_prev_siblings
-	__attribute__((unused)))
+	CDXLTranslationContextArray *ctxt_translation_prev_siblings GPOS_UNUSED)
 {
 	// translation context for column mappings
 	CDXLTranslateContextBaseTable base_table_context(m_mp);

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -5369,7 +5369,7 @@ CTranslatorDXLToPlStmt::TranslateDXLProjList(
 		target_entry->resname =
 			CTranslatorUtils::CreateMultiByteCharStringFromWCString(
 				sc_proj_elem_dxlop->GetMdNameAlias()->GetMDName()->GetBuffer());
-		target_entry->resno = (AttrNumber) (ul + 1);
+		target_entry->resno = (AttrNumber)(ul + 1);
 
 		if (IsA(expr, Var))
 		{

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -31,7 +31,6 @@
 #include "gpopt/translate/CIndexQualInfo.h"
 #include "gpopt/translate/CPartPruneStepsBuilder.h"
 #include "gpopt/translate/CTranslatorUtils.h"
-#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/operators/CDXLDatumGeneric.h"
 #include "naucrates/dxl/operators/CDXLDirectDispatchInfo.h"
 #include "naucrates/dxl/operators/CDXLNode.h"

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -429,8 +429,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar(
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarParamToScalar(
-	const CDXLNode *scalar_param_node,
-	CMappingColIdVar *colid_var __attribute__((unused)))
+	const CDXLNode *scalar_param_node, CMappingColIdVar *colid_var GPOS_UNUSED)
 {
 	GPOS_ASSERT(nullptr != scalar_param_node);
 	CDXLScalarParam *scalar_param_dxl =

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -12,17 +12,7 @@
 //	@test:
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "catalog/pg_collation.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "utils/datum.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include <vector>
 
@@ -439,7 +429,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar(
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarParamToScalar(
-	const CDXLNode *scalar_param_node, CMappingColIdVar *colid_var)
+	const CDXLNode *scalar_param_node, CMappingColIdVar *colid_var __attribute__ ((unused)))
 {
 	GPOS_ASSERT(nullptr != scalar_param_node);
 	CDXLScalarParam *scalar_param_dxl =

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -12,7 +12,7 @@
 //	@test:
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorDXLToScalar.h"
 
 #include <vector>
 
@@ -24,8 +24,8 @@
 #include "gpopt/mdcache/CMDAccessorUtils.h"
 #include "gpopt/translate/CMappingColIdVarPlStmt.h"
 #include "gpopt/translate/CTranslatorDXLToPlStmt.h"
-#include "gpopt/translate/CTranslatorDXLToScalar.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/CDXLDatumBool.h"
 #include "naucrates/dxl/operators/CDXLDatumGeneric.h"
@@ -429,7 +429,8 @@ CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar(
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarParamToScalar(
-	const CDXLNode *scalar_param_node, CMappingColIdVar *colid_var __attribute__ ((unused)))
+	const CDXLNode *scalar_param_node,
+	CMappingColIdVar *colid_var __attribute__((unused)))
 {
 	GPOS_ASSERT(nullptr != scalar_param_node);
 	CDXLScalarParam *scalar_param_dxl =

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -124,7 +124,7 @@ CTranslatorDXLToScalar::TranslateDXLToScalar(const CDXLNode *dxlnode,
 		}
 		case EdxlopScalarParam:
 		{
-			return TranslateDXLScalarParamToScalar(dxlnode, colid_var);
+			return TranslateDXLScalarParamToScalar(dxlnode);
 		}
 		case EdxlopScalarArrayComp:
 		{
@@ -429,7 +429,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarOpExprToScalar(
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLScalarParamToScalar(
-	const CDXLNode *scalar_param_node, CMappingColIdVar *colid_var GPOS_UNUSED)
+	const CDXLNode *scalar_param_node)
 {
 	GPOS_ASSERT(nullptr != scalar_param_node);
 	CDXLScalarParam *scalar_param_dxl =

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -14,18 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "access/sysattr.h"
-#include "catalog/heap.h"
-#include "catalog/pg_class.h"
-#include "nodes/makefuncs.h"
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "optimizer/walkers.h"
-#include "utils/rel.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoTimer.h"
@@ -77,6 +66,8 @@ extern "C" {
 #include "naucrates/md/IMDTypeInt4.h"
 #include "naucrates/md/IMDTypeInt8.h"
 #include "naucrates/traceflags/traceflags.h"
+
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 
 using namespace gpdxl;
 using namespace gpos;
@@ -1787,7 +1778,8 @@ CTranslatorQueryToDXL::TranslateWindowSpecToDXL(
 CDXLNode *
 CTranslatorQueryToDXL::TranslateWindowToDXL(
 	CDXLNode *child_dxlnode, List *target_list, List *window_clause,
-	List *sort_clause, IntToUlongMap *sort_col_attno_to_colid_mapping,
+	List *sort_clause __attribute__ ((unused)),
+	IntToUlongMap *sort_col_attno_to_colid_mapping,
 	IntToUlongMap *output_attno_to_colid_mapping)
 {
 	if (0 == gpdb::ListLength(window_clause))
@@ -3644,7 +3636,7 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 CDXLNode *
 CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
 												  ULONG rt_index,
-												  ULONG current_query_level)
+												  ULONG current_query_level __attribute__ ((unused)))
 {
 	List *tuples_list = rte->values_lists;
 	GPOS_ASSERT(nullptr != tuples_list);
@@ -5069,5 +5061,7 @@ CTranslatorQueryToDXL::IsDMLQuery()
 {
 	return (m_is_top_query_dml || m_query->resultRelation != 0);
 }
+
+#pragma GCC diagnostic pop
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -14,7 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorQueryToDXL.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoTimer.h"
@@ -25,9 +25,9 @@
 #include "gpopt/translate/CCTEListEntry.h"
 #include "gpopt/translate/CQueryMutators.h"
 #include "gpopt/translate/CTranslatorDXLToPlStmt.h"
-#include "gpopt/translate/CTranslatorQueryToDXL.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/CDXLDatumInt4.h"
 #include "naucrates/dxl/operators/CDXLDatumInt8.h"
@@ -1778,7 +1778,7 @@ CTranslatorQueryToDXL::TranslateWindowSpecToDXL(
 CDXLNode *
 CTranslatorQueryToDXL::TranslateWindowToDXL(
 	CDXLNode *child_dxlnode, List *target_list, List *window_clause,
-	List *sort_clause __attribute__ ((unused)),
+	List *sort_clause __attribute__((unused)),
 	IntToUlongMap *sort_col_attno_to_colid_mapping,
 	IntToUlongMap *output_attno_to_colid_mapping)
 {
@@ -3636,7 +3636,8 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 CDXLNode *
 CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
 												  ULONG rt_index,
-												  ULONG current_query_level __attribute__ ((unused)))
+												  ULONG current_query_level
+												  __attribute__((unused)))
 {
 	List *tuples_list = rte->values_lists;
 	GPOS_ASSERT(nullptr != tuples_list);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4753,7 +4753,7 @@ CTranslatorQueryToDXL::CreateDXLConstValueTrue()
 CDXLNode *
 CTranslatorQueryToDXL::TranslateGroupingFuncToDXL(
 	const Expr *expr, CBitSet *bitset,
-	UlongToUlongMap *grpcol_index_to_colid_mapping) const
+	UlongToUlongMap *grpcol_index_to_colid_mapping __attribute__((unused))) const
 {
 	GPOS_ASSERT(IsA(expr, GroupingFunc));
 	GPOS_ASSERT(nullptr != grpcol_index_to_colid_mapping);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -5059,6 +5059,4 @@ CTranslatorQueryToDXL::IsDMLQuery()
 	return (m_is_top_query_dml || m_query->resultRelation != 0);
 }
 
-#pragma GCC diagnostic pop
-
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1778,7 +1778,7 @@ CTranslatorQueryToDXL::TranslateWindowSpecToDXL(
 CDXLNode *
 CTranslatorQueryToDXL::TranslateWindowToDXL(
 	CDXLNode *child_dxlnode, List *target_list, List *window_clause,
-	List *sort_clause __attribute__((unused)),
+	List *sort_clause GPOS_UNUSED,
 	IntToUlongMap *sort_col_attno_to_colid_mapping,
 	IntToUlongMap *output_attno_to_colid_mapping)
 {
@@ -3634,10 +3634,9 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
-												  ULONG rt_index,
-												  ULONG current_query_level
-												  __attribute__((unused)))
+CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(
+	const RangeTblEntry *rte, ULONG rt_index,
+	ULONG current_query_level GPOS_UNUSED)
 {
 	List *tuples_list = rte->values_lists;
 	GPOS_ASSERT(nullptr != tuples_list);
@@ -4753,8 +4752,7 @@ CTranslatorQueryToDXL::CreateDXLConstValueTrue()
 CDXLNode *
 CTranslatorQueryToDXL::TranslateGroupingFuncToDXL(
 	const Expr *expr, CBitSet *bitset,
-	UlongToUlongMap *grpcol_index_to_colid_mapping
-	__attribute__((unused))) const
+	UlongToUlongMap *grpcol_index_to_colid_mapping GPOS_UNUSED) const
 {
 	GPOS_ASSERT(IsA(expr, GroupingFunc));
 	GPOS_ASSERT(nullptr != grpcol_index_to_colid_mapping);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -4753,7 +4753,8 @@ CTranslatorQueryToDXL::CreateDXLConstValueTrue()
 CDXLNode *
 CTranslatorQueryToDXL::TranslateGroupingFuncToDXL(
 	const Expr *expr, CBitSet *bitset,
-	UlongToUlongMap *grpcol_index_to_colid_mapping __attribute__((unused))) const
+	UlongToUlongMap *grpcol_index_to_colid_mapping
+	__attribute__((unused))) const
 {
 	GPOS_ASSERT(IsA(expr, GroupingFunc));
 	GPOS_ASSERT(nullptr != grpcol_index_to_colid_mapping);

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -681,8 +681,7 @@ CTranslatorQueryToDXL::TranslateSelectQueryToDXL()
 		GPOS_ASSERT(nullptr == m_query->groupingSets);
 		child_dxlnode = TranslateWindowToDXL(
 			dxlnode, m_query->targetList, m_query->windowClause,
-			m_query->sortClause, sort_group_attno_to_colid_mapping,
-			output_attno_to_colid_mapping);
+			sort_group_attno_to_colid_mapping, output_attno_to_colid_mapping);
 	}
 	else
 	{
@@ -1778,7 +1777,6 @@ CTranslatorQueryToDXL::TranslateWindowSpecToDXL(
 CDXLNode *
 CTranslatorQueryToDXL::TranslateWindowToDXL(
 	CDXLNode *child_dxlnode, List *target_list, List *window_clause,
-	List *sort_clause GPOS_UNUSED,
 	IntToUlongMap *sort_col_attno_to_colid_mapping,
 	IntToUlongMap *output_attno_to_colid_mapping)
 {
@@ -3357,7 +3355,7 @@ CTranslatorQueryToDXL::TranslateFromClauseToDXL(Node *node)
 			}
 			case RTE_VALUES:
 			{
-				return TranslateValueScanRTEToDXL(rte, rt_index, m_query_level);
+				return TranslateValueScanRTEToDXL(rte, rt_index);
 			}
 			case RTE_CTE:
 			{
@@ -3634,9 +3632,8 @@ CTranslatorQueryToDXL::NoteDistributionPolicyOpclasses(const RangeTblEntry *rte)
 //
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(
-	const RangeTblEntry *rte, ULONG rt_index,
-	ULONG current_query_level GPOS_UNUSED)
+CTranslatorQueryToDXL::TranslateValueScanRTEToDXL(const RangeTblEntry *rte,
+												  ULONG rt_index)
 {
 	List *tuples_list = rte->values_lists;
 	GPOS_ASSERT(nullptr != tuples_list);

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -12,30 +12,7 @@
 //
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include "postgres.h"
-
-#include "access/heapam.h"
-#include "catalog/heap.h"
-#include "catalog/namespace.h"
-#include "catalog/pg_am.h"
-#include "catalog/pg_proc.h"
-#include "catalog/pg_statistic.h"
-#include "catalog/pg_statistic_ext.h"
-#include "cdb/cdbhash.h"
-#include "partitioning/partdesc.h"
-#include "utils/array.h"
-#include "utils/datum.h"
-#include "utils/elog.h"
-#include "utils/guc.h"
-#include "utils/lsyscache.h"
-#include "utils/partcache.h"
-#include "utils/rel.h"
-#include "utils/relcache.h"
-#include "utils/syscache.h"
-#include "utils/typcache.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoRef.h"
@@ -684,7 +661,7 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 //---------------------------------------------------------------------------
 CMDColumnArray *
 CTranslatorRelcacheToDXL::RetrieveRelColumns(CMemoryPool *mp,
-											 CMDAccessor *md_accessor,
+											 CMDAccessor *md_accessor __attribute__ ((unused)),
 											 Relation rel)
 {
 	CMDColumnArray *mdcol_array = GPOS_NEW(mp) CMDColumnArray(mp);
@@ -908,7 +885,7 @@ CTranslatorRelcacheToDXL::RetrieveRelDistributionOpFamilies(CMemoryPool *mp,
 void
 CTranslatorRelcacheToDXL::AddSystemColumns(CMemoryPool *mp,
 										   CMDColumnArray *mdcol_array,
-										   Relation rel)
+										   Relation rel __attribute__ ((unused)))
 {
 	for (INT i = SelfItemPointerAttributeNumber;
 		 i > FirstLowInvalidHeapAttributeNumber; i--)
@@ -2636,7 +2613,8 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 //---------------------------------------------------------------------------
 void
 CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
-												   Relation rel, OID oid,
+												   Relation rel,
+												   OID oid __attribute__ ((unused)),
 												   ULongPtrArray **part_keys,
 												   CharPtrArray **part_types)
 {

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -24,7 +24,6 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"
-#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/xml/dxltokens.h"

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -659,10 +659,8 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 //
 //---------------------------------------------------------------------------
 CMDColumnArray *
-CTranslatorRelcacheToDXL::RetrieveRelColumns(CMemoryPool *mp,
-											 CMDAccessor *md_accessor
-											 __attribute__((unused)),
-											 Relation rel)
+CTranslatorRelcacheToDXL::RetrieveRelColumns(
+	CMemoryPool *mp, CMDAccessor *md_accessor GPOS_UNUSED, Relation rel)
 {
 	CMDColumnArray *mdcol_array = GPOS_NEW(mp) CMDColumnArray(mp);
 
@@ -885,7 +883,7 @@ CTranslatorRelcacheToDXL::RetrieveRelDistributionOpFamilies(CMemoryPool *mp,
 void
 CTranslatorRelcacheToDXL::AddSystemColumns(CMemoryPool *mp,
 										   CMDColumnArray *mdcol_array,
-										   Relation rel __attribute__((unused)))
+										   Relation rel GPOS_UNUSED)
 {
 	for (INT i = SelfItemPointerAttributeNumber;
 		 i > FirstLowInvalidHeapAttributeNumber; i--)
@@ -2612,9 +2610,11 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(
-	CMemoryPool *mp, Relation rel, OID oid __attribute__((unused)),
-	ULongPtrArray **part_keys, CharPtrArray **part_types)
+CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
+												   Relation rel,
+												   OID oid GPOS_UNUSED,
+												   ULongPtrArray **part_keys,
+												   CharPtrArray **part_types)
 {
 	GPOS_ASSERT(nullptr != rel);
 

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -548,7 +548,7 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	rel_ao_version = get_ao_version(rel);
 
 	// get relation columns
-	mdcol_array = RetrieveRelColumns(mp, md_accessor, rel.get());
+	mdcol_array = RetrieveRelColumns(mp, rel.get());
 	const ULONG max_cols =
 		GPDXL_SYSTEM_COLUMNS + (ULONG) rel->rd_att->natts + 1;
 	ULONG *attno_mapping = ConstructAttnoMapping(mp, mdcol_array, max_cols);
@@ -588,7 +588,7 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	// get number of leaf partitions
 	if (is_partitioned)
 	{
-		RetrievePartKeysAndTypes(mp, rel.get(), oid, &part_keys, &part_types);
+		RetrievePartKeysAndTypes(mp, rel.get(), &part_keys, &part_types);
 
 		partition_oids = GPOS_NEW(mp) IMdIdArray(mp);
 		PartitionDesc part_desc =
@@ -659,8 +659,7 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 //
 //---------------------------------------------------------------------------
 CMDColumnArray *
-CTranslatorRelcacheToDXL::RetrieveRelColumns(
-	CMemoryPool *mp, CMDAccessor *md_accessor GPOS_UNUSED, Relation rel)
+CTranslatorRelcacheToDXL::RetrieveRelColumns(CMemoryPool *mp, Relation rel)
 {
 	CMDColumnArray *mdcol_array = GPOS_NEW(mp) CMDColumnArray(mp);
 
@@ -724,7 +723,7 @@ CTranslatorRelcacheToDXL::RetrieveRelColumns(
 	// add system columns
 	if (RelHasSystemColumns(rel->rd_rel->relkind))
 	{
-		AddSystemColumns(mp, mdcol_array, rel);
+		AddSystemColumns(mp, mdcol_array);
 	}
 
 	return mdcol_array;
@@ -882,8 +881,7 @@ CTranslatorRelcacheToDXL::RetrieveRelDistributionOpFamilies(CMemoryPool *mp,
 //---------------------------------------------------------------------------
 void
 CTranslatorRelcacheToDXL::AddSystemColumns(CMemoryPool *mp,
-										   CMDColumnArray *mdcol_array,
-										   Relation rel GPOS_UNUSED)
+										   CMDColumnArray *mdcol_array)
 {
 	for (INT i = SelfItemPointerAttributeNumber;
 		 i > FirstLowInvalidHeapAttributeNumber; i--)
@@ -2612,7 +2610,6 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 void
 CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
 												   Relation rel,
-												   OID oid GPOS_UNUSED,
 												   ULongPtrArray **part_keys,
 												   CharPtrArray **part_types)
 {

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -12,7 +12,7 @@
 //
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CAutoRef.h"
@@ -22,9 +22,9 @@
 #include "gpopt/base/CUtils.h"
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/mdcache/CMDAccessor.h"
-#include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/xml/dxltokens.h"
@@ -661,7 +661,8 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 //---------------------------------------------------------------------------
 CMDColumnArray *
 CTranslatorRelcacheToDXL::RetrieveRelColumns(CMemoryPool *mp,
-											 CMDAccessor *md_accessor __attribute__ ((unused)),
+											 CMDAccessor *md_accessor
+											 __attribute__((unused)),
 											 Relation rel)
 {
 	CMDColumnArray *mdcol_array = GPOS_NEW(mp) CMDColumnArray(mp);
@@ -885,7 +886,7 @@ CTranslatorRelcacheToDXL::RetrieveRelDistributionOpFamilies(CMemoryPool *mp,
 void
 CTranslatorRelcacheToDXL::AddSystemColumns(CMemoryPool *mp,
 										   CMDColumnArray *mdcol_array,
-										   Relation rel __attribute__ ((unused)))
+										   Relation rel __attribute__((unused)))
 {
 	for (INT i = SelfItemPointerAttributeNumber;
 		 i > FirstLowInvalidHeapAttributeNumber; i--)
@@ -1154,7 +1155,7 @@ CTranslatorRelcacheToDXL::PopulateAttnoPositionMap(CMemoryPool *mp,
 
 		INT attno = md_col->AttrNum();
 
-		ULONG idx = (ULONG)(GPDXL_SYSTEM_COLUMNS + attno);
+		ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
 		GPOS_ASSERT(size > idx);
 		attno_mapping[idx] = ul;
 	}
@@ -2612,11 +2613,9 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 //
 //---------------------------------------------------------------------------
 void
-CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
-												   Relation rel,
-												   OID oid __attribute__ ((unused)),
-												   ULongPtrArray **part_keys,
-												   CharPtrArray **part_types)
+CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(
+	CMemoryPool *mp, Relation rel, OID oid __attribute__((unused)),
+	ULongPtrArray **part_keys, CharPtrArray **part_types)
 {
 	GPOS_ASSERT(nullptr != rel);
 

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1155,7 +1155,7 @@ CTranslatorRelcacheToDXL::PopulateAttnoPositionMap(CMemoryPool *mp,
 
 		INT attno = md_col->AttrNum();
 
-		ULONG idx = (ULONG) (GPDXL_SYSTEM_COLUMNS + attno);
+		ULONG idx = (ULONG)(GPDXL_SYSTEM_COLUMNS + attno);
 		GPOS_ASSERT(size > idx);
 		attno_mapping[idx] = ul;
 	}

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -13,17 +13,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "utils/date.h"
-#include "utils/datum.h"
-#include "utils/guc.h"
-#include "utils/uuid.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include <vector>
 
@@ -275,7 +265,7 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorScalarToDXL::TranslateParamToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping)
+	const Expr *expr, const CMappingVarColId *var_colid_mapping __attribute__ ((unused)))
 {
 	GPOS_ASSERT(IsA(expr, Param));
 	const Param *param = (Param *) expr;
@@ -2172,7 +2162,7 @@ CTranslatorScalarToDXL::TranslateArrayRefToDXL(
 
 CDXLNode *
 CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping)
+	const Expr *expr, const CMappingVarColId *var_colid_mapping __attribute__ ((unused)))
 {
 	GPOS_ASSERT(IsA(expr, SortGroupClause));
 	const SortGroupClause *sgc = (SortGroupClause *) expr;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -264,8 +264,7 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorScalarToDXL::TranslateParamToDXL(
-	const Expr *expr,
-	const CMappingVarColId *var_colid_mapping __attribute__((unused)))
+	const Expr *expr, const CMappingVarColId *var_colid_mapping GPOS_UNUSED)
 {
 	GPOS_ASSERT(IsA(expr, Param));
 	const Param *param = (Param *) expr;
@@ -2162,8 +2161,7 @@ CTranslatorScalarToDXL::TranslateArrayRefToDXL(
 
 CDXLNode *
 CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(
-	const Expr *expr,
-	const CMappingVarColId *var_colid_mapping __attribute__((unused)))
+	const Expr *expr, const CMappingVarColId *var_colid_mapping GPOS_UNUSED)
 {
 	GPOS_ASSERT(IsA(expr, SortGroupClause));
 	const SortGroupClause *sgc = (SortGroupClause *) expr;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -263,8 +263,7 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 //		Create a DXL node for a scalar param expression from a GPDB Param
 //---------------------------------------------------------------------------
 CDXLNode *
-CTranslatorScalarToDXL::TranslateParamToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping GPOS_UNUSED)
+CTranslatorScalarToDXL::TranslateParamToDXL(const Expr *expr)
 {
 	GPOS_ASSERT(IsA(expr, Param));
 	const Param *param = (Param *) expr;
@@ -318,8 +317,7 @@ CTranslatorScalarToDXL::TranslateScalarToDXL(
 					GPOS_WSZ_LIT(
 						"Use optimizer_enable_query_parameter to enable Orca with query parameters"));
 			}
-			return CTranslatorScalarToDXL::TranslateParamToDXL(
-				expr, var_colid_mapping);
+			return CTranslatorScalarToDXL::TranslateParamToDXL(expr);
 		}
 		case T_Var:
 		{
@@ -438,8 +436,7 @@ CTranslatorScalarToDXL::TranslateScalarToDXL(
 		}
 		case T_SortGroupClause:
 		{
-			return CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(
-				expr, var_colid_mapping);
+			return CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(expr);
 		}
 		case T_FieldSelect:
 		{
@@ -2160,8 +2157,7 @@ CTranslatorScalarToDXL::TranslateArrayRefToDXL(
 }
 
 CDXLNode *
-CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping GPOS_UNUSED)
+CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(const Expr *expr)
 {
 	GPOS_ASSERT(IsA(expr, SortGroupClause));
 	const SortGroupClause *sgc = (SortGroupClause *) expr;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -13,7 +13,7 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorScalarToDXL.h"
 
 #include <vector>
 
@@ -26,8 +26,8 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/translate/CCTEListEntry.h"
 #include "gpopt/translate/CTranslatorQueryToDXL.h"
-#include "gpopt/translate/CTranslatorScalarToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/CDXLDatumBool.h"
 #include "naucrates/dxl/operators/CDXLDatumInt2.h"
@@ -265,7 +265,8 @@ CTranslatorScalarToDXL::TranslateVarToDXL(
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorScalarToDXL::TranslateParamToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping __attribute__ ((unused)))
+	const Expr *expr,
+	const CMappingVarColId *var_colid_mapping __attribute__((unused)))
 {
 	GPOS_ASSERT(IsA(expr, Param));
 	const Param *param = (Param *) expr;
@@ -2162,7 +2163,8 @@ CTranslatorScalarToDXL::TranslateArrayRefToDXL(
 
 CDXLNode *
 CTranslatorScalarToDXL::TranslateSortGroupClauseToDXL(
-	const Expr *expr, const CMappingVarColId *var_colid_mapping __attribute__ ((unused)))
+	const Expr *expr,
+	const CMappingVarColId *var_colid_mapping __attribute__((unused)))
 {
 	GPOS_ASSERT(IsA(expr, SortGroupClause));
 	const SortGroupClause *sgc = (SortGroupClause *) expr;

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -27,7 +27,6 @@
 #include "gpopt/translate/CCTEListEntry.h"
 #include "gpopt/translate/CTranslatorQueryToDXL.h"
 #include "gpopt/translate/CTranslatorUtils.h"
-#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/operators/CDXLDatumBool.h"
 #include "naucrates/dxl/operators/CDXLDatumInt2.h"

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -14,7 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/translate/CTranslatorUtils.h"
 
 #include "gpos/attributes.h"
 #include "gpos/base.h"
@@ -28,7 +28,7 @@
 #include "gpopt/translate/CDXLTranslateContext.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"
-#include "gpopt/translate/CTranslatorUtils.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/operators/CDXLColDescr.h"

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -14,19 +14,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "access/sysattr.h"
-#include "catalog/pg_proc.h"
-#include "catalog/pg_statistic.h"
-#include "catalog/pg_type.h"
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-#include "optimizer/walkers.h"
-#include "utils/guc.h"
-#include "utils/rel.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/attributes.h"
 #include "gpos/base.h"

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -28,7 +28,6 @@
 #include "gpopt/translate/CDXLTranslateContext.h"
 #include "gpopt/translate/CTranslatorRelcacheToDXL.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"
-#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CDXLUtils.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/operators/CDXLColDescr.h"

--- a/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
+++ b/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
@@ -13,11 +13,11 @@
 //	@test:
 //
 //---------------------------------------------------------------------------
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/utils/CConstExprEvaluatorProxy.h"
 
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"
-#include "gpopt/utils/CConstExprEvaluatorProxy.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/exception.h"
 

--- a/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
+++ b/src/backend/gpopt/utils/CConstExprEvaluatorProxy.cpp
@@ -13,12 +13,7 @@
 //	@test:
 //
 //---------------------------------------------------------------------------
-
-extern "C" {
-#include "postgres.h"
-
-#include "executor/executor.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/translate/CTranslatorScalarToDXL.h"

--- a/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
@@ -11,11 +11,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "utils/memutils.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/memory/CMemoryPool.h"
 

--- a/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
@@ -11,12 +11,11 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/utils/CMemoryPoolPalloc.h"
 
 #include "gpos/memory/CMemoryPool.h"
 
 #include "gpopt/gpdbwrappers.h"
-#include "gpopt/utils/CMemoryPoolPalloc.h"
 
 using namespace gpos;
 

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -11,11 +11,7 @@
 //
 //---------------------------------------------------------------------------
 
-extern "C" {
-#include "postgres.h"
-
-#include "utils/memutils.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpopt/utils/CMemoryPoolPalloc.h"
 #include "gpopt/utils/CMemoryPoolPallocManager.h"

--- a/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPallocManager.cpp
@@ -11,10 +11,10 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gpopt/utils/gpdbdefs.h"
+#include "gpopt/utils/CMemoryPoolPallocManager.h"
 
 #include "gpopt/utils/CMemoryPoolPalloc.h"
-#include "gpopt/utils/CMemoryPoolPallocManager.h"
+#include "gpopt/utils/gpdbdefs.h"
 
 using namespace gpos;
 

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -15,8 +15,6 @@
 
 #include "gpopt/utils/COptTasks.h"
 
-#include "gpopt/utils/gpdbdefs.h"
-
 #include "gpos/_api.h"
 #include "gpos/base.h"
 #include "gpos/common/CAutoP.h"

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -15,14 +15,7 @@
 
 #include "gpopt/utils/COptTasks.h"
 
-extern "C" {
-#include "cdb/cdbvars.h"
-#include "optimizer/hints.h"
-#include "optimizer/orca.h"
-#include "storage/proc.h"
-#include "utils/fmgroids.h"
-#include "utils/guc.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/_api.h"
 #include "gpos/base.h"

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -15,13 +15,7 @@
 
 #include <sys/stat.h>
 
-extern "C" {
-#include "postgres.h"
-
-#include "fmgr.h"
-#include "lib/stringinfo.h"
-#include "utils/builtins.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/_api.h"
 

--- a/src/backend/gpopt/utils/funcs.cpp
+++ b/src/backend/gpopt/utils/funcs.cpp
@@ -13,15 +13,14 @@
 //
 //---------------------------------------------------------------------------
 
-#include <sys/stat.h>
+#include "gpopt/utils/funcs.h"
 
-#include "gpopt/utils/gpdbdefs.h"
+#include <sys/stat.h>
 
 #include "gpos/_api.h"
 
 #include "gpopt/gpdbwrappers.h"
 #include "gpopt/utils/COptTasks.h"
-#include "gpopt/utils/funcs.h"
 
 #include "xercesc/util/XercesVersion.hpp"
 

--- a/src/include/gpopt/CGPOptimizer.h
+++ b/src/include/gpopt/CGPOptimizer.h
@@ -15,13 +15,7 @@
 #ifndef CGPOptimizer_H
 #define CGPOptimizer_H
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/params.h"
-#include "nodes/parsenodes.h"
-#include "nodes/plannodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 class CGPOptimizer
 {

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -707,12 +707,13 @@ gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
 		 ? gpdb::MemCtxtAllocZeroAligned(CurrentMemoryContext, (sz)) \
 		 : gpdb::MemCtxtAllocZero(CurrentMemoryContext, (sz)))
 
-static inline Node* NewNode(Size size, NodeTag tag)
+static inline Node *
+NewNode(Size size, NodeTag tag)
 {
-    AssertMacro(size >= sizeof(Node)); /* need the tag, at least */
-    Node *_result = (Node *) Palloc0Fast(size);
-    _result->type = tag;
-    return _result;
+	AssertMacro(size >= sizeof(Node)); /* need the tag, at least */
+	Node *_result = (Node *) Palloc0Fast(size);
+	_result->type = tag;
+	return _result;
 }
 
 #define MakeNode(_type_) ((_type_ *) NewNode(sizeof(_type_), T_##_type_))

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -14,19 +14,7 @@
 //---------------------------------------------------------------------------
 #ifndef GPDB_gpdbwrappers_H
 #define GPDB_gpdbwrappers_H
-
-extern "C" {
-#include "postgres.h"
-
-#include "access/amapi.h"
-#include "access/attnum.h"
-#include "optimizer/plancat.h"
-#include "parser/parse_coerce.h"
-#include "statistics/statistics.h"
-#include "utils/faultinjector.h"
-#include "utils/lsyscache.h"
-}
-
+#include "gpopt/utils/gpdbdefs.h"
 #include "gpos/types.h"
 
 // fwd declarations
@@ -719,7 +707,8 @@ gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
 		 : gpdb::MemCtxtAllocZero(CurrentMemoryContext, (sz)))
 
 #ifdef __GNUC__
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 /* With GCC, we can use a compound statement within an expression */
 #define NewNode(size, tag)                                                \
 	({                                                                    \
@@ -730,6 +719,7 @@ gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
 		_result;                                                          \
 	})
 #else
+#pragma GCC diagnostic pop
 
 /*
  *	There is no way to dereference the palloc'ed pointer to assign the

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -707,21 +707,6 @@ gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
 		 ? gpdb::MemCtxtAllocZeroAligned(CurrentMemoryContext, (sz)) \
 		 : gpdb::MemCtxtAllocZero(CurrentMemoryContext, (sz)))
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-/* With GCC, we can use a compound statement within an expression */
-#define NewNode(size, tag)                                                \
-	({                                                                    \
-		Node *_result;                                                    \
-		AssertMacro((size) >= sizeof(Node)); /* need the tag, at least */ \
-		_result = (Node *) Palloc0Fast(size);                             \
-		_result->type = (tag);                                            \
-		_result;                                                          \
-	})
-#else
-#pragma GCC diagnostic pop
-
 /*
  *	There is no way to dereference the palloc'ed pointer to assign the
  *	tag, and also return the pointer itself, so we need a holder variable.
@@ -734,7 +719,6 @@ extern PGDLLIMPORT Node *newNodeMacroHolder;
 	(AssertMacro((size) >= sizeof(Node)), /* need the tag, at least */ \
 	 newNodeMacroHolder = (Node *) Palloc0Fast(size),                  \
 	 newNodeMacroHolder->type = (tag), newNodeMacroHolder)
-#endif	// __GNUC__
 
 #define MakeNode(_type_) ((_type_ *) NewNode(sizeof(_type_), T_##_type_))
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -14,8 +14,9 @@
 //---------------------------------------------------------------------------
 #ifndef GPDB_gpdbwrappers_H
 #define GPDB_gpdbwrappers_H
-#include "gpopt/utils/gpdbdefs.h"
 #include "gpos/types.h"
+
+#include "gpopt/utils/gpdbdefs.h"
 
 // fwd declarations
 using SysScanDesc = struct SysScanDescData *;

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -707,18 +707,13 @@ gpos::BOOL WalkQueryTree(Query *query, bool (*walker)(), void *context,
 		 ? gpdb::MemCtxtAllocZeroAligned(CurrentMemoryContext, (sz)) \
 		 : gpdb::MemCtxtAllocZero(CurrentMemoryContext, (sz)))
 
-/*
- *	There is no way to dereference the palloc'ed pointer to assign the
- *	tag, and also return the pointer itself, so we need a holder variable.
- *	Fortunately, this macro isn't recursive so we just define
- *	a global variable for this purpose.
- */
-extern PGDLLIMPORT Node *newNodeMacroHolder;
-
-#define NewNode(size, tag)                                             \
-	(AssertMacro((size) >= sizeof(Node)), /* need the tag, at least */ \
-	 newNodeMacroHolder = (Node *) Palloc0Fast(size),                  \
-	 newNodeMacroHolder->type = (tag), newNodeMacroHolder)
+static inline Node* NewNode(Size size, NodeTag tag)
+{
+    AssertMacro(size >= sizeof(Node)); /* need the tag, at least */
+    Node *_result = (Node *) Palloc0Fast(size);
+    _result->type = tag;
+    return _result;
+}
 
 #define MakeNode(_type_) ((_type_ *) NewNode(sizeof(_type_), T_##_type_))
 

--- a/src/include/gpopt/translate/CDXLTranslateContext.h
+++ b/src/include/gpopt/translate/CDXLTranslateContext.h
@@ -17,13 +17,12 @@
 #ifndef GPDXL_CDXLTranslateContext_H
 #define GPDXL_CDXLTranslateContext_H
 
-#include "gpopt/utils/gpdbdefs.h"
-
 #include "gpos/base.h"
 #include "gpos/common/CHashMap.h"
 #include "gpos/common/CHashMapIter.h"
 
 #include "gpopt/translate/CMappingElementColIdParamId.h"
+#include "gpopt/utils/gpdbdefs.h"
 
 
 // fwd decl

--- a/src/include/gpopt/translate/CDXLTranslateContext.h
+++ b/src/include/gpopt/translate/CDXLTranslateContext.h
@@ -17,11 +17,7 @@
 #ifndef GPDXL_CDXLTranslateContext_H
 #define GPDXL_CDXLTranslateContext_H
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/plannodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CHashMap.h"

--- a/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
+++ b/src/include/gpopt/translate/CDXLTranslateContextBaseTable.h
@@ -22,10 +22,7 @@
 #include "gpos/base.h"
 #include "gpos/common/CHashMap.h"
 
-extern "C" {
-#include "postgres.h"  // Index
-}
-
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/gpdb_types.h"
 
 namespace gpdxl

--- a/src/include/gpopt/translate/CQueryMutators.h
+++ b/src/include/gpopt/translate/CQueryMutators.h
@@ -213,7 +213,7 @@ public:
 												ULONG attno);
 
 	// return the column name of the target entry
-	static CHAR *GetTargetEntryColName(TargetEntry *target_entry, Query *query);
+	static CHAR *GetTargetEntryColName(TargetEntry *target_entry);
 
 	// make the input query into a derived table and return a new root query
 	static Query *ConvertToDerivedTable(const Query *original_query,

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -16,10 +16,6 @@
 #ifndef GPDXL_CTranslatorDxlToPlStmt_H
 #define GPDXL_CTranslatorDxlToPlStmt_H
 
-extern "C" {
-#include "postgres.h"
-}
-
 #include "gpos/base.h"
 
 #include "gpopt/translate/CContextDXLToPlStmt.h"
@@ -27,6 +23,7 @@ extern "C" {
 #include "gpopt/translate/CDXLTranslateContextBaseTable.h"
 #include "gpopt/translate/CMappingColIdVarPlStmt.h"
 #include "gpopt/translate/CTranslatorDXLToScalar.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CIdGenerator.h"
 #include "naucrates/dxl/operators/CDXLCtasStorageOptions.h"
 #include "naucrates/dxl/operators/CDXLPhysicalIndexScan.h"

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -204,11 +204,8 @@ private:
 		CDXLTranslationContextArray *ctxt_translation_prev_siblings);
 
 	// translate DXL table scan node into a SeqScan node
-	Plan *TranslateDXLTblScan(
-		const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *
-			ctxt_translation_prev_siblings	// translation contexts of previous siblings
-	);
+	Plan *TranslateDXLTblScan(const CDXLNode *tbl_scan_dxlnode,
+							  CDXLTranslateContext *output_context);
 
 	// translate DXL index scan node into a IndexScan node
 	Plan *TranslateDXLIndexScan(
@@ -316,17 +313,14 @@ private:
 	);
 
 	// translate DXL TVF into a GPDB Function Scan node
-	Plan *TranslateDXLTvf(
-		const CDXLNode *tvf_dxlnode, CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *
-			ctxt_translation_prev_siblings	// translation contexts of previous siblings
-	);
+	Plan *TranslateDXLTvf(const CDXLNode *tvf_dxlnode,
+						  CDXLTranslateContext *output_context);
 
 
 	Plan *TranslateDXLProjectSet(const CDXLNode *result_dxlnode);
 
 	Plan *CreateProjectSetNodeTree(const CDXLNode *result_dxlnode,
-								   Plan *result_node_plan, Plan *child_plan,
+								   Plan *result_node_plan,
 								   Plan *&project_set_child_plan,
 								   BOOL &will_require_result_node);
 
@@ -366,12 +360,8 @@ private:
 	);
 
 	// translate a dynamic table scan operator
-	Plan *TranslateDXLDynTblScan(
-		const CDXLNode *dyn_tbl_scan_dxlnode,
-		CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *
-			ctxt_translation_prev_siblings	// translation contexts of previous siblings
-	);
+	Plan *TranslateDXLDynTblScan(const CDXLNode *dyn_tbl_scan_dxlnode,
+								 CDXLTranslateContext *output_context);
 
 	// translate a dynamic index scan operator
 	Plan *TranslateDXLDynIdxScan(
@@ -390,12 +380,8 @@ private:
 	);
 
 	// translate a dynamic foreign scan operator
-	Plan *TranslateDXLDynForeignScan(
-		const CDXLNode *dyn_foreign_scan_dxlnode,
-		CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *
-			ctxt_translation_prev_siblings	// translation contexts of previous siblings
-	);
+	Plan *TranslateDXLDynForeignScan(const CDXLNode *dyn_foreign_scan_dxlnode,
+									 CDXLTranslateContext *output_context);
 
 	// translate a DML operator
 	Plan *TranslateDXLDml(
@@ -429,10 +415,7 @@ private:
 	// translate a CTE consumer into a GPDB share input scan
 	Plan *TranslateDXLCTEConsumerToSharedScan(
 		const CDXLNode *cte_consumer_dxlnode,
-		CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *
-			ctxt_translation_prev_siblings	// translation contexts of previous siblings
-	);
+		CDXLTranslateContext *output_context);
 
 	// translate a (dynamic) bitmap table scan operator
 	Plan *TranslateDXLBitmapTblScan(
@@ -451,10 +434,8 @@ private:
 	);
 
 	// translate a DXL Value Scan into GPDB Value Scan
-	Plan *TranslateDXLValueScan(
-		const CDXLNode *value_scan_dxlnode,
-		CDXLTranslateContext *output_context,
-		CDXLTranslationContextArray *ctxt_translation_prev_siblings);
+	Plan *TranslateDXLValueScan(const CDXLNode *value_scan_dxlnode,
+								CDXLTranslateContext *output_context);
 
 	// translate DXL filter list into GPDB filter list
 	List *TranslateDXLFilterList(
@@ -575,9 +556,9 @@ private:
 
 	// translate the index condition list in an Index scan
 	void TranslateIndexConditions(
-		CDXLNode *index_cond_list_dxlnode, const CDXLTableDescr *dxl_tbl_descr,
-		BOOL is_bitmap_index_probe, const IMDIndex *index,
-		const IMDRelation *md_rel, CDXLTranslateContext *output_context,
+		CDXLNode *index_cond_list_dxlnode, BOOL is_bitmap_index_probe,
+		const IMDIndex *index, const IMDRelation *md_rel,
+		CDXLTranslateContext *output_context,
 		CDXLTranslateContextBaseTable *base_table_context,
 		CDXLTranslationContextArray *ctxt_translation_prev_siblings,
 		List **index_cond, List **index_orig_cond);
@@ -609,7 +590,7 @@ private:
 
 	// translate the distribution policy for a DXL physical CTAS operator
 	static GpPolicy *TranslateDXLPhyCtasToDistrPolicy(
-		const CDXLPhysicalCTAS *dxlop, List *target_list);
+		const CDXLPhysicalCTAS *dxlop);
 
 	// translate CTAS storage options
 	static List *TranslateDXLCtasStorageOptions(

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -89,8 +89,7 @@ private:
 	Expr *TranslateDXLScalarArrayCompToScalar(
 		const CDXLNode *scalar_array_cmp_node, CMappingColIdVar *colid_var);
 
-	Expr *TranslateDXLScalarParamToScalar(const CDXLNode *scalar_param_node,
-										  CMappingColIdVar *colid_var);
+	Expr *TranslateDXLScalarParamToScalar(const CDXLNode *scalar_param_node);
 
 	Expr *TranslateDXLScalarOpExprToScalar(const CDXLNode *scalar_op_expr_node,
 										   CMappingColIdVar *colid_var);

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -178,7 +178,7 @@ private:
 	// translate a window operator
 	CDXLNode *TranslateWindowToDXL(
 		CDXLNode *child_dxlnode, List *target_list, List *window_clause,
-		List *sort_clause, IntToUlongMap *sort_col_attno_to_colid_mapping,
+		IntToUlongMap *sort_col_attno_to_colid_mapping,
 		IntToUlongMap *output_attno_to_colid_mapping);
 
 	// translate window spec
@@ -317,9 +317,7 @@ private:
 		CDXLNodeArray *dxl_project_elements) const;
 
 	// translate a value scan range table entry
-	CDXLNode *TranslateValueScanRTEToDXL(const RangeTblEntry *rte, ULONG rti,
-										 ULONG	//current_query_level
-	);
+	CDXLNode *TranslateValueScanRTEToDXL(const RangeTblEntry *rte, ULONG rti);
 
 	// create a dxl node from a array of datums and project elements
 	CDXLNode *TranslateTVFToDXL(const RangeTblEntry *rte, ULONG rti,

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -19,6 +19,7 @@
 #define GPDXL_CTranslatorRelcacheToDXL_H
 
 #include "gpos/base.h"
+
 #include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/operators/CDXLColDescr.h"

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -18,6 +18,15 @@
 #ifndef GPDXL_CTranslatorRelcacheToDXL_H
 #define GPDXL_CTranslatorRelcacheToDXL_H
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+extern "C" {
+#include "postgres.h"
+}
+
+#pragma GCC diagnostic pop
+
 #include "gpos/base.h"
 
 #include "gpopt/utils/gpdbdefs.h"

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -19,15 +19,7 @@
 #define GPDXL_CTranslatorRelcacheToDXL_H
 
 #include "gpos/base.h"
-
-extern "C" {
-#include "postgres.h"
-
-#include "access/tupdesc.h"
-#include "catalog/gp_distribution_policy.h"
-#include "foreign/foreign.h"
-}
-
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/gpdb_types.h"
 #include "naucrates/dxl/operators/CDXLColDescr.h"
 #include "naucrates/md/CDXLColStats.h"

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -205,7 +205,7 @@ private:
 		ULONG num_mcv_values, const Datum *hist_values, ULONG num_hist_values);
 
 	// get partition keys and types for a relation
-	static void RetrievePartKeysAndTypes(CMemoryPool *mp, Relation rel, OID oid,
+	static void RetrievePartKeysAndTypes(CMemoryPool *mp, Relation rel,
 										 ULongPtrArray **part_keys,
 										 CharPtrArray **part_types);
 
@@ -223,9 +223,7 @@ private:
 									 CDouble *null_freq);
 
 	// get the relation columns
-	static CMDColumnArray *RetrieveRelColumns(CMemoryPool *mp,
-											  CMDAccessor *md_accessor,
-											  Relation rel);
+	static CMDColumnArray *RetrieveRelColumns(CMemoryPool *mp, Relation rel);
 
 	// get the distribution columns
 	static ULongPtrArray *RetrieveRelDistributionCols(
@@ -300,8 +298,7 @@ public:
 									IMDId *mdid);
 
 	// add system columns (oid, tid, xmin, etc) in table descriptors
-	static void AddSystemColumns(CMemoryPool *mp, CMDColumnArray *mdcol_array,
-								 Relation rel);
+	static void AddSystemColumns(CMemoryPool *mp, CMDColumnArray *mdcol_array);
 
 	// retrieve an index from the relcache
 	static IMDIndex *RetrieveIndex(CMemoryPool *mp, CMDAccessor *md_accessor,

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -18,15 +18,10 @@
 
 #include "gpos/base.h"
 
-extern "C" {
-#include "postgres.h"
-
-#include "nodes/primnodes.h"
-}
-
 #include "gpopt/translate/CCTEListEntry.h"
 #include "gpopt/translate/CContextQueryToDXL.h"
 #include "gpopt/translate/CMappingVarColId.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/base/IDatum.h"
 #include "naucrates/dxl/operators/CDXLScalarArrayRefIndexList.h"
 #include "naucrates/dxl/operators/CDXLScalarBoolExpr.h"

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -195,8 +195,7 @@ private:
 	CDXLNode *TranslateVarToDXL(const Expr *expr,
 								const CMappingVarColId *var_colid_mapping);
 
-	CDXLNode *TranslateParamToDXL(const Expr *expr,
-								  const CMappingVarColId *var_colid_mapping);
+	CDXLNode *TranslateParamToDXL(const Expr *expr);
 
 	CDXLNode *CreateInitPlanFromParam(const Param *param) const;
 
@@ -227,8 +226,7 @@ private:
 	CDXLNode *TranslateArrayRefToDXL(const Expr *expr,
 									 const CMappingVarColId *var_colid_mapping);
 
-	CDXLNode *TranslateSortGroupClauseToDXL(
-		const Expr *expr, const CMappingVarColId *var_colid_mapping);
+	CDXLNode *TranslateSortGroupClauseToDXL(const Expr *expr);
 
 	// add an indexlist to the given DXL arrayref node
 	void AddArrayIndexList(

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -16,12 +16,11 @@
 #ifndef GPDXL_CTranslatorUtils_H
 #define GPDXL_CTranslatorUtils_H
 #define GPDXL_SYSTEM_COLUMNS 8
-#include "gpopt/utils/gpdbdefs.h"
-
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"
 
 #include "gpopt/translate/CMappingVarColId.h"
+#include "gpopt/utils/gpdbdefs.h"
 #include "naucrates/dxl/CIdGenerator.h"
 #include "naucrates/dxl/operators/CDXLIndexDescr.h"
 #include "naucrates/dxl/operators/CDXLLogicalSetOp.h"

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -16,14 +16,7 @@
 #ifndef GPDXL_CTranslatorUtils_H
 #define GPDXL_CTranslatorUtils_H
 #define GPDXL_SYSTEM_COLUMNS 8
-
-extern "C" {
-#include "postgres.h"
-
-#include "access/sdir.h"
-#include "access/skey.h"
-#include "nodes/parsenodes.h"
-}
+#include "gpopt/utils/gpdbdefs.h"
 
 #include "gpos/base.h"
 #include "gpos/common/CBitSet.h"

--- a/src/include/gpopt/utils/CMemoryPoolPalloc.h
+++ b/src/include/gpopt/utils/CMemoryPoolPalloc.h
@@ -17,6 +17,8 @@
 #include "gpos/base.h"
 #include "gpos/memory/CMemoryPool.h"
 
+#include "gpopt/utils/gpdbdefs.h"
+
 namespace gpos
 {
 // Memory pool that maps to a Postgres MemoryContext.

--- a/src/include/gpopt/utils/funcs.h
+++ b/src/include/gpopt/utils/funcs.h
@@ -10,14 +10,9 @@
 #ifndef GPOPT_funcs_H
 #define GPOPT_funcs_H
 
+#include "gpopt/utils/gpdbdefs.h"
 
 extern "C" {
-
-#include "postgres.h"
-
-#include "fmgr.h"
-#include "utils/builtins.h"
-
 extern Datum DisableXform(PG_FUNCTION_ARGS);
 extern Datum EnableXform(PG_FUNCTION_ARGS);
 extern Datum LibraryVersion();

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -18,6 +18,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 
 extern "C" {
 

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -15,8 +15,10 @@
 
 #ifndef GPDBDefs_H
 #define GPDBDefs_H
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+
 extern "C" {
 
 #include "postgres.h"
@@ -29,10 +31,10 @@ extern "C" {
 #include "nodes/nodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/plannodes.h"
-#include "optimizer/walkers.h"
 #include "optimizer/hints.h"
 #include "optimizer/orca.h"
 #include "optimizer/plancat.h"
+#include "optimizer/walkers.h"
 #include "parser/parse_clause.h"
 #include "parser/parse_expr.h"
 #include "parser/parse_oper.h"

--- a/src/include/gpopt/utils/gpdbdefs.h
+++ b/src/include/gpopt/utils/gpdbdefs.h
@@ -15,26 +15,40 @@
 
 #ifndef GPDBDefs_H
 #define GPDBDefs_H
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 extern "C" {
 
 #include "postgres.h"
 
+#include "access/amapi.h"
+#include "catalog/heap.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_statistic_ext.h"
+#include "cdb/cdbvars.h"
 #include "nodes/nodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/plannodes.h"
 #include "optimizer/walkers.h"
+#include "optimizer/hints.h"
+#include "optimizer/orca.h"
+#include "optimizer/plancat.h"
 #include "parser/parse_clause.h"
 #include "parser/parse_expr.h"
 #include "parser/parse_oper.h"
 #include "parser/parse_relation.h"
 #include "parser/parsetree.h"
+#include "partitioning/partdesc.h"
+#include "statistics/statistics.h"
+#include "storage/proc.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
+#include "utils/fmgroids.h"
+#include "utils/guc.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
+#include "utils/partcache.h"
 #include "utils/syscache.h"
 #if 0
 #include "cdb/partitionselection.h"
@@ -63,6 +77,7 @@ extern "C" {
 
 }  // end extern C
 
+#pragma GCC diagnostic pop
 
 #endif	// GPDBDefs_H
 


### PR DESCRIPTION
Align compilation flags for gpopt with gporca

Before this patch source files in 'gpopt' and 'gporca' folders were built
with different sets of the compilation flags.

This patch makes the compilation flags for 'gpopt' to be the same as for the
'gporca' sources. It gives following benefits:
 - it will help us in the possible future separation of ORCA into a shared lib;
 - it makes the compilation of the 'gpopt' much more strict.

But enabling the same set of compilation flags introduces build failures for the
'gpopt' sources. Most part of the failures come from the places where the 'C++'
code of the 'gpopt' is "glued" with the 'C' GPDB core code (mostly because some
features, that are appropriate in 'C', are not part of the 'C++' standard).

This patch intends not to alter the 'gpopt' logic, so fixes are done mostly with
compiler commands.

List of issues and changes:
1. Some functions have unused parameters (or parameters that are used only in
asserts, thus they become unused if the build is configured without the
'--enable-cassert' option). These parameters are removed where possible. In the
places where it is not possible, such parameters are marked now with the
'unused' attribute (via GPOS_UNUSED).
2. There are several places that triggered function type mismatch, where the
"*_walker()" functions are used. These places are covered by disabling the
"-Wcast-function-type" check via the 'pragma' command.
3. Inclusion of headers for the 'C' code triggered "ISO C++ forbids flexible
array member", which is used widely in the 'C' code, and "unused parameter". It
is covered by disabling the "-Wpedantic" and "-Wunused-parameter" checks via
the 'pragma' command before including the headers, and restoring after the
inclusion is done.
To reduce the number of places where we need to apply this change, most part of
the 'C' header inclusions are moved to the 'gpdbdefs.h' file. And a plenty of
the 'gpopt' sources are reworked to include the 'gpdbdefs.h' file instead of
directly including the 'C' header files.
Note 1: 'gpdbwrapper.cpp' still has direct includes that are specific only to
this source file, they are left there in order not to blow up 'gpdbdefs.h'
too much.
Note 2: 'CTranslatorRelcacheToDXL.h' still has a separate include of
'postgres.h' at the beginning, as the consequent includes rely on the defines
from this file. Without it in the first place, bfv_statistic test will fail. And
we can't move 'gpdbdefs.h' to the file start instead of it due to the
'clang-format' check.
4. One assert check in 'CTranslatorDXLToPlStmt::ProcessDXLTblDescr()' is
removed, as it compares unsigned integer value to be not negative, which is
meaningless.
5. 'NewNode' macro generates "ISO C++ forbids braced-groups within expressions",
so its implementation is changed. For the same reason
'gpdb::GPDBAllocSetContextCreate()' is also wrapped with 'pragma'.

Tested build with GCC 11 and Clang 15.