### PR TITLE
Fix stuck query after cancel or termination when segment is not responding

### DIFF
--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -647,6 +647,9 @@ cdbcomponent_cleanupIdleQEs(bool includeWriter)
 		}
 	}
 
+	/* reset flag in libpq, that is used to avoid stuck in a loop in PQcancel*/
+	PQbypassConnCloseAtCancel(false);
+
 	return;
 }
 

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -32,6 +32,7 @@
 #include "postmaster/fts.h"
 #include "postmaster/ftsprobe.h"
 #include "postmaster/postmaster.h"
+#include "storage/pmsignal.h"
 #include "utils/builtins.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -1254,6 +1255,7 @@ processResponse(fts_context *context)
 					   primary->config->segindex, primary->config->dbid);
 				updateSegmentDownStatus(primary,true, context->has_mirrors);
 				ftsInfo->state = FTS_RESPONSE_PROCESSED;
+				SendPostmasterSignal(PMSIGNAL_FTS_PROMOTED_MIRROR);
 				break;
 			case FTS_SYNCREP_OFF_SUCCESS:
 				elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,

--- a/src/backend/storage/ipc/procsignal.c
+++ b/src/backend/storage/ipc/procsignal.c
@@ -20,6 +20,7 @@
 #include "access/parallel.h"
 #include "cdb/cdbvars.h"
 #include "commands/async.h"
+#include "libpq-fe.h"
 #include "miscadmin.h"
 #include "replication/walsender.h"
 #include "storage/ipc.h"
@@ -274,6 +275,23 @@ QueryFinishHandler(void)
 }
 
 /*
+ * Coordinator postmaster signals that FTS has detected a failed segment and
+ * promoted the mirror.
+ */
+static void
+FtsPromotedMirrorHandler(void)
+{
+	/*
+	 * In case the promotion is done during cancel or termination of a query,
+	 * there is a very high chance that libpq will be stuck forever trying to
+	 * wait cancel confirmation from the segment, which is not responding. Code
+	 * below handles this case.
+	 */
+	if (QueryCancelCleanup || TermSignalReceived)
+		PQbypassConnCloseAtCancel(true);
+}
+
+/*
  * procsignal_sigusr1_handler - handle SIGUSR1 signal.
  */
 void
@@ -319,6 +337,9 @@ procsignal_sigusr1_handler(SIGNAL_ARGS)
 
 	if (CheckProcSignal(PROCSIG_RESOURCE_GROUP_MOVE_QUERY))
 		HandleMoveResourceGroup();
+
+	if (CheckProcSignal(PROCSIG_FTS_PROMOTED_MIRROR))
+		FtsPromotedMirrorHandler();
 
 	SetLatch(MyLatch);
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3553,6 +3553,7 @@ die(SIGNAL_ARGS)
 	{
 		InterruptPending = true;
 		ProcDiePending = true;
+		TermSignalReceived = true;
 	}
 
 	/* If we're still here, waken anything waiting on the process latch */

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -40,6 +40,8 @@ volatile sig_atomic_t QueryCancelCleanup = false;
 volatile sig_atomic_t QueryCancelPending = false;
 volatile sig_atomic_t QueryFinishPending = false;
 
+volatile sig_atomic_t TermSignalReceived = false;
+
 /*
  * GPDB: Make these signed integers (instead of uint32) to detect garbage
  * negative values.

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -101,6 +101,7 @@ extern PGDLLIMPORT volatile sig_atomic_t ClientConnectionLost;
 extern PGDLLIMPORT volatile sig_atomic_t CheckClientConnectionPending;
 
 /* these are marked volatile because they are examined by signal handlers: */
+extern PGDLLIMPORT volatile sig_atomic_t TermSignalReceived;
 extern PGDLLIMPORT volatile int32 InterruptHoldoffCount;
 extern PGDLLIMPORT volatile int32 QueryCancelHoldoffCount;
 extern PGDLLIMPORT volatile int32 CritSectionCount;

--- a/src/include/storage/pmsignal.h
+++ b/src/include/storage/pmsignal.h
@@ -46,6 +46,8 @@ typedef enum
 	PMSIGNAL_WAKEN_DTX_RECOVERY,         /* wake up dtx recovery to abort dtx xacts */
 	PMSIGNAL_DTM_RECOVERED,     /* distributed recovery completed */
 
+	PMSIGNAL_FTS_PROMOTED_MIRROR, /* FTS has detected failed primary and promoted mirror*/
+
 	NUM_PMSIGNALS				/* Must be last value of enum! */
 } PMSignalReason;
 

--- a/src/include/storage/procsignal.h
+++ b/src/include/storage/procsignal.h
@@ -46,6 +46,8 @@ typedef enum
 	PROCSIG_QUERY_FINISH,		/* query finish */
 	PROCSIG_RESOURCE_GROUP_MOVE_QUERY,	/* move query to a new resource group */
 
+	PROCSIG_FTS_PROMOTED_MIRROR, /* FTS has detected failed primary and promoted mirror*/
+
 	NUM_PROCSIGNALS				/* Must be last! */
 } ProcSignalReason;
 

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -419,6 +419,8 @@ static const PQEnvironmentOption EnvironmentOptions[] =
 static const char uri_designator[] = "postgresql://";
 static const char short_uri_designator[] = "postgres://";
 
+static bool bypass_conn_close_at_cancel = false;
+
 static bool connectOptions1(PGconn *conn, const char *conninfo);
 static bool connectOptions2(PGconn *conn);
 static int	connectDBStart(PGconn *conn);
@@ -4369,6 +4371,15 @@ PQfreeCancel(PGcancel *cancel)
 		free(cancel);
 }
 
+/*
+ * PQbypassConnCloseAtCancel:
+ * set a flag, that allows to fix an issue with internal hanging in
+ * 'internal_cancel'. For details refer to comments in 'internal_cancel'.
+ */
+void PQbypassConnCloseAtCancel(pqbool bypass)
+{
+	bypass_conn_close_at_cancel = bypass;
+}
 
 /*
  * PQcancel and PQrequestCancel: attempt to request cancellation of the
@@ -4462,6 +4473,26 @@ retry4:
 	 */
 #ifndef WIN32
 retry5:
+
+	/*
+	 * GPDB: in case this function is called by the coordinator process to
+	 * communicate with the segments (when performing cancel/terminate of a
+	 * backend) and one of the segments has hanged keeping the listening socket
+	 * open, we will be stuck in this function for infinite amount of time
+	 * (hanging on the 'poll' in a loop). The check below helps to avoid this
+	 * situation:
+	 *  1. The flag 'bypass_conn_close_at_cancel' is set from a signal handler.
+	 *  2. The signal is originally initiated by the FTS, which detects that a
+	 *  segment went down.
+	 *  3. If the signal comes before the 'poll' is called, it will be just
+	 *  skipped and this function will return an error.
+	 *  4. If the signal comes after the 'poll' is called, the 'poll' will be
+	 *  interrupted with EINTR, and the next iteration will be skipped and this
+	 *  function will return an error.
+	 */
+	if (bypass_conn_close_at_cancel)
+		goto cancel_errReturn;
+
 	pollFds[0].fd = tmpsock;
 	pollFds[0].events = POLLIN;
 	pollFds[0].revents = 0;

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -316,6 +316,8 @@ extern void PQfreeCancel(PGcancel *cancel);
 /* issue a cancel request */
 extern int	PQcancel(PGcancel *cancel, char *errbuf, int errbufsize);
 
+extern void PQbypassConnCloseAtCancel(pqbool bypass); /* GPDB only */
+
 /* issue a finsh request */
 extern int	PQrequestFinish(PGcancel *cancel, char *errbuf, int errbufsize);
 

--- a/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views_seg_down.out
@@ -1,0 +1,292 @@
+-- The test below checks that FTS can break the stuck cancelled/terminated
+-- query, if one of the segments has hanged.
+-- Original problem was:
+-- 1. For some reason (the reason itself is not important) at some point segment hangs.
+-- 2. Query to 'gp_resgroup_status_per_segment' also hangs.
+-- 3. If 'pg_cancel_backend' or 'pg_terminate_backend' is called before FTS makes
+-- promotion, the query stays is stuck condition.
+
+-- Change FTS settings to make FTS probe work faster in the test.
+!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
+(exited with code 0)
+!\retcode gpconfig -c gp_fts_probe_retries -v 1 --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE EXTENSION
+
+-- Case 1: check the scenario with 'pg_cancel_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+ count 
+-------
+ 4     
+(1 row)
+
+-- Emulate hanged segment condition:
+-- 0. Store the name of datadir for seg0 - we will need it on step 2.
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
+2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+1: SELECT gp_inject_fault('exec_mpp_query_start', 'suspend', dbid, current_setting('gp_session_id')::int) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';  <waiting ...>
+
+-- Cancel the hanging query.
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | m    | d      | n    
+ 0       | m              | p    | u      | n    
+(2 rows)
+
+-- Check the hanged query has complete.
+SELECT count(*) = 0 AS query_complete FROM pg_stat_activity WHERE state = 'active' AND query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+ query_complete 
+----------------
+ t              
+(1 row)
+
+-- Recover back the segment
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | m              | p    | u      | s    
+ 0       | p              | m    | u      | s    
+(2 rows)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+1<:  <... completed>
+ERROR:  canceling statement due to user request
+
+-- Case 2: check the scenario with 'pg_terminate_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+ count 
+-------
+ 4     
+(1 row)
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
+1: SELECT gp_inject_fault('exec_mpp_query_start', 'suspend', dbid, current_setting('gp_session_id')::int) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';  <waiting ...>
+
+-- Terminate the hanging query.
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+ pg_terminate_backend 
+----------------------
+ t                    
+(1 row)
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | p              | m    | d      | n    
+ 0       | m              | p    | u      | n    
+(2 rows)
+
+-- Check the hanged query has complete.
+SELECT count(*) = 0 AS query_complete FROM pg_stat_activity WHERE state = 'active' AND query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+ query_complete 
+----------------
+ t              
+(1 row)
+
+-- Recover back the segment
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+ exec_cmd_on_segments 
+----------------------
+ OK                   
+ OK                   
+ OK                   
+(3 rows)
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'resume', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode FROM gp_segment_configuration WHERE content = 0;
+ content | preferred_role | role | status | mode 
+---------+----------------+------+--------+------
+ 0       | m              | p    | u      | s    
+ 0       | p              | m    | u      | s    
+(2 rows)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+1<:  <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1q: ... <quitting>
+
+-- Restore parameters.
+!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+(exited with code 0)
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -198,3 +198,10 @@ CREATE FUNCTION
 
 CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 1200; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE FUNCTION
+
+--
+-- exec_cmd_on_segments:
+--   Execute shell command on all segments
+--
+create or replace function exec_cmd_on_segments(cmd text) returns table(result text) as $$ import subprocess returncode = subprocess.call(cmd, shell=True) if returncode == 0: return ['OK'] else: return ['Fail'] $$ language plpython3u execute on all segments;
+CREATE FUNCTION

--- a/src/test/isolation2/isolation2_resgroup_v1_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v1_schedule
@@ -18,6 +18,7 @@ test: resgroup/resgroup_bypass
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
+test: resgroup/resgroup_views_seg_down
 
 # functions
 test: resgroup/resgroup_concurrency

--- a/src/test/isolation2/isolation2_resgroup_v2_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v2_schedule
@@ -18,6 +18,7 @@ test: resgroup/resgroup_bypass
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
+test: resgroup/resgroup_views_seg_down
 
 # functions
 test: resgroup/resgroup_concurrency

--- a/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_views_seg_down.sql
@@ -1,0 +1,158 @@
+-- The test below checks that FTS can break the stuck cancelled/terminated
+-- query, if one of the segments has hanged.
+-- Original problem was:
+-- 1. For some reason (the reason itself is not important) at some point segment hangs.
+-- 2. Query to 'gp_resgroup_status_per_segment' also hangs.
+-- 3. If 'pg_cancel_backend' or 'pg_terminate_backend' is called before FTS makes
+-- promotion, the query stays is stuck condition.
+
+-- Change FTS settings to make FTS probe work faster in the test.
+!\retcode gpconfig -c gp_fts_probe_timeout -v 5 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 1 --masteronly;
+!\retcode gpstop -u;
+
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+-- Case 1: check the scenario with 'pg_cancel_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+
+-- Emulate hanged segment condition:
+-- 0. Store the name of datadir for seg0 - we will need it on step 2.
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
+2: @post_run 'get_tuple_cell DATADIR 1 1': SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+1: SELECT gp_inject_fault('exec_mpp_query_start', 'suspend', dbid, current_setting('gp_session_id')::int)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+
+-- Cancel the hanging query.
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+-- Check the hanged query has complete.
+SELECT count(*) = 0 AS query_complete FROM pg_stat_activity
+WHERE state = 'active' AND query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+
+-- Recover back the segment
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+!\retcode gprecoverseg -ar;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+
+1<:
+
+-- Case 2: check the scenario with 'pg_terminate_backend'.
+
+-- Reset FTS probe interval.
+SELECT gp_request_fts_probe_scan();
+
+-- Make a successfull query to allocate query executer backends on the segments.
+1:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+
+-- Emulate hanged segment condition:
+-- 1. Stop the backends from processing requests by injecting a fault.
+-- 2. Stop segment postmaster process. This can't be done by the fault injection,
+-- as we wouldn't be able to recover the postmaster back to life in this case.
+-- Thus do it by sending a STOP signal. We need to do it on all segments (not on
+-- the coordinator), as the segment process may be running on a separate machine.
+1: SELECT gp_inject_fault('exec_mpp_query_start', 'suspend', dbid, current_setting('gp_session_id')::int)
+FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -STOP');
+
+-- Launch the query again, now it will hang.
+1&:SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = 'admin_group';
+
+-- Terminate the hanging query.
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+WHERE query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+
+-- Trigger FTS scan.
+SELECT gp_request_fts_probe_scan();
+
+-- Expect to see the content 0, preferred primary is mirror and it is down,
+-- the preferred mirror is primary
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+-- Check the hanged query has complete.
+SELECT count(*) = 0 AS query_complete FROM pg_stat_activity
+WHERE state = 'active' AND query = 'SELECT count(1) FROM gp_toolkit.gp_resgroup_status_per_segment WHERE groupname = ''admin_group'';';
+
+-- Recover back the segment
+2: @pre_run ' echo "${RAW_STR}" | sed "s#@DATADIR#${DATADIR}#" ': SELECT exec_cmd_on_segments('ps aux | grep ''@DATADIR'' | awk ''FNR == 1 {print $2; exit}'' | xargs kill -CONT');
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'resume', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+SELECT gp_inject_fault('exec_mpp_query_start', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- Fully recover the failed primary as new mirror.
+!\retcode gprecoverseg -aF --no-progress;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Expect to see roles flipped and in sync.
+SELECT content, preferred_role, role, status, mode
+FROM gp_segment_configuration WHERE content = 0;
+
+!\retcode gprecoverseg -ar;
+
+-- Wait while segments come in sync.
+SELECT wait_until_all_segments_synchronized();
+
+-- Verify that no segment is down after the recovery.
+SELECT count(*) FROM gp_segment_configuration WHERE status = 'd';
+
+1<:
+1q:
+
+-- Restore parameters.
+!\retcode gpconfig -r gp_fts_probe_timeout --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpstop -u;
+

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -586,3 +586,17 @@ end if; /* in func */
 end loop; /* in func */
 end; /* in func */
 $$ language plpgsql;
+
+--
+-- exec_cmd_on_segments:
+--   Execute shell command on all segments
+--
+create or replace function exec_cmd_on_segments(cmd text)
+returns table(result text) as $$
+    import subprocess
+    returncode = subprocess.call(cmd, shell=True)
+    if returncode == 0:
+        return ['OK']
+    else:
+        return ['Fail']
+$$ language plpython3u execute on all segments;


### PR DESCRIPTION
Fix stuck query after cancel or termination when segment is not responding (#1132)

Problem:
The following scenario caused a stuck state of a coordinator backend process:
1. At some moment one of the segments stopped processing incoming requests (the
reason itself is not important, as sometimes bad things may happen with any
segment, and the system should be able to recover).
2. A query, which dispatches requests to segments, was executed (for example,
select from 'gp_toolkit.gp_resgroup_status_per_segment'). As one of the segments
was not responding, the coordinator hanged in 'checkDispatchResult' (it is
expected, and can be handled by the FTS).
3. The stuck query was canceled or terminated (by 'pg_cancel_backend' or
'pg_terminate_backend'). It didn't help to return from the stuck state, but
after this step the query became completely unrecoverable. Even after FTS had
detected the malfunction segment and had promoted the mirror, the query was
still hanging forever.

Expected behavior is that after FTS mirror promotion, all stuck queries are
unblocked and canceled successfully.

Note: if FTS mirror promotion happened before step 3, the FTS canceled the
query successfully.

Root cause:
During cancel or termination, the coordinator tried to do abort of the current
transaction, and it hanged in the function 'internal_cancel' (called from
PQcancel) on 'poll' system call. It has a timeout of 660 seconds, and, moreover,
after the timeout expired, it looped forever trying to do 'poll' again. So, if
the socket was opened on the segment side, but nobody replied (as the segment
process became not available for some reason), 'internal_cancel' had no way to
return.

Fix:
Once FTS promotes a mirror, it sends the  signal to the coordinator
postmaster (with PMSIGNAL_FTS_PROMOTED_MIRROR reason). On receiving of the
signal, the coordinator postmaster sends the SIGUSR1 signal (with
PROCSIG_FTS_PROMOTED_MIRROR reason) to all of its usual backends. Once the
backend receives the signal, if it is in the state of cancelling or terminating
of the query, it sets a flag in libpq. 'internal_cancel' checks this flag before
calling the 'poll' system call. If it is set, it will return with an error.
Thus:
a. if the FTS promotion happens before cancel/terminate, the query will be
canceled by the old logic;
b. if the FTS promotion happens after cancel/terminate, but before the
'internal_cancel' calls the 'poll', 'internal_cancel' will return an error
without calling the 'poll';
c. if the FTS promotion happens when the 'poll' is already called, the 'poll'
will return EINTR (as the SIGUSR1 was received), and a new 'poll' will not be
called, as the flag is set.

(cherry picked from commit https://github.com/arenadata/gpdb/commit/96ed1ad4825f593b02c24c9426273894da18b3ba)

Differences comparing to the original commit:
1. exec_cmd_on_segments() is placed inside setup.sql file instead of
server_helper.sql, as the latter doesn't exist in GPDB 7 (and all functions from
this file are located in setup.sql)
2. The check 'GpIdentity.segindex == MASTER_CONTENT_ID' in 'sigusr1_handler()'
is replaced with 'IS_QUERY_DISPATCHER()', which is equivalent. It is done,
because MASTER_CONTENT_ID was renamed to COORDINATOR_CONTENT_ID in GPDB 7.
3. 'TermSignalReceived' global var was removed in GPDB 7 (when it was merged
with PostgreSQL 9.5), so it is brought back.
4. exec_cmd_on_segments() is reworked due to limitation in GPDB 7. Previous
version failed with "ERROR:  EXECUTE ON ALL SEGMENTS is only supported for
set-returning functions", so now it returns a table with TEXT field instead of
a single string. Also, exec_cmd_on_segments() is changed to use 'plpython3u'
language instead of 'plpythonu'.
5. Test is updated to work on GPDB 7.
6. File 'isolation2_resgroup_schedule' doesn't exist anymore, so the test is
added to 'isolation2_resgroup_v1_schedule' and 'isolation2_resgroup_v2_schedule'
files.

-----------------------

Should be rebased.