### PR TITLE
ADBDEV-6677 Freeze LLVM to 17 version in Dockerfile

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -18,8 +18,7 @@ RUN dnf makecache && \
     dnf -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     dnf -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
     dnf -y install python3.11-psycopg2 python3.11-pyyaml python3.11-lxml python3.11-pip && \
-    dnf -y install llvm-devel-17.0.6-3.module+el8.10.0+1869+0b51ffa4 && \
-    dnf -y install clang-17.0.6-1.module+el8.10.0+1869+0b51ffa4 && \
+    dnf -y install llvm-devel-17.0.6 clang-17.0.6 && \
     dnf clean all && \
     #we install pytest from pypi since the version from the repository does not contain an executable file
     #the rest of the packages are not available in the repository.

--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -18,7 +18,8 @@ RUN dnf makecache && \
     dnf -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     dnf -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
     dnf -y install python3.11-psycopg2 python3.11-pyyaml python3.11-lxml python3.11-pip && \
-    dnf -y install llvm-devel clang && \
+    dnf -y install llvm-devel-17.0.6-3.module+el8.10.0+1869+0b51ffa4 && \
+    dnf -y install clang-17.0.6-1.module+el8.10.0+1869+0b51ffa4 && \
     dnf clean all && \
     #we install pytest from pypi since the version from the repository does not contain an executable file
     #the rest of the packages are not available in the repository.


### PR DESCRIPTION
Freeze LLVM to 17 version in Dockerfile

In our rockylinux8 docker container Clang is installed like `dnf install clang`
which doesn’t force any version and uses that version which is considered
current in the repo. Until now, the default LLVM version was 17, but it has
been recently promoted to 18 which caused our JIT tests to fail.

The reason of this problem is that postgres isn’t ready for LLVM 18, that is,
it uses an old API which isn’t compatible with new LLVM 18. Currently, there's
no patch even in the postgres upstream which addresses this problem.

As a temporary solution, this patch freezes Clang and LLVM packages to the 17
version