### PR TITLE
Decouple Orca from the GPMemoryProtect_TrackStartupMemory()

### DIFF
--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -3,6 +3,8 @@
 #include "cdb/cdbvars.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/vmem_tracker.h"
 
 PG_MODULE_MAGIC;
 
@@ -19,6 +21,16 @@ _PG_init(void)
 
 	if (!IS_QUERY_DISPATCHER())
 		return;
+
+	Size orca_mem = 6L << BITS_IN_MB;
+	/*
+	 * When optimizer_use_gpdb_allocators is on, at least 2MB of above will be
+	 * tracked by vmem tracker later, so do not recount them.
+	 */
+	if (optimizer_use_gpdb_allocators)
+		orca_mem -= (2L << BITS_IN_MB);
+
+	GPMemoryProtect_RequestAddinStartupMemory(orca_mem);
 }
 
 void

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -22,6 +22,7 @@ _PG_init(void)
 	if (!IS_QUERY_DISPATCHER())
 		return;
 
+	/* When compile with ORCA it will commit 6MB more */
 	Size orca_mem = 6L << BITS_IN_MB;
 	/*
 	 * When optimizer_use_gpdb_allocators is on, at least 2MB of above will be

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -79,7 +79,6 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/timeout.h"
-#include "utils/vmem_tracker.h"
 
 #include "utils/resource_manager.h"
 #include "utils/session_state.h"
@@ -696,20 +695,6 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 
 		InitGPOPT();
 	}
-
-	// TODO: move to _PG_init when ORCA shared lib skeleton is ready
-
-	/* When compile with ORCA it will commit 6MB more */
-	Size orca_mem = 6L << BITS_IN_MB;
-	/*
-	 * When optimizer_use_gpdb_allocators is on, at least 2MB of above will be
-	 * tracked by vmem tracker later, so do not recount them.  This GUC is not
-	 * available until gpdb 5.1.0 .
-	 */
-	if (optimizer_use_gpdb_allocators)
-		orca_mem -= 2L << BITS_IN_MB;
-
-	GPMemoryProtect_RequestAddinStartupMemory(orca_mem);
 #endif
 
 	/*

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -79,6 +79,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/timeout.h"
+#include "utils/vmem_tracker.h"
 
 #include "utils/resource_manager.h"
 #include "utils/session_state.h"
@@ -695,6 +696,20 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 
 		InitGPOPT();
 	}
+
+	// TODO: move to _PG_init when ORCA shared lib skeleton is ready
+
+	/* When compile with ORCA it will commit 6MB more */
+	Size orca_mem = 6L << BITS_IN_MB;
+	/*
+	 * When optimizer_use_gpdb_allocators is on, at least 2MB of above will be
+	 * tracked by vmem tracker later, so do not recount them.  This GUC is not
+	 * available until gpdb 5.1.0 .
+	 */
+	if (optimizer_use_gpdb_allocators)
+		orca_mem -= 2L << BITS_IN_MB;
+
+	GPMemoryProtect_RequestAddinStartupMemory(orca_mem);
 #endif
 
 	/*

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -265,12 +265,12 @@ GPMemoryProtect_TrackStartupMemory(void)
 	 */
 	bytes += 6L << BITS_IN_MB;
 
+	/* Leave some buffer for extensions like metrics_collector */
+	bytes += 2L << BITS_IN_MB;
+
 	/* freeze the addin request size and include it */
 	startup_mem_addin_request_allowed = false;
 	bytes = add_size(bytes, startup_mem_total_addin_request);
-
-	/* Leave some buffer for extensions like metrics_collector */
-	bytes += 2L << BITS_IN_MB;
 
 	/* Ensure we do not overflow when converting to signed */
 	Assert((int64)bytes > 0);

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -255,7 +255,7 @@ void
 GPMemoryProtect_TrackStartupMemory(void)
 {
 	MemoryAllocationStatus status;
-	int64		bytes = 0;
+	Size		bytes = 0;
 
 	Assert(gp_mp_inited);
 
@@ -272,8 +272,10 @@ GPMemoryProtect_TrackStartupMemory(void)
 	/* Leave some buffer for extensions like metrics_collector */
 	bytes += 2L << BITS_IN_MB;
 
+	/* Ensure we do not overflow when converting to signed */
+	Assert((int64)bytes > 0);
 	/* Register the startup memory */
-	status = VmemTracker_RegisterStartupMemory(bytes);
+	status = VmemTracker_RegisterStartupMemory((int64)bytes);
 	if (status != MemoryAllocation_Success)
 		gp_failed_to_alloc(status, 0, bytes);
 }

--- a/src/backend/utils/mmgr/memprot.c
+++ b/src/backend/utils/mmgr/memprot.c
@@ -217,14 +217,12 @@ void GPMemoryProtect_Shutdown()
  *		memory for use by a loadable module.
  *
  * This is only useful if called from the _PG_init hook of a library that
- * is loaded into the postmaster via shared_preload_libraries.  Once
- * shared memory has been allocated, calls will be ignored.
+ * is loaded into the postmaster via shared_preload_libraries.
  */
 void
 GPMemoryProtect_RequestAddinStartupMemory(Size size)
 {
-	// TODO: unkomment IsUnderPostmaster when moving to _PG_init
-	if (/* IsUnderPostmaster ||*/ !startup_mem_addin_request_allowed)
+	if (IsUnderPostmaster || !startup_mem_addin_request_allowed)
 		return;					/* too late */
 
 	startup_mem_total_addin_request = add_size(startup_mem_total_addin_request, size);

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -210,6 +210,7 @@ extern void GPMemoryProtect_ShmemInit(void);
 extern void GPMemoryProtect_Init(void);
 extern void GPMemoryProtect_Shutdown(void);
 extern void GPMemoryProtect_TrackStartupMemory(void);
+extern void GPMemoryProtect_RequestAddinStartupMemory(Size size);
 extern void UpdateTimeAtomically(volatile OOMTimeType* time_var);
 
 /*


### PR DESCRIPTION
Decouple Orca from the GPMemoryProtect_TrackStartupMemory()

GPMemoryProtect_TrackStartupMemory() contained compile-time dependency on Orca.
It prevented moving of all Orca's code into a shared lib and making its work
transparent to the GPDB core.

This patch reworks the logic of the GPMemoryProtect_TrackStartupMemory(). Now
extension should call GPMemoryProtect_RequestAddinStartupMemory() at its
_PG_init(), if the extension affects the per-process startup committed memory.
Such call is added to the Orca's _PG_init(). Orca related code is removed from
the GPMemoryProtect_TrackStartupMemory().