### PR TITLE
ADBDEV-5478: Truncate segment files of AO relations before unlink (#675)

### DIFF
--- a/src/backend/access/appendonly/test/aomd_test.c
+++ b/src/backend/access/appendonly/test/aomd_test.c
@@ -16,6 +16,8 @@ static bool file_present[MAX_SEGNO_FILES];
 static int num_unlink_called = 0;
 static bool unlink_passing = true;
 
+int __wrap_do_truncate(const char *path);
+
 static void
 setup_test_structures()
 {
@@ -58,6 +60,17 @@ mock_unlink(const char *path)
 		path, segfile, num_unlink_called, unlink_passing);
 #endif
 	return ec;
+}
+
+/*
+ * Make do_truncate return always Ok during unit test,
+ * because otherwise mdunlink_ao will return before actual invoke of unlink,
+ * if called with test file names.
+ */
+int
+__wrap_do_truncate(const char *path)
+{
+	return 0;
 }
 /*
  *******************************************************************************

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -324,7 +324,7 @@ mdunlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo)
 /*
  * Truncate a file to release disk space.
  */
-static int
+int
 do_truncate(const char *path)
 {
 	int			save_errno;

--- a/src/include/storage/md.h
+++ b/src/include/storage/md.h
@@ -50,4 +50,6 @@ extern int	mdunlinkfiletag(const FileTag *ftag, char *path);
 extern bool mdfiletagmatches(const FileTag *ftag, const FileTag *candidate);
 
 extern int	aosyncfiletag(const FileTag *ftag, char *path);
+
+extern int	do_truncate(const char *path);
 #endif							/* MD_H */

--- a/src/test/regress/input/tablespace.source
+++ b/src/test/regress/input/tablespace.source
@@ -309,6 +309,7 @@ ALTER TABLE ALL IN TABLESPACE regress_tblspace_renamed SET TABLESPACE pg_default
 
 -- Should succeed
 DROP TABLESPACE regress_tblspace_renamed;
+RESET default_tablespace;
 
 DROP SCHEMA testschema CASCADE;
 
@@ -333,3 +334,24 @@ SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.relta
 
 DROP TABLE tablespace_part;
 DROP TABLESPACE myts;
+
+-- Create a new tablespace and check that within this tablespace,
+-- after dropping the table, the size of all deleted (but still opened) files is 0.
+CREATE TABLESPACE testspace LOCATION '@testtablespace@';
+-- start_ignore
+DROP TABLE IF EXISTS t;
+-- end_ignore
+
+-- Checking that the AO row-oriented table doesn't leave non-zero files.
+CREATE TABLE t(a int, b int) WITH (appendoptimized=true, orientation=row) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+
+-- Checking that the AO column-oriented table doesn't leave non-zero files.
+CREATE TABLE t(a int, b int) WITH (appendoptimized=true, orientation=column) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+
+DROP TABLESPACE testspace;

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -702,6 +702,7 @@ ALTER TABLE ALL IN TABLESPACE regress_tblspace_renamed SET TABLESPACE pg_default
 NOTICE:  no matching relations in tablespace "regress_tblspace_renamed" found
 -- Should succeed
 DROP TABLESPACE regress_tblspace_renamed;
+RESET default_tablespace;
 DROP SCHEMA testschema CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table testschema.foo
@@ -737,3 +738,19 @@ SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.relta
 
 DROP TABLE tablespace_part;
 DROP TABLESPACE myts;
+-- Create a new tablespace and check that within this tablespace,
+-- after dropping the table, the size of all deleted (but still opened) files is 0.
+CREATE TABLESPACE testspace LOCATION '@testtablespace@';
+-- Checking that the AO row-oriented table doesn't leave non-zero files.
+CREATE TABLE t(a int, b int) WITH (appendoptimized=true, orientation=row) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+size: 0
+-- Checking that the AO column-oriented table doesn't leave non-zero files.
+CREATE TABLE t(a int, b int) WITH (appendoptimized=true, orientation=column) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+size: 0
+DROP TABLESPACE testspace;


### PR DESCRIPTION
Truncate segment files of AO relations before unlink (#675)

Problem description:
Segment files of the AO tables were not truncated before unlink. As a result,
after relation drop, if there were file descriptors of segment files, not closed
by some backend process, disk space was not returned to the OS.

Root cause:
In mdunlinkfork, mdunlink_ao is called for an AO relation instead of truncating
all segment files. And mdunlink_ao doesn't perform truncation of segment files.

Fix:
Truncation of segment files for AO tables was added into mdunlink_ao_perFile,
which is called from mdunlink_ao for each segment file. For that purpose, static
function do_truncate was changed to global. Plus aomd unit test was updated.
Reason - unit test calls mdunlink_ao with filenames of not-existing files. Unit
test replaces unlink, so it can handle such filenames. But now
mdunlink_ao_perFile returns before invoking unlink, because do_truncate fails to
do truncation of these files. To fix it, do_truncate in aomd unit test was
replaced with a stub during the test.

Changes from original commit:
1. Added RESET for `default_tablespace` to previous test.

(cherry picked from commit https://github.com/arenadata/gpdb/commit/6f0a2c14350642400b695e9d87eb809ba23d6a98)

---

Note: do not squash to preserve authorship
