### PR TITLE
ADBDEV-5498: Add filter to prohibit using encoding for columns at foreign tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1028,12 +1028,16 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	 * create child partition create stmts which would only include explicitly
 	 * specified column encodings from the current root partition
 	 *
+	 * For RELKIND_FOREIGN_TABLE the attribute encoding clauses are not used,
+	 * but we add it here to produce an error message for the user inside
+	 * transformColumnEncoding().
+	 *
 	 * This is done in dispatcher (and in utility mode). In QE, we receive
 	 * the already-processed options from the QD.
 	 */
 
 	if ((relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW ||
-		 relkind == RELKIND_PARTITIONED_TABLE) &&
+		 relkind == RELKIND_PARTITIONED_TABLE || relkind == RELKIND_FOREIGN_TABLE ) &&
 		Gp_role != GP_ROLE_EXECUTE)
 	{
 		/*

--- a/src/test/regress/expected/foreign_data.out
+++ b/src/test/regress/expected/foreign_data.out
@@ -2050,7 +2050,131 @@ ALTER TABLE temp_parted ATTACH PARTITION foreign_part DEFAULT;  -- ERROR
 ERROR:  cannot attach a permanent relation as partition of temporary relation "temp_parted"
 DROP FOREIGN TABLE foreign_part;
 DROP TABLE temp_parted;
+------------------------------------------------------------------------------
+-- Test to check column encoding at foreign tables.
+-- Not use column encoding at foreign tables.
+------------------------------------------------------------------------------
+CREATE DATABASE foreign_tables_test_db;
+\c foreign_tables_test_db
+CREATE FOREIGN DATA WRAPPER dummy;
+CREATE SERVER test FOREIGN DATA WRAPPER dummy;
+-- Do not create foreign tables with encoding clause
+-- Expect: failure
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+ERROR:  ENCODING clause only supported with column oriented tables
+SET default_table_access_method = 'ao_column';
+SET gp_default_storage_options = 'blocksize=32768,compresstype=zstd,compresslevel=3,checksum=true';
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+ERROR:  ENCODING clause only supported with column oriented tables
+-- Check that created foreign table does not apply gp_default_storage_options
+-- Expect: success
+CREATE FOREIGN TABLE foreign_table (
+    a integer
+) SERVER test;
+ALTER FOREIGN TABLE public.foreign_table OWNER to regress_foreign_data_user;
+\d+ foreign_table
+                                  Foreign table "public.foreign_table"
+ Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
+ a      | integer |           |          |         |             | plain   |              | 
+Server: test
+
+-- Check that pg_dump generates valid table definition
+-- Expect: success
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+--
+-- Greenplum Database database dump
+--
+
+-- Dumped from database version 12.12
+-- Dumped by pg_dump version 12.12
+
+SET gp_default_storage_options = '';
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+SET gp_enable_statement_trigger = on;
+
+SET default_tablespace = '';
+
+--
+-- Name: foreign_table; Type: FOREIGN TABLE; Schema: public; Owner: regress_foreign_data_user
+--
+
+CREATE FOREIGN TABLE public.foreign_table (
+    a integer
+)
+SERVER test;
+
+
+ALTER FOREIGN TABLE public.foreign_table OWNER TO regress_foreign_data_user;
+
+--
+-- Greenplum Database database dump complete
+--
+
+-- End of pg_dump output
+-- Check that pg_dump generates valid table definition after resetting gp_default_storage_options
+-- Expect: success
+RESET default_table_access_method;
+RESET gp_default_storage_options;
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+--
+-- Greenplum Database database dump
+--
+
+-- Dumped from database version 12.12
+-- Dumped by pg_dump version 12.12
+
+SET gp_default_storage_options = '';
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+SET gp_enable_statement_trigger = on;
+
+SET default_tablespace = '';
+
+--
+-- Name: foreign_table; Type: FOREIGN TABLE; Schema: public; Owner: regress_foreign_data_user
+--
+
+CREATE FOREIGN TABLE public.foreign_table (
+    a integer
+)
+SERVER test;
+
+
+ALTER FOREIGN TABLE public.foreign_table OWNER TO regress_foreign_data_user;
+
+--
+-- Greenplum Database database dump complete
+--
+
+-- End of pg_dump output
 -- Cleanup
+DROP FOREIGN TABLE foreign_table;
+DROP SERVER test;
+DROP FOREIGN DATA WRAPPER dummy;
+\c regression
+DROP DATABASE foreign_tables_test_db;
 DROP SCHEMA foreign_schema CASCADE;
 DROP ROLE regress_test_role;                                -- ERROR
 ERROR:  role "regress_test_role" cannot be dropped because some objects depend on it

--- a/src/test/regress/sql/foreign_data.sql
+++ b/src/test/regress/sql/foreign_data.sql
@@ -865,7 +865,56 @@ ALTER TABLE temp_parted ATTACH PARTITION foreign_part DEFAULT;  -- ERROR
 DROP FOREIGN TABLE foreign_part;
 DROP TABLE temp_parted;
 
+------------------------------------------------------------------------------
+-- Test to check column encoding at foreign tables.
+-- Not use column encoding at foreign tables.
+------------------------------------------------------------------------------
+
+CREATE DATABASE foreign_tables_test_db;
+\c foreign_tables_test_db
+
+CREATE FOREIGN DATA WRAPPER dummy;
+CREATE SERVER test FOREIGN DATA WRAPPER dummy;
+
+-- Do not create foreign tables with encoding clause
+-- Expect: failure
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+
+SET default_table_access_method = 'ao_column';
+SET gp_default_storage_options = 'blocksize=32768,compresstype=zstd,compresslevel=3,checksum=true';
+CREATE FOREIGN TABLE foreign_table (
+    a integer ENCODING (compresstype=zstd,blocksize=32768,compresslevel=3)
+) SERVER test;
+
+-- Check that created foreign table does not apply gp_default_storage_options
+-- Expect: success
+CREATE FOREIGN TABLE foreign_table (
+    a integer
+) SERVER test;
+ALTER FOREIGN TABLE public.foreign_table OWNER to regress_foreign_data_user;
+\d+ foreign_table
+
+-- Check that pg_dump generates valid table definition
+-- Expect: success
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+-- End of pg_dump output
+
+-- Check that pg_dump generates valid table definition after resetting gp_default_storage_options
+-- Expect: success
+RESET default_table_access_method;
+RESET gp_default_storage_options;
+\! pg_dump -t public.foreign_table foreign_tables_test_db
+-- End of pg_dump output
+
 -- Cleanup
+DROP FOREIGN TABLE foreign_table;
+DROP SERVER test;
+DROP FOREIGN DATA WRAPPER dummy;
+\c regression
+DROP DATABASE foreign_tables_test_db;
+
 DROP SCHEMA foreign_schema CASCADE;
 DROP ROLE regress_test_role;                                -- ERROR
 DROP SERVER t1 CASCADE;


### PR DESCRIPTION
Add filter to prohibit using encoding for columns at foreign tables

Setting ENCODING for columns of foreign tables is useless, but not forbidden
by grammar, so it was silently ignored. This patch adds an error message when
the user tries to explicitly specify the encoding for a foreign table.
We also make sure that GUCs like `default_table_access_method` and
`gp_default_storage_options` are correctly ignored for foreign tables.

The code changes are completely rewritten compared to the original commit.
However, the test is taken from the original commit, with slight
modifications to account for GPDB 7 differences.

(cherry picked from commit bb5a6b85b52161d40aa081dc2c5ec9561eabdb65)
