### PR TITLE
Move setting of 'optimizer' GUC to the extension

### DIFF
--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -139,6 +139,8 @@ _PG_init(void)
 
 	prev_planner = planner_hook;
 	planner_hook = gp_orca_planner;
+
+	SetConfigOption("optimizer", "on", PGC_POSTMASTER, PGC_S_DYNAMIC_DEFAULT);
 }
 
 void

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5155,6 +5155,10 @@ check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source)
 static bool
 check_optimizer(bool *newval, void **extra, GucSource source)
 {
+	/*
+	 * Assume that, if no planner_hook is registered, we can use only standard
+	 * Postgres planner. Thus, forbid setting the GUC.
+	 */
 	if ((GP_ROLE_DISPATCH == Gp_role) &&
 		(NULL == planner_hook) &&
 		*newval)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5155,16 +5155,28 @@ check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source)
 static bool
 check_optimizer(bool *newval, void **extra, GucSource source)
 {
-	/*
-	 * Assume that, if no planner_hook is registered, we can use only standard
-	 * Postgres planner. Thus, forbid setting the GUC.
-	 */
-	if ((GP_ROLE_DISPATCH == Gp_role) &&
-		(NULL == planner_hook) &&
-		*newval)
+	if (*newval)
 	{
-		GUC_check_errmsg("External planner is not registered");
-		return false;
+		/*
+		 * Use external planner only on dispatcher.
+		 * Others do not have information if external planner is used or not,
+		 * so always disable 'optimizer' if we are not at dispatcher.
+		 * We can't return false here, as it will break SET command, when it is
+		 * dispatched across segments, if external planner is registered for
+		 * the dispatcher.
+		 */
+		if (GP_ROLE_DISPATCH != Gp_role)
+			*newval = false;
+		else if (NULL == planner_hook)
+		{
+			/*
+			 * Assume that, if no planner_hook is registered for the
+			 * coordinator, we can use only standard Postgres planner.
+			 * Thus, forbid setting the GUC.
+			 */
+			GUC_check_errmsg("External planner is not registered");
+			return false;
+		}
 	}
 
 	if (!optimizer_control)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -37,6 +37,7 @@
 #include "miscadmin.h"
 #include "optimizer/cost.h"
 #include "optimizer/planmain.h"
+#include "optimizer/planner.h"
 #include "pgstat.h"
 #include "parser/scansup.h"
 #include "postmaster/autovacuum.h"
@@ -1865,15 +1866,11 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 	{
 		{"optimizer", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enable GPORCA."),
+			gettext_noop("Enable external planner."),
 			NULL
 		},
 		&optimizer,
-#ifdef USE_ORCA
-		true,
-#else
 		false,
-#endif
 		check_optimizer, NULL, NULL
 	},
 
@@ -5158,13 +5155,13 @@ check_gp_resource_group_bypass(bool *newval, void **extra, GucSource source)
 static bool
 check_optimizer(bool *newval, void **extra, GucSource source)
 {
-#ifndef USE_ORCA
-	if (*newval)
+	if ((GP_ROLE_DISPATCH == Gp_role) &&
+		(NULL == planner_hook) &&
+		*newval)
 	{
-		GUC_check_errmsg("ORCA is not supported by this build");
+		GUC_check_errmsg("External planner is not registered");
 		return false;
 	}
-#endif
 
 	if (!optimizer_control)
 	{


### PR DESCRIPTION
Move setting of 'optimizer' GUC to the extension

Problem:
File 'guc_gp.c' contained a compile-time dependency on Orca, related to
'optimizer' GUC. It prevented moving of all Orca's code into a shared lib and
making its work transparent to the GPDB core.

This patch:
1. Sets the default value for 'optimizer' GUC to 'false'.
2. Adds enabling of 'optimizer' GUC in gp_orca extension shared lib.
3. Updates check in 'check_optimizer()' function. Now it utilizes runtime check
of planner_hook presence to distinguish if an external planner is available or
not.

Note: the semantic of 'optimizer' GUC has changed. Previously it was used
solely to enable & disable Orca. Now it is used to enable & disable any general
external planner. The name of GUC hasn't been changed, because too many places
in code and infrastructure rely on it, and we aim not to blow up the size of
the patch.