### PR TITLE
ADBDEV-6625 Decouple ORCA from the pg_hint_plan extension

### DIFF
--- a/gpcontrib/pg_hint_plan/pg_hint_plan.c
+++ b/gpcontrib/pg_hint_plan/pg_hint_plan.c
@@ -30,7 +30,6 @@
 #include "optimizer/geqo.h"
 #endif
 #include "optimizer/joininfo.h"
-#include "optimizer/orca.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
@@ -412,9 +411,9 @@ static void pg_hint_plan_ProcessUtility(PlannedStmt *pstmt,
 					ProcessUtilityContext context,
 					ParamListInfo params, QueryEnvironment *queryEnv,
 					DestReceiver *dest, char *completionTag);
-#ifdef USE_ORCA
-static void *external_plan_hint_hook(Query *parse);
-#endif
+
+static HintState *external_plan_hint_hook(Query *parse);
+
 static PlannedStmt *pg_hint_plan_planner(Query *parse, int cursorOptions,
 										 ParamListInfo boundParams);
 static RelOptInfo *pg_hint_plan_join_search(PlannerInfo *root,
@@ -575,9 +574,7 @@ static join_search_hook_type prev_join_search = NULL;
 static set_rel_pathlist_hook_type prev_set_rel_pathlist = NULL;
 static ProcessUtility_hook_type prev_ProcessUtility_hook = NULL;
 static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
-#ifdef USE_ORCA
 static plan_hint_hook_type prev_plan_hint_hook = NULL;
-#endif
 
 /* Hold reference to currently active hint */
 static HintState *current_hint_state = NULL;
@@ -733,10 +730,8 @@ _PG_init(void)
 	ProcessUtility_hook = pg_hint_plan_ProcessUtility;
 	prev_ExecutorEnd = ExecutorEnd_hook;
 	ExecutorEnd_hook = pg_hint_ExecutorEnd;
-#ifdef USE_ORCA
 	prev_plan_hint_hook = plan_hint_hook;
 	plan_hint_hook = external_plan_hint_hook;
-#endif
 
 	/* setup PL/pgSQL plugin hook */
 	var_ptr = (PLpgSQL_plugin **) find_rendezvous_variable("PLpgSQL_plugin");
@@ -761,9 +756,7 @@ _PG_fini(void)
 	set_rel_pathlist_hook = prev_set_rel_pathlist;
 	ProcessUtility_hook = prev_ProcessUtility_hook;
 	ExecutorEnd_hook = prev_ExecutorEnd;
-#ifdef USE_ORCA
 	plan_hint_hook = prev_plan_hint_hook;
-#endif
 
 	/* uninstall PL/pgSQL plugin hook */
 	var_ptr = (PLpgSQL_plugin **) find_rendezvous_variable("PLpgSQL_plugin");
@@ -5038,12 +5031,11 @@ void plpgsql_query_erase_callback(ResourceReleasePhase phase,
 #include "pg_stat_statements.c"
 
 
-#ifdef USE_ORCA
 /*
  * This function hook allows external code (i.e. backend) to parse a query into
  * hint structures.
  */
-static void *
+static HintState *
 external_plan_hint_hook(Query *parse)
 {
 	HintState *hstate;
@@ -5060,4 +5052,3 @@ external_plan_hint_hook(Query *parse)
 	hstate = create_hintstate(parse, pstrdup(current_hint_str));
 	return hstate;
 }
-#endif

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -570,7 +570,7 @@ COptTasks::GetPlanHints(CMemoryPool *mp, Query *query)
 	{
 		// Calling plan_hint_hook creates pg_hint_plan hint structures
 		// (see optimizer/hints.h).
-		hintstate = (HintState *) plan_hint_hook(query);
+		hintstate = plan_hint_hook(query);
 	}
 
 	if (nullptr == hintstate)

--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -65,6 +65,8 @@
 #include "naucrates/md/IMDRelStats.h"
 #include "naucrates/traceflags/traceflags.h"
 
+#include "optimizer/planner.h"
+
 using namespace gpos;
 using namespace gpopt;
 using namespace gpdxl;
@@ -78,8 +80,6 @@ using namespace gpdbcost;
 
 // default id for the source system
 const CSystemId default_sysid(IMDId::EmdidGeneral, GPOS_WSZ_STR_LENGTH("GPDB"));
-
-plan_hint_hook_type plan_hint_hook = nullptr;
 
 // Check one-to-one mapping of row hint types
 GPOS_CPL_ASSERT(CRowHint::RVT_ABSOLUTE ==

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -96,6 +96,7 @@ bool		parallel_leader_participation = true;
 planner_hook_type planner_hook = NULL;
 plan_hint_hook_type plan_hint_hook = NULL;
 
+
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 create_upper_paths_hook_type create_upper_paths_hook = NULL;
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -92,8 +92,9 @@ double		cursor_tuple_fraction = DEFAULT_CURSOR_TUPLE_FRACTION;
 int			force_parallel_mode = FORCE_PARALLEL_OFF;
 bool		parallel_leader_participation = true;
 
-/* Hook for plugins to get control in planner() */
+/* Hooks for plugins to get control in planner() */
 planner_hook_type planner_hook = NULL;
+plan_hint_hook_type plan_hint_hook = NULL;
 
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 create_upper_paths_hook_type create_upper_paths_hook = NULL;

--- a/src/include/optimizer/orca.h
+++ b/src/include/optimizer/orca.h
@@ -24,10 +24,6 @@
 extern PlannedStmt * optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams);
 extern Node *transformGroupedWindows(Node *node, void *context);
 
-// plan_hint_hook generates HintState by parsing a Query.
-typedef void *(*plan_hint_hook_type) (Query *parse);
-extern PGDLLIMPORT plan_hint_hook_type plan_hint_hook;
-
 #endif
 
 #endif /* ORCA_H */

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -29,6 +29,13 @@ typedef PlannedStmt *(*planner_hook_type) (Query *parse,
 										   ParamListInfo boundParams);
 extern PGDLLIMPORT planner_hook_type planner_hook;
 
+typedef struct HintState HintState;
+
+/* plan_hint_hook generates HintState by parsing a Query. */
+typedef HintState *(*plan_hint_hook_type) (Query *parse);
+extern PGDLLIMPORT plan_hint_hook_type plan_hint_hook;
+
+
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 typedef void (*create_upper_paths_hook_type) (PlannerInfo *root,
 											  UpperRelationKind stage,


### PR DESCRIPTION
Decouple ORCA from the pg_hint_plan extension.

This change moves the definition of plan_hint_hook from ORCA, which is going to
be an extension to the planner. Although this hook is currently used only in
ORCA, it makes it possible to use it with any planner that needs to get a hint
list from an extension, such as pg_hint_plan.

Additionally, we make this hook, plan_hint_hook, typed and return a pointer to
HintState, as it actually does. There is no reason to keep it generic and
returning void *.