### PR TITLE
ADBDEV-5484: Fix deadlock by shared SegmentGeneral CTE & planning failure by shari…

### DIFF
--- a/src/test/regress/expected/rowtypes.out
+++ b/src/test/regress/expected/rowtypes.out
@@ -1155,16 +1155,14 @@ with r(a,b) as materialized
   (values (1,row(1,2)), (1,row(null,null)), (1,null),
           (null,row(1,2)), (null,row(null,null)), (null,null) )
 select r, r is null as isnull, r is not null as isnotnull from r;
-                          QUERY PLAN                          
---------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Subquery Scan on r
    Output: r.*, (r.* IS NULL), (r.* IS NOT NULL)
-   ->  Shared Scan (share slice:id 0:0)
-         Output: share0_ref1.column1, share0_ref1.column2
-         ->  Values Scan on "*VALUES*"
-               Output: "*VALUES*".column1, "*VALUES*".column2
- Optimizer: Postgres query optimizer
-(7 rows)
+   ->  Values Scan on "*VALUES*"
+         Output: "*VALUES*".column1, "*VALUES*".column2
+ Optimizer: Postgres-based planner
+(6 rows)
 
 with r(a,b) as materialized
   (values (1,row(1,2)), (1,row(null,null)), (1,null),

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2581,3 +2581,82 @@ SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (
   2 |  0
 (2 rows)
 
+-- Test if sharing is disabled for a SegmentGeneral CTE to avoid deadlock if CTE is
+-- executed with 1-gang and joined with n-gang
+--start_ignore
+DROP TABLE IF EXISTS d;
+DROP TABLE IF EXISTS r;
+NOTICE:  table "r" does not exist, skipping
+--end_ignore
+CREATE TABLE d (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO d VALUES ( 1, 2 ),( 2, 3 );
+CREATE TABLE r (a int, b int) DISTRIBUTED REPLICATED;
+INSERT INTO r VALUES ( 1, 2 ),( 3, 4 );
+EXPLAIN (COSTS off)
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Hash Join
+   Hash Cond: (r.a = d_join_cte.a)
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Seq Scan on r
+   ->  Hash
+         ->  Subquery Scan on d_join_cte
+               ->  Limit
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Limit
+                                 ->  Hash Join
+                                       Hash Cond: (r_1.a = d.a)
+                                       ->  Seq Scan on r r_1
+                                       ->  Hash
+                                             ->  Seq Scan on d
+ Optimizer: Postgres-based planner
+(15 rows)
+
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+-- Test if sharing is disabled for a General CTE to avoid deadlock if CTE is
+-- executed with coordinator gang and joined with n-gang
+EXPLAIN (COSTS OFF)
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Hash Join
+   Hash Cond: ((count(*)) = (count(*)))
+   ->  Limit
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Limit
+                     ->  Hash Join
+                           Hash Cond: (d.a = (count(*)))
+                           ->  Seq Scan on d
+                           ->  Hash
+                                 ->  Aggregate
+                                       ->  Values Scan on "*VALUES*"
+   ->  Hash
+         ->  Aggregate
+               ->  Values Scan on "*VALUES*_1"
+ Optimizer: Postgres-based planner
+(15 rows)
+
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+ a | b 
+---+---
+ 2 | 3
+(1 row)
+
+DROP TABLE d;
+DROP TABLE r;

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -2604,3 +2604,93 @@ SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (
 --start_ignore
 DROP TABLE d;
 --end_ignore
+-- Test if sharing is disabled for a SegmentGeneral CTE to avoid deadlock if CTE is
+-- executed with 1-gang and joined with n-gang
+--start_ignore
+DROP TABLE IF EXISTS d;
+DROP TABLE IF EXISTS r;
+NOTICE:  table "r" does not exist, skipping
+--end_ignore
+CREATE TABLE d (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO d VALUES ( 1, 2 ),( 2, 3 );
+CREATE TABLE r (a int, b int) DISTRIBUTED REPLICATED;
+INSERT INTO r VALUES ( 1, 2 ),( 3, 4 );
+EXPLAIN (COSTS off)
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Result
+                     One-Time Filter: (gp_execution_segment() = 1)
+                     ->  Seq Scan on r
+         ->  Hash Join
+               Hash Cond: (d.a = share0_ref2.a)
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  Result
+                           Filter: (d.a = share0_ref3.a)
+                           ->  Limit
+                                 ->  Hash Join
+                                       Hash Cond: (d.a = share0_ref3.a)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                             ->  Seq Scan on d
+                                       ->  Hash
+                                             ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                   ->  Shared Scan (share slice:id 4:0)
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                           ->  Shared Scan (share slice:id 5:0)
+ Optimizer: GPORCA
+(23 rows)
+
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+-- Test if sharing is disabled for a General CTE to avoid deadlock if CTE is
+-- executed with coordinator gang and joined with n-gang
+EXPLAIN (COSTS OFF)
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Values Scan on "Values"
+   ->  Hash Join
+         Hash Cond: (share0_ref3.a = share0_ref2.a)
+         ->  Result
+               Filter: (d.a = share0_ref3.a)
+               ->  Limit
+                     ->  Hash Join
+                           Hash Cond: ((d.a)::bigint = share0_ref3.a)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Seq Scan on d
+                           ->  Hash
+                                 ->  Shared Scan (share slice:id 0:0)
+         ->  Hash
+               ->  Shared Scan (share slice:id 0:0)
+ Optimizer: GPORCA
+(18 rows)
+
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+ a | b 
+---+---
+ 2 | 3
+(1 row)
+
+DROP TABLE d;
+DROP TABLE r;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1250,6 +1250,43 @@ WITH cte AS (
 SELECT * FROM cte a JOIN (SELECT * FROM d JOIN cte USING (c1) LIMIT 1) b USING (c1);
 
 --start_ignore
+RESET enable_nestloop;
 DROP TABLE d;
 --end_ignore
 
+-- Test if sharing is disabled for a SegmentGeneral CTE to avoid deadlock if CTE is
+-- executed with 1-gang and joined with n-gang
+--start_ignore
+DROP TABLE IF EXISTS d;
+DROP TABLE IF EXISTS r;
+--end_ignore
+
+CREATE TABLE d (a int, b int) DISTRIBUTED BY (a);
+INSERT INTO d VALUES ( 1, 2 ),( 2, 3 );
+CREATE TABLE r (a int, b int) DISTRIBUTED REPLICATED;
+INSERT INTO r VALUES ( 1, 2 ),( 3, 4 );
+
+EXPLAIN (COSTS off)
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+
+WITH cte AS (
+    SELECT a FROM r
+) SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+
+-- Test if sharing is disabled for a General CTE to avoid deadlock if CTE is
+-- executed with coordinator gang and joined with n-gang
+EXPLAIN (COSTS OFF)
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+
+WITH cte AS (
+    SELECT count(*) a FROM (VALUES ( 1, 2 ),( 3, 4 )) v
+)
+SELECT * FROM cte JOIN (SELECT * FROM d JOIN cte USING (a) LIMIT 1) d_join_cte USING (a);
+
+DROP TABLE d;
+DROP TABLE r;


### PR DESCRIPTION
Depending on the usage of the shared CTE with General or SegmentGeneral
subplan, the number of segments the CTE is executed on may be single for joins
with Singleton nodes, and multiple for nodes with other types of locus. In the
current implementation this may lead to deadlock if the CTE is used for both
join targets: the Join with the Singleton node results in the Share Input Scan
producer being executed with 1-gang, while the Join with the N-gang node
creates Share Input Scan reader on multiple segments, so the plan execution
hangs for the SegmentGeneral, and throw error inside
shareinput_mutator_xslice_2 functions for the General. If we force execution of
CTE on multiple segments, it will cause redundant motions in case of joining the
CTE with another General or SegmentGeneral. At the moment, we do not have the
way to execute a section of the plan on the N segments and take the result from
only one. Because replicated tables are considered small, the most universal and
optimal way to fix deadlock would be to inline CTE scans with General or
SegmentGeneral locus.

Inline is implemented by adding subpath to CtePath and removing subroot from
cteplaninfo. This should be done after processing the volatile functions in the
target list and having qual so as not to do inline in case this part of the plan
will still be executed on singleQE.

(cherry picked from commit 6cac355c7cfc4684018b210697cec37b0d7dd021)

Differences from 6X:
	The inline method is adapted for 7X.
	The test for replicated tables has been changed so that it reproduces the
problem on 7X.

Co-authored-by: Viktor Kurilko <v.kurilko@arenadata.io>

***
Note: do not squash to preserve authorship