### PR TITLE
ADBDEV-6593: Fix vacuum_progress isolation tests

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -587,7 +587,11 @@ GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep)
 	LWLockRelease(SyncRepLock);
 
 	if (!response->IsMirrorUp)
+	{
 		response->RequestRetry = is_probe_retry_needed();
+		if (!response->RequestRetry)
+			SIMPLE_FAULT_INJECTOR("replication_mirror_down");
+	}
 }
 
 /*

--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -587,11 +587,7 @@ GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep)
 	LWLockRelease(SyncRepLock);
 
 	if (!response->IsMirrorUp)
-	{
 		response->RequestRetry = is_probe_retry_needed();
-		if (!response->RequestRetry)
-			SIMPLE_FAULT_INJECTOR("replication_mirror_down");
-	}
 }
 
 /*

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -348,7 +348,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
+2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -359,18 +359,24 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 --------------------------
  Success:                 
 (1 row)
--- wait for FTS probe
-2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+-- wait for the mirror stop to be detected
+2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+-- wait for FTS probe
+2: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -341,12 +341,41 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
  Success:        
 (3 rows)
+
+-- we shouldn't proceed until FTS probe has bumped the version
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
+-- wait for FTS probe
+2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
 -- Ensure we enter into the target logic which stops cumulative data but
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point
@@ -397,14 +426,14 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
  gp_segment_id | relname                   | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------------+---------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- 2             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
- 0             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
- 1             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 2             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 9                  | 2                  | 0               | 0               
+ 1             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 9                  | 2                  | 0               | 0               
+ 0             | vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 9                  | 2                  | 0               | 0               
 (3 rows)
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
  relname                   | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ vacuum_progress_ao_column | append-optimized post-cleanup | 0               | 0                 | 27                 | 6                  | 0               | 0               
 (1 row)
 
 2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -348,7 +348,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
  Success:        
 (3 rows)
-
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -318,6 +318,13 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 --------------------------
  Success:                 
 (1 row)
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
+-- ensuring the backends are restarted before they start the post-cleanup phase.
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
@@ -342,13 +349,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
--- ensuring the backends are restarted before they start the post-cleanup phase.
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
- gp_inject_fault 
------------------
- Success:        
-(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -348,33 +348,17 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
- gp_inject_fault 
------------------
- Success:        
-(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
--- wait for the mirror stop to be detected
-2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
- gp_inject_fault 
------------------
- Success:        
-(1 row)
--- wait for FTS probe
-2: SELECT gp_request_fts_probe_scan();
- gp_request_fts_probe_scan 
----------------------------
- t                         
+-- wait for the mirror stop to be detected (timeout 2 minutes)
+2: SELECT wait_for_mirror_down(1::smallint, 120);
+ wait_for_mirror_down 
+----------------------
+ t                    
 (1 row)
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
  gp_inject_fault 

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -342,7 +342,8 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- we shouldn't proceed until FTS probe has bumped the version
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -342,7 +342,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
 -- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
  gp_inject_fault 

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -401,7 +401,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
+2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -412,18 +412,24 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 --------------------------
  Success:                 
 (1 row)
--- wait for FTS probe
-2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+-- wait for the mirror stop to be detected
+2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+-- wait for FTS probe
+2: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
  gp_inject_fault 
 -----------------
  Success:        

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -394,12 +394,41 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
  Success:        
 (3 rows)
+
+-- we shouldn't proceed until FTS probe has bumped the version
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
+-- wait for FTS probe
+2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
 -- Ensure we enter into the target logic which stops cumulative data but
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point
@@ -450,14 +479,14 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 select gp_segment_id, relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > -1;
  gp_segment_id | relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------------+------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- 0             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
- 2             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
- 1             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ 2             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 19                 | 2                  | 0               | 0               
+ 0             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 19                 | 2                  | 0               | 0               
+ 1             | vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 19                 | 2                  | 0               | 0               
 (3 rows)
 select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
  relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 0                  | 0                  | 0               | 0               
+ vacuum_progress_ao_row | append-optimized post-cleanup | 0               | 0                 | 57                 | 6                  | 0               | 0               
 (1 row)
 
 2: SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -371,6 +371,13 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 --------------------------
  Success:                 
 (1 row)
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
+-- ensuring the backends are restarted before they start the post-cleanup phase.
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
 2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
@@ -395,13 +402,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
--- ensuring the backends are restarted before they start the post-cleanup phase.
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
- gp_inject_fault 
------------------
- Success:        
-(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -395,7 +395,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
 -- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
  gp_inject_fault 

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -401,7 +401,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
  Success:        
 (3 rows)
-
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -401,33 +401,17 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -----------------
  Success:        
 (1 row)
-2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
- gp_inject_fault 
------------------
- Success:        
-(1 row)
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
--- wait for the mirror stop to be detected
-2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
-2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
- gp_inject_fault 
------------------
- Success:        
-(1 row)
--- wait for FTS probe
-2: SELECT gp_request_fts_probe_scan();
- gp_request_fts_probe_scan 
----------------------------
- t                         
+-- wait for the mirror stop to be detected (timeout 2 minutes)
+2: SELECT wait_for_mirror_down(1::smallint, 120);
+ wait_for_mirror_down 
+----------------------
+ t                    
 (1 row)
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
  gp_inject_fault 

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -395,7 +395,8 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
  Success:        
 (3 rows)
 
--- we shouldn't proceed until FTS probe has bumped the version
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
  gp_inject_fault 
 -----------------

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -139,8 +139,17 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume walsender to detect mirror down and suspend at the beginning
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- we shouldn't proceed until FTS probe has bumped the version
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- wait for FTS probe
+2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+
 -- Ensure we enter into the target logic which stops cumulative data but
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -132,6 +132,9 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 
 -- Resume execution of compact phase and block at syncrep on one segment.
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
+-- ensuring the backends are restarted before they start the post-cleanup phase.
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
 2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- stop the mirror should turn off syncrep
 2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content = 1 AND role = 'm';
@@ -140,9 +143,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
--- ensuring the backends are restarted before they start the post-cleanup phase.
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- wait for the mirror stop to be detected (timeout 2 minutes)

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -142,14 +142,10 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 
 -- we shouldn't proceed until FTS probe has bumped the version
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
-2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
--- wait for the mirror stop to be detected
-2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
--- wait for FTS probe
-2: SELECT gp_request_fts_probe_scan();
+-- wait for the mirror stop to be detected (timeout 2 minutes)
+2: SELECT wait_for_mirror_down(1::smallint, 120);
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
 
 -- Ensure we enter into the target logic which stops cumulative data but

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -140,7 +140,8 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- we shouldn't proceed until FTS probe has bumped the version
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -142,7 +142,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume walsender to detect mirror down and suspend at the beginning
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
-
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- wait for the mirror stop to be detected (timeout 2 minutes)

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -140,7 +140,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
 -- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_column', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -143,8 +143,17 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume walsender to detect mirror down and suspend at the beginning
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- we shouldn't proceed until FTS probe has bumped the version
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- wait for FTS probe
+2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
+2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+
 -- Ensure we enter into the target logic which stops cumulative data but
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.
 -- Also all segments should reach to the same "vacuum_worker_changed" point

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -146,13 +146,15 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 
 -- we shouldn't proceed until FTS probe has bumped the version
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'skip', 1) FROM master();
+2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- wait for the mirror stop to be detected
+2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- wait for FTS probe
-2: SELECT gp_wait_until_triggered_fault('ftsLoop_after_probe', 1, 1) FROM master();
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', 1) FROM master();
-2: SELECT gp_inject_fault('ftsLoop_after_probe', 'reset', 1) FROM master();
+2: SELECT gp_request_fts_probe_scan();
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
 
 -- Ensure we enter into the target logic which stops cumulative data but
 -- initializes a new vacrelstats at the beginning of post-cleanup phase.

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -146,14 +146,10 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 
 -- we shouldn't proceed until FTS probe has bumped the version
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
-2: SELECT gp_inject_fault('replication_mirror_down', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
--- wait for the mirror stop to be detected
-2: SELECT gp_wait_until_triggered_fault('replication_mirror_down', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-2: SELECT gp_inject_fault('replication_mirror_down', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
--- wait for FTS probe
-2: SELECT gp_request_fts_probe_scan();
+-- wait for the mirror stop to be detected (timeout 2 minutes)
+2: SELECT wait_for_mirror_down(1::smallint, 120);
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid) FROM master();
 
 -- Ensure we enter into the target logic which stops cumulative data but

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -144,7 +144,7 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
 -- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -146,7 +146,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- Resume walsender to detect mirror down and suspend at the beginning
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
-
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- wait for the mirror stop to be detected (timeout 2 minutes)

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -144,7 +144,8 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- we shouldn't proceed until FTS probe has bumped the version
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated, 
+-- ensuring the backends are restarted before they start the post-cleanup phase.
 2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -136,6 +136,9 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 
 -- Resume execution of compact phase and block at syncrep.
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
+-- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
+-- ensuring the backends are restarted before they start the post-cleanup phase.
+2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
 2: SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- stop the mirror should turn off syncrep
 2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=1 AND role = 'm';
@@ -144,9 +147,6 @@ select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, he
 -- of post-cleanup taken over by a new vacuum worker.
 2: SELECT gp_inject_fault('vacuum_worker_changed', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
--- Dispatcher shouldn't proceed until status_version in FtsVersion in FtsProbeInfo is updated,
--- ensuring the backends are restarted before they start the post-cleanup phase.
-2: SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'suspend', '', '', 'vacuum_progress_ao_row', 1, 1, 0, 1) FROM master();
 -- resume walsender and let it exit so that mirror stop can be detected
 2: SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' and content = 1;
 -- wait for the mirror stop to be detected (timeout 2 minutes)


### PR DESCRIPTION
Fix vacuum_progress isolation tests

Isolation tests `vacuum_progress_column` and `vacuum_progress_row` would
previously fail sometimes because `vacuum_worker_changed` fault injector was
never reached. This happened because vacuum execution and FTS version upgrade
are not synchronized: after FTS disables syncrep according to the test, it
should bump FTS version, which should be detected by the dispatcher on the
next `StartTransaction` call, and then the segment backends will be restarted
(making `vacuum_worker_changed` fault accessible). However, if FTS is too slow
(or dispatcher too fast), it might skip `StartTransaction` calls before FTS
version is bumped, and the segment restart will happen after vacuum is
complete, without triggering `vacuum_worker_changed`. This is an acceptable
behavior for the code since the restart still happens milliseconds after
disabling syncrep, but the test doesn't expect it.

This patch fixes the test by making the dispatcher wait on
`vacuum_rel_finished_one_relation` fault until waits until mirror down is
detected by FTS, ensuring FTS version bump happens before dispatcher proceeds.

Note that the patch also changes expected output: it seems like previously
restart happened on the last `StartTransaction`, making all the collected
stats to be zero. However, post-cleanup vacuum phase (which is executed after
`vacuum_worker_changed`) is also responsible for vacuuming the indexes, so the
correct output should include those too. Note that `num_dead_tuples` value is
still zero, indicating that `vacrelstats` was indeed reset correctly.