### PR TITLE
Fix EnableXform() & DisableXform() functions when optimizer is off

### DIFF
--- a/gpcontrib/gp_orca/funcs.cpp
+++ b/gpcontrib/gp_orca/funcs.cpp
@@ -36,6 +36,8 @@
 extern "C" {
 Datum DisableXform(PG_FUNCTION_ARGS)
 {
+	Assert(NULL != OptimizerMemoryContext);
+
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
 	bool is_result = COptTasks::SetXform(szXform, true /*fDisable*/);
 
@@ -68,6 +70,8 @@ Datum DisableXform(PG_FUNCTION_ARGS)
 extern "C" {
 Datum EnableXform(PG_FUNCTION_ARGS)
 {
+	Assert(NULL != OptimizerMemoryContext);
+
 	char *szXform = text_to_cstring(PG_GETARG_TEXT_P(0));
 	bool is_result = COptTasks::SetXform(szXform, false /*fDisable*/);
 

--- a/gpcontrib/gp_orca/gporca.c
+++ b/gpcontrib/gp_orca/gporca.c
@@ -84,40 +84,48 @@ gp_orca_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 *
 	 * PARALLEL RETRIEVE CURSOR is not supported by ORCA yet.
 	 */
-	if (optimizer && GP_ROLE_DISPATCH == Gp_role && IS_QUERY_DISPATCHER() &&
-		(cursorOptions & CURSOR_OPT_SKIP_FOREIGN_PARTITIONS) == 0 &&
-		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)
+	if (GP_ROLE_DISPATCH == Gp_role && IS_QUERY_DISPATCHER())
 	{
-		instr_time starttime;
-		instr_time endtime;
-
+		/*
+		 * Init Orca even if GUC is disabled, as the query might involve
+		 * functions that update internal Orca's state (for example affecting
+		 * available transformations).
+		 */
 		if (NULL == OptimizerMemoryContext)
 			gp_orca_init();
 
-		if (gp_log_optimization_time)
-			INSTR_TIME_SET_CURRENT(starttime);
-
-		result = optimize_query(parse, cursorOptions, boundParams);
-
-		/* decide jit state */
-		if (result)
+		if (optimizer &&
+			(cursorOptions & CURSOR_OPT_SKIP_FOREIGN_PARTITIONS) == 0 &&
+			(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)
 		{
-			/*
-			 * Setting Jit flags for Optimizer
-			 */
-			gp_orca_compute_jit_flags(result);
-		}
+			instr_time starttime;
+			instr_time endtime;
 
-		if (gp_log_optimization_time)
-		{
-			INSTR_TIME_SET_CURRENT(endtime);
-			INSTR_TIME_SUBTRACT(endtime, starttime);
-			elog(LOG, "Optimizer Time: %.3f ms",
-				 INSTR_TIME_GET_MILLISEC(endtime));
-		}
+			if (gp_log_optimization_time)
+				INSTR_TIME_SET_CURRENT(starttime);
 
-		if (result)
-			return result;
+			result = optimize_query(parse, cursorOptions, boundParams);
+
+			/* decide jit state */
+			if (result)
+			{
+				/*
+				 * Setting Jit flags for Optimizer
+				 */
+				gp_orca_compute_jit_flags(result);
+			}
+
+			if (gp_log_optimization_time)
+			{
+				INSTR_TIME_SET_CURRENT(endtime);
+				INSTR_TIME_SUBTRACT(endtime, starttime);
+				elog(LOG, "Optimizer Time: %.3f ms",
+					 INSTR_TIME_GET_MILLISEC(endtime));
+			}
+
+			if (result)
+				return result;
+		}
 	}
 
 	if (prev_planner)


### PR DESCRIPTION
Fix EnableXform() & DisableXform() functions when optimizer is off

Problem:
If a session was started with disabled 'optimizer' GUC, and EnableXform() or
DisableXform() was called from a query, the query failed with a crash. The issue
was found on 'rowhints' test.

Cause:
The functions mentioned above tried to access internal Orca's structures, that
were not initialized, as the init was done during first planning only if
'optimizer' was on.

Fix:
Init Orca when planner is invoked first time regardless the value of
'optimizer'.

Note:
One can think that it is better to perform Orca init somewhen at the backend
init. But we'd like to keep Orca init after GPMemoryProtect_Init() (as it was
before Orca moved to an extension). And there is no existing standard hook to
call after GPMemoryProtect_Init() and before PostgresMain() enters its main
loop. Thus it is where it is.

No new tests are added, as existing 'rowhints' test can catch this issue.

----------

Better to review the delta with 'Hide whitespaces' enabled.