### PR TITLE
ADBDEV-6314: Fix unexpected output for empty grouping set

### DIFF
--- a/src/backend/nodes/list.c
+++ b/src/backend/nodes/list.c
@@ -838,6 +838,32 @@ list_intersection(const List *list1, const List *list2)
 }
 
 /*
+ * As list_intersection but operates on lists of integers.
+ */
+List *
+list_intersection_int(const List *list1, const List *list2)
+{
+	List	   *result;
+	const ListCell *cell;
+
+	if (list1 == NIL || list2 == NIL)
+		return NIL;
+
+	Assert(IsIntegerList(list1));
+	Assert(IsIntegerList(list2));
+
+	result = NIL;
+	foreach(cell, list1)
+	{
+		if (list_member_int(list2, lfirst_int(cell)))
+			result = lappend_int(result, lfirst_int(cell));
+	}
+
+	check_list_invariants(result);
+	return result;
+}
+
+/*
  * Return a list that contains all the cells in list1 that are not in
  * list2. The returned list is freshly allocated via palloc(), but the
  * cells themselves point to the same objects as the cells of the

--- a/src/backend/nodes/list.c
+++ b/src/backend/nodes/list.c
@@ -843,7 +843,7 @@ list_intersection(const List *list1, const List *list2)
 List *
 list_intersection_int(const List *list1, const List *list2)
 {
-	List	   *result;
+	List	   *result = NIL;
 	const ListCell *cell;
 
 	if (list1 == NIL || list2 == NIL)
@@ -852,7 +852,6 @@ list_intersection_int(const List *list1, const List *list2)
 	Assert(IsIntegerList(list1));
 	Assert(IsIntegerList(list2));
 
-	result = NIL;
 	foreach(cell, list1)
 	{
 		if (list_member_int(list2, lfirst_int(cell)))

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -1571,6 +1571,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 	{
 		TargetEntry *tle = get_sortgroupclause_tle((SortGroupClause *) grpcl, targetList);
 		result = lappend_int(result, tle->ressortgroupref);
+		return result;
 	}
 	else if (IsA(grpcl, GroupingClause))
 	{
@@ -1598,19 +1599,14 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 
 		return com_refs;
 	}
-	else
+	List *tles = (List *)grpcl;
+	ListCell *lc;
+	foreach(lc, tles)
 	{
-		List *tles = (List *)grpcl;
-		ListCell *lc;
-
-		foreach(lc, tles)
-		{
-			List *chunk = get_com_grouping_ressortgroupref_routine((Node *)lfirst(lc), targetList, com_refs);
-			if (!chunk)
-				return NIL;
-
-			result = list_concat(result, chunk);
-		}
+		List *chunk = get_com_grouping_ressortgroupref_routine((Node *)lfirst(lc), targetList, com_refs);
+		if (!chunk)
+			return NIL;
+		result = list_concat(result, chunk);
 	}
 
 	return result;

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -878,11 +878,12 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	}
 
 	/*
-	 * Getting adjacent TargetEntrys in groupings. Common tle will be needed
-	 * in case of ungrouped attributes in target list. In fact we get a list
-	 * of tle->ressortgroupref because we need to check for matching expressions
-	 * after flatten_joinalias_vars. We also find out if there are grouping
-	 * expressions.
+	 * Getting ressortgrouprefs of common TargetEntrys in groupings.
+	 * TargetEntry is common if it appears in several grouping expressions
+	 * (including nesting) and in a regular GROUP BY (general case). They
+	 * will be needed in case of ungrouped attributes in target list. We get
+	 * a list of tle->ressortgroupref instead of tle because we need to check
+	 * for matching expressions after flatten_joinalias_vars.
 	 */
 	comGroupingRessortgrouprefs = get_com_grouping_ressortgroupref(qry, groupClauses);
 
@@ -1591,20 +1592,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 				return NIL;
 
 			/*Exclude refs that did not appear in this grouping*/
-			ListCell *lc = list_head(com_refs);
-			while (lc)
-			{
-				if (list_member_int(grouping_refs, lfirst_int(lc)))
-				{
-					lc = lnext(lc);
-				}
-				else
-				{
-					ListCell *lc_del = lc;
-					lc = lnext(lc);
-					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));
-				}
-			}
+			com_refs = list_intersection_int(com_refs, grouping_refs);
 		}
 
 		return com_refs;
@@ -1661,7 +1649,7 @@ get_com_grouping_ressortgroupref(Query *qry, List *grp_tles)
 					list_append_unique_int(com_group_expr_ressortgroupref, te->ressortgroupref);
 			}
 			com_group_expr_ressortgroupref =
-				get_com_grouping_ressortgroupref_routine(grp, qry->targetList,com_group_expr_ressortgroupref);
+				get_com_grouping_ressortgroupref_routine(grp, qry->targetList, com_group_expr_ressortgroupref);
 
 			/* Form a list of common refs for grouping clauses. */
 			com_grouping_ressortgroupref =

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -71,8 +71,7 @@ static void check_ungrouped_columns(Node *node, ParseState *pstate, Query *qry,
 static bool check_ungrouped_columns_walker(Node *node,
 							   check_ungrouped_columns_context *context);
 static List* get_groupclause_tles(Node *grpcl, List *targetList);
-static List* get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping,
-						List *grp_tles);
+static List* get_com_grouping_ressortgroupref(Query *qry, List *grp_tles);
 static Node *make_agg_arg(Oid argtype, Oid argcollation);
 
 
@@ -826,7 +825,6 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	bool		hasSelfRefRTEs;
 	PlannerInfo *root;
 	Node	   *clause;
-	bool		hasGrouping = false;
 
 	/* This should only be called if we found aggregates or grouping */
 	Assert(pstate->p_hasAggs || qry->groupClause || qry->havingQual);
@@ -886,7 +884,7 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	 * after flatten_joinalias_vars. We also find out if there are grouping
 	 * expressions.
 	 */
-	comGroupingRessortgrouprefs = get_com_grouping_ressortgroupref(qry, &hasGrouping, groupClauses);
+	comGroupingRessortgrouprefs = get_com_grouping_ressortgroupref(qry, groupClauses);
 
 	/*
 	 * If there are join alias vars involved, we have to flatten them to the
@@ -926,8 +924,7 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 		{
 			have_non_var_grouping = true;
 		}
-		else if (!hasGrouping ||
-				 list_member_int(comGroupingRessortgrouprefs, tle->ressortgroupref))
+		else if (list_member_int(comGroupingRessortgrouprefs, tle->ressortgroupref))
 		{
 			groupClauseCommonVars = lappend(groupClauseCommonVars, tle->expr);
 		}
@@ -1586,7 +1583,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 			if(!grouping_refs)
 				return NIL;
 
-			/*Exclude refs that did not appear in this group*/
+			/*Exclude refs that did not appear in this grouping*/
 			ListCell *lc;
 			lc = list_head(com_refs);
 			while(lc){
@@ -1625,36 +1622,19 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
  * get_com_grouping_tles -
  *     Return a list of common ressortgroupref expressions appeared in group
  * 	   clauses.
- * 	   Also check for a grouping expressions.
  */
 List*
-get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping, List *grp_tles){
-	if(!qry || !hasGrouping || !grp_tles)
+get_com_grouping_ressortgroupref(Query *qry, List *grp_tles){
+	if(!qry || !grp_tles)
 		return NIL;
 
-	/*
-	 *The first list is for common attributes in grouping expressions.
-	 *We assume that attributes are present in all grouping expressions.
-     *The second is for attributes in group by.
-	*/
-	List *com_grouping_expr_ressortgroupref = NIL;
-	List *group_expr_ressortgroupref = NIL;
-	ListCell *l;
+	List *com_grouping_ressortgroupref = NIL;
+	ListCell *gc;
 
-	foreach(l, grp_tles){
-		TargetEntry* te = (TargetEntry*) lfirst(l);
-		com_grouping_expr_ressortgroupref = list_append_unique_int(com_grouping_expr_ressortgroupref, te->ressortgroupref);
-	}
-	foreach(l, qry->groupClause)
+	foreach(gc, qry->groupClause)
 	{
-		/*
-		 * If there are no common attributes, there is no need to scan the
-		 * groupings. The attributes from group by are scanned first.
-		 */
-		if(!com_grouping_expr_ressortgroupref)
-			break;
-
-		Node *grp = lfirst(l);
+		List *com_group_expr_ressortgroupref = NIL;
+		Node *grp = lfirst(gc);
 
 		if (grp == NULL)
 			continue;
@@ -1662,21 +1642,29 @@ get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping, List *grp_tles){
 		/* Scan in grouping expression*/
 		if(IsA(grp, GroupingClause))
 		{
-			*hasGrouping = true;
-			com_grouping_expr_ressortgroupref =
-				get_com_grouping_ressortgroupref_routine(grp, qry->targetList,com_grouping_expr_ressortgroupref);
+			/* We assume that attributes are present in current grouping expression. */
+			ListCell *lc;
+			foreach(lc, grp_tles)
+			{
+				TargetEntry* te = (TargetEntry*) lfirst(lc);
+				com_group_expr_ressortgroupref =
+					list_append_unique_int(com_group_expr_ressortgroupref, te->ressortgroupref);
+			}
+			com_group_expr_ressortgroupref =
+				get_com_grouping_ressortgroupref_routine(grp, qry->targetList,com_group_expr_ressortgroupref);
 		}
 		/* Scan in group by*/
 		if (IsA(grp, SortGroupClause))
 		{
 			TargetEntry *tle = get_sortgroupclause_tle((SortGroupClause *) grp, qry->targetList);
-			group_expr_ressortgroupref = lappend_int(group_expr_ressortgroupref, tle->ressortgroupref);
+			com_group_expr_ressortgroupref = lappend_int(com_group_expr_ressortgroupref, tle->ressortgroupref);
 		}
+		/* Form a list of common refs for all clauses */
+		com_grouping_ressortgroupref = list_concat_unique_int(com_grouping_ressortgroupref, com_group_expr_ressortgroupref);
+		list_free(com_group_expr_ressortgroupref);
 	}
-	/* Form a list of common ressortgroupref for all clauses */
-	com_grouping_expr_ressortgroupref = list_concat_unique_int(com_grouping_expr_ressortgroupref, group_expr_ressortgroupref);
 
-	return com_grouping_expr_ressortgroupref;
+	return com_grouping_ressortgroupref;
 }
 
 static bool

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -819,7 +819,7 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	List	   *groupClauses = NIL;
 	bool		have_non_var_grouping;
 	List	   *groupClauseCommonVars = NIL;
-	List 	   *com_grouping_ressortgroupref = NIL;
+	List 	   *comGroupingRessortgrouprefs = NIL;
 	List	   *func_grouped_rels = NIL;
 	ListCell   *l;
 	bool		hasJoinRTEs;
@@ -847,7 +847,7 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	}
 
 	/*
-	 * Build a list of the acceptable unique GROUP BY expressions for use by
+	 * Build a list of the acceptable GROUP BY expressions for use by
 	 * check_ungrouped_columns().
 	 *
 	 * We get the TLE, not just the expr, because GROUPING wants to know the
@@ -884,9 +884,9 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	 * in case of ungrouped attributes in target list. In fact we get a list
 	 * of tle->ressortgroupref because we need to check for matching expressions
 	 * after flatten_joinalias_vars. We also find out if there are grouping
-	 * extensions.
+	 * expressions.
 	 */
-	com_grouping_ressortgroupref = get_com_grouping_ressortgroupref(qry, &hasGrouping, groupClauses);
+	comGroupingRessortgrouprefs = get_com_grouping_ressortgroupref(qry, &hasGrouping, groupClauses);
 
 	/*
 	 * If there are join alias vars involved, we have to flatten them to the
@@ -920,15 +920,14 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 	have_non_var_grouping = false;
 	foreach(l, groupClauses)
 	{
-
 		TargetEntry *tle = lfirst(l);
 
 		if (!IsA(tle->expr, Var))
 		{
 			have_non_var_grouping = true;
 		}
-			else if (!hasGrouping ||
-				 list_member_int(com_grouping_ressortgroupref, tle->ressortgroupref))
+		else if (!hasGrouping ||
+				 list_member_int(comGroupingRessortgrouprefs, tle->ressortgroupref))
 		{
 			groupClauseCommonVars = lappend(groupClauseCommonVars, tle->expr);
 		}
@@ -1064,12 +1063,11 @@ check_ungrouped_columns_walker(Node *node,
 	 */
 	if (context->have_non_var_grouping && context->sublevels_up == 0)
 	{
-
 		foreach(gl, context->groupClauses)
 		{
 			TargetEntry *tle = lfirst(gl);
 
-			  if (equal(node, tle->expr))
+			if (equal(node, tle->expr))
 				return false;	/* acceptable, do not descend more */
 		}
 	}
@@ -1523,7 +1521,6 @@ get_groupclause_tles(Node *grpcl, List *targetList)
 		TargetEntry *te = get_sortgroupclause_tle((SortGroupClause *) grpcl, targetList);
 		result = lappend(result, te);
 	}
-
 	else if (IsA(grpcl, GroupingClause))
 	{
 		ListCell* l;
@@ -1555,10 +1552,9 @@ get_groupclause_tles(Node *grpcl, List *targetList)
 static List*
 get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *com_refs)
 {
-
 	List *result = NIL;
 
-	if ( !grpcl)
+	if (!grpcl)
 		return result;
 
 	Assert(IsA(grpcl, SortGroupClause) ||
@@ -1570,14 +1566,14 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 		TargetEntry *tle = get_sortgroupclause_tle((SortGroupClause *) grpcl, targetList);
 		result = lappend_int(result, tle->ressortgroupref);
 	}
-
 	else if (IsA(grpcl, GroupingClause))
 	{
 		ListCell *l;
 		GroupingClause *gc = (GroupingClause*)grpcl;
 
 		/* Cube and Rollup do not contain common attributes */
-		if(gc->groupType == GROUPINGTYPE_CUBE || gc->groupType == GROUPINGTYPE_ROLLUP){
+		if(gc->groupType == GROUPINGTYPE_CUBE || gc->groupType == GROUPINGTYPE_ROLLUP)
+		{
 			list_free(com_refs);
 			return NIL;
 		}
@@ -1590,17 +1586,18 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 			if(!grouping_refs)
 				return NIL;
 
-			/*Exclude tle that did not appear in this group*/
+			/*Exclude refs that did not appear in this group*/
 			ListCell *lc;
 			lc = list_head(com_refs);
 			while(lc){
-				if(!list_member_int(grouping_refs, lfirst_int(lc))){
+				if(list_member_int(grouping_refs, lfirst_int(lc)))
+					lc = lc->next;
+				else
+				{
 					ListCell *lc_del = lc;
 					lc = lc->next;
-					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));
+					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));					
 				}
-				else
-					lc = lc->next;
 			}
 		}
 
@@ -1628,17 +1625,16 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
  * get_com_grouping_tles -
  *     Return a list of common ressortgroupref expressions appeared in group
  * 	   clauses.
- * 	   Also check for a group extensions.
+ * 	   Also check for a grouping expressions.
  */
 List*
 get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping, List *grp_tles){
-
 	if(!qry || !hasGrouping || !grp_tles)
 		return NIL;
 
 	/*
-	 *The first list is for common attributes in group extensions.
-	 *We assume that attributes are present in all grouping extensions.
+	 *The first list is for common attributes in grouping expressions.
+	 *We assume that attributes are present in all grouping expressions.
      *The second is for attributes in group by.
 	*/
 	List *com_grouping_expr_ressortgroupref = NIL;
@@ -1649,10 +1645,8 @@ get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping, List *grp_tles){
 		TargetEntry* te = (TargetEntry*) lfirst(l);
 		com_grouping_expr_ressortgroupref = list_append_unique_int(com_grouping_expr_ressortgroupref, te->ressortgroupref);
 	}
-
 	foreach(l, qry->groupClause)
 	{
-
 		/*
 		 * If there are no common attributes, there is no need to scan the
 		 * groupings. The attributes from group by are scanned first.
@@ -1665,14 +1659,16 @@ get_com_grouping_ressortgroupref(Query *qry, bool *hasGrouping, List *grp_tles){
 		if (grp == NULL)
 			continue;
 
-		/* Scan in grouping extensions*/
-		if(IsA(grp, GroupingClause)){
+		/* Scan in grouping expression*/
+		if(IsA(grp, GroupingClause))
+		{
 			*hasGrouping = true;
 			com_grouping_expr_ressortgroupref =
 				get_com_grouping_ressortgroupref_routine(grp, qry->targetList,com_grouping_expr_ressortgroupref);
 		}
 		/* Scan in group by*/
-		if (IsA(grp, SortGroupClause)){
+		if (IsA(grp, SortGroupClause))
+		{
 			TargetEntry *tle = get_sortgroupclause_tle((SortGroupClause *) grp, qry->targetList);
 			group_expr_ressortgroupref = lappend_int(group_expr_ressortgroupref, tle->ressortgroupref);
 		}

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -1599,6 +1599,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 
 		return com_refs;
 	}
+	
 	List *tles = (List *)grpcl;
 	ListCell *lc;
 	foreach(lc, tles)

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -1546,6 +1546,13 @@ get_groupclause_tles(Node *grpcl, List *targetList)
 	return result;
 }
 
+/*
+ * get_com_grouping_ressortgroupref_routine -
+ *     Return a list of common ressortgrouprefs of the current grouping
+ *     expression recursively. It is assumed that attributes used in all
+ *     groupings are already present in the current grouping. Otherwise,
+ *     missing references are removed from the com_refs list.
+ */
 static List*
 get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *com_refs)
 {
@@ -1585,7 +1592,8 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 
 			/*Exclude refs that did not appear in this grouping*/
 			ListCell *lc = list_head(com_refs);
-			while (lc) {
+			while (lc)
+			{
 				if (list_member_int(grouping_refs, lfirst_int(lc)))
 				{
 					lc = lnext(lc);
@@ -1594,7 +1602,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 				{
 					ListCell *lc_del = lc;
 					lc = lnext(lc);
-					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));					
+					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));
 				}
 			}
 		}
@@ -1625,26 +1633,27 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
  * 	   clauses.
  */
 List*
-get_com_grouping_ressortgroupref(Query *qry, List *grp_tles){
-	if (!qry || !grp_tles)
-		return NIL;
-
+get_com_grouping_ressortgroupref(Query *qry, List *grp_tles)
+{
 	List *com_grouping_ressortgroupref = NIL;
 	ListCell *gc;
 
+	if (!qry || !grp_tles)
+		return NIL;
+
 	foreach(gc, qry->groupClause)
 	{
-		List *com_group_expr_ressortgroupref = NIL;
 		Node *grp = lfirst(gc);
 
 		if (grp == NULL)
 			continue;
 
-		/* Scan in grouping expression*/
+		/* Scan in grouping expression. */
 		if (IsA(grp, GroupingClause))
 		{
-			/* We assume that attributes are present in current grouping expression. */
+			List *com_group_expr_ressortgroupref = NIL;
 			ListCell *lc;
+			/* We assume that attributes are present in current grouping expression. */
 			foreach(lc, grp_tles)
 			{
 				TargetEntry* te = (TargetEntry*) lfirst(lc);
@@ -1653,16 +1662,22 @@ get_com_grouping_ressortgroupref(Query *qry, List *grp_tles){
 			}
 			com_group_expr_ressortgroupref =
 				get_com_grouping_ressortgroupref_routine(grp, qry->targetList,com_group_expr_ressortgroupref);
+
+			/* Form a list of common refs for grouping clauses. */
+			com_grouping_ressortgroupref =
+				list_concat_unique_int(com_grouping_ressortgroupref, com_group_expr_ressortgroupref);
+			list_free(com_group_expr_ressortgroupref);
 		}
-		/* Scan in group by*/
+
+		/*
+		 * Scan in GROUP BY.
+		 * In this case the attribute is also common.
+		 */
 		if (IsA(grp, SortGroupClause))
 		{
 			TargetEntry *tle = get_sortgroupclause_tle((SortGroupClause *) grp, qry->targetList);
-			com_group_expr_ressortgroupref = lappend_int(com_group_expr_ressortgroupref, tle->ressortgroupref);
+			com_grouping_ressortgroupref = list_append_unique_int(com_grouping_ressortgroupref, tle->ressortgroupref);
 		}
-		/* Form a list of common refs for all clauses */
-		com_grouping_ressortgroupref = list_concat_unique_int(com_grouping_ressortgroupref, com_group_expr_ressortgroupref);
-		list_free(com_group_expr_ressortgroupref);
 	}
 
 	return com_grouping_ressortgroupref;

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -1536,7 +1536,7 @@ get_groupclause_tles(Node *grpcl, List *targetList)
 		List *exprs = (List *)grpcl;
 		ListCell *lc;
 
-		foreach (lc, exprs)
+		foreach(lc, exprs)
 		{
 			result = list_concat(result, get_groupclause_tles((Node *)lfirst(lc),
 															   targetList));
@@ -1551,7 +1551,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 {
 	List *result = NIL;
 
-	if (!grpcl)
+	if ( !grpcl )
 		return result;
 
 	Assert(IsA(grpcl, SortGroupClause) ||
@@ -1569,7 +1569,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 		GroupingClause *gc = (GroupingClause*)grpcl;
 
 		/* Cube and Rollup do not contain common attributes */
-		if(gc->groupType == GROUPINGTYPE_CUBE || gc->groupType == GROUPINGTYPE_ROLLUP)
+		if (gc->groupType == GROUPINGTYPE_CUBE || gc->groupType == GROUPINGTYPE_ROLLUP)
 		{
 			list_free(com_refs);
 			return NIL;
@@ -1580,19 +1580,20 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 			List *grouping_refs = get_com_grouping_ressortgroupref_routine((Node*)lfirst(l), targetList, com_refs);
 			
 			/* An empty grouping has no common attributes */
-			if(!grouping_refs)
+			if (!grouping_refs)
 				return NIL;
 
 			/*Exclude refs that did not appear in this grouping*/
-			ListCell *lc;
-			lc = list_head(com_refs);
-			while(lc){
-				if(list_member_int(grouping_refs, lfirst_int(lc)))
-					lc = lc->next;
+			ListCell *lc = list_head(com_refs);
+			while (lc) {
+				if (list_member_int(grouping_refs, lfirst_int(lc)))
+				{
+					lc = lnext(lc);
+				}
 				else
 				{
 					ListCell *lc_del = lc;
-					lc = lc->next;
+					lc = lnext(lc);
 					com_refs = list_delete_int(com_refs, lfirst_int(lc_del));					
 				}
 			}
@@ -1605,7 +1606,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 		List *tles = (List *)grpcl;
 		ListCell *lc;
 
-		foreach (lc, tles)
+		foreach(lc, tles)
 		{
 			List *chunk = get_com_grouping_ressortgroupref_routine((Node *)lfirst(lc), targetList, com_refs);
 			if(!chunk)
@@ -1625,7 +1626,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
  */
 List*
 get_com_grouping_ressortgroupref(Query *qry, List *grp_tles){
-	if(!qry || !grp_tles)
+	if (!qry || !grp_tles)
 		return NIL;
 
 	List *com_grouping_ressortgroupref = NIL;
@@ -1640,7 +1641,7 @@ get_com_grouping_ressortgroupref(Query *qry, List *grp_tles){
 			continue;
 
 		/* Scan in grouping expression*/
-		if(IsA(grp, GroupingClause))
+		if (IsA(grp, GroupingClause))
 		{
 			/* We assume that attributes are present in current grouping expression. */
 			ListCell *lc;

--- a/src/backend/parser/parse_agg.c
+++ b/src/backend/parser/parse_agg.c
@@ -879,11 +879,12 @@ parseCheckAggregates(ParseState *pstate, Query *qry)
 
 	/*
 	 * Getting ressortgrouprefs of common TargetEntrys in groupings.
-	 * TargetEntry is common if it appears in several grouping expressions
-	 * (including nesting) and in a regular GROUP BY (general case). They
-	 * will be needed in case of ungrouped attributes in target list. We get
-	 * a list of tle->ressortgroupref instead of tle because we need to check
-	 * for matching expressions after flatten_joinalias_vars.
+	 * TargetEntry is common if it appears in all grouping expressions
+	 * (including nesting) or in a regular GROUP BY (a simple GROUPING SETS
+	 * with one attribute can be considered as a GROUP BY). They will be
+	 * needed in case of ungrouped attributes in target list. We get a list of
+	 * tle->ressortgroupref instead of tle because we need to check for
+	 * matching expressions after flatten_joinalias_vars.
 	 */
 	comGroupingRessortgrouprefs = get_com_grouping_ressortgroupref(qry, groupClauses);
 
@@ -1559,8 +1560,8 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 {
 	List *result = NIL;
 
-	if ( !grpcl )
-		return result;
+	if (!grpcl)
+		return NIL;
 
 	Assert(IsA(grpcl, SortGroupClause) ||
 		   IsA(grpcl, GroupingClause) ||
@@ -1605,7 +1606,7 @@ get_com_grouping_ressortgroupref_routine(Node *grpcl, List *targetList, List *co
 		foreach(lc, tles)
 		{
 			List *chunk = get_com_grouping_ressortgroupref_routine((Node *)lfirst(lc), targetList, com_refs);
-			if(!chunk)
+			if (!chunk)
 				return NIL;
 
 			result = list_concat(result, chunk);

--- a/src/include/nodes/pg_list.h
+++ b/src/include/nodes/pg_list.h
@@ -240,8 +240,9 @@ extern List *list_union_int(const List *list1, const List *list2);
 extern List *list_union_oid(const List *list1, const List *list2);
 
 extern List *list_intersection(const List *list1, const List *list2);
+extern List *list_intersection_int(const List *list1, const List *list2);
 
-/* currently, there's no need for list_intersection_int etc */
+/* currently, there's no need for list_intersection_ptr etc */
 
 extern List *list_difference(const List *list1, const List *list2);
 extern List *list_difference_ptr(const List *list1, const List *list2);

--- a/src/test/regress/expected/functional_deps.out
+++ b/src/test/regress/expected/functional_deps.out
@@ -16,6 +16,9 @@ CREATE TEMP TABLE articles_in_category (
     changed date,
     PRIMARY KEY (article_id, category_id)
 );
+-- The patch https://github.com/arenadata/gpdb/pull/1117 changes the parser
+-- behavior so that queries with ungrouped columns by non-key attributes in
+-- groups no longer work.
 -- test functional dependencies based on primary keys/unique constraints
 -- base tables
 -- group by primary key (OK)
@@ -173,7 +176,41 @@ select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t
    1 | 1 | 1 | 1
 (3 rows)
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
+-- modified for ungrouped columns
+explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  GroupAggregate
+         Group Key: "rollup".prelim_aggref_1, "rollup".prelim_aggref_2, "rollup"."grouping", "rollup"."group_id"
+         ->  Subquery Scan on "rollup"
+               ->  Sort
+                     Sort Key: rollup_1.prelim_aggref_1, rollup_1.prelim_aggref_2, (Grouping), (group_id())
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: rollup_1.prelim_aggref_1, rollup_1.prelim_aggref_2, (Grouping), group_id()
+                           ->  GroupAggregate
+                                 Group Key: rollup_1.prelim_aggref_1, rollup_1."grouping", rollup_1."group_id", rollup_1.prelim_aggref_2
+                                 ->  Subquery Scan on rollup_1
+                                       ->  GroupAggregate
+                                             Group Key: funcdep1.a, funcdep1.b
+                                             ->  Sort
+                                                   Sort Key: funcdep1.a, funcdep1.b
+                                                   ->  Seq Scan on funcdep1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
+ sum | c | d | grouping 
+-----+---+---+----------
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+(6 rows)
+
+explain (costs off) select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
@@ -195,76 +232,96 @@ explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grou
  Optimizer: Postgres query optimizer
 (17 rows)
 
-select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
- sum | c | d | grouping 
------+---+---+----------
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   3 | 1 | 1 |        1
+select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
+ sum | sum | sum | grouping 
+-----+-----+-----+----------
+   1 |   1 |   1 |        0
+   1 |   1 |   1 |        0
+   1 |   1 |   1 |        0
+   3 |   3 |   3 |        1
 (4 rows)
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  GroupAggregate
-         Group Key: "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
-         ->  Subquery Scan on "rollup"
-               ->  Sort
-                     Sort Key: rollup_1.prelim_aggref_1, (Grouping), (group_id())
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: rollup_1.prelim_aggref_1, (Grouping), group_id()
-                           ->  GroupAggregate
-                                 Group Key: rollup_1."grouping", rollup_1."group_id", rollup_1.prelim_aggref_1
-                                 ->  Subquery Scan on rollup_1
-                                       ->  GroupAggregate
-                                             Group Key: funcdep1.a
-                                             ->  Sort
-                                                   Sort Key: funcdep1.a
-                                                   ->  Seq Scan on funcdep1
+explain (costs off) select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Append
+         ->  GroupAggregate
+               Group Key: "rollup".c, "rollup".b, "rollup".a, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"
+                     ->  Sort
+                           Sort Key: rollup_1.c, rollup_1.b, rollup_1.a, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: rollup_1.c, rollup_1.b, rollup_1.a, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_1."grouping", rollup_1."group_id", rollup_1.a, rollup_1.c, rollup_1.b
+                                       ->  Subquery Scan on rollup_1
+                                             ->  GroupAggregate
+                                                   Group Key: rollup_2.c, rollup_2."grouping", rollup_2."group_id", rollup_2.b, rollup_2.a
+                                                   ->  Subquery Scan on rollup_2
+                                                         ->  GroupAggregate
+                                                               Group Key: rollup_3.c, rollup_3.b, rollup_3."grouping", rollup_3."group_id", rollup_3.a
+                                                               ->  Subquery Scan on rollup_3
+                                                                     ->  GroupAggregate
+                                                                           Group Key: share0_ref1.c, share0_ref1.b, share0_ref1.a
+                                                                           ->  Sort
+                                                                                 Sort Key: share0_ref1.c, share0_ref1.b, share0_ref1.a
+                                                                                 ->  Shared Scan (share slice:id 1:0)
+                                                                                       ->  Materialize
+                                                                                             ->  Seq Scan on funcdep1
+         ->  GroupAggregate
+               Group Key: rollup_4.a, rollup_4.c, rollup_4.b, rollup_4."grouping", rollup_4."group_id"
+               ->  Subquery Scan on rollup_4
+                     ->  Sort
+                           Sort Key: rollup_5.a, rollup_5.c, rollup_5.b, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: rollup_5.a, rollup_5.c, rollup_5.b, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_5.a, rollup_5."grouping", rollup_5."group_id", rollup_5.c, rollup_5.b
+                                       ->  Subquery Scan on rollup_5
+                                             ->  GroupAggregate
+                                                   Group Key: share0_ref2.a, share0_ref2.c, share0_ref2.b
+                                                   ->  Sort
+                                                         Sort Key: share0_ref2.a, share0_ref2.c, share0_ref2.b
+                                                         ->  Shared Scan (share slice:id 2:0)
+         ->  GroupAggregate
+               Group Key: rollup_6.b, rollup_6.a, rollup_6.c, rollup_6."grouping", rollup_6."group_id"
+               ->  Subquery Scan on rollup_6
+                     ->  Sort
+                           Sort Key: rollup_7.b, rollup_7.a, rollup_7.c, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: rollup_7.b, rollup_7.a, rollup_7.c, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_7.b, rollup_7."grouping", rollup_7."group_id", rollup_7.a, rollup_7.c
+                                       ->  Subquery Scan on rollup_7
+                                             ->  GroupAggregate
+                                                   Group Key: share0_ref3.b, share0_ref3.a, share0_ref3.c
+                                                   ->  Sort
+                                                         Sort Key: share0_ref3.b, share0_ref3.a, share0_ref3.c
+                                                         ->  Shared Scan (share slice:id 3:0)
  Optimizer: Postgres query optimizer
-(17 rows)
+(56 rows)
 
-select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
- sum | c | d | grouping 
------+---+---+----------
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   3 | 1 | 1 |        1
-(4 rows)
-
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  GroupAggregate
-         Group Key: "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
-         ->  Subquery Scan on "rollup"
-               ->  Sort
-                     Sort Key: rollup_1.prelim_aggref_1, (Grouping), (group_id())
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: rollup_1.prelim_aggref_1, (Grouping), group_id()
-                           ->  GroupAggregate
-                                 Group Key: rollup_1."grouping", rollup_1."group_id", rollup_1.prelim_aggref_1
-                                 ->  Subquery Scan on rollup_1
-                                       ->  GroupAggregate
-                                             Group Key: funcdep1.a
-                                             ->  Sort
-                                                   Sort Key: funcdep1.a
-                                                   ->  Seq Scan on funcdep1
- Optimizer: Postgres query optimizer
-(17 rows)
-
-select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
- sum | c | d | grouping 
------+---+---+----------
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   3 | 1 | 1 |        1
-(4 rows)
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+ sum | a | b | c | grouping 
+-----+---+---+---+----------
+   1 | 1 | 1 | 1 |        0
+   1 | 1 |   |   |        0
+   1 | 2 |   | 1 |        0
+   1 | 2 |   |   |        0
+   1 | 3 |   | 1 |        0
+   1 | 3 |   |   |        0
+   1 | 3 | 1 | 1 |        0
+   3 |   | 1 | 1 |        1
+   1 | 1 |   | 1 |        0
+   1 | 2 | 1 |   |        0
+   3 |   | 1 |   |        1
+   1 | 2 | 1 | 1 |        0
+   3 |   |   | 1 |        1
+   3 |   |   |   |        1
+   1 | 1 | 1 |   |        0
+   1 | 3 | 1 |   |        0
+(16 rows)
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
                                         QUERY PLAN                                         
@@ -387,7 +444,7 @@ explain (verbose on, costs off) select a, b , sum(c + d), e from mfuncdep1 join 
                                              ->  Seq Scan on public.mfuncdep1
                                                    Output: mfuncdep1.a, mfuncdep1.b, mfuncdep1.c, mfuncdep1.d, mfuncdep1.e
  Optimizer: Postgres query optimizer
- Settings: enable_groupagg=off
+ Settings: enable_groupagg=off, optimizer=off
 (28 rows)
 
 select a, b , sum(c + d), e from mfuncdep1 join mfuncdep2 on c = b2 group by a,b order by 1;
@@ -784,72 +841,6 @@ SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a, b;
  25 | text0 | 0
 (25 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  2 | text2 | 1
-  3 | text3 | 0
-  4 | text4 | 1
-  5 | text0 | 0
-  6 | text1 | 1
-  7 | text2 | 0
-  8 | text3 | 1
-  9 | text4 | 0
- 10 | text0 | 1
- 11 | text1 | 0
- 12 | text2 | 1
- 13 | text3 | 0
- 14 | text4 | 1
- 15 | text0 | 0
- 16 | text1 | 1
- 17 | text2 | 0
- 18 | text3 | 1
- 19 | text4 | 0
- 20 | text0 | 1
- 21 | text1 | 0
- 22 | text2 | 1
- 23 | text3 | 0
- 24 | text4 | 1
- 25 | text0 | 0
-    |       |  
-(26 rows)
-
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b)) ORDER BY a, b;
- a  |   b   | c 
-----+-------+---
-  1 |       | 0
-  2 |       | 1
-  3 |       | 0
-  4 |       | 1
-  5 |       | 0
-  6 |       | 1
-  7 |       | 0
-  8 |       | 1
-  9 |       | 0
- 10 |       | 1
- 11 |       | 0
- 12 |       | 1
- 13 |       | 0
- 14 |       | 1
- 15 |       | 0
- 16 |       | 1
- 17 |       | 0
- 18 |       | 1
- 19 |       | 0
- 20 |       | 1
- 21 |       | 0
- 22 |       | 1
- 23 |       | 0
- 24 |       | 1
- 25 |       | 0
-    | text0 |  
-    | text1 |  
-    | text2 |  
-    | text3 |  
-    | text4 |  
-(30 rows)
-
 SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
  a  |   b   | c 
 ----+-------+---
@@ -880,180 +871,171 @@ SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
  25 | text0 | 0
 (25 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), ()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), (a,c)) ORDER BY a, b, c;
  a  |   b   | c 
 ----+-------+---
-  1 | text1 | 0
+  1 | text1 |  
   1 |       | 0
-  2 | text2 | 1
+  1 |       |  
+  2 | text2 |  
   2 |       | 1
-  3 | text3 | 0
+  2 |       |  
+  3 | text3 |  
   3 |       | 0
-  4 | text4 | 1
+  3 |       |  
+  4 | text4 |  
   4 |       | 1
-  5 | text0 | 0
+  4 |       |  
+  5 | text0 |  
   5 |       | 0
-  6 | text1 | 1
+  5 |       |  
+  6 | text1 |  
   6 |       | 1
-  7 | text2 | 0
+  6 |       |  
+  7 | text2 |  
   7 |       | 0
-  8 | text3 | 1
+  7 |       |  
+  8 | text3 |  
   8 |       | 1
-  9 | text4 | 0
+  8 |       |  
+  9 | text4 |  
   9 |       | 0
- 10 | text0 | 1
+  9 |       |  
+ 10 | text0 |  
  10 |       | 1
- 11 | text1 | 0
+ 10 |       |  
+ 11 | text1 |  
  11 |       | 0
- 12 | text2 | 1
+ 11 |       |  
+ 12 | text2 |  
  12 |       | 1
- 13 | text3 | 0
+ 12 |       |  
+ 13 | text3 |  
  13 |       | 0
- 14 | text4 | 1
+ 13 |       |  
+ 14 | text4 |  
  14 |       | 1
- 15 | text0 | 0
+ 14 |       |  
+ 15 | text0 |  
  15 |       | 0
- 16 | text1 | 1
+ 15 |       |  
+ 16 | text1 |  
  16 |       | 1
- 17 | text2 | 0
+ 16 |       |  
+ 17 | text2 |  
  17 |       | 0
- 18 | text3 | 1
+ 17 |       |  
+ 18 | text3 |  
  18 |       | 1
- 19 | text4 | 0
+ 18 |       |  
+ 19 | text4 |  
  19 |       | 0
- 20 | text0 | 1
+ 19 |       |  
+ 20 | text0 |  
  20 |       | 1
- 21 | text1 | 0
+ 20 |       |  
+ 21 | text1 |  
  21 |       | 0
- 22 | text2 | 1
+ 21 |       |  
+ 22 | text2 |  
  22 |       | 1
- 23 | text3 | 0
+ 22 |       |  
+ 23 | text3 |  
  23 |       | 0
- 24 | text4 | 1
+ 23 |       |  
+ 24 | text4 |  
  24 |       | 1
- 25 | text0 | 0
+ 24 |       |  
+ 25 | text0 |  
  25 |       | 0
-    |       |  
-(51 rows)
+ 25 |       |  
+(75 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  2 | text2 | 1
-  3 | text3 | 0
-  4 | text4 | 1
-  5 | text0 | 0
-  6 | text1 | 1
-  7 | text2 | 0
-  8 | text3 | 1
-  9 | text4 | 0
- 10 | text0 | 1
- 11 | text1 | 0
- 12 | text2 | 1
- 13 | text3 | 0
- 14 | text4 | 1
- 15 | text0 | 0
- 16 | text1 | 1
- 17 | text2 | 0
- 18 | text3 | 1
- 19 | text4 | 0
- 20 | text0 | 1
- 21 | text1 | 0
- 22 | text2 | 1
- 23 | text3 | 0
- 24 | text4 | 1
- 25 | text0 | 0
-    |       |  
-(26 rows)
-
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, ...
+                  ^
 -- Check rollup
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a,b,c) ORDER BY a, b, c;
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
+  1 | text1 |  
+  1 |       |  
   2 | text2 | 1
+  2 | text2 |  
+  2 |       |  
   3 | text3 | 0
+  3 | text3 |  
+  3 |       |  
   4 | text4 | 1
+  4 | text4 |  
+  4 |       |  
   5 | text0 | 0
+  5 | text0 |  
+  5 |       |  
   6 | text1 | 1
+  6 | text1 |  
+  6 |       |  
   7 | text2 | 0
+  7 | text2 |  
+  7 |       |  
   8 | text3 | 1
+  8 | text3 |  
+  8 |       |  
   9 | text4 | 0
+  9 | text4 |  
+  9 |       |  
  10 | text0 | 1
+ 10 | text0 |  
+ 10 |       |  
  11 | text1 | 0
+ 11 | text1 |  
+ 11 |       |  
  12 | text2 | 1
+ 12 | text2 |  
+ 12 |       |  
  13 | text3 | 0
+ 13 | text3 |  
+ 13 |       |  
  14 | text4 | 1
+ 14 | text4 |  
+ 14 |       |  
  15 | text0 | 0
+ 15 | text0 |  
+ 15 |       |  
  16 | text1 | 1
+ 16 | text1 |  
+ 16 |       |  
  17 | text2 | 0
+ 17 | text2 |  
+ 17 |       |  
  18 | text3 | 1
+ 18 | text3 |  
+ 18 |       |  
  19 | text4 | 0
+ 19 | text4 |  
+ 19 |       |  
  20 | text0 | 1
+ 20 | text0 |  
+ 20 |       |  
  21 | text1 | 0
+ 21 | text1 |  
+ 21 |       |  
  22 | text2 | 1
+ 22 | text2 |  
+ 22 |       |  
  23 | text3 | 0
+ 23 | text3 |  
+ 23 |       |  
  24 | text4 | 1
+ 24 | text4 |  
+ 24 |       |  
  25 | text0 | 0
+ 25 | text0 |  
+ 25 |       |  
     |       |  
-(26 rows)
-
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a, b) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  1 |       | 0
-  2 | text2 | 1
-  2 |       | 1
-  3 | text3 | 0
-  3 |       | 0
-  4 | text4 | 1
-  4 |       | 1
-  5 | text0 | 0
-  5 |       | 0
-  6 | text1 | 1
-  6 |       | 1
-  7 | text2 | 0
-  7 |       | 0
-  8 | text3 | 1
-  8 |       | 1
-  9 | text4 | 0
-  9 |       | 0
- 10 | text0 | 1
- 10 |       | 1
- 11 | text1 | 0
- 11 |       | 0
- 12 | text2 | 1
- 12 |       | 1
- 13 | text3 | 0
- 13 |       | 0
- 14 | text4 | 1
- 14 |       | 1
- 15 | text0 | 0
- 15 |       | 0
- 16 | text1 | 1
- 16 |       | 1
- 17 | text2 | 0
- 17 |       | 0
- 18 | text3 | 1
- 18 |       | 1
- 19 | text4 | 0
- 19 |       | 0
- 20 | text0 | 1
- 20 |       | 1
- 21 | text1 | 0
- 21 |       | 0
- 22 | text2 | 1
- 22 |       | 1
- 23 | text3 | 0
- 23 |       | 0
- 24 | text4 | 1
- 24 |       | 1
- 25 | text0 | 0
- 25 |       | 0
-    |       |  
-(51 rows)
+(76 rows)
 
 -- Check expressions in target list
 SELECT a, b, c, 1+(a+c)*2 AS exp_ac FROM test_table1 GROUP BY a ORDER BY a, b, c, exp_ac;
@@ -1146,104 +1128,116 @@ SELECT 1+(a+c)*2 AS exp_ac_1, 100+(a+c)*2 AS exp_ac_2 FROM test_table1 GROUP BY 
        51 |      150
 (25 rows)
 
-SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
+SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
  exp_ac | a  
 --------+----
       3 |  1
+      3 |  1
+      7 |  2
       7 |  2
       7 |  3
+      7 |  3
+     11 |  4
      11 |  4
      11 |  5
+     11 |  5
+     15 |  6
      15 |  6
      15 |  7
+     15 |  7
+     19 |  8
      19 |  8
      19 |  9
+     19 |  9
+     23 | 10
      23 | 10
      23 | 11
+     23 | 11
+     27 | 12
      27 | 12
      27 | 13
+     27 | 13
+     31 | 14
      31 | 14
      31 | 15
+     31 | 15
+     35 | 16
      35 | 16
      35 | 17
+     35 | 17
+     39 | 18
      39 | 18
      39 | 19
+     39 | 19
+     43 | 20
      43 | 20
      43 | 21
+     43 | 21
+     47 | 22
      47 | 22
      47 | 23
+     47 | 23
+     51 | 24
      51 | 24
      51 | 25
-        |   
-(26 rows)
+     51 | 25
+(50 rows)
 
 -- Check together with aggregate functions in target list
-SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
+SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
  cnt | exp_ac | a  
 -----+--------+----
    1 |      3 |  1
+   1 |      3 |  1
+   1 |      7 |  2
    1 |      7 |  2
    1 |      7 |  3
+   1 |      7 |  3
+   1 |     11 |  4
    1 |     11 |  4
    1 |     11 |  5
+   1 |     11 |  5
+   1 |     15 |  6
    1 |     15 |  6
    1 |     15 |  7
+   1 |     15 |  7
+   1 |     19 |  8
    1 |     19 |  8
    1 |     19 |  9
+   1 |     19 |  9
+   1 |     23 | 10
    1 |     23 | 10
    1 |     23 | 11
+   1 |     23 | 11
+   1 |     27 | 12
    1 |     27 | 12
    1 |     27 | 13
+   1 |     27 | 13
+   1 |     31 | 14
    1 |     31 | 14
    1 |     31 | 15
+   1 |     31 | 15
+   1 |     35 | 16
    1 |     35 | 16
    1 |     35 | 17
+   1 |     35 | 17
+   1 |     39 | 18
    1 |     39 | 18
    1 |     39 | 19
+   1 |     39 | 19
+   1 |     43 | 20
    1 |     43 | 20
    1 |     43 | 21
+   1 |     43 | 21
+   1 |     47 | 22
    1 |     47 | 22
    1 |     47 | 23
+   1 |     47 | 23
+   1 |     51 | 24
    1 |     51 | 24
    1 |     51 | 25
-  25 |        |   
-(26 rows)
-
-SELECT avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
-         avg_c          | c 
-------------------------+---
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.40000000000000000000 |  
- 0.40000000000000000000 |  
- 0.40000000000000000000 |  
- 0.48000000000000000000 |  
- 0.60000000000000000000 |  
- 0.60000000000000000000 |  
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
-(31 rows)
+   1 |     51 | 25
+(50 rows)
 
 -- Check with grouping function in target list
 SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
@@ -1276,7 +1270,7 @@ SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) OR
    0 | 25 | text0
 (25 rows)
 
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
+SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c;
  g_a | g_b |         avg_c          
 -----+-----+------------------------
    0 |   1 | 0.00000000000000000000
@@ -1312,122 +1306,121 @@ SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 
    0 |   1 | 1.00000000000000000000
 (31 rows)
 
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
- g_a | g_b |         avg_c          | c 
------+-----+------------------------+---
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   1 | 0.48000000000000000000 |  
-   1 |   0 | 0.60000000000000000000 |  
-   1 |   0 | 0.60000000000000000000 |  
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-(31 rows)
-
 -- Check aggregate functions in ORDER BY clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY avg(c), a, b;
  a  |   b   
 ----+-------
   1 | text1
+  1 | 
   3 | text3
+  3 | 
   5 | text0
+  5 | 
   7 | text2
+  7 | 
   9 | text4
+  9 | 
  11 | text1
+ 11 | 
  13 | text3
+ 13 | 
  15 | text0
+ 15 | 
  17 | text2
+ 17 | 
  19 | text4
+ 19 | 
  21 | text1
+ 21 | 
  23 | text3
+ 23 | 
  25 | text0
-    | 
+ 25 | 
   2 | text2
+  2 | 
   4 | text4
+  4 | 
   6 | text1
+  6 | 
   8 | text3
+  8 | 
  10 | text0
+ 10 | 
  12 | text2
+ 12 | 
  14 | text4
+ 14 | 
  16 | text1
+ 16 | 
  18 | text3
+ 18 | 
  20 | text0
+ 20 | 
  22 | text2
+ 22 | 
  24 | text4
-(26 rows)
+ 24 | 
+(50 rows)
 
 -- Check aggregate functions in HAVING clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
  a  |   b   
 ----+-------
-    | 
   2 | text2
+  2 | 
   4 | text4
+  4 | 
   6 | text1
+  6 | 
   8 | text3
+  8 | 
  10 | text0
+ 10 | 
  12 | text2
+ 12 | 
  14 | text4
+ 14 | 
  16 | text1
+ 16 | 
  18 | text3
+ 18 | 
  20 | text0
+ 20 | 
  22 | text2
+ 22 | 
  24 | text4
-(13 rows)
+ 24 | 
+(24 rows)
 
 -- Check grouping functions in HAVING clause
-SELECT grouping(a) AS g_a, a, b, c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, b, c;
- g_a | a  |   b   | c 
------+----+-------+---
-   0 |  1 | text1 | 0
-   0 |  2 | text2 | 1
-   0 |  3 | text3 | 0
-   0 |  4 | text4 | 1
-   0 |  5 | text0 | 0
-   0 |  6 | text1 | 1
-   0 |  7 | text2 | 0
-   0 |  8 | text3 | 1
-   0 |  9 | text4 | 0
-   0 | 10 | text0 | 1
-   0 | 11 | text1 | 0
-   0 | 12 | text2 | 1
-   0 | 13 | text3 | 0
-   0 | 14 | text4 | 1
-   0 | 15 | text0 | 0
-   0 | 16 | text1 | 1
-   0 | 17 | text2 | 0
-   0 | 18 | text3 | 1
-   0 | 19 | text4 | 0
-   0 | 20 | text0 | 1
-   0 | 21 | text1 | 0
-   0 | 22 | text2 | 1
-   0 | 23 | text3 | 0
-   0 | 24 | text4 | 1
-   0 | 25 | text0 | 0
+SELECT grouping(a) AS g_a, a, avg(c) as avg_c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, avg_c;
+ g_a | a  |         avg_c          
+-----+----+------------------------
+   0 |  1 | 0.00000000000000000000
+   0 |  2 | 1.00000000000000000000
+   0 |  3 | 0.00000000000000000000
+   0 |  4 | 1.00000000000000000000
+   0 |  5 | 0.00000000000000000000
+   0 |  6 | 1.00000000000000000000
+   0 |  7 | 0.00000000000000000000
+   0 |  8 | 1.00000000000000000000
+   0 |  9 | 0.00000000000000000000
+   0 | 10 | 1.00000000000000000000
+   0 | 11 | 0.00000000000000000000
+   0 | 12 | 1.00000000000000000000
+   0 | 13 | 0.00000000000000000000
+   0 | 14 | 1.00000000000000000000
+   0 | 15 | 0.00000000000000000000
+   0 | 16 | 1.00000000000000000000
+   0 | 17 | 0.00000000000000000000
+   0 | 18 | 1.00000000000000000000
+   0 | 19 | 0.00000000000000000000
+   0 | 20 | 1.00000000000000000000
+   0 | 21 | 0.00000000000000000000
+   0 | 22 | 1.00000000000000000000
+   0 | 23 | 0.00000000000000000000
+   0 | 24 | 1.00000000000000000000
+   0 | 25 | 0.00000000000000000000
 (25 rows)
 
 SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a, b HAVING grouping(b) = 0 ORDER BY exp_ac_1, b;
@@ -1461,76 +1454,124 @@ SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a,
 (25 rows)
 
 SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ())
-	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c, c;
+	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c;
  g_a | g_b |         avg_c          
 -----+-----+------------------------
    1 |   1 | 0.48000000000000000000
 (1 row)
 
 -- Check sub-query
-SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t;
+SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a) AS sub_t;
  a  |   b   | c 
 ----+-------+---
+  1 | text1 |  
   1 | text1 | 0
+  2 | text2 |  
   2 | text2 | 1
+  3 | text3 |  
   3 | text3 | 0
+  4 | text4 |  
   4 | text4 | 1
+  5 | text0 |  
   5 | text0 | 0
+  6 | text1 |  
   6 | text1 | 1
   7 | text2 | 0
+  7 | text2 |  
+  8 | text3 |  
   8 | text3 | 1
+  9 | text4 |  
   9 | text4 | 0
  10 | text0 | 1
+ 10 | text0 |  
+ 11 | text1 |  
  11 | text1 | 0
+ 12 | text2 |  
  12 | text2 | 1
  13 | text3 | 0
+ 13 | text3 |  
+ 14 | text4 |  
  14 | text4 | 1
+ 15 | text0 |  
  15 | text0 | 0
  16 | text1 | 1
+ 16 | text1 |  
+ 17 | text2 |  
  17 | text2 | 0
+ 18 | text3 |  
  18 | text3 | 1
+ 19 | text4 |  
  19 | text4 | 0
+ 20 | text0 |  
  20 | text0 | 1
  21 | text1 | 0
+ 21 | text1 |  
  22 | text2 | 1
+ 22 | text2 |  
+ 23 | text3 |  
  23 | text3 | 0
+ 24 | text4 |  
  24 | text4 | 1
+ 25 | text0 |  
  25 | text0 | 0
-    |       |  
-(26 rows)
+(50 rows)
 
-SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a;
+SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
+  1 | text1 |  
   2 | text2 | 1
+  2 | text2 |  
   3 | text3 | 0
+  3 | text3 |  
   4 | text4 | 1
+  4 | text4 |  
   5 | text0 | 0
+  5 | text0 |  
   6 | text1 | 1
+  6 | text1 |  
   7 | text2 | 0
+  7 | text2 |  
   8 | text3 | 1
+  8 | text3 |  
   9 | text4 | 0
+  9 | text4 |  
  10 | text0 | 1
+ 10 | text0 |  
  11 | text1 | 0
+ 11 | text1 |  
  12 | text2 | 1
+ 12 | text2 |  
  13 | text3 | 0
+ 13 | text3 |  
  14 | text4 | 1
+ 14 | text4 |  
  15 | text0 | 0
+ 15 | text0 |  
  16 | text1 | 1
+ 16 | text1 |  
  17 | text2 | 0
+ 17 | text2 |  
  18 | text3 | 1
+ 18 | text3 |  
  19 | text4 | 0
+ 19 | text4 |  
  20 | text0 | 1
+ 20 | text0 |  
  21 | text1 | 0
+ 21 | text1 |  
  22 | text2 | 1
+ 22 | text2 |  
  23 | text3 | 0
+ 23 | text3 |  
  24 | text4 | 1
+ 24 | text4 |  
  25 | text0 | 0
+ 25 | text0 |  
     |       |  
-    |       |  
-(27 rows)
+(51 rows)
 
 SELECT (SELECT c) FROM test_table1 GROUP BY a ORDER BY a;
  c 
@@ -1608,68 +1649,30 @@ SELECT a, b, c FROM test_table2 GROUP BY a, c ORDER BY a, c;
  5 | text|5|1|  |  1
 (10 rows)
 
-SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c;
- a |     b      | c  
----+------------+----
- 1 | text|1|-1| | -1
- 1 | text|1|1|  |  1
- 1 |            |   
- 2 | text|2|-1| | -1
- 2 | text|2|1|  |  1
- 2 |            |   
- 3 | text|3|-1| | -1
- 3 | text|3|1|  |  1
- 3 |            |   
- 4 | text|4|-1| | -1
- 4 | text|4|1|  |  1
- 4 |            |   
- 5 | text|5|-1| | -1
- 5 | text|5|1|  |  1
- 5 |            |   
-(15 rows)
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, ...
+                  ^
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, avg(c) FROM test_table2 GROUP BY GROUPING SETS ((a, c), () ) ORDER BY a, c;
+ g_a | g_c | cnt | a |           avg           
+-----+-----+-----+---+-------------------------
+   0 |   0 |   1 | 1 | -1.00000000000000000000
+   0 |   0 |   1 | 1 |  1.00000000000000000000
+   0 |   0 |   1 | 2 | -1.00000000000000000000
+   0 |   0 |   1 | 2 |  1.00000000000000000000
+   0 |   0 |   1 | 3 | -1.00000000000000000000
+   0 |   0 |   1 | 3 |  1.00000000000000000000
+   0 |   0 |   1 | 4 | -1.00000000000000000000
+   0 |   0 |   1 | 4 |  1.00000000000000000000
+   0 |   0 |   1 | 5 | -1.00000000000000000000
+   0 |   0 |   1 | 5 |  1.00000000000000000000
+   1 |   1 |  10 |   |  0.00000000000000000000
+(11 rows)
 
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a) ) ORDER BY a, c;
- g_a | g_c | cnt | a |     b      | c  
------+-----+-----+---+------------+----
-   0 |   0 |   1 | 1 | text|1|-1| | -1
-   0 |   0 |   1 | 1 | text|1|1|  |  1
-   0 |   1 |   2 | 1 |            |   
-   0 |   0 |   1 | 2 | text|2|-1| | -1
-   0 |   0 |   1 | 2 | text|2|1|  |  1
-   0 |   1 |   2 | 2 |            |   
-   0 |   0 |   1 | 3 | text|3|-1| | -1
-   0 |   0 |   1 | 3 | text|3|1|  |  1
-   0 |   1 |   2 | 3 |            |   
-   0 |   0 |   1 | 4 | text|4|-1| | -1
-   0 |   0 |   1 | 4 | text|4|1|  |  1
-   0 |   1 |   2 | 4 |            |   
-   0 |   0 |   1 | 5 | text|5|-1| | -1
-   0 |   0 |   1 | 5 | text|5|1|  |  1
-   0 |   1 |   2 | 5 |            |   
-(15 rows)
-
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c;
- g_a | g_c | a |     b      | c  
------+-----+---+------------+----
-   0 |   0 | 1 | text|1|-1| | -1
-   0 |   0 | 1 | text|1|1|  |  1
-   0 |   0 | 2 | text|2|-1| | -1
-   0 |   0 | 2 | text|2|1|  |  1
-   0 |   0 | 3 | text|3|-1| | -1
-   0 |   0 | 3 | text|3|1|  |  1
-   0 |   0 | 4 | text|4|-1| | -1
-   0 |   0 | 4 | text|4|1|  |  1
-   0 |   0 | 5 | text|5|-1| | -1
-   0 |   0 | 5 | text|5|1|  |  1
-   0 |   1 | 1 |            |   
-   0 |   1 | 2 |            |   
-   0 |   1 | 3 |            |   
-   0 |   1 | 4 |            |   
-   0 |   1 | 5 |            |   
-   1 |   0 |   |            | -1
-   1 |   0 |   |            |  1
-(17 rows)
-
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM ...
+                                                          ^
 SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c) ) ORDER BY g_a, g_c, a, c;
  g_a | g_c | a |     b      | c  
 -----+-----+---+------------+----
@@ -1795,25 +1798,580 @@ SELECT l.a, l.b, r.a, r.b FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a
  10 | text0 | 10 | t3-text0
 (10 rows)
 
-SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, l.b, r.a, r.b, r.c
+SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, r.a, r.c
 	FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY GROUPING SETS ((l.a, r.a), (r.c), ()) ORDER BY l.a, r.c;
- g_l_a | g_r_a | g_r_c | a  |   b   | a  |    b     | c 
--------+-------+-------+----+-------+----+----------+---
-     0 |     0 |     1 |  1 | text1 |  1 | t3-text1 |  
-     0 |     0 |     1 |  2 | text2 |  2 | t3-text2 |  
-     0 |     0 |     1 |  3 | text3 |  3 | t3-text3 |  
-     0 |     0 |     1 |  4 | text4 |  4 | t3-text4 |  
-     0 |     0 |     1 |  5 | text0 |  5 | t3-text0 |  
-     0 |     0 |     1 |  6 | text1 |  6 | t3-text1 |  
-     0 |     0 |     1 |  7 | text2 |  7 | t3-text2 |  
-     0 |     0 |     1 |  8 | text3 |  8 | t3-text3 |  
-     0 |     0 |     1 |  9 | text4 |  9 | t3-text4 |  
-     0 |     0 |     1 | 10 | text0 | 10 | t3-text0 |  
-     1 |     1 |     0 |    |       |    |          | 0
-     1 |     1 |     0 |    |       |    |          | 1
-     1 |     1 |     1 |    |       |    |          |  
+ g_l_a | g_r_a | g_r_c | a  | a  | c 
+-------+-------+-------+----+----+---
+     0 |     0 |     1 |  1 |  1 |  
+     0 |     0 |     1 |  2 |  2 |  
+     0 |     0 |     1 |  3 |  3 |  
+     0 |     0 |     1 |  4 |  4 |  
+     0 |     0 |     1 |  5 |  5 |  
+     0 |     0 |     1 |  6 |  6 |  
+     0 |     0 |     1 |  7 |  7 |  
+     0 |     0 |     1 |  8 |  8 |  
+     0 |     0 |     1 |  9 |  9 |  
+     0 |     0 |     1 | 10 | 10 |  
+     1 |     1 |     0 |    |    | 0
+     1 |     1 |     0 |    |    | 1
+     1 |     1 |     1 |    |    |  
 (13 rows)
 
+-- Checking for ungrouped columns in TL
+-- grouping extension and GROUP BY
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(75 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(75 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+-- only grouping extension
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+ a  |   b   | c 
+----+-------+---
+  1 |       |  
+  1 |       |  
+  2 |       |  
+  2 |       |  
+  3 |       |  
+  3 |       |  
+  4 |       |  
+  4 |       |  
+  5 |       |  
+  5 |       |  
+  6 |       |  
+  6 |       |  
+  7 |       |  
+  7 |       |  
+  8 |       |  
+  8 |       |  
+  9 |       |  
+  9 |       |  
+ 10 |       |  
+ 10 |       |  
+ 11 |       |  
+ 11 |       |  
+ 12 |       |  
+ 12 |       |  
+ 13 |       |  
+ 13 |       |  
+ 14 |       |  
+ 14 |       |  
+ 15 |       |  
+ 15 |       |  
+ 16 |       |  
+ 16 |       |  
+ 17 |       |  
+ 17 |       |  
+ 18 |       |  
+ 18 |       |  
+ 19 |       |  
+ 19 |       |  
+ 20 |       |  
+ 20 |       |  
+ 21 |       |  
+ 21 |       |  
+ 22 |       |  
+ 22 |       |  
+ 23 |       |  
+ 23 |       |  
+ 24 |       |  
+ 24 |       |  
+ 25 |       |  
+ 25 |       |  
+    | text0 |  
+    | text1 |  
+    | text2 |  
+    | text3 |  
+    | text4 |  
+    |       | 0
+    |       | 1
+(57 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT
+-- composite Primary Key
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
+ERROR:  syntax error at or near "SELECT"
+LINE 3: SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),(...
+        ^
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a |     b      | c  
+---+------------+----
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+(20 rows)
+
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a;
+                 ^
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a |     b      | c  
+---+------------+----
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+(30 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), ...
+                 ^
 DROP TABLE test_table1;
 DROP TABLE test_table2;
 DROP TABLE test_table3;

--- a/src/test/regress/expected/functional_deps.out
+++ b/src/test/regress/expected/functional_deps.out
@@ -1818,7 +1818,7 @@ SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l
 (13 rows)
 
 -- Checking for ungrouped columns in TL
--- grouping extension and GROUP BY
+-- grouping expression and GROUP BY
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
@@ -2213,7 +2213,7 @@ SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- 
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
                    ^
--- only grouping extension
+-- only grouping expression
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...

--- a/src/test/regress/expected/functional_deps.out
+++ b/src/test/regress/expected/functional_deps.out
@@ -168,12 +168,12 @@ explain (costs off) select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join fun
  Optimizer: Postgres query optimizer
 (17 rows)
 
-select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
+select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a order by t1.a;
  sum | a | b | c 
 -----+---+---+---
-   1 | 3 | 1 | 1
-   1 | 2 | 1 | 1
    1 | 1 | 1 | 1
+   1 | 2 | 1 | 1
+   1 | 3 | 1 | 1
 (3 rows)
 
 -- modified for ungrouped columns
@@ -302,25 +302,25 @@ explain (costs off) select sum(d), a, b, c, grouping(a) from funcdep1 group by c
  Optimizer: Postgres query optimizer
 (56 rows)
 
-select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c) order by a, b, c;
  sum | a | b | c | grouping 
 -----+---+---+---+----------
    1 | 1 | 1 | 1 |        0
+   1 | 1 | 1 |   |        0
+   1 | 1 |   | 1 |        0
    1 | 1 |   |   |        0
+   1 | 2 | 1 | 1 |        0
+   1 | 2 | 1 |   |        0
    1 | 2 |   | 1 |        0
    1 | 2 |   |   |        0
+   1 | 3 | 1 | 1 |        0
+   1 | 3 | 1 |   |        0
    1 | 3 |   | 1 |        0
    1 | 3 |   |   |        0
-   1 | 3 | 1 | 1 |        0
    3 |   | 1 | 1 |        1
-   1 | 1 |   | 1 |        0
-   1 | 2 | 1 |   |        0
    3 |   | 1 |   |        1
-   1 | 2 | 1 | 1 |        0
    3 |   |   | 1 |        1
    3 |   |   |   |        1
-   1 | 1 | 1 |   |        0
-   1 | 3 | 1 |   |        0
 (16 rows)
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
@@ -1817,9 +1817,9 @@ SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l
      1 |     1 |     1 |    |    |  
 (13 rows)
 
--- Checking for ungrouped columns in TL
+-- Checking for ungrouped columns in TargetList
 -- grouping expression and GROUP BY
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()), a ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -1901,7 +1901,7 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (75 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -1983,15 +1983,15 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (75 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -2098,11 +2098,11 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (100 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -2209,16 +2209,255 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (100 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
 -- only grouping expression
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (a,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 | text1 | 0
+  2 | text2 | 1
+  2 | text2 | 1
+  3 | text3 | 0
+  3 | text3 | 0
+  4 | text4 | 1
+  4 | text4 | 1
+  5 | text0 | 0
+  5 | text0 | 0
+  6 | text1 | 1
+  6 | text1 | 1
+  7 | text2 | 0
+  7 | text2 | 0
+  8 | text3 | 1
+  8 | text3 | 1
+  9 | text4 | 0
+  9 | text4 | 0
+ 10 | text0 | 1
+ 10 | text0 | 1
+ 11 | text1 | 0
+ 11 | text1 | 0
+ 12 | text2 | 1
+ 12 | text2 | 1
+ 13 | text3 | 0
+ 13 | text3 | 0
+ 14 | text4 | 1
+ 14 | text4 | 1
+ 15 | text0 | 0
+ 15 | text0 | 0
+ 16 | text1 | 1
+ 16 | text1 | 1
+ 17 | text2 | 0
+ 17 | text2 | 0
+ 18 | text3 | 1
+ 18 | text3 | 1
+ 19 | text4 | 0
+ 19 | text4 | 0
+ 20 | text0 | 1
+ 20 | text0 | 1
+ 21 | text1 | 0
+ 21 | text1 | 0
+ 22 | text2 | 1
+ 22 | text2 | 1
+ 23 | text3 | 0
+ 23 | text3 | 0
+ 24 | text4 | 1
+ 24 | text4 | 1
+ 25 | text0 | 0
+ 25 | text0 | 0
+(50 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (b,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+(50 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), ...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()...
+                  ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()...
+                  ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (a),a)),
+		                                 GROUPING SETS (b,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (b),a)),
+		                                 GROUPING SETS (b,()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROU...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  a  |   b   | c 
@@ -2282,25 +2521,24 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
     |       | 1
 (57 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),())); --fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), ROLLUP(a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
 -- composite Primary Key
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
-ERROR:  syntax error at or near "SELECT"
-LINE 3: SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),(...
-        ^
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a, c ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a |     b      | c  
@@ -2327,11 +2565,19 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  5 | text|5|1|  |  1
 (20 rows)
 
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c), GROUPING SETS (a,c)); -- fail
 ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a;
-                 ^
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c)...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a;
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a, c ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a |     b      | c  
@@ -2368,10 +2614,6 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  5 | text|5|1|  |  1
 (30 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
-ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), ...
-                 ^
 DROP TABLE test_table1;
 DROP TABLE test_table2;
 DROP TABLE test_table3;

--- a/src/test/regress/expected/functional_deps_optimizer.out
+++ b/src/test/regress/expected/functional_deps_optimizer.out
@@ -16,6 +16,9 @@ CREATE TEMP TABLE articles_in_category (
     changed date,
     PRIMARY KEY (article_id, category_id)
 );
+-- The patch https://github.com/arenadata/gpdb/pull/1117 changes the parser
+-- behavior so that queries with ungrouped columns by non-key attributes in
+-- groups no longer work.
 -- test functional dependencies based on primary keys/unique constraints
 -- base tables
 -- group by primary key (OK)
@@ -168,9 +171,10 @@ select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t
    1 | 3 | 1 | 1
 (3 rows)
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+-- modified for ungrouped columns
+explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Sequence
    ->  Shared Scan (share slice:id 0:0)
          ->  Materialize
@@ -178,8 +182,11 @@ explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grou
                      ->  Seq Scan on funcdep1
    ->  Append
          ->  Result
-               ->  Aggregate
-                     ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.d
+                     ->  Sort
+                           Sort Key: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.d
+                           ->  Shared Scan (share slice:id 0:0)
          ->  Result
                ->  GroupAggregate
                      Group Key: share0_ref3.a, share0_ref3.c, share0_ref3.d
@@ -187,20 +194,22 @@ explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grou
                            Sort Key: share0_ref3.a, share0_ref3.c, share0_ref3.d
                            ->  Shared Scan (share slice:id 0:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(19 rows)
 
-select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
+select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
  sum | c | d | grouping 
 -----+---+---+----------
-   3 |   |   |        1
    1 | 1 | 1 |        0
    1 | 1 | 1 |        0
    1 | 1 | 1 |        0
-(4 rows)
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+   1 | 1 | 1 |        0
+(6 rows)
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+explain (costs off) select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Sequence
    ->  Shared Scan (share slice:id 0:0)
          ->  Materialize
@@ -209,9 +218,9 @@ explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by roll
    ->  Append
          ->  Result
                ->  GroupAggregate
-                     Group Key: share0_ref2.a, share0_ref2.c, share0_ref2.d
+                     Group Key: share0_ref2.a
                      ->  Sort
-                           Sort Key: share0_ref2.a, share0_ref2.c, share0_ref2.d
+                           Sort Key: share0_ref2.a
                            ->  Shared Scan (share slice:id 0:0)
          ->  Result
                ->  Aggregate
@@ -219,49 +228,100 @@ explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by roll
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
-select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
- sum | c | d | grouping 
------+---+---+----------
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   3 |   |   |        1
+select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
+ sum | sum | sum | grouping 
+-----+-----+-----+----------
+   1 |   1 |   1 |        0
+   1 |   1 |   1 |        0
+   1 |   1 |   1 |        0
+   3 |   3 |   3 |        1
 (4 rows)
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
+explain (costs off) select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Cube
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   ->  GroupAggregate
-         Group Key: "rollup".prelim_aggref_1, "rollup"."grouping", "rollup"."group_id"
-         ->  Subquery Scan on "rollup"
-               ->  Sort
-                     Sort Key: rollup_1.prelim_aggref_1, (Grouping), (group_id())
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                           Hash Key: rollup_1.prelim_aggref_1, (Grouping), group_id()
-                           ->  GroupAggregate
-                                 Group Key: rollup_1."grouping", rollup_1."group_id", rollup_1.prelim_aggref_1
-                                 ->  Subquery Scan on rollup_1
-                                       ->  GroupAggregate
-                                             Group Key: funcdep1.a
-                                             ->  Sort
-                                                   Sort Key: funcdep1.a
-                                                   ->  Seq Scan on funcdep1
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Append
+         ->  GroupAggregate
+               Group Key: "rollup".c, "rollup".b, "rollup".a, "rollup"."grouping", "rollup"."group_id"
+               ->  Subquery Scan on "rollup"
+                     ->  Sort
+                           Sort Key: rollup_1.c, rollup_1.b, rollup_1.a, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: rollup_1.c, rollup_1.b, rollup_1.a, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_1."grouping", rollup_1."group_id", rollup_1.a, rollup_1.c, rollup_1.b
+                                       ->  Subquery Scan on rollup_1
+                                             ->  GroupAggregate
+                                                   Group Key: rollup_2.c, rollup_2."grouping", rollup_2."group_id", rollup_2.b, rollup_2.a
+                                                   ->  Subquery Scan on rollup_2
+                                                         ->  GroupAggregate
+                                                               Group Key: rollup_3.c, rollup_3.b, rollup_3."grouping", rollup_3."group_id", rollup_3.a
+                                                               ->  Subquery Scan on rollup_3
+                                                                     ->  GroupAggregate
+                                                                           Group Key: share0_ref1.c, share0_ref1.b, share0_ref1.a
+                                                                           ->  Sort
+                                                                                 Sort Key: share0_ref1.c, share0_ref1.b, share0_ref1.a
+                                                                                 ->  Shared Scan (share slice:id 1:0)
+                                                                                       ->  Materialize
+                                                                                             ->  Seq Scan on funcdep1
+         ->  GroupAggregate
+               Group Key: rollup_4.a, rollup_4.c, rollup_4.b, rollup_4."grouping", rollup_4."group_id"
+               ->  Subquery Scan on rollup_4
+                     ->  Sort
+                           Sort Key: rollup_5.a, rollup_5.c, rollup_5.b, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Hash Key: rollup_5.a, rollup_5.c, rollup_5.b, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_5.a, rollup_5."grouping", rollup_5."group_id", rollup_5.c, rollup_5.b
+                                       ->  Subquery Scan on rollup_5
+                                             ->  GroupAggregate
+                                                   Group Key: share0_ref2.a, share0_ref2.c, share0_ref2.b
+                                                   ->  Sort
+                                                         Sort Key: share0_ref2.a, share0_ref2.c, share0_ref2.b
+                                                         ->  Shared Scan (share slice:id 2:0)
+         ->  GroupAggregate
+               Group Key: rollup_6.b, rollup_6.a, rollup_6.c, rollup_6."grouping", rollup_6."group_id"
+               ->  Subquery Scan on rollup_6
+                     ->  Sort
+                           Sort Key: rollup_7.b, rollup_7.a, rollup_7.c, (Grouping), (group_id())
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: rollup_7.b, rollup_7.a, rollup_7.c, (Grouping), group_id()
+                                 ->  GroupAggregate
+                                       Group Key: rollup_7.b, rollup_7."grouping", rollup_7."group_id", rollup_7.a, rollup_7.c
+                                       ->  Subquery Scan on rollup_7
+                                             ->  GroupAggregate
+                                                   Group Key: share0_ref3.b, share0_ref3.a, share0_ref3.c
+                                                   ->  Sort
+                                                         Sort Key: share0_ref3.b, share0_ref3.a, share0_ref3.c
+                                                         ->  Shared Scan (share slice:id 3:0)
  Optimizer: Postgres query optimizer
-(17 rows)
+(56 rows)
 
-select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Cube
- sum | c | d | grouping 
------+---+---+----------
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   1 | 1 | 1 |        0
-   3 | 1 | 1 |        1
-(4 rows)
+ sum | a | b | c | grouping 
+-----+---+---+---+----------
+   1 | 3 | 1 | 1 |        0
+   3 |   | 1 | 1 |        1
+   1 | 1 |   | 1 |        0
+   1 | 2 | 1 |   |        0
+   3 |   | 1 |   |        1
+   1 | 2 | 1 | 1 |        0
+   3 |   |   | 1 |        1
+   3 |   |   |   |        1
+   1 | 1 | 1 |   |        0
+   1 | 3 | 1 |   |        0
+   1 | 1 | 1 | 1 |        0
+   1 | 1 |   |   |        0
+   1 | 2 |   | 1 |        0
+   1 | 2 |   |   |        0
+   1 | 3 |   | 1 |        0
+   1 | 3 |   |   |        0
+(16 rows)
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
                 QUERY PLAN                
@@ -776,72 +836,6 @@ SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a, b;
  25 | text0 | 0
 (25 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  2 | text2 | 1
-  3 | text3 | 0
-  4 | text4 | 1
-  5 | text0 | 0
-  6 | text1 | 1
-  7 | text2 | 0
-  8 | text3 | 1
-  9 | text4 | 0
- 10 | text0 | 1
- 11 | text1 | 0
- 12 | text2 | 1
- 13 | text3 | 0
- 14 | text4 | 1
- 15 | text0 | 0
- 16 | text1 | 1
- 17 | text2 | 0
- 18 | text3 | 1
- 19 | text4 | 0
- 20 | text0 | 1
- 21 | text1 | 0
- 22 | text2 | 1
- 23 | text3 | 0
- 24 | text4 | 1
- 25 | text0 | 0
-    |       |  
-(26 rows)
-
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b)) ORDER BY a, b;
- a  |   b   | c 
-----+-------+---
-  1 |       | 0
-  2 |       | 1
-  3 |       | 0
-  4 |       | 1
-  5 |       | 0
-  6 |       | 1
-  7 |       | 0
-  8 |       | 1
-  9 |       | 0
- 10 |       | 1
- 11 |       | 0
- 12 |       | 1
- 13 |       | 0
- 14 |       | 1
- 15 |       | 0
- 16 |       | 1
- 17 |       | 0
- 18 |       | 1
- 19 |       | 0
- 20 |       | 1
- 21 |       | 0
- 22 |       | 1
- 23 |       | 0
- 24 |       | 1
- 25 |       | 0
-    | text0 |  
-    | text1 |  
-    | text2 |  
-    | text3 |  
-    | text4 |  
-(30 rows)
-
 SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
  a  |   b   | c 
 ----+-------+---
@@ -872,180 +866,171 @@ SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
  25 | text0 | 0
 (25 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), ()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), (a,c)) ORDER BY a, b, c;
  a  |   b   | c 
 ----+-------+---
-  1 | text1 | 0
+  1 | text1 |  
   1 |       | 0
-  2 | text2 | 1
+  1 |       |  
+  2 | text2 |  
   2 |       | 1
-  3 | text3 | 0
+  2 |       |  
+  3 | text3 |  
   3 |       | 0
-  4 | text4 | 1
+  3 |       |  
+  4 | text4 |  
   4 |       | 1
-  5 | text0 | 0
+  4 |       |  
+  5 | text0 |  
   5 |       | 0
-  6 | text1 | 1
+  5 |       |  
+  6 | text1 |  
   6 |       | 1
-  7 | text2 | 0
+  6 |       |  
+  7 | text2 |  
   7 |       | 0
-  8 | text3 | 1
+  7 |       |  
+  8 | text3 |  
   8 |       | 1
-  9 | text4 | 0
+  8 |       |  
+  9 | text4 |  
   9 |       | 0
- 10 | text0 | 1
+  9 |       |  
+ 10 | text0 |  
  10 |       | 1
- 11 | text1 | 0
+ 10 |       |  
+ 11 | text1 |  
  11 |       | 0
- 12 | text2 | 1
+ 11 |       |  
+ 12 | text2 |  
  12 |       | 1
- 13 | text3 | 0
+ 12 |       |  
+ 13 | text3 |  
  13 |       | 0
- 14 | text4 | 1
+ 13 |       |  
+ 14 | text4 |  
  14 |       | 1
- 15 | text0 | 0
+ 14 |       |  
+ 15 | text0 |  
  15 |       | 0
- 16 | text1 | 1
+ 15 |       |  
+ 16 | text1 |  
  16 |       | 1
- 17 | text2 | 0
+ 16 |       |  
+ 17 | text2 |  
  17 |       | 0
- 18 | text3 | 1
+ 17 |       |  
+ 18 | text3 |  
  18 |       | 1
- 19 | text4 | 0
+ 18 |       |  
+ 19 | text4 |  
  19 |       | 0
- 20 | text0 | 1
+ 19 |       |  
+ 20 | text0 |  
  20 |       | 1
- 21 | text1 | 0
+ 20 |       |  
+ 21 | text1 |  
  21 |       | 0
- 22 | text2 | 1
+ 21 |       |  
+ 22 | text2 |  
  22 |       | 1
- 23 | text3 | 0
+ 22 |       |  
+ 23 | text3 |  
  23 |       | 0
- 24 | text4 | 1
+ 23 |       |  
+ 24 | text4 |  
  24 |       | 1
- 25 | text0 | 0
+ 24 |       |  
+ 25 | text0 |  
  25 |       | 0
-    |       |  
-(51 rows)
+ 25 |       |  
+(75 rows)
 
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  2 | text2 | 1
-  3 | text3 | 0
-  4 | text4 | 1
-  5 | text0 | 0
-  6 | text1 | 1
-  7 | text2 | 0
-  8 | text3 | 1
-  9 | text4 | 0
- 10 | text0 | 1
- 11 | text1 | 0
- 12 | text2 | 1
- 13 | text3 | 0
- 14 | text4 | 1
- 15 | text0 | 0
- 16 | text1 | 1
- 17 | text2 | 0
- 18 | text3 | 1
- 19 | text4 | 0
- 20 | text0 | 1
- 21 | text1 | 0
- 22 | text2 | 1
- 23 | text3 | 0
- 24 | text4 | 1
- 25 | text0 | 0
-    |       |  
-(26 rows)
-
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, ...
+                  ^
 -- Check rollup
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a,b,c) ORDER BY a, b, c;
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
+  1 | text1 |  
+  1 |       |  
   2 | text2 | 1
+  2 | text2 |  
+  2 |       |  
   3 | text3 | 0
+  3 | text3 |  
+  3 |       |  
   4 | text4 | 1
+  4 | text4 |  
+  4 |       |  
   5 | text0 | 0
+  5 | text0 |  
+  5 |       |  
   6 | text1 | 1
+  6 | text1 |  
+  6 |       |  
   7 | text2 | 0
+  7 | text2 |  
+  7 |       |  
   8 | text3 | 1
+  8 | text3 |  
+  8 |       |  
   9 | text4 | 0
+  9 | text4 |  
+  9 |       |  
  10 | text0 | 1
+ 10 | text0 |  
+ 10 |       |  
  11 | text1 | 0
+ 11 | text1 |  
+ 11 |       |  
  12 | text2 | 1
+ 12 | text2 |  
+ 12 |       |  
  13 | text3 | 0
+ 13 | text3 |  
+ 13 |       |  
  14 | text4 | 1
+ 14 | text4 |  
+ 14 |       |  
  15 | text0 | 0
+ 15 | text0 |  
+ 15 |       |  
  16 | text1 | 1
+ 16 | text1 |  
+ 16 |       |  
  17 | text2 | 0
+ 17 | text2 |  
+ 17 |       |  
  18 | text3 | 1
+ 18 | text3 |  
+ 18 |       |  
  19 | text4 | 0
+ 19 | text4 |  
+ 19 |       |  
  20 | text0 | 1
+ 20 | text0 |  
+ 20 |       |  
  21 | text1 | 0
+ 21 | text1 |  
+ 21 |       |  
  22 | text2 | 1
+ 22 | text2 |  
+ 22 |       |  
  23 | text3 | 0
+ 23 | text3 |  
+ 23 |       |  
  24 | text4 | 1
+ 24 | text4 |  
+ 24 |       |  
  25 | text0 | 0
+ 25 | text0 |  
+ 25 |       |  
     |       |  
-(26 rows)
-
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a, b) ORDER BY a, b, c;
- a  |   b   | c 
-----+-------+---
-  1 | text1 | 0
-  1 |       | 0
-  2 | text2 | 1
-  2 |       | 1
-  3 | text3 | 0
-  3 |       | 0
-  4 | text4 | 1
-  4 |       | 1
-  5 | text0 | 0
-  5 |       | 0
-  6 | text1 | 1
-  6 |       | 1
-  7 | text2 | 0
-  7 |       | 0
-  8 | text3 | 1
-  8 |       | 1
-  9 | text4 | 0
-  9 |       | 0
- 10 | text0 | 1
- 10 |       | 1
- 11 | text1 | 0
- 11 |       | 0
- 12 | text2 | 1
- 12 |       | 1
- 13 | text3 | 0
- 13 |       | 0
- 14 | text4 | 1
- 14 |       | 1
- 15 | text0 | 0
- 15 |       | 0
- 16 | text1 | 1
- 16 |       | 1
- 17 | text2 | 0
- 17 |       | 0
- 18 | text3 | 1
- 18 |       | 1
- 19 | text4 | 0
- 19 |       | 0
- 20 | text0 | 1
- 20 |       | 1
- 21 | text1 | 0
- 21 |       | 0
- 22 | text2 | 1
- 22 |       | 1
- 23 | text3 | 0
- 23 |       | 0
- 24 | text4 | 1
- 24 |       | 1
- 25 | text0 | 0
- 25 |       | 0
-    |       |  
-(51 rows)
+(76 rows)
 
 -- Check expressions in target list
 SELECT a, b, c, 1+(a+c)*2 AS exp_ac FROM test_table1 GROUP BY a ORDER BY a, b, c, exp_ac;
@@ -1138,104 +1123,116 @@ SELECT 1+(a+c)*2 AS exp_ac_1, 100+(a+c)*2 AS exp_ac_2 FROM test_table1 GROUP BY 
        51 |      150
 (25 rows)
 
-SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
+SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
  exp_ac | a  
 --------+----
       3 |  1
+      3 |  1
+      7 |  2
       7 |  2
       7 |  3
+      7 |  3
+     11 |  4
      11 |  4
      11 |  5
+     11 |  5
+     15 |  6
      15 |  6
      15 |  7
+     15 |  7
+     19 |  8
      19 |  8
      19 |  9
+     19 |  9
+     23 | 10
      23 | 10
      23 | 11
+     23 | 11
+     27 | 12
      27 | 12
      27 | 13
+     27 | 13
+     31 | 14
      31 | 14
      31 | 15
+     31 | 15
+     35 | 16
      35 | 16
      35 | 17
+     35 | 17
+     39 | 18
      39 | 18
      39 | 19
+     39 | 19
+     43 | 20
      43 | 20
      43 | 21
+     43 | 21
+     47 | 22
      47 | 22
      47 | 23
+     47 | 23
+     51 | 24
      51 | 24
      51 | 25
-        |   
-(26 rows)
+     51 | 25
+(50 rows)
 
 -- Check together with aggregate functions in target list
-SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
+SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
  cnt | exp_ac | a  
 -----+--------+----
    1 |      3 |  1
+   1 |      3 |  1
+   1 |      7 |  2
    1 |      7 |  2
    1 |      7 |  3
+   1 |      7 |  3
+   1 |     11 |  4
    1 |     11 |  4
    1 |     11 |  5
+   1 |     11 |  5
+   1 |     15 |  6
    1 |     15 |  6
    1 |     15 |  7
+   1 |     15 |  7
+   1 |     19 |  8
    1 |     19 |  8
    1 |     19 |  9
+   1 |     19 |  9
+   1 |     23 | 10
    1 |     23 | 10
    1 |     23 | 11
+   1 |     23 | 11
+   1 |     27 | 12
    1 |     27 | 12
    1 |     27 | 13
+   1 |     27 | 13
+   1 |     31 | 14
    1 |     31 | 14
    1 |     31 | 15
+   1 |     31 | 15
+   1 |     35 | 16
    1 |     35 | 16
    1 |     35 | 17
+   1 |     35 | 17
+   1 |     39 | 18
    1 |     39 | 18
    1 |     39 | 19
+   1 |     39 | 19
+   1 |     43 | 20
    1 |     43 | 20
    1 |     43 | 21
+   1 |     43 | 21
+   1 |     47 | 22
    1 |     47 | 22
    1 |     47 | 23
+   1 |     47 | 23
+   1 |     51 | 24
    1 |     51 | 24
    1 |     51 | 25
-  25 |        |   
-(26 rows)
-
-SELECT avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
-         avg_c          | c 
-------------------------+---
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.00000000000000000000 | 0
- 0.40000000000000000000 |  
- 0.40000000000000000000 |  
- 0.40000000000000000000 |  
- 0.48000000000000000000 |  
- 0.60000000000000000000 |  
- 0.60000000000000000000 |  
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
- 1.00000000000000000000 | 1
-(31 rows)
+   1 |     51 | 25
+(50 rows)
 
 -- Check with grouping function in target list
 SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
@@ -1268,7 +1265,7 @@ SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) OR
    0 | 25 | text0
 (25 rows)
 
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
+SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c;
  g_a | g_b |         avg_c          
 -----+-----+------------------------
    0 |   1 | 0.00000000000000000000
@@ -1304,122 +1301,121 @@ SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 
    0 |   1 | 1.00000000000000000000
 (31 rows)
 
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
- g_a | g_b |         avg_c          | c 
------+-----+------------------------+---
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   0 |   1 | 0.00000000000000000000 | 0
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   0 | 0.40000000000000000000 |  
-   1 |   1 | 0.48000000000000000000 |  
-   1 |   0 | 0.60000000000000000000 |  
-   1 |   0 | 0.60000000000000000000 |  
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-   0 |   1 | 1.00000000000000000000 | 1
-(31 rows)
-
 -- Check aggregate functions in ORDER BY clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY avg(c), a, b;
  a  |   b   
 ----+-------
   1 | text1
+  1 | 
   3 | text3
+  3 | 
   5 | text0
+  5 | 
   7 | text2
+  7 | 
   9 | text4
+  9 | 
  11 | text1
+ 11 | 
  13 | text3
+ 13 | 
  15 | text0
+ 15 | 
  17 | text2
+ 17 | 
  19 | text4
+ 19 | 
  21 | text1
+ 21 | 
  23 | text3
+ 23 | 
  25 | text0
-    | 
+ 25 | 
   2 | text2
+  2 | 
   4 | text4
+  4 | 
   6 | text1
+  6 | 
   8 | text3
+  8 | 
  10 | text0
+ 10 | 
  12 | text2
+ 12 | 
  14 | text4
+ 14 | 
  16 | text1
+ 16 | 
  18 | text3
+ 18 | 
  20 | text0
+ 20 | 
  22 | text2
+ 22 | 
  24 | text4
-(26 rows)
+ 24 | 
+(50 rows)
 
 -- Check aggregate functions in HAVING clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
  a  |   b   
 ----+-------
-    | 
   2 | text2
+  2 | 
   4 | text4
+  4 | 
   6 | text1
+  6 | 
   8 | text3
+  8 | 
  10 | text0
+ 10 | 
  12 | text2
+ 12 | 
  14 | text4
+ 14 | 
  16 | text1
+ 16 | 
  18 | text3
+ 18 | 
  20 | text0
+ 20 | 
  22 | text2
+ 22 | 
  24 | text4
-(13 rows)
+ 24 | 
+(24 rows)
 
 -- Check grouping functions in HAVING clause
-SELECT grouping(a) AS g_a, a, b, c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, b, c;
- g_a | a  |   b   | c 
------+----+-------+---
-   0 |  1 | text1 | 0
-   0 |  2 | text2 | 1
-   0 |  3 | text3 | 0
-   0 |  4 | text4 | 1
-   0 |  5 | text0 | 0
-   0 |  6 | text1 | 1
-   0 |  7 | text2 | 0
-   0 |  8 | text3 | 1
-   0 |  9 | text4 | 0
-   0 | 10 | text0 | 1
-   0 | 11 | text1 | 0
-   0 | 12 | text2 | 1
-   0 | 13 | text3 | 0
-   0 | 14 | text4 | 1
-   0 | 15 | text0 | 0
-   0 | 16 | text1 | 1
-   0 | 17 | text2 | 0
-   0 | 18 | text3 | 1
-   0 | 19 | text4 | 0
-   0 | 20 | text0 | 1
-   0 | 21 | text1 | 0
-   0 | 22 | text2 | 1
-   0 | 23 | text3 | 0
-   0 | 24 | text4 | 1
-   0 | 25 | text0 | 0
+SELECT grouping(a) AS g_a, a, avg(c) as avg_c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, avg_c;
+ g_a | a  |         avg_c          
+-----+----+------------------------
+   0 |  1 | 0.00000000000000000000
+   0 |  2 | 1.00000000000000000000
+   0 |  3 | 0.00000000000000000000
+   0 |  4 | 1.00000000000000000000
+   0 |  5 | 0.00000000000000000000
+   0 |  6 | 1.00000000000000000000
+   0 |  7 | 0.00000000000000000000
+   0 |  8 | 1.00000000000000000000
+   0 |  9 | 0.00000000000000000000
+   0 | 10 | 1.00000000000000000000
+   0 | 11 | 0.00000000000000000000
+   0 | 12 | 1.00000000000000000000
+   0 | 13 | 0.00000000000000000000
+   0 | 14 | 1.00000000000000000000
+   0 | 15 | 0.00000000000000000000
+   0 | 16 | 1.00000000000000000000
+   0 | 17 | 0.00000000000000000000
+   0 | 18 | 1.00000000000000000000
+   0 | 19 | 0.00000000000000000000
+   0 | 20 | 1.00000000000000000000
+   0 | 21 | 0.00000000000000000000
+   0 | 22 | 1.00000000000000000000
+   0 | 23 | 0.00000000000000000000
+   0 | 24 | 1.00000000000000000000
+   0 | 25 | 0.00000000000000000000
 (25 rows)
 
 SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a, b HAVING grouping(b) = 0 ORDER BY exp_ac_1, b;
@@ -1453,76 +1449,124 @@ SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a,
 (25 rows)
 
 SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ())
-	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c, c;
+	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c;
  g_a | g_b |         avg_c          
 -----+-----+------------------------
    1 |   1 | 0.48000000000000000000
 (1 row)
 
 -- Check sub-query
-SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t;
+SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a) AS sub_t;
  a  |   b   | c 
 ----+-------+---
+  1 | text1 |  
   1 | text1 | 0
+  2 | text2 |  
   2 | text2 | 1
+  3 | text3 |  
   3 | text3 | 0
+  4 | text4 |  
   4 | text4 | 1
+  5 | text0 |  
   5 | text0 | 0
+  6 | text1 |  
   6 | text1 | 1
   7 | text2 | 0
+  7 | text2 |  
+  8 | text3 |  
   8 | text3 | 1
+  9 | text4 |  
   9 | text4 | 0
  10 | text0 | 1
+ 10 | text0 |  
+ 11 | text1 |  
  11 | text1 | 0
+ 12 | text2 |  
  12 | text2 | 1
  13 | text3 | 0
+ 13 | text3 |  
+ 14 | text4 |  
  14 | text4 | 1
+ 15 | text0 |  
  15 | text0 | 0
  16 | text1 | 1
+ 16 | text1 |  
+ 17 | text2 |  
  17 | text2 | 0
+ 18 | text3 |  
  18 | text3 | 1
+ 19 | text4 |  
  19 | text4 | 0
+ 20 | text0 |  
  20 | text0 | 1
  21 | text1 | 0
+ 21 | text1 |  
  22 | text2 | 1
+ 22 | text2 |  
+ 23 | text3 |  
  23 | text3 | 0
+ 24 | text4 |  
  24 | text4 | 1
+ 25 | text0 |  
  25 | text0 | 0
-    |       |  
-(26 rows)
+(50 rows)
 
-SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a;
+SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
+  1 | text1 |  
   2 | text2 | 1
+  2 | text2 |  
   3 | text3 | 0
+  3 | text3 |  
   4 | text4 | 1
+  4 | text4 |  
   5 | text0 | 0
+  5 | text0 |  
   6 | text1 | 1
+  6 | text1 |  
   7 | text2 | 0
+  7 | text2 |  
   8 | text3 | 1
+  8 | text3 |  
   9 | text4 | 0
+  9 | text4 |  
  10 | text0 | 1
+ 10 | text0 |  
  11 | text1 | 0
+ 11 | text1 |  
  12 | text2 | 1
+ 12 | text2 |  
  13 | text3 | 0
+ 13 | text3 |  
  14 | text4 | 1
+ 14 | text4 |  
  15 | text0 | 0
+ 15 | text0 |  
  16 | text1 | 1
+ 16 | text1 |  
  17 | text2 | 0
+ 17 | text2 |  
  18 | text3 | 1
+ 18 | text3 |  
  19 | text4 | 0
+ 19 | text4 |  
  20 | text0 | 1
+ 20 | text0 |  
  21 | text1 | 0
+ 21 | text1 |  
  22 | text2 | 1
+ 22 | text2 |  
  23 | text3 | 0
+ 23 | text3 |  
  24 | text4 | 1
+ 24 | text4 |  
  25 | text0 | 0
+ 25 | text0 |  
     |       |  
-    |       |  
-(27 rows)
+(51 rows)
 
 SELECT (SELECT c) FROM test_table1 GROUP BY a ORDER BY a;
  c 
@@ -1600,68 +1644,30 @@ SELECT a, b, c FROM test_table2 GROUP BY a, c ORDER BY a, c;
  5 | text|5|1|  |  1
 (10 rows)
 
-SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c;
- a |     b      | c  
----+------------+----
- 1 | text|1|-1| | -1
- 1 | text|1|1|  |  1
- 1 |            |   
- 2 | text|2|-1| | -1
- 2 | text|2|1|  |  1
- 2 |            |   
- 3 | text|3|-1| | -1
- 3 | text|3|1|  |  1
- 3 |            |   
- 4 | text|4|-1| | -1
- 4 | text|4|1|  |  1
- 4 |            |   
- 5 | text|5|-1| | -1
- 5 | text|5|1|  |  1
- 5 |            |   
-(15 rows)
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, ...
+                  ^
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, avg(c) FROM test_table2 GROUP BY GROUPING SETS ((a, c), () ) ORDER BY a, c;
+ g_a | g_c | cnt | a |           avg           
+-----+-----+-----+---+-------------------------
+   0 |   0 |   1 | 1 | -1.00000000000000000000
+   0 |   0 |   1 | 1 |  1.00000000000000000000
+   0 |   0 |   1 | 2 | -1.00000000000000000000
+   0 |   0 |   1 | 2 |  1.00000000000000000000
+   0 |   0 |   1 | 3 | -1.00000000000000000000
+   0 |   0 |   1 | 3 |  1.00000000000000000000
+   0 |   0 |   1 | 4 | -1.00000000000000000000
+   0 |   0 |   1 | 4 |  1.00000000000000000000
+   0 |   0 |   1 | 5 | -1.00000000000000000000
+   0 |   0 |   1 | 5 |  1.00000000000000000000
+   1 |   1 |  10 |   |  0.00000000000000000000
+(11 rows)
 
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a) ) ORDER BY a, c;
- g_a | g_c | cnt | a |     b      | c  
------+-----+-----+---+------------+----
-   0 |   0 |   1 | 1 | text|1|-1| | -1
-   0 |   0 |   1 | 1 | text|1|1|  |  1
-   0 |   1 |   2 | 1 |            |   
-   0 |   0 |   1 | 2 | text|2|-1| | -1
-   0 |   0 |   1 | 2 | text|2|1|  |  1
-   0 |   1 |   2 | 2 |            |   
-   0 |   0 |   1 | 3 | text|3|-1| | -1
-   0 |   0 |   1 | 3 | text|3|1|  |  1
-   0 |   1 |   2 | 3 |            |   
-   0 |   0 |   1 | 4 | text|4|-1| | -1
-   0 |   0 |   1 | 4 | text|4|1|  |  1
-   0 |   1 |   2 | 4 |            |   
-   0 |   0 |   1 | 5 | text|5|-1| | -1
-   0 |   0 |   1 | 5 | text|5|1|  |  1
-   0 |   1 |   2 | 5 |            |   
-(15 rows)
-
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c;
- g_a | g_c | a |     b      | c  
------+-----+---+------------+----
-   0 |   0 | 1 | text|1|-1| | -1
-   0 |   0 | 1 | text|1|1|  |  1
-   0 |   0 | 2 | text|2|-1| | -1
-   0 |   0 | 2 | text|2|1|  |  1
-   0 |   0 | 3 | text|3|-1| | -1
-   0 |   0 | 3 | text|3|1|  |  1
-   0 |   0 | 4 | text|4|-1| | -1
-   0 |   0 | 4 | text|4|1|  |  1
-   0 |   0 | 5 | text|5|-1| | -1
-   0 |   0 | 5 | text|5|1|  |  1
-   0 |   1 | 1 |            |   
-   0 |   1 | 2 |            |   
-   0 |   1 | 3 |            |   
-   0 |   1 | 4 |            |   
-   0 |   1 | 5 |            |   
-   1 |   0 |   |            | -1
-   1 |   0 |   |            |  1
-(17 rows)
-
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM ...
+                                                          ^
 SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c) ) ORDER BY g_a, g_c, a, c;
  g_a | g_c | a |     b      | c  
 -----+-----+---+------------+----
@@ -1787,25 +1793,580 @@ SELECT l.a, l.b, r.a, r.b FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a
  10 | text0 | 10 | t3-text0
 (10 rows)
 
-SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, l.b, r.a, r.b, r.c
+SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, r.a, r.c
 	FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY GROUPING SETS ((l.a, r.a), (r.c), ()) ORDER BY l.a, r.c;
- g_l_a | g_r_a | g_r_c | a  |   b   | a  |    b     | c 
--------+-------+-------+----+-------+----+----------+---
-     0 |     0 |     1 |  1 | text1 |  1 | t3-text1 |  
-     0 |     0 |     1 |  2 | text2 |  2 | t3-text2 |  
-     0 |     0 |     1 |  3 | text3 |  3 | t3-text3 |  
-     0 |     0 |     1 |  4 | text4 |  4 | t3-text4 |  
-     0 |     0 |     1 |  5 | text0 |  5 | t3-text0 |  
-     0 |     0 |     1 |  6 | text1 |  6 | t3-text1 |  
-     0 |     0 |     1 |  7 | text2 |  7 | t3-text2 |  
-     0 |     0 |     1 |  8 | text3 |  8 | t3-text3 |  
-     0 |     0 |     1 |  9 | text4 |  9 | t3-text4 |  
-     0 |     0 |     1 | 10 | text0 | 10 | t3-text0 |  
-     1 |     1 |     0 |    |       |    |          | 0
-     1 |     1 |     0 |    |       |    |          | 1
-     1 |     1 |     1 |    |       |    |          |  
+ g_l_a | g_r_a | g_r_c | a  | a  | c 
+-------+-------+-------+----+----+---
+     0 |     0 |     1 |  1 |  1 |  
+     0 |     0 |     1 |  2 |  2 |  
+     0 |     0 |     1 |  3 |  3 |  
+     0 |     0 |     1 |  4 |  4 |  
+     0 |     0 |     1 |  5 |  5 |  
+     0 |     0 |     1 |  6 |  6 |  
+     0 |     0 |     1 |  7 |  7 |  
+     0 |     0 |     1 |  8 |  8 |  
+     0 |     0 |     1 |  9 |  9 |  
+     0 |     0 |     1 | 10 | 10 |  
+     1 |     1 |     0 |    |    | 0
+     1 |     1 |     0 |    |    | 1
+     1 |     1 |     1 |    |    |  
 (13 rows)
 
+-- Checking for ungrouped columns in TL
+-- grouping extension and GROUP BY
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(75 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(75 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
+                   ^
+-- only grouping extension
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+ a  |   b   | c 
+----+-------+---
+  1 |       |  
+  1 |       |  
+  2 |       |  
+  2 |       |  
+  3 |       |  
+  3 |       |  
+  4 |       |  
+  4 |       |  
+  5 |       |  
+  5 |       |  
+  6 |       |  
+  6 |       |  
+  7 |       |  
+  7 |       |  
+  8 |       |  
+  8 |       |  
+  9 |       |  
+  9 |       |  
+ 10 |       |  
+ 10 |       |  
+ 11 |       |  
+ 11 |       |  
+ 12 |       |  
+ 12 |       |  
+ 13 |       |  
+ 13 |       |  
+ 14 |       |  
+ 14 |       |  
+ 15 |       |  
+ 15 |       |  
+ 16 |       |  
+ 16 |       |  
+ 17 |       |  
+ 17 |       |  
+ 18 |       |  
+ 18 |       |  
+ 19 |       |  
+ 19 |       |  
+ 20 |       |  
+ 20 |       |  
+ 21 |       |  
+ 21 |       |  
+ 22 |       |  
+ 22 |       |  
+ 23 |       |  
+ 23 |       |  
+ 24 |       |  
+ 24 |       |  
+ 25 |       |  
+ 25 |       |  
+    | text0 |  
+    | text1 |  
+    | text2 |  
+    | text3 |  
+    | text4 |  
+    |       | 0
+    |       | 1
+(57 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
+                   ^
+SELECT
+-- composite Primary Key
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
+ERROR:  syntax error at or near "SELECT"
+LINE 3: SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),(...
+        ^
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a |     b      | c  
+---+------------+----
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+(20 rows)
+
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a;
+                 ^
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
+ a |     b      | c  
+---+------------+----
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|-1| | -1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 1 | text|1|1|  |  1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|-1| | -1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 2 | text|2|1|  |  1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|-1| | -1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 3 | text|3|1|  |  1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|-1| | -1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 4 | text|4|1|  |  1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|-1| | -1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+ 5 | text|5|1|  |  1
+(30 rows)
+
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), ...
+                 ^
 DROP TABLE test_table1;
 DROP TABLE test_table2;
 DROP TABLE test_table3;

--- a/src/test/regress/expected/functional_deps_optimizer.out
+++ b/src/test/regress/expected/functional_deps_optimizer.out
@@ -1813,7 +1813,7 @@ SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l
 (13 rows)
 
 -- Checking for ungrouped columns in TL
--- grouping extension and GROUP BY
+-- grouping expression and GROUP BY
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
@@ -2208,7 +2208,7 @@ SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- 
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
                    ^
--- only grouping extension
+-- only grouping expression
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...

--- a/src/test/regress/expected/functional_deps_optimizer.out
+++ b/src/test/regress/expected/functional_deps_optimizer.out
@@ -163,7 +163,7 @@ explain (costs off) select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join fun
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
-select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
+select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a order by t1.a;
  sum | a | b | c 
 -----+---+---+---
    1 | 1 | 1 | 1
@@ -300,27 +300,27 @@ DETAIL:  Feature not supported: Cube
  Optimizer: Postgres query optimizer
 (56 rows)
 
-select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c) order by a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Cube
  sum | a | b | c | grouping 
 -----+---+---+---+----------
-   1 | 3 | 1 | 1 |        0
-   3 |   | 1 | 1 |        1
-   1 | 1 |   | 1 |        0
-   1 | 2 | 1 |   |        0
-   3 |   | 1 |   |        1
-   1 | 2 | 1 | 1 |        0
-   3 |   |   | 1 |        1
-   3 |   |   |   |        1
-   1 | 1 | 1 |   |        0
-   1 | 3 | 1 |   |        0
    1 | 1 | 1 | 1 |        0
+   1 | 1 | 1 |   |        0
+   1 | 1 |   | 1 |        0
    1 | 1 |   |   |        0
+   1 | 2 | 1 | 1 |        0
+   1 | 2 | 1 |   |        0
    1 | 2 |   | 1 |        0
    1 | 2 |   |   |        0
+   1 | 3 | 1 | 1 |        0
+   1 | 3 | 1 |   |        0
    1 | 3 |   | 1 |        0
    1 | 3 |   |   |        0
+   3 |   | 1 | 1 |        1
+   3 |   | 1 |   |        1
+   3 |   |   | 1 |        1
+   3 |   |   |   |        1
 (16 rows)
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
@@ -1812,9 +1812,9 @@ SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l
      1 |     1 |     1 |    |    |  
 (13 rows)
 
--- Checking for ungrouped columns in TL
+-- Checking for ungrouped columns in TargetList
 -- grouping expression and GROUP BY
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()), a ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -1896,7 +1896,7 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (75 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -1978,15 +1978,15 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (75 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -2093,11 +2093,11 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (100 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a  |   b   | c 
@@ -2204,16 +2204,255 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  25 |       | 0
 (100 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a)...
-                   ^
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
+                     ^
 -- only grouping expression
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (a,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 | text1 | 0
+  2 | text2 | 1
+  2 | text2 | 1
+  3 | text3 | 0
+  3 | text3 | 0
+  4 | text4 | 1
+  4 | text4 | 1
+  5 | text0 | 0
+  5 | text0 | 0
+  6 | text1 | 1
+  6 | text1 | 1
+  7 | text2 | 0
+  7 | text2 | 0
+  8 | text3 | 1
+  8 | text3 | 1
+  9 | text4 | 0
+  9 | text4 | 0
+ 10 | text0 | 1
+ 10 | text0 | 1
+ 11 | text1 | 0
+ 11 | text1 | 0
+ 12 | text2 | 1
+ 12 | text2 | 1
+ 13 | text3 | 0
+ 13 | text3 | 0
+ 14 | text4 | 1
+ 14 | text4 | 1
+ 15 | text0 | 0
+ 15 | text0 | 0
+ 16 | text1 | 1
+ 16 | text1 | 1
+ 17 | text2 | 0
+ 17 | text2 | 0
+ 18 | text3 | 1
+ 18 | text3 | 1
+ 19 | text4 | 0
+ 19 | text4 | 0
+ 20 | text0 | 1
+ 20 | text0 | 1
+ 21 | text1 | 0
+ 21 | text1 | 0
+ 22 | text2 | 1
+ 22 | text2 | 1
+ 23 | text3 | 0
+ 23 | text3 | 0
+ 24 | text4 | 1
+ 24 | text4 | 1
+ 25 | text0 | 0
+ 25 | text0 | 0
+(50 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (b,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple grouping sets specifications
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 |       | 0
+(50 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), ...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()...
+                  ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()...
+                  ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (a),a)),
+		                                 GROUPING SETS (b,()) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+ a  |   b   | c 
+----+-------+---
+  1 | text1 | 0
+  1 | text1 | 0
+  1 |       | 0
+  1 |       | 0
+  2 | text2 | 1
+  2 | text2 | 1
+  2 |       | 1
+  2 |       | 1
+  3 | text3 | 0
+  3 | text3 | 0
+  3 |       | 0
+  3 |       | 0
+  4 | text4 | 1
+  4 | text4 | 1
+  4 |       | 1
+  4 |       | 1
+  5 | text0 | 0
+  5 | text0 | 0
+  5 |       | 0
+  5 |       | 0
+  6 | text1 | 1
+  6 | text1 | 1
+  6 |       | 1
+  6 |       | 1
+  7 | text2 | 0
+  7 | text2 | 0
+  7 |       | 0
+  7 |       | 0
+  8 | text3 | 1
+  8 | text3 | 1
+  8 |       | 1
+  8 |       | 1
+  9 | text4 | 0
+  9 | text4 | 0
+  9 |       | 0
+  9 |       | 0
+ 10 | text0 | 1
+ 10 | text0 | 1
+ 10 |       | 1
+ 10 |       | 1
+ 11 | text1 | 0
+ 11 | text1 | 0
+ 11 |       | 0
+ 11 |       | 0
+ 12 | text2 | 1
+ 12 | text2 | 1
+ 12 |       | 1
+ 12 |       | 1
+ 13 | text3 | 0
+ 13 | text3 | 0
+ 13 |       | 0
+ 13 |       | 0
+ 14 | text4 | 1
+ 14 | text4 | 1
+ 14 |       | 1
+ 14 |       | 1
+ 15 | text0 | 0
+ 15 | text0 | 0
+ 15 |       | 0
+ 15 |       | 0
+ 16 | text1 | 1
+ 16 | text1 | 1
+ 16 |       | 1
+ 16 |       | 1
+ 17 | text2 | 0
+ 17 | text2 | 0
+ 17 |       | 0
+ 17 |       | 0
+ 18 | text3 | 1
+ 18 | text3 | 1
+ 18 |       | 1
+ 18 |       | 1
+ 19 | text4 | 0
+ 19 | text4 | 0
+ 19 |       | 0
+ 19 |       | 0
+ 20 | text0 | 1
+ 20 | text0 | 1
+ 20 |       | 1
+ 20 |       | 1
+ 21 | text1 | 0
+ 21 | text1 | 0
+ 21 |       | 0
+ 21 |       | 0
+ 22 | text2 | 1
+ 22 | text2 | 1
+ 22 |       | 1
+ 22 |       | 1
+ 23 | text3 | 0
+ 23 | text3 | 0
+ 23 |       | 0
+ 23 |       | 0
+ 24 | text4 | 1
+ 24 | text4 | 1
+ 24 |       | 1
+ 24 |       | 1
+ 25 | text0 | 0
+ 25 | text0 | 0
+ 25 |       | 0
+ 25 |       | 0
+(100 rows)
+
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (b),a)),
+		                                 GROUPING SETS (b,()); -- fail
+ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROU...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  a  |   b   | c 
@@ -2277,25 +2516,24 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
     |       | 1
 (57 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),())); --fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), ROLLUP(a)); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b)...
-                   ^
-SELECT
+LINE 1: SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),...
+                     ^
 -- composite Primary Key
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
-ERROR:  syntax error at or near "SELECT"
-LINE 3: SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),(...
-        ^
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a, c ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a |     b      | c  
@@ -2322,11 +2560,19 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  5 | text|5|1|  |  1
 (20 rows)
 
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c), GROUPING SETS (a,c)); -- fail
 ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a;
-                 ^
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c)...
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a; -- fail
+ERROR:  column "test_table2.b" must appear in the GROUP BY clause or be used in an aggregate function
+LINE 1: SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a;
+                  ^
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a, c ORDER BY a, b, c;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  a |     b      | c  
@@ -2363,10 +2609,6 @@ DETAIL:  Feature not supported: Mixing grouping sets with simple group by lists
  5 | text|5|1|  |  1
 (30 rows)
 
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
-ERROR:  column "test_table1.b" must appear in the GROUP BY clause or be used in an aggregate function
-LINE 1: SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), ...
-                 ^
 DROP TABLE test_table1;
 DROP TABLE test_table2;
 DROP TABLE test_table3;

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -20,6 +20,10 @@ CREATE TEMP TABLE articles_in_category (
     PRIMARY KEY (article_id, category_id)
 );
 
+-- The patch https://github.com/arenadata/gpdb/pull/1117 changes the parser
+-- behavior so that queries with ungrouped columns by non-key attributes in
+-- groups no longer work.
+
 -- test functional dependencies based on primary keys/unique constraints
 
 -- base tables
@@ -123,12 +127,13 @@ insert into funcdep2 values(1,1,1,1);
 explain (costs off) select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
 select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
 
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
-select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), ());
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
-select sum(b), c, d, grouping(a) from funcdep1 group by rollup(a);
-explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
-select sum(b), c, d, grouping(a) from funcdep1 group by cube(a);
+-- modified for ungrouped columns
+explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
+select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
+explain (costs off) select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
+select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
+explain (costs off) select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
 select count(distinct b), c, d from funcdep1 group by a;
@@ -338,46 +343,41 @@ SELECT a, b, c FROM test_table1 GROUP BY a, b ORDER BY a;
 SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
 SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a)) ORDER BY a;
 SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a, b;
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a, b, c;
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b)) ORDER BY a, b;
 SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), ()) ORDER BY a, b, c;
-SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), (a,c)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c; -- fail
 -- Check rollup
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a) ORDER BY a, b, c;
-SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a, b) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a,b,c) ORDER BY a, b, c;
 -- Check expressions in target list
 SELECT a, b, c, 1+(a+c)*2 AS exp_ac FROM test_table1 GROUP BY a ORDER BY a, b, c, exp_ac;
 SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY a ORDER BY a;
 SELECT 1+(a+c)*2 AS exp_ac_1, 100+(a+c)*2 AS exp_ac_2 FROM test_table1 GROUP BY a ORDER BY exp_ac_1;
-SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
+SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
 -- Check together with aggregate functions in target list
-SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a;
-SELECT avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
+SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
 -- Check with grouping function in target list
 SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
-SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c, c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c, c;
+SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c;
 -- Check aggregate functions in ORDER BY clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY avg(c), a, b;
 -- Check aggregate functions in HAVING clause
-SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), ()) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
 -- Check grouping functions in HAVING clause
-SELECT grouping(a) AS g_a, a, b, c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, b, c;
+SELECT grouping(a) AS g_a, a, avg(c) as avg_c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, avg_c;
 SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a, b HAVING grouping(b) = 0 ORDER BY exp_ac_1, b;
 SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ())
-	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c, c;
+	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c;
 -- Check sub-query
-SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t;
-SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), ()) ORDER BY a) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a;
+SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a) AS sub_t;
+SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
 SELECT (SELECT c) FROM test_table1 GROUP BY a ORDER BY a;
 SELECT b, (SELECT c FROM (SELECT c) AS alias_test_table1) FROM test_table1 GROUP BY a ORDER BY a;
 -- Check cases with primary key consisting of more than 1 column
 SELECT a, b, c FROM test_table2 GROUP BY a, c ORDER BY a, c;
-SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c;
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a) ) ORDER BY a, c;
-SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c; -- fail
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, avg(c) FROM test_table2 GROUP BY GROUPING SETS ((a, c), () ) ORDER BY a, c;
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c; -- fail
 SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c) ) ORDER BY g_a, g_c, a, c;
 -- Check cases with join and grouping by primary key of one of the tables
 SELECT l.a, l.b, count(r.b) AS cnt FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
@@ -394,8 +394,34 @@ SELECT l.a, l.b, avg(l.a + l.c) AS agg_expr FROM test_table1 AS l JOIN test_tabl
 SELECT l.a, l.b, avg(r.a + l.c) + count(r.b) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
 -- Check cases with join of 2 tables on their primary key
 SELECT l.a, l.b, r.a, r.b FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY l.a, r.a ORDER BY l.a;
-SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, l.b, r.a, r.b, r.c
+SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, r.a, r.c
 	FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY GROUPING SETS ((l.a, r.a), (r.c), ()) ORDER BY l.a, r.c;
+
+-- Checking for ungrouped columns in TL
+
+-- grouping extension and GROUP BY
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+
+-- only grouping extension
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
+SELECT
+-- composite Primary Key
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
+SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
+SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
+SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
 
 DROP TABLE test_table1;
 DROP TABLE test_table2;

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -399,7 +399,7 @@ SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l
 
 -- Checking for ungrouped columns in TL
 
--- grouping extension and GROUP BY
+-- grouping expression and GROUP BY
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
 SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
 SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
@@ -409,7 +409,7 @@ SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -
 SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
 SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
 
--- only grouping extension
+-- only grouping expression
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
 SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -125,7 +125,7 @@ insert into funcdep1 values(3,1,1,1);
 insert into funcdep2 values(1,1,1,1);
 
 explain (costs off) select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
-select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a;
+select sum(t2.a), t1.a, t1.b, t1.c from funcdep1 t1 join funcdep2 t2 on t1.b = t2.b group by t1.a order by t1.a;
 
 -- modified for ungrouped columns
 explain (costs off) select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b));
@@ -133,7 +133,7 @@ select sum(b), c, d, grouping(a) from funcdep1 group by grouping sets((a), (a,b)
 explain (costs off) select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
 select sum(b), sum(c), sum(d), grouping(a) from funcdep1 group by rollup(a);
 explain (costs off) select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
-select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c);
+select sum(d), a, b, c, grouping(a) from funcdep1 group by cube(a,b,c) order by a, b, c;
 
 explain (costs off) select count(distinct b), c, d from funcdep1 group by a;
 select count(distinct b), c, d from funcdep1 group by a;
@@ -397,31 +397,41 @@ SELECT l.a, l.b, r.a, r.b FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a
 SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, r.a, r.c
 	FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY GROUPING SETS ((l.a, r.a), (r.c), ()) ORDER BY l.a, r.c;
 
--- Checking for ungrouped columns in TL
+-- Checking for ungrouped columns in TargetList
 
 -- grouping expression and GROUP BY
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()), a ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
-SELECT a,b,c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()), a ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
 
 -- only grouping expression
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b),()); -- fail
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),())); --fail
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a),(b), ROLLUP(a)); -- fail
-SELECT
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (a,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (b,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (a),a)),
+		                                 GROUPING SETS (b,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (b),a)),
+		                                 GROUPING SETS (b,()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), ROLLUP(a)); -- fail
+
 -- composite Primary Key
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a; -- fail
-SELECT a,b,c FROM test_table2 GROUP BY GROUPING SETS((a,c),()), a, c ORDER BY a, b, c;
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a; -- fail
-SELECT a,b,c FROM test_table2 GROUP BY ROLLUP(a,c), a, c ORDER BY a, b, c;
-SELECT a,b,c FROM test_table1 GROUP BY GROUPING SETS((a,c), GROUPING SETS (a,c)); -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a, c ORDER BY a, b, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c), GROUPING SETS (a,c)); -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a, c ORDER BY a, b, c;
 
 DROP TABLE test_table1;
 DROP TABLE test_table2;


### PR DESCRIPTION
Fix unexpected output for empty grouping set

Problem:
Queries with grouping expressions and ungrouped attributes in TL could
produce unexpected output if the group did not have a primary key.

Example with 3 columns where "a" is a primary key:
     SELECT a,b,c FROM t GROUP BY GROUPING SETS((a),(b));

Grouping "(a)" had correct output of columns "a", "b", "c". Attribute "b" in
group "(b)" is not a primary key, so it is not unique, so it can be grouped.
In this case, the output of column "c" was undefined. This also applied to
"GROUPING SETS ((a),())", ROLLUP and CUBE (detailed behavior is
described in tests with ungrouped check).
Grouping expressions were introduced in PostgreSQL 9.5 ([f3d3118](https://github.com/postgres/postgres/commit/f3d3118532175541a9a96ed78881a3b04a057128)) and
such queries were prohibited. And this patch aligns the behavior with that.

Solution:
Improve parse-stage validation for ungrouped columns when using grouping
expressions.

Changes:
Similar to PostgreSQL, the parsing stage for queries with grouping
expressions reads common attributes for all groups. If any, they are placed in
"groupClauseCommonVars". In case of ungrouped attributes in TL, this list is
used to check for PK in groups.
Compared to the original, the "groupClauses" list uses TargetEntry rather than
an expression. Added function to get common refsortgroupref in grouping
clauses. At the beginning, the function assumes that all expressions are found
in grouping clauses. By running through the groupings, missing expressions
are excluded from the common refs list. The extraction function in the form
"list_intersection_int" taken from f3d3118.
The patch does not change the behavior of regular GROUP BY.

Co-authored-by: anarazel <andres@anarazel.de>