### PR TITLE
ADBDEV-6596: Add UTF-8 locale requirement for tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ make installcheck-world
   upstream. We try to keep the upstream tests identical to the upstream
   versions, to make merging with newer PostgreSQL releases easier.
 
+* Tests require a UTF-8 compatible locale. Ensure your system is set up
+  correctly before making the test cluster, e.g., `export LANG=en_US.UTF-8`.
+
 ## Alternative Configurations
 
 ### Building GPDB without GPORCA


### PR DESCRIPTION
Tests require the cluster to be created with a UTF-8 locale when run manually.
Add this information to the README file. CI environments already use the correct
LANG settings as configured in Dockerfiles and concourse/scripts/common.bash.
