### PR TITLE
ADBDEV-5489: Make InitPlans non-rescannable (GPDB 7)

### DIFF
--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -50,7 +50,8 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 	  m_result_relation_index(0),
 	  m_into_clause(nullptr),
 	  m_distribution_policy(nullptr),
-	  m_part_selector_to_param_map(nullptr)
+	  m_part_selector_to_param_map(nullptr),
+	  m_subplan_planids_bms(nullptr)
 {
 	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
 	m_part_selector_to_param_map = GPOS_NEW(m_mp) UlongToUlongMap(m_mp);
@@ -587,6 +588,12 @@ CContextDXLToPlStmt::GetRTEIndexByAssignedQueryId(
 	//	`assigned_query_id_for_target_rel` of table descriptor which points to
 	//	result relation wasn't previously processed - create a new index.
 	return gpdb::ListLength(m_rtable_entries_list) + 1;
+}
+
+void
+CContextDXLToPlStmt::AddSubplanPlanId(int id)
+{
+	m_subplan_planids_bms = gpdb::BmsAddMember(m_subplan_planids_bms, id);
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -245,6 +245,10 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 
 	topslice = &planned_stmt->slices[0];
 
+	// Always set the REWIND flag for subplans, since ORCA cannot generate
+	// InitPlans.
+	planned_stmt->rewindPlanIDs = m_dxl_to_plstmt_context->GetSubplanPlanIds();
+
 	// Can we do direct dispatch?
 	if (CMD_SELECT == m_cmd_type &&
 		nullptr != dxlnode->GetDXLDirectDispatchInfo())

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -1163,6 +1163,8 @@ CTranslatorDXLToScalar::TranslateSubplanFromChildPlan(
 	subplan->is_multirow = false;
 	subplan->unknownEqFalse = false;
 
+	dxl_to_plstmt_ctxt->AddSubplanPlanId(subplan->plan_id);
+
 	return subplan;
 }
 

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -779,13 +779,10 @@ build_subplan(PlannerInfo *root, Plan *plan, PlannerInfo *subroot,
 		root->init_plans = lappend(root->init_plans, splan);
 
 	/*
-	 * A parameterless subplan (not initplan) should be prepared to handle
-	 * REWIND efficiently.  If it has direct parameters then there's no point
-	 * since it'll be reset on each scan anyway; and if it's an initplan then
-	 * there's no point since it won't get re-run without parameter changes
-	 * anyway.  The input of a hashed subplan doesn't need REWIND either.
+	 * If it's an initplan, then there's no point in REWIND, since it won't get
+	 * re-run without parameter changes anyway.
 	 */
-	if (splan->parParam == NIL && !splan->is_initplan && !splan->useHashTable)
+	if (!splan->is_initplan)
 		root->glob->rewindPlanIDs = bms_add_member(root->glob->rewindPlanIDs,
 												   splan->plan_id);
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -135,6 +135,8 @@ private:
 	// hash map of the queryid (of DML query) and the target relation index
 	HMUlIndex *m_used_rte_indexes;
 
+	Bitmapset *m_subplan_planids_bms;
+
 public:
 	// ctor/dtor
 	CContextDXLToPlStmt(CMemoryPool *mp, CIdGenerator *plan_id_counter,
@@ -248,6 +250,14 @@ public:
 
 	Index GetRTEIndexByAssignedQueryId(ULONG assigned_query_id_for_target_rel,
 									   BOOL *is_rte_exists);
+
+	void AddSubplanPlanId(int id);
+
+	Bitmapset *
+	GetSubplanPlanIds()
+	{
+		return m_subplan_planids_bms;
+	}
 };
 
 }  // namespace gpdxl

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3996,3 +3996,14 @@ reset optimizer;
 drop table outer_foo;
 drop table inner_bar;
 drop table t;
+-- Make sure we don't mark InitPlans as rescannable.
+create table foo (i int, j int) distributed by (i);
+create table bar (i int, j int) distributed by (j);
+with cte as (update foo set i = 2 returning foo.i)
+select * from bar where 2 = (select cte.i from cte);
+ i | j 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -4062,3 +4062,14 @@ reset optimizer;
 drop table outer_foo;
 drop table inner_bar;
 drop table t;
+-- Make sure we don't mark InitPlans as rescannable.
+create table foo (i int, j int) distributed by (i);
+create table bar (i int, j int) distributed by (j);
+with cte as (update foo set i = 2 returning foo.i)
+select * from bar where 2 = (select cte.i from cte);
+ i | j 
+---+---
+(0 rows)
+
+drop table foo;
+drop table bar;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1479,3 +1479,13 @@ reset optimizer;
 drop table outer_foo;
 drop table inner_bar;
 drop table t;
+
+-- Make sure we don't mark InitPlans as rescannable.
+create table foo (i int, j int) distributed by (i);
+create table bar (i int, j int) distributed by (j);
+
+with cte as (update foo set i = 2 returning foo.i)
+select * from bar where 2 = (select cte.i from cte);
+
+drop table foo;
+drop table bar;


### PR DESCRIPTION
This is a cherry-pick of f42c552. This PR should be rebased to preserve authorship.

The original commit was adapted for GPDB 7. All ORCA plans are now marked with REWIND flag, since it can't generate InitPlans at all (refer to e7cc27f). Changes in the ORCA code were modified to allow extracting subplans inside subplans, since extract_nodes_plan() can't do it. The test was simplified.