### PR TITLE
Fix explain_format and auto_explain tests

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -101,7 +101,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
 Optimizer: Postgres-based planner
-Settings: enable_nestloop = 'on', optimizer = 'off'
+Settings: enable_nestloop = 'on'
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -101,7 +101,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                           ->  Seq Scan on auto_explain_test.t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on auto_explain_test.t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
 Optimizer: GPORCA
-Settings: enable_nestloop = 'on'
+Settings: enable_nestloop = 'on', optimizer = 'on'
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,5 +1,5 @@
 -- Tests EXPLAIN format output
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -8,12 +8,12 @@
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
 -- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
+-- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 -- To produce stable regression test output, it's usually necessary to
@@ -299,7 +299,6 @@ explain_filter
   Optimizer: "Postgres-based planner"
   Settings: 
     cpu_index_tuple_cost: "N.N"
-    optimizer: "off"
     random_page_cost: "N"
 (1 row)
 select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
@@ -342,7 +341,6 @@ explain_filter
   Settings: 
     cpu_index_tuple_cost: "N.N"
     random_page_cost: "N"
-    optimizer: "off"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
 select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
@@ -566,7 +564,7 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
         ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: Postgres-based planner
-Settings: cpu_index_tuple_cost = 'N.N', optimizer = 'off', random_page_cost = 'N'
+Settings: cpu_index_tuple_cost = 'N.N', random_page_cost = 'N'
 Planning Time: N.N ms
   (sliceN)    Executor memory: NK bytes.
   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,5 +1,5 @@
 -- Tests EXPLAIN format output
--- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -7,13 +7,10 @@
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 -- To produce stable regression test output, it's usually necessary to

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,5 +1,5 @@
 -- Tests EXPLAIN format output
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -8,12 +8,12 @@
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
 -- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
+-- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 -- To produce stable regression test output, it's usually necessary to

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,5 +1,5 @@
 -- Tests EXPLAIN format output
--- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -7,13 +7,10 @@
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 -- To produce stable regression test output, it's usually necessary to
@@ -281,6 +278,7 @@ explain_filter
   Optimizer: "GPORCA"
   Settings: 
     cpu_index_tuple_cost: "N.N"
+    optimizer: "on"
     random_page_cost: "N"
 (1 row)
 select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
@@ -323,6 +321,7 @@ explain_filter
   Settings: 
     cpu_index_tuple_cost: "N.N"
     random_page_cost: "N"
+    optimizer: "on"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
 select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
@@ -514,7 +513,7 @@ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual
         ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: GPORCA
-Settings: cpu_index_tuple_cost = 'N.N', random_page_cost = 'N'
+Settings: cpu_index_tuple_cost = 'N.N', optimizer = 'on', random_page_cost = 'N'
 Planning Time: N.N ms
   (sliceN)    Executor memory: NK bytes.
   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,6 +1,6 @@
 -- Tests EXPLAIN format output
 
--- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -9,13 +9,13 @@
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
 -- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
+-- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,6 +1,6 @@
 -- Tests EXPLAIN format output
 
--- ignore the variable JIT gucs and "optimizer = 'on'" in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
@@ -8,14 +8,11 @@
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'on'//g
 -- end_matchsubs
 
 -- ignore variable JIT gucs which can be shown when SETTINGS=ON
 -- start_matchignore
 -- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"on"/
 -- m/^\s+optimizer_jit\w*:/
 -- end_matchignore
 


### PR DESCRIPTION
Fix explain_format and auto_explain tests

Problem:
'explain_format' test failed if 'optimizer' GUC was set to 'on'.
'auto_explain' test failed with any 'optimizer' GUC value.

Cause:
Explain command outputs values of GUCs that affect planning if their value
differ from the default. Default value for 'optimizer' GUC has been changed to
'off' recently. So, the output of the tests has been changed as well.

Fix:
The patch updates matchsubs in 'explain_format' test to exclude handling of
'optimizer' GUC value and introduces respective updates in the files with
expected output. For 'auto_explain' test, it just updates the files with
expected output.