### PR TITLE
ADBDEV-6756: [6X] Migrate ADBC dependencies to the base image

### DIFF
--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -61,9 +61,6 @@ FROM base as test
 COPY --from=code /home/gpadmin/gpdb_src gpdb_src
 COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
 
-# Make sure python3.9 persists as $PYTHON3 for ADCC tests
-ENV PYTHON3=$adb_python3_bin
-
 # Install entab used by pgindent utility.
 # This should be done using gpdb sources.
 RUN make -C gpdb_src/src/tools/entab install clean

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -4,6 +4,8 @@ ARG sigar=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/communit
 ARG sigar_headers=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/sigar-headers_1.6.5-3304%2Bgite8961a6_all.deb
 ARG adb_python3=https://downloads.adsw.io/ADB/6.27.1_arenadata56/ubuntu/22.04/community/x86_64/packages/adb6-python_3.9.18-3304_all.deb
 
+ARG adb_python3_bin=/opt/adb6-python3.9/bin/python3
+
 COPY README.ubuntu.bash ./
 RUN set -eux; \
     ./README.ubuntu.bash; \
@@ -29,13 +31,9 @@ RUN set -eux; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
     pip2 cache purge; \
-# Use ADB's python3.9 over Ubuntu-provided 3.10
-    ln -s -t /usr/local/bin/ /opt/adb6-python3.9/bin/*; \
-# Fix pip3's broken symlink. Do this after symlinking python3.9 as to not overwrite python2
-    ln -s /opt/adb6-python3.9/bin/python3 /opt/adb6-python3.9/bin/python; \
-# Protobuf for ADCC-extension
-    pip3 install protobuf==3.20.0; \
-    pip3 cache purge
+# ADCC extension dependencies
+    $adb_python3_bin -m pip install protobuf==3.20.0; \
+    $adb_python3_bin -m pip cache purge
 
 WORKDIR /home/gpadmin
 
@@ -48,7 +46,8 @@ RUN mkdir /home/gpadmin/bin_gpdb
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
 ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
-ENV PYTHON3=/opt/adb6-python3.9/bin/python3
+# Use python3.9 to compile into GPDB's plpython3u
+ENV PYTHON3=$adb_python3_bin
 
 # Compile with running mocking tests
 RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash
@@ -61,6 +60,9 @@ RUN rm -rf gpdb_src/.git/
 FROM base as test
 COPY --from=code /home/gpadmin/gpdb_src gpdb_src
 COPY --from=build /home/gpadmin/bin_gpdb /home/gpadmin/bin_gpdb
+
+# Make sure python3.9 persists as $PYTHON3 for ADCC tests
+ENV PYTHON3=$adb_python3_bin
 
 # Install entab used by pgindent utility.
 # This should be done using gpdb sources.

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -23,10 +23,19 @@ RUN set -eux; \
 # Alter precedence in favor of IPv4 during resolving
     echo 'precedence ::ffff:0:0/96  100' >> /etc/gai.conf; \
 # Packages for tests
-    DEBIAN_FRONTEND=noninteractive apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip openjdk-11-jdk; \
+    DEBIAN_FRONTEND=noninteractive \
+        apt install -y krb5-kdc krb5-admin-server fakeroot sudo python-pip \
+            openjdk-11-jdk protobuf-compiler; \
 # Install allure-behave for behave tests
     pip2 install allure-behave==2.4.0; \
-    pip2 cache purge
+    pip2 cache purge; \
+# Use ADB's python3.9 over Ubuntu-provided 3.10
+    ln -s -t /usr/local/bin/ /opt/adb6-python3.9/bin/*; \
+# Fix pip3's broken symlink. Do this after symlinking python3.9 as to not overwrite python2
+    ln -s /opt/adb6-python3.9/bin/python3 /opt/adb6-python3.9/bin/python; \
+# Protobuf for ADCC-extension
+    pip3 install protobuf==3.20.0; \
+    pip3 cache purge
 
 WORKDIR /home/gpadmin
 
@@ -38,7 +47,7 @@ RUN mkdir /home/gpadmin/bin_gpdb
 
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend" 
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
 ENV PYTHON3=/opt/adb6-python3.9/bin/python3
 
 # Compile with running mocking tests


### PR DESCRIPTION
[6X] Migrate ADBC dependencies to the base image

The ADCC extension's scripts are split in different files due to differences in
dependencies across Linux distributions. This patch adds required dependencies
to the base Ubuntu image.

* Move adb-python bin/ directory to a reusable variable.
* Add protobuf-compiler to apt packages and protobuf==3.20.0 python module to
  base image for Ubuntu.