### PR TITLE
Fix deadlock if the cross slice SharedScan consumer is on slice 0 (#623)

### DIFF
--- a/src/include/executor/nodeShareInputScan.h
+++ b/src/include/executor/nodeShareInputScan.h
@@ -24,6 +24,8 @@ extern void ExecEndShareInputScan(ShareInputScanState *node);
 extern void ExecReScanShareInputScan(ShareInputScanState *node);
 extern void ExecSquelchShareInputScan(ShareInputScanState *node);
 
+extern void ShareInputReaderNotifyDone(ShareInputScanState *node);
+
 extern Size ShareInputShmemSize(void);
 extern void ShareInputShmemInit(void);
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -682,6 +682,9 @@ typedef struct EState
 	 */
 	bool		gp_bypass_unique_check;
 
+	/* List of cross-slice SharedScan consumers in the current slice */
+	List	   *sharedScanConsumers;
+
 } EState;
 
 struct PlanState;

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2539,3 +2539,45 @@ JOIN cte b USING (i);
 (1 row)
 
 DROP TABLE with_test;
+-- Test cross slice Shared Scan with consumer in slice 0.
+CREATE TABLE d (c1 int, c2 int) DISTRIBUTED BY (c1);
+INSERT INTO d (VALUES ( 2, 0 ),( 2 , 0 ));
+-- The consumer should be in slice 0
+EXPLAIN (COSTS OFF) WITH cte AS (
+	SELECT c1 FROM d LIMIT 2
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Nested Loop
+   Join Filter: (share0_ref2.c1 = d.c1)
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Limit
+                     ->  Hash Join
+                           Hash Cond: (d.c1 = share0_ref1.c1)
+                           ->  Seq Scan on d
+                           ->  Hash
+                                 ->  Redistribute Motion 1:3  (slice2)
+                                       Hash Key: share0_ref1.c1
+                                       ->  Shared Scan (share slice:id 2:0)
+                                             ->  Limit
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                         ->  Limit
+                                                               ->  Seq Scan on d d_1
+   ->  Materialize
+         ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Postgres-based planner
+(19 rows)
+
+-- Deadlock shouldn't happen
+WITH cte AS (
+	SELECT c1 FROM d LIMIT 2
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+ c1 | c2 
+----+----
+  2 |  0
+  2 |  0
+(2 rows)
+

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -2555,3 +2555,52 @@ JOIN cte b USING (i);
 (1 row)
 
 DROP TABLE with_test;
+-- Test cross slice Shared Scan with consumer in slice 0.
+--start_ignore
+SET enable_nestloop = ON;
+DROP TABLE IF EXISTS d;
+--end_ignore
+CREATE TABLE d (c1 int, c2 int) DISTRIBUTED BY (c1);
+INSERT INTO d (VALUES ( 2, 0 ),( 2 , 0 ));
+-- The consumer should be in slice 0
+EXPLAIN (COSTS OFF) WITH cte AS (
+	SELECT c1 FROM d LIMIT 2
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Limit
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on d
+   ->  Hash Join
+         Hash Cond: (d_1.c1 = share0_ref2.c1)
+         ->  Result
+               Filter: (d_1.c1 = share0_ref3.c1)
+               ->  Limit
+                     ->  Hash Join
+                           Hash Cond: (d_1.c1 = share0_ref3.c1)
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on d d_1
+                           ->  Hash
+                                 ->  Shared Scan (share slice:id 0:0)
+         ->  Hash
+               ->  Shared Scan (share slice:id 0:0)
+ Optimizer: GPORCA
+(19 rows)
+
+-- Deadlock shouldn't happen
+WITH cte AS (
+	SELECT c1 FROM d LIMIT 2
+)
+SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
+ c1 | c2 
+----+----
+  2 |  0
+  2 |  0
+(2 rows)
+
+--start_ignore
+DROP TABLE d;
+--end_ignore


### PR DESCRIPTION
Fix deadlock if the cross slice SharedScan consumer is on slice 0 (#1115)

When the consumer of the cross slice SharedScan is in slice 0 and the producer
is in another slice, a deadlock may occur. The deadlock could happen because QD
does not complete slice 0 until other slices will be completed. But the
producer's slice cannot finish until it receives notification from the consumer
about the completion of reading. The consumer does not send this notification
before all QEs are completed.

This patch fixes the deadlock by creating a list of cross-slice consumers for
the current slice and sending notifications before waiting for QEs completion.
We can omit the share_lk_ctxt check for NULL since only cross slice Shared Scans
are added to the list.

Original patch was modified, because notifying producers was rewritten by
commit d21b113d131b502c89b09486734cb3de21d08530. But the main idea of the
original patch was not changed.

(cherry picked from commit f6f95b6622a3fbdf441ec86164d5921b472694d7)


Co-authored-by: Evgeniy Ratkov <e.ratkov@arenadata.io>