### PR TITLE
ADBDEV-5487: gplogfilter: fix timerange validation

### DIFF
--- a/gpMgmt/bin/gplogfilter
+++ b/gpMgmt/bin/gplogfilter
@@ -362,6 +362,12 @@ if (options.zip is None and
     options.zip = '9'
 
 try:
+    if (begin and end) and begin >= end:
+        raise IOError(
+            'Invalid arguments: "begin" date (%s) is >= "end" date (%s)'
+            % (begin, end)
+        )
+
     # If no inputfile arg, try COORDINATOR_DATA_DIRECTORY environment variable
     if len(args) == 0:
         s = get_coordinatordatadir()
@@ -401,44 +407,27 @@ try:
                    % (begin or 'beginning of data', end or 'end of data'))
             print(msg, file=sys.stderr)
 
-        # Loop over input files
-        for ifn in args:
-            """ 
-            Open each file in the logs directory. Check to see if the file name
-            looks anything like a log file name with a time stamp that we 
-            recognize. If true, and the user specified a time range, skip the
-            file if it is outside the range. That is, close the file and any
-            associated temporary files.
+        # Transform given array of log names (args array) into corresponding
+        # array of LogNameInfo structures. Final array is concatenation of
+        # LogNameInfo arrays with and without timestamps in log names.
+        # Both arrays are ordered:
+        # - first part is ordered by the time stamp of log name and after by
+        #   name (in case of time stamp equality)
+        # - second part is ordered by name and lays out at the end
+        # All LogNameInfo structures are marked for belonging to the user
+        # specified time range. Log names without time stamp always should
+        # be processed, because them may contain log entries inside specified
+        # range, so LogNameInfo for such names always marked as belonging to
+        # the range.
+        logsInfoArr = getLogInfoArrayByNamesOrderedAndMarkedInTSRange(args, begin, end)
 
-            All other files with names that do not look like time stamps are
-            processed. That is, their log information is extracted, and if 
-            the user specified a time range, only those entries that are
-            within that range are kept.
-            """
+        for logInfo in logsInfoArr:
+            if not logInfo.belongsToTimeRangeFilter:
+                print("SKIP file: %s" % logInfo.name, file=sys.stderr)
+                continue
+
             # Open next input file
-            fileIn, inputFilesToClose, ifn, zname = openInputFile(ifn, options)
-
-            # if we can skip the whole file, let's do so
-            if zname.startswith('gpdb') and zname.endswith('.csv'):
-                goodFormat = True
-                try:
-                    # try format YYYY-MM-DD_HHMMSS
-                    filedate = datetime.strptime(zname[5:-4], '%Y-%m-%d_%H%M%S')
-                except:
-                    try:
-                        # try format YYYY-MM-DD
-                        filedate = datetime.strptime(zname[5:-4], '%Y-%m-%d')
-                    except:
-                        # the format isn't anything I understand
-                        goodFormat = False
-
-                if goodFormat and begin and filedate < begin:
-                    if end and filedate > end:
-                        print("SKIP file: %s" % zname, file=sys.stderr)
-                        for f in inputFilesToClose:
-                            f.close()
-                        inputFilesToClose = []
-                        continue
+            fileIn, inputFilesToClose, ifn, zname = openInputFile(logInfo.name, options)
 
             # Announce each input file *before* its output file if --out is dir
             if options.verbose and outputFilePerInputFile:

--- a/gpMgmt/bin/gppylib/logfilter.py
+++ b/gpMgmt/bin/gppylib/logfilter.py
@@ -57,6 +57,14 @@ timestampPattern = re.compile(r'\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d*)?')
 # A timezone specifier may follow the timestamp, but we ignore that.
 
 
+# This pattern matches the date and time stamp at the log file name of a
+# GPDB log file. The timestamp format is: YYYY-MM-DD_HHMMSS or the
+# YYYY-MM-DD (to preserve an old behaviour).
+logNameTSPattern = re.compile(
+    '^.*gpdb-(?P<datetime>\d+-\d+-\d+(?P<time>_\d+)?)\.csv$'
+)
+
+
 def FilterLogEntries(iterable,
                      msgfile=sys.stderr,
                      verbose=False,
@@ -281,6 +289,7 @@ class CsvFlatten(object):
         item[16] = item[16] + ": "
 
         self.buffer.truncate(0)
+        self.buffer.seek(0) # This is required for Python 3
         self.writer.writerow(item)
 
         return self.buffer.getvalue()
@@ -543,14 +552,13 @@ def TimestampInBounds(iterable, begin, end):
 
     # Fetch first item from input stream.
     source = iter(iterable)
-    item = next(source)
 
-    # If first item is a string, assume input consists of individual lines.
-    # Yield lines which start with a timestamp within the given bounds, plus
-    # any following lines which do not have timestamps.
-    if isinstance(item, str):
-        withinbounds = False
-        for item in source:
+    withinbounds = False
+    for item in source:
+        if isinstance(item, str):
+            # If item is a string, assume input consists of individual lines.
+            # Yield lines which start with a timestamp within the given bounds, plus
+            # any following lines which do not have timestamps.
             if begin <= item < end:
                 withinbounds = True
                 yield item
@@ -558,14 +566,13 @@ def TimestampInBounds(iterable, begin, end):
                 withinbounds = False
             elif withinbounds:
                 yield item
-
-    # Else assume input consists of groups (i.e. sequences) of lines.
-    # Yield groups in which the first line starts with a timestamp within
-    # the given bounds.  Skip groups which are empty or have no timestamp.
-    for item in source:
-        if (len(item) > 0 and
-            begin <= item[0] < end):
-            yield item
+        else:
+            # Else assume input consists of groups (i.e. sequences) of lines.
+            # Yield groups in which the first line starts with a timestamp within
+            # the given bounds.  Skip groups which are empty or have no timestamp.
+            if (len(item) > 0 and
+                begin <= item[0] < end):
+                yield item
 
 #--------------------------- Pattern Matching ----------------------------
     
@@ -977,3 +984,116 @@ def spiffInterval(begin=None, end=None, duration=None):
 
     return begin, end
 
+class LogNameInfo(object):
+    """
+    Object to store main information about log file name:
+    - name of log file
+    - parsed time stamp from name, if exists
+    - belonging to user specified time range
+    """
+    def __init__(self, name, dateTime=None, belongsToTimeRangeFilter=True):
+        self.name = name
+        self.dateTime = dateTime
+        self.belongsToTimeRangeFilter = belongsToTimeRangeFilter
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            raise TypeError('comparing different types: %s and %s' % (type(self), type(other)))
+
+        return (self.name == other.name and self.dateTime == other.dateTime
+                and self.belongsToTimeRangeFilter == other.belongsToTimeRangeFilter)
+
+def _parseLogFileName(name):
+    """
+    Parses log file into LogNameInfo. The log name may contain the time
+    stamp, when it was created, so if log name matches `logNameTSPattern`
+    the result LogNameInfo would contain this time stamp, but there may be
+    other log files that doesn't match such format (for ex. startup.log) in
+    such case result won't contain time stamp.
+    """
+
+    # matchedGroup in case of match would be not None and contains next
+    # groups:
+    # - group(0) - whole file name
+    # - group('datetime') - timestamp of log (may be without time suffix)
+    # - group('time') - not None if time suffix exists
+    matchedGroup = logNameTSPattern.match(name)
+
+    if not matchedGroup:
+        return LogNameInfo(name)
+
+    pattern = '%Y-%m-%d'
+    if matchedGroup.group('time'):
+        # we have time preix, so use extended pattern
+        pattern = '%Y-%m-%d_%H%M%S'
+
+    dt = None
+    try:
+        dt = datetime.strptime(matchedGroup.group('datetime'), pattern)
+    except:
+        pass
+
+    return LogNameInfo(name, dt)
+
+def _getOrderedLogNameInfoArrByNameTS(fileNames):
+    """
+    By the given array of log names this function returns ordered LogNameInfo
+    array. The returned array is a concatenation of two LogNameInfo arrays
+    with time stamp in log name and without. Both arrays are ordered:
+    - first part is ordered by the time stamp of log name and after by the log
+    name. Ordering by name is used for test purposes, because under the normal
+    conditions log directory shouldn't contain different log files with the same
+    time stamp, but with different string representation of time stamp (for ex.
+    gpdb-2023-1-1_000000.csv and gpdb-2023-01-01_000000.csv, the last variant is
+    a correct representation of log name with time stamp).
+    - the second part is ordered only by name.
+    """
+
+    withTS = []
+    withoutTS = []
+    for name in fileNames:
+        info = _parseLogFileName(name)
+        if info.dateTime:
+            withTS.append(info)
+        else:
+            withoutTS.append(info)
+
+    withTS.sort(key = lambda x: (x.dateTime, x.name))
+    withoutTS.sort(key = lambda x: x.name)
+    return withTS + withoutTS
+
+
+def getLogInfoArrayByNamesOrderedAndMarkedInTSRange(logNames, begin, end):
+    """
+    By the given array of log names and time range filters `begin` (inclusive)
+    and `end` (exclusive) this function returns the ordered array of LogNameInfo,
+    where each LogNameInfo is marked for belonging to the given range.
+    Array is ordered by the log time stamp (and in case of equaltiy by the name)
+    log file names without time stamp is ordered by name and lays out at the end
+    of array.
+    """
+
+    orderedInfoArr = _getOrderedLogNameInfoArrByNameTS(logNames)
+
+    # we should find the nearest date before (or equal) the user-specified
+    # `begin` inside dates from log file names, because of each file with time
+    # stamp contain log entries with time stamp, matching next range:
+    # time stamp of log name <= time stamp of log entry AND
+    # time stamp of log entry < (log name time stamp + GUC:`log_rotation_age`) or restart time
+    beginDateRounded = begin
+    if beginDateRounded:
+        for info in orderedInfoArr:
+            if info.dateTime is None or begin < info.dateTime:
+                break
+            beginDateRounded = info.dateTime
+
+    for info in orderedInfoArr:
+        dt = info.dateTime
+        if dt is None:
+            # file names without time stamp - no need to process
+            break
+
+        if (beginDateRounded and dt < beginDateRounded) or (end and end <= dt):
+            info.belongsToTimeRangeFilter = False
+
+    return orderedInfoArr

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_logfilter.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_logfilter.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import unittest
+import yaml
+from datetime import datetime
+import gppylib.logfilter as lf
+
+class GppylibLogFilterTestCase(unittest.TestCase):
+    def test_parse_log_name(self):
+        testData = [
+            ('gp_era', lf.LogNameInfo('gp_era', None, True)),
+            ('startup.log', lf.LogNameInfo('startup.log', None, True)),
+            ('gpdb-2023-10-05_090100.csv', lf.LogNameInfo('gpdb-2023-10-05_090100.csv', datetime(2023, 10, 5, 9, 1), True)),
+            ('gpdb-2023-10-05_09050.csv', lf.LogNameInfo('gpdb-2023-10-05_09050.csv', datetime(2023, 10, 5, 9, 5), True)),
+            ('gpdb-2023-10-05.csv', lf.LogNameInfo('gpdb-2023-10-05.csv', datetime(2023, 10, 5, 0, 0), True)),
+            ('gpdb-2023-10-05_09010.csv', lf.LogNameInfo('gpdb-2023-10-05_09010.csv', datetime(2023, 10, 5, 9, 1), True)),
+            ('gpdb-23-10-05_09011.csv', lf.LogNameInfo('gpdb-23-10-05_09011.csv', None, True)), # invalid format %Y should have 4 digits
+            ('gpdb-2023-1-05_2000.csv', lf.LogNameInfo('gpdb-2023-1-05_2000.csv', datetime(2023, 1, 5, 20, 0), True)),
+            ('gpdb-2023-1-5_0000.csv', lf.LogNameInfo('gpdb-2023-1-5_0000.csv', datetime(2023, 1, 5, 0, 0), True)),
+        ]
+
+        for testTuple in testData:
+            got = lf._parseLogFileName(testTuple[0])
+            expected = testTuple[1]
+            self.assertEqual(got, expected, '\nEXPECTED:\n%s\nGOT:\n%s' % (yaml.dump(got), yaml.dump(expected)))
+
+    def test_getOrderedLogNameInfoArrByNameTS(self):
+        # only file names without timestamp
+        fNamesWithoutTS = ['b', 'c', 'a']
+        expectedOrderWithoutTS = [
+            lf.LogNameInfo('a'), lf.LogNameInfo('b'), lf.LogNameInfo('c'),
+        ]
+        self.assertEqual(lf._getOrderedLogNameInfoArrByNameTS(fNamesWithoutTS), expectedOrderWithoutTS)
+
+        # only file names with timestamp
+        fNamesWithTS = ['gpdb-2023-10-05_090100.csv', 'gpdb-2023-01-05_090100.csv', 'gpdb-2023-2-05_080000.csv']
+        expectedOrderWithTS = [
+            lf.LogNameInfo('gpdb-2023-01-05_090100.csv', datetime(2023, 1, 5, 9, 1), True),
+            lf.LogNameInfo('gpdb-2023-2-05_080000.csv', datetime(2023, 2, 5, 8, 0), True),
+            lf.LogNameInfo('gpdb-2023-10-05_090100.csv', datetime(2023, 10, 5, 9, 1), True),
+        ]
+        self.assertEqual(lf._getOrderedLogNameInfoArrByNameTS(fNamesWithTS), expectedOrderWithTS)
+
+        # combination of file names with and w/o timestamps
+        self.assertEqual(
+            lf._getOrderedLogNameInfoArrByNameTS(fNamesWithoutTS + fNamesWithTS),
+            expectedOrderWithTS + expectedOrderWithoutTS
+        )
+
+    def test_getLogInfoArrayByNamesOrderedAndMarkedInTSRange_corner(self):
+        fnToTest = lf.getLogInfoArrayByNamesOrderedAndMarkedInTSRange
+
+        ########################
+        # empty input
+        self.assertEqual([], fnToTest([], None, None))
+
+        ########################
+        # test `begin` date: there would be always one file which is not skipped even begin date is
+        # greater than it's time stamp
+        testArr = ['gpdb-2023-10-05_000000.csv']
+        expectedArr = [lf.LogNameInfo('gpdb-2023-10-05_000000.csv', datetime(2023, 10, 5), True)]
+        self.assertEqual(expectedArr, fnToTest(testArr, None, None))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 10, 5), None))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 10, 6), None))
+
+        ########################
+        # test `end` date
+        self.assertEqual(expectedArr, fnToTest(testArr, None, datetime(2023, 10, 6)))
+
+        expectedArr[0].belongsToTimeRangeFilter = False
+        self.assertEqual(expectedArr, fnToTest(testArr, None, datetime(2023, 10, 5)))
+        self.assertEqual(expectedArr, fnToTest(testArr, None, datetime(2023, 10, 4)))
+
+        ########################
+        # test file that doesn't match time stamp pattern it would be always not skipped
+        testArr = ['status.log']
+        expectedArr = [lf.LogNameInfo('status.log', None, True)]
+        self.assertEqual(expectedArr, fnToTest(testArr, None, None))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 10, 5), None))
+        self.assertEqual(expectedArr, fnToTest(testArr, None, datetime(2023, 10, 5)))
+
+        ########################
+        # test complex queries
+        testArr = [
+            'gp_era',
+            'startup.log',
+            'gpdb-2023-10-05_090100.csv',
+            'gpdb-2023-10-05_09050.csv',
+            'gpdb-2023-10-05.csv',
+            'gpdb-2023-10-5.csv',
+            'gpdb-2023-10-05_09010.csv',
+            'gpdb-23-10-05_09011.csv',
+            'gpdb-2023-1-05_2000.csv',
+            'gpdb-2023-1-5_0000.csv',
+            'gpdb-9999-12-31_235959.csv'
+        ]
+
+        # ordered by the time stamp and after by name (file names without timestamp are considered as
+        # datetime.max)
+        expectedArr = [
+            lf.LogNameInfo('gpdb-2023-1-5_0000.csv', datetime(2023, 1, 5, 0, 0), True), # format changed - first number of day is skipped and time doesn't contain seconds
+            lf.LogNameInfo('gpdb-2023-1-05_2000.csv', datetime(2023, 1, 5, 20, 0), True), # format changed - time doesn't contain seconds
+            lf.LogNameInfo('gpdb-2023-10-05.csv', datetime(2023, 10, 5, 0, 0), True), # format changed - no time prefix
+            lf.LogNameInfo('gpdb-2023-10-5.csv', datetime(2023, 10, 5, 0, 0), True), # format changed - first number of day is skipped
+            lf.LogNameInfo('gpdb-2023-10-05_09010.csv', datetime(2023, 10, 5, 9, 1), True), # format changed - last second is skipped
+            lf.LogNameInfo('gpdb-2023-10-05_090100.csv', datetime(2023, 10, 5, 9, 1), True),
+            lf.LogNameInfo('gpdb-2023-10-05_09050.csv', datetime(2023, 10, 5, 9, 5), True), # format changed - last second is skipped
+            lf.LogNameInfo('gpdb-9999-12-31_235959.csv', datetime(9999, 12, 31, 23, 59, 59), True), # timestamp is around datetime.max
+            # files without timestamps
+            lf.LogNameInfo('gp_era', None, True),
+            lf.LogNameInfo('gpdb-23-10-05_09011.csv', None, True),
+            lf.LogNameInfo('startup.log', None, True),
+        ]
+
+        # all matches
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime.min, datetime.max))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime.min, datetime.max))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 1, 5, 10), datetime.max))
+
+        # first element doesn't match the `begin` date
+        expectedArr[0].belongsToTimeRangeFilter = False
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 1, 5, 20), datetime.max))
+        self.assertEqual(expectedArr, fnToTest(testArr, datetime(2023, 1, 5, 21), datetime.max))
+
+        # `end` date is added
+        expectedArr[-4].belongsToTimeRangeFilter = False
+        expectedArr[-5].belongsToTimeRangeFilter = False
+        expectedArr[-6].belongsToTimeRangeFilter = False
+        expectedArr[-7].belongsToTimeRangeFilter = False
+        self.assertEqual(expectedArr,
+            fnToTest(testArr, datetime(2023, 1, 5, 20), datetime(2023, 10, 5, 9, 1))
+        )

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -21,7 +21,8 @@ def before_all(context):
 def before_feature(context, feature):
     # we should be able to run gpexpand without having a cluster initialized
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
-                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet']
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
+                    'gplogfilter']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -123,7 +124,8 @@ def before_scenario(context, scenario):
         context.gpssh_exkeys_context = GpsshExkeysMgmtContext(context)
 
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpstate', 'gpmovemirrors',
-                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet']
+                    'gpconfig', 'gpssh-exkeys', 'gpstop', 'gpinitsystem', 'cross_subnet',
+                    'gplogfilter']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 
@@ -155,7 +157,8 @@ def after_scenario(context, scenario):
 
     # NOTE: gpconfig after_scenario cleanup is in the step `the gpconfig context is setup`
     tags_to_skip = ['gpexpand', 'gpaddmirrors', 'gpinitstandby',
-                    'gpconfig', 'gpstop', 'gpinitsystem', 'cross_subnet']
+                    'gpconfig', 'gpstop', 'gpinitsystem', 'cross_subnet',
+                    'gplogfilter']
     if set(context.feature.tags).intersection(tags_to_skip):
         return
 

--- a/gpMgmt/test/behave/mgmt_utils/gplogfilter.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gplogfilter.feature
@@ -1,0 +1,69 @@
+@gplogfilter
+Feature: gplogfilter tests
+    Scenario: invalid begin and end arguments
+        When the user runs "gplogfilter -b "2023-10-05 09:01" -e "2023-10-05 09:01""
+        Then gplogfilter should print "gplogfilter: \(IOError\) "Invalid arguments: "begin" date \(2023-10-05 09:01:00\) is >= "end" date \(2023-10-05 09:01:00\)"" error message
+        When the user runs "gplogfilter -b "2023-10-05 09:01:01" -e "2023-10-05 09:00:00""
+        Then gplogfilter should print "gplogfilter: \(IOError\) "Invalid arguments: "begin" date \(2023-10-05 09:01:01\) is >= "end" date \(2023-10-05 09:00:00\)"" error message
+
+    Scenario: time range covers all files
+        Given log directory with files
+            | name                       | start_time          |
+            | status.log                 | 2023-01-01 00:00:00 |
+            | gpdb-2023-1-1_000000.csv   | 2023-01-01 00:00:00 |
+            | gpdb-2022-12-31_235959.csv | 2022-12-31 23:59:59 |
+        When under changed DATA_DIR user runs "gplogfilter"
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2022-12-31_235959.csv | 10    |
+            | gpdb-2023-1-1_000000.csv   | 10    |
+            | status.log                 | 10    |
+        When under changed DATA_DIR user runs "gplogfilter -b "1990-1-1" -e "9999-12-31""
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2022-12-31_235959.csv | 10    |
+            | gpdb-2023-1-1_000000.csv   | 10    |
+            | status.log                 | 10    |
+        When under changed DATA_DIR user runs "gplogfilter -b "2022-12-31""
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2022-12-31_235959.csv | 10    |
+            | gpdb-2023-1-1_000000.csv   | 10    |
+            | status.log                 | 10    |
+        When under changed DATA_DIR user runs "gplogfilter -e "2024-1-1""
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2022-12-31_235959.csv | 10    |
+            | gpdb-2023-1-1_000000.csv   | 10    |
+            | status.log                 | 10    |
+
+    Scenario: time range doesn't covers all files
+        Given log directory with files
+            | name                       | start_time          |
+            | status.log                 | 2023-01-05 00:00:00 |
+            | gpdb-2023-1-5_0000.csv     | 2023-01-05 00:00:00 |
+            | gpdb-2023-1-05_2000.csv    | 2023-01-05 20:00:00 |
+            | gpdb-2023-10-05_09010.csv  | 2023-10-05 09:01:00 |
+            | gpdb-2023-10-05_090100.csv | 2023-10-05 09:04:00 |
+            | gpdb-2023-10-05_09050.csv  | 2023-10-05 09:05:00 |
+        When under changed DATA_DIR user runs "gplogfilter -b "2023-10-05 09:01""
+        # status.log has timestamps ranging from 00:00:00 to 00:01:30, so 0 log lines match the filter
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2023-10-05_09010.csv  | 10    |
+            | gpdb-2023-10-05_090100.csv | 10    |
+            | gpdb-2023-10-05_09050.csv  | 10    |
+            | status.log                 | 0     |
+        When under changed DATA_DIR user runs "gplogfilter -e "2023-01-05 20:00""
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2023-1-5_0000.csv     | 10    |
+            | status.log                 | 10    |
+        When under changed DATA_DIR user runs "gplogfilter -b "2023-10-05" -e "2023-10-05 09:05""
+        # gpdb-2023-10-05_090100.csv has timestamps ranging from 09:04:00 to 09:05:30, so 6 log lines match the filter (from 09:04:00 to 09:04:50)
+        Then gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)
+            | name                       | count |
+            | gpdb-2023-1-05_2000.csv    | 0     |
+            | gpdb-2023-10-05_09010.csv  | 10    |
+            | gpdb-2023-10-05_090100.csv | 6     |
+            | status.log                 | 0     |

--- a/gpMgmt/test/behave/mgmt_utils/steps/gplogfilter.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gplogfilter.py
@@ -1,0 +1,79 @@
+import os
+import tempfile
+import yaml
+from datetime import datetime, timedelta
+
+from behave import given, when, then
+from test.behave_utils.utils import *
+
+def parse_processed_files(cmdStderr, cmdStdout):
+    res = []
+    counts = {}
+    for line in cmdStdout.splitlines():
+        # Currently gplogfilter doesn't replace all delimeters with '|'
+        # We should check both ',' and '|' before splitting
+        if '|' in line:
+            filename = line.split('|')[1]
+        elif ',' in line:
+            filename = line.split(',')[1]
+        else:
+            continue
+
+        if filename not in counts:
+            counts[filename] = 0
+        counts[filename] += 1
+    for line in cmdStderr.splitlines():
+        if line.startswith('-'):
+            filename = os.path.basename(line.strip('- '))
+            count = counts.get(filename, 0)
+            res.append({'name': filename, 'count': count})
+    return res
+
+# Expects a table with columns `name` and `start_time`.
+# For each row creates a log file with the given name and 10 lines of logs.
+# The first line has time `start_time`, and other 9 lines have an interval of 10 seconds.
+# For example if start_time is 2024-01-01 09:00:00, then we will have 10 lines with times
+# ranging from 2024-01-01 09:00:00 to 2024-01-01 09:01:30.
+@given('log directory with files')
+def impl(context):
+    newMasterDir = tempfile.mkdtemp()
+
+    logDir = os.path.join(newMasterDir, 'log')
+    os.mkdir(logDir)
+    for r in context.table:
+        filename = r["name"]
+        with open(os.path.join(logDir, filename), 'w') as f:
+            datetime_format = '%Y-%m-%d %H:%M:%S'
+            start_time = datetime.strptime(r["start_time"], datetime_format)
+            for i in range(10):
+                time = start_time + timedelta(seconds=10 * i)
+                s = datetime.strftime(time, datetime_format)
+                f.write(s + ' UTC,' + filename + ','*28 + ' tagged line\n')
+
+    context.newMasterDir = newMasterDir
+
+@when('under changed DATA_DIR user runs "{command}"')
+def impl(context, command):
+    run_gpcommand(context, command, "COORDINATOR_DATA_DIRECTORY=%s" % context.newMasterDir)
+
+# Expects a table with columns `name` and `count`.
+# Each row corresponds to a log file that was read,
+# and `count` is the number of lines that passed the filter.
+# If all log lines pass the filter, the `count` will be 10.
+# If no log lines passed the filter, but the file was read, the `count` will be 0.
+# If the file was filtered out entirely, there won't be a corresponding row in the table.
+@then("gplogiflter shouldn't skip next files from directory (files ordered by time stamp and by name)")
+def impl(context):
+    processed = parse_processed_files(context.error_message, context.stdout_message)
+    expected = [{"name": row["name"], "count": int(row["count"])} for row in context.table]
+
+    if len(processed) != len(expected):
+        raise Exception('got:\n%s\ndiffers with expected:\n%s'
+                        % (yaml.dump(processed), yaml.dump(expected)))
+
+    for i in range(0, len(processed)):
+        name_matches = processed[i]["name"] == expected[i]["name"]
+        count_matches = processed[i]["count"] == expected[i]["count"]
+        if not name_matches or not count_matches:
+            raise Exception('got:\n%s\ndiffers with expected:\n%s'
+                            % (yaml.dump(processed), yaml.dump(expected)))


### PR DESCRIPTION
gplogfilter: fix timerange validation

Previously the time range filtering of log files was incorrect: there was a check for belonging a log file to specified time range which worked like a binary `AND` (if time < begin AND time > end - skip file), but something like binary `OR` is needed here. Thus file filtering never worked. Also this validation was executed after the file was opened, so in case of failed validation there was a redundant `open/close` operations. This patch fixes such behavior, by:
- moving the logic of belonging log file name the user specified range to the separate function (it's also helps to cover corner cases)
- skip file processing, if it doesn't belong to range, at the begin of loop to prevent redundant `open/close` operations

Changes from original commit:
1. Fix print() syntax for Python 3
2. Add StringIO.seek(0) after StringIO.truncate(0) for Python 3
3. Make sure gplogfilter doesn't skip the first line.
4. Update behave test for GPDB 7 (use COORDINATOR_DATA_DIRECTORY and /log)
5. Add file content checking to behave test (counting lines that were read)

(cherry picked from commit e971286894929db3e071aa87198ae97905e2f14d)

---

Note: do not squash to preserve authorship
