### PR TITLE
Connect Orca via a planner hook

### DIFF
--- a/gpcontrib/gp_orca/.clang-format
+++ b/gpcontrib/gp_orca/.clang-format
@@ -1,0 +1,187 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '"postgres\.h"'
+    Priority:        -1
+    SortPriority:    0
+  - Regex:           '"gpos/.*'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '"(gpopt|naucrates|gpdbcost)/.*'
+    Priority:        4
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Always
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -1,17 +1,85 @@
 #include "postgres.h"
 
 #include "cdb/cdbvars.h"
+#include "executor/executor.h"
 #include "miscadmin.h"
+#include "optimizer/orca.h"
+#include "optimizer/planner.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/memutils.h"
+
+PG_MODULE_MAGIC;
 
 extern void InitGPOPT();
 extern void TerminateGPOPT();
 
-PG_MODULE_MAGIC;
+extern void compute_jit_flags(PlannedStmt* pstmt);
 
 void		_PG_init(void);
 void		_PG_fini(void);
+
+static planner_hook_type prev_planner = NULL;
+
+static PlannedStmt *
+gp_orca_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
+{
+	PlannedStmt	   *result = NULL;
+
+	/*
+	 * Use ORCA only if it is enabled and we are in a coordinator QD process.
+	 *
+	 * ORCA excels in complex queries, most of which will access distributed
+	 * tables. We can't run such queries from the segments slices anyway because
+	 * they require dispatching a query within another - which is not allowed in
+	 * GPDB (see querytree_safe_for_qe()). Note that this restriction also
+	 * applies to non-QD coordinator slices.  Furthermore, ORCA doesn't currently
+	 * support pl/<lang> statements (relevant when they are planned on the segments).
+	 * For these reasons, restrict to using ORCA on the coordinator QD processes only.
+	 *
+	 * PARALLEL RETRIEVE CURSOR is not supported by ORCA yet.
+	 */
+	if (optimizer &&
+		GP_ROLE_DISPATCH == Gp_role &&
+		IS_QUERY_DISPATCHER() &&
+		(cursorOptions & CURSOR_OPT_SKIP_FOREIGN_PARTITIONS) == 0 &&
+		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)
+	{
+		instr_time		starttime;
+		instr_time		endtime;
+
+		if (gp_log_optimization_time)
+			INSTR_TIME_SET_CURRENT(starttime);
+
+		result = optimize_query(parse, cursorOptions, boundParams);
+
+		/* decide jit state */
+		if (result)
+		{
+			/*
+			 * Setting Jit flags for Optimizer
+			 */
+			compute_jit_flags(result);
+		}
+
+		if (gp_log_optimization_time)
+		{
+			INSTR_TIME_SET_CURRENT(endtime);
+			INSTR_TIME_SUBTRACT(endtime, starttime);
+			elog(LOG, "Optimizer Time: %.3f ms", INSTR_TIME_GET_MILLISEC(endtime));
+		}
+
+		if (result)
+			return result;
+	}
+
+	if (prev_planner)
+		result = (*prev_planner) (parse, cursorOptions, boundParams);
+	else
+		result = standard_planner(parse, cursorOptions, boundParams);
+
+	return result;
+}
 
 void
 _PG_init(void)
@@ -34,6 +102,9 @@ _PG_init(void)
 													ALLOCSET_DEFAULT_MAXSIZE);
 
 		InitGPOPT();
+
+		prev_planner = planner_hook;
+		planner_hook = gp_orca_planner;
 	}
 }
 
@@ -42,6 +113,8 @@ _PG_fini(void)
 {
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		planner_hook = prev_planner;
+
 		TerminateGPOPT();
 
 		if (OptimizerMemoryContext != NULL)

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -51,7 +51,6 @@ static PlannedStmt *
 gp_orca_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt	   *result = NULL;
-	static bool first_call = true;
 
 	/*
 	 * Use ORCA only if it is enabled and we are in a coordinator QD process.
@@ -75,11 +74,8 @@ gp_orca_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		instr_time		starttime;
 		instr_time		endtime;
 
-		if (first_call)
-		{
+		if (NULL == OptimizerMemoryContext)
 			gp_orca_init();
-			first_call = false;
-		}
 
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -26,6 +26,9 @@ static planner_hook_type prev_planner = NULL;
 static void
 gp_orca_shutdown(int code, Datum arg)
 {
+	(void) code;
+	(void) arg;
+
 	TerminateGPOPT();
 
 	if (NULL != OptimizerMemoryContext)

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -101,10 +101,6 @@ static void process_startup_options(Port *port, bool am_superuser);
 static void process_settings(Oid databaseid, Oid roleid);
 
 extern bool DoingCommandRead;
-#ifdef USE_ORCA
-extern void InitGPOPT();
-extern void TerminateGPOPT();
-#endif
 
 
 /*** InitPostgres support ***/
@@ -682,20 +678,6 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	SessionState_Init();
 	/* Initialize memory protection */
 	GPMemoryProtect_Init();
-
-#ifdef USE_ORCA
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		/* Initialize GPOPT */
-		OptimizerMemoryContext = AllocSetContextCreate(TopMemoryContext,
-													"GPORCA Top-level Memory Context",
-													ALLOCSET_DEFAULT_MINSIZE,
-													ALLOCSET_DEFAULT_INITSIZE,
-													ALLOCSET_DEFAULT_MAXSIZE);
-
-		InitGPOPT();
-	}
-#endif
 
 	/*
 	 * Initialize my entry in the shared-invalidation manager's array of
@@ -1459,16 +1441,6 @@ ShutdownPostgres(int code, Datum arg)
 	 * our usage, report now.
 	 */
 	ReportOOMConsumption();
-
-#ifdef USE_ORCA
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		TerminateGPOPT();
-
-		if (OptimizerMemoryContext != NULL)
-			MemoryContextDelete(OptimizerMemoryContext);
-	}
-#endif
 
 	/* Disable memory protection */
 	GPMemoryProtect_Shutdown();


### PR DESCRIPTION
Connect Orca via a planner hook

Problem:
Orca's code was strongly coupled with the standard_planner() code. It introduced
difficulties for moving Orca's functionality into a shared lib.

This patch:
1. moves the invocation of Orca planner out from the standard_planner() into a
hook in gp_orca shared lib;
2. moves the init procedure of Orca to the first call of the hook (thus the init
is done when the backend has already been initialized including its memory
protection means);
3. moves the deinit procedure of Orca into a callback, that is registered at the
init (thus the deinit is done right before ShutdownPostgres() is called, where
it was before).
4. adds clang-format config file