### PR TITLE
ADBDEV-6757: [7X] Migrate ADBC dependencies to the base image

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -19,10 +19,12 @@ RUN dnf makecache && \
     dnf -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
     dnf -y install python3.11-psycopg2 python3.11-pyyaml python3.11-lxml python3.11-pip && \
     dnf -y install llvm-devel-17.0.6 clang-17.0.6 && \
+    dnf -y install protobuf-compiler && \
     dnf clean all && \
     #we install pytest from pypi since the version from the repository does not contain an executable file
     #the rest of the packages are not available in the repository.
-    pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave psutil
+    pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave psutil && \
+    pip3 install protobuf==3.20.0
 
 # setup ssh configuration
 RUN ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -14,8 +14,9 @@ RUN set -eux; \
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
 # Packages for tests
     apt install -y rsync iproute2 fakeroot lsof sudo python3.11 python3.11-dev openjdk-17-jdk libipc-run-perl; \
+    apt install -y protobuf-compiler; \
 # Install allure-behave for behave tests
-    pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave==2.4.0; \
+    pip3 install pytest gsutil behave~=1.2.6 coverage~=4.5 'mock<=5.0.0' allure-behave==2.4.0 protobuf==3.20.0; \
     pip3 cache purge
 
 WORKDIR /home/gpadmin


### PR DESCRIPTION
[7X] Migrate ADBC dependencies to the base image

The ADCC extension's scripts are split in different files due to differences in
dependencies across Linux distributions. This patch adds required dependencies
to the Ubuntu and Rocky Linux images.

Add protobuf-compiler to apt packages and protobuf==3.20.0 python module to base
images for Rocky Linux and Ubuntu.

---

A new tag is needed to propagate these changes to ADBC pipelines.