### PR TITLE
ADBDEV-4603: Allow multiple params in the child nodes of <dxl:TestExpr>

### DIFF
--- a/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
+++ b/src/backend/gpopt/translate/CMappingColIdVarPlStmt.cpp
@@ -85,6 +85,34 @@ CMappingColIdVarPlStmt::GetOutputContext()
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CMappingColIdVarPlStmt::GetChildContexts
+//
+//	@doc:
+//		Returns the child contexts
+//
+//---------------------------------------------------------------------------
+CDXLTranslationContextArray *
+CMappingColIdVarPlStmt::GetChildContexts()
+{
+	return m_child_contexts;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CMappingColIdVarPlStmt::GetBaseTableContext
+//
+//	@doc:
+//		Returns the base table context
+//
+//---------------------------------------------------------------------------
+const CDXLTranslateContextBaseTable *
+CMappingColIdVarPlStmt::GetBaseTableContext()
+{
+	return m_base_table_context;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CMappingColIdVarPlStmt::ParamFromDXLNodeScId
 //
 //	@doc:

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -751,6 +751,8 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	// Generate var mapping to handle test expression based on the required
 	// output context. Test expression may contain vars from external
 	// (relative to subplan) nodes, so add their context too.
+	// We create a copy of the external mapping because we don't want to
+	// add TestExpr params to the original.
 	CMappingColIdVarPlStmt test_expr_var_mapping = CMappingColIdVarPlStmt(
 		m_mp, m_base_table_context, outer_child_contexts,
 		&test_expr_output_ctxt, plstmt->GetDXLToPlStmtContext());
@@ -762,7 +764,6 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 		dxlop->GetDxlTestExpr(), slink, &test_expr_var_mapping);
 
 	const CDXLColRefArray *outer_refs = dxlop->GetDxlOuterColRefsArray();
-
 	const ULONG len = outer_refs->Size();
 
 	// Translate a copy of the translate context: the param mappings from the outer scope get copied in the constructor

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -702,18 +702,64 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 
 	CDXLTranslateContext *output_context = plstmt->GetOutputContext();
 	CContextDXLToPlStmt *dxl_to_plstmt_ctxt = plstmt->GetDXLToPlStmtContext();
+	CDXLTranslationContextArray *outer_child_contexts =
+		plstmt->GetChildContexts();
+	const CDXLTranslateContextBaseTable *m_base_table_context =
+		plstmt->GetBaseTableContext();
 
 	CDXLScalarSubPlan *dxlop =
 		CDXLScalarSubPlan::Cast(scalar_subplan_node->GetOperator());
 
-	// translate subplan test expression
-	List *param_ids = NIL;
+	// Generate outer context for test expression.
+	// When walking through the test expression tree, the params (inner
+	// subplan output columns) will be looked for in the outer context.
+	CDXLTranslateContext test_expr_output_ctxt(
+		m_mp, output_context->IsParentAggNode(),
+		output_context->GetColIdToParamIdMap());
 
+	List *param_ids = NIL;
+	const CDXLColRefArray *test_expr_params = dxlop->GetTestExprParams();
+	// Fill in the param mapping of the outer context and save the param ids
+	if (NULL != test_expr_params)
+	{
+		const ULONG size = test_expr_params->Size();
+		for (ULONG ul = 0; ul < size; ul++)
+		{
+			CDXLColRef *dxl_colref = (*test_expr_params)[ul];
+			IMDId *mdid = dxl_colref->MdidType();
+			ULONG colid = dxl_colref->Id();
+			INT type_modifier = dxl_colref->TypeModifier();
+
+			if (NULL == test_expr_output_ctxt.GetParamIdMappingElement(colid))
+			{
+				CMappingElementColIdParamId *colid_to_param_id_map =
+					GPOS_NEW(m_mp) CMappingElementColIdParamId(
+						colid, dxl_to_plstmt_ctxt->GetNextParamId(), mdid,
+						type_modifier);
+#ifdef GPOS_DEBUG
+				BOOL is_inserted =
+#endif
+					test_expr_output_ctxt.FInsertParamMapping(
+						colid, colid_to_param_id_map);
+
+				Param *param = TranslateParamFromMapping(colid_to_param_id_map);
+				param_ids = gpdb::LAppendInt(param_ids, param->paramid);
+			}
+		}
+	}
+
+	// Generate var mapping to handle test expression based on the required
+	// output context. Test expression may contain vars from external
+	// (relative to subplan) nodes, so add their context too.
+	CMappingColIdVarPlStmt test_expr_var_mapping = CMappingColIdVarPlStmt(
+		m_mp, m_base_table_context, outer_child_contexts,
+		&test_expr_output_ctxt, plstmt->GetDXLToPlStmtContext());
+
+	// translate subplan test expression
 	SubLinkType slink = CTranslatorUtils::MapDXLSubplanToSublinkType(
 		dxlop->GetDxlSubplanType());
 	Expr *test_expr = TranslateDXLSubplanTestExprToScalar(
-		dxlop->GetDxlTestExpr(), slink, colid_var, dxlop->FOuterParam(),
-		&param_ids);
+		dxlop->GetDxlTestExpr(), slink, &test_expr_var_mapping);
 
 	const CDXLColRefArray *outer_refs = dxlop->GetDxlOuterColRefsArray();
 
@@ -785,57 +831,6 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	return (Expr *) subplan;
 }
 
-//---------------------------------------------------------------------------
-//      @function:
-//              CTranslatorDXLToScalar::TranslateDXLTestExprScalarIdentToExpr
-//
-//      @doc:
-//              Translate subplan test expression parameter
-//
-//---------------------------------------------------------------------------
-void
-CTranslatorDXLToScalar::TranslateDXLTestExprScalarIdentToExpr(
-	CDXLNode *child_node, Param *param, CDXLScalarIdent **ident, Expr **expr)
-{
-	if (EdxlopScalarIdent == child_node->GetOperator()->GetDXLOperator())
-	{
-		// Ident
-		*ident = CDXLScalarIdent::Cast(child_node->GetOperator());
-		*expr = (Expr *) param;
-	}
-	else if (EdxlopScalarCast == child_node->GetOperator()->GetDXLOperator() &&
-			 child_node->Arity() > 0 &&
-			 EdxlopScalarIdent ==
-				 (*child_node)[0]->GetOperator()->GetDXLOperator())
-	{
-		// Casted Ident
-		*ident = CDXLScalarIdent::Cast((*child_node)[0]->GetOperator());
-		CDXLScalarCast *scalar_cast =
-			CDXLScalarCast::Cast(child_node->GetOperator());
-		*expr =
-			TranslateDXLScalarCastWithChildExpr(scalar_cast, (Expr *) param);
-	}
-	else if (EdxlopScalarCoerceViaIO ==
-				 child_node->GetOperator()->GetDXLOperator() &&
-			 child_node->Arity() > 0 &&
-			 EdxlopScalarIdent ==
-				 (*child_node)[0]->GetOperator()->GetDXLOperator())
-	{
-		// CoerceViaIO over Ident
-		*ident = CDXLScalarIdent::Cast((*child_node)[0]->GetOperator());
-		CDXLScalarCoerceViaIO *coerce =
-			CDXLScalarCoerceViaIO::Cast(child_node->GetOperator());
-		*expr =
-			TranslateDXLScalarCoerceViaIOWithChildExpr(coerce, (Expr *) param);
-	}
-	else
-	{
-		// ORCA currently only supports PARAMs of the form id or cast(id)
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   GPOS_WSZ_LIT("Unsupported subplan test expression"));
-	}
-}
-
 
 //---------------------------------------------------------------------------
 //      @function:
@@ -847,8 +842,7 @@ CTranslatorDXLToScalar::TranslateDXLTestExprScalarIdentToExpr(
 //---------------------------------------------------------------------------
 Expr *
 CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
-	CDXLNode *test_expr_node, SubLinkType slink, CMappingColIdVar *colid_var,
-	BOOL has_outer_refs, List **param_ids)
+	CDXLNode *test_expr_node, SubLinkType slink, CMappingColIdVar *colid_var)
 {
 	if (EXPR_SUBLINK == slink || EXISTS_SUBLINK == slink ||
 		NOT_EXISTS_SUBLINK == slink)
@@ -876,72 +870,19 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 
 	// Translate arguments
 	List *args = NULL;
+	Expr *outer_expr = NULL;
+	Expr *inner_expr = NULL;
 
 	CDXLNode *outer_child_node = (*test_expr_node)[0];
 	CDXLNode *inner_child_node = (*test_expr_node)[1];
 
-	CContextDXLToPlStmt *dxl_to_plstmt_ctxt =
-		(dynamic_cast<CMappingColIdVarPlStmt *>(colid_var))
-			->GetDXLToPlStmtContext();
+	outer_expr = TranslateDXLToScalar(outer_child_node, colid_var);
+	GPOS_ASSERT(NULL != outer_expr);
+	args = gpdb::LAppend(args, outer_expr);
 
-	// translate outer expression (can be a deep scalar tree)
-	Expr *outer_arg_expr = NULL;
-	if (has_outer_refs)
-	{
-		Param *param1 = MakeNode(Param);
-		param1->paramkind = PARAM_EXEC;
-
-		CDXLScalarIdent *outer_ident = NULL;
-		Expr *outer_expr = NULL;
-
-		TranslateDXLTestExprScalarIdentToExpr(outer_child_node, param1,
-											  &outer_ident, &outer_expr);
-		GPOS_ASSERT(NULL != outer_ident);
-		GPOS_ASSERT(NULL != outer_expr);
-
-		// finalize outer expression
-		param1->paramtype = CMDIdGPDB::CastMdid(outer_ident->MdidType())->Oid();
-		param1->paramtypmod = outer_ident->TypeModifier();
-		param1->paramid = dxl_to_plstmt_ctxt->GetNextParamId();
-
-		// test expression is used for non-scalar subplan,
-		// first arg of test expression must be an EXEC param1 referring to subplan output
-		args = gpdb::LAppend(args, outer_expr);
-
-		// also, add this param1 to subplan param1 ids before translating other params
-		*param_ids = gpdb::LAppendInt(*param_ids, param1->paramid);
-	}
-	else
-	{
-		outer_arg_expr = TranslateDXLToScalar(outer_child_node, colid_var);
-		args = gpdb::LAppend(args, outer_arg_expr);
-	}
-
-	// translate inner expression (only certain forms supported)
-	// second arg must be an EXEC param which is replaced during query execution with subplan output
-	Param *param = MakeNode(Param);
-	param->paramkind = PARAM_EXEC;
-	param->paramid = dxl_to_plstmt_ctxt->GetNextParamId();
-
-	CDXLScalarIdent *inner_ident = NULL;
-	Expr *inner_expr = NULL;
-
-	TranslateDXLTestExprScalarIdentToExpr(inner_child_node, param, &inner_ident,
-										  &inner_expr);
-
-	GPOS_ASSERT(NULL != inner_ident);
+	inner_expr = TranslateDXLToScalar(inner_child_node, colid_var);
 	GPOS_ASSERT(NULL != inner_expr);
-
-	// finalize inner expression
-	param->paramtype = CMDIdGPDB::CastMdid(inner_ident->MdidType())->Oid();
-	param->paramtypmod = inner_ident->TypeModifier();
-
-	// test expression is used for non-scalar subplan,
-	// second arg of test expression must be an EXEC param referring to subplan output
 	args = gpdb::LAppend(args, inner_expr);
-
-	// also, add this param to subplan param ids before translating other params
-	*param_ids = gpdb::LAppendInt(*param_ids, param->paramid);
 
 	// finally, create an OpExpr for subplan test expression
 	CDXLScalarComp *scalar_cmp_dxl =
@@ -2020,6 +1961,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar(
 				dxlop->GetDXLColRef()->Id()))
 	{
 		// not an outer ref -> Translate var node
+
 		result_expr = (Expr *) colid_var->VarFromDXLNodeScId(dxlop);
 	}
 	else

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -740,7 +740,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 #endif
 					test_expr_output_ctxt.FInsertParamMapping(
 						colid, colid_to_param_id_map);
-
+				GPOS_ASSERT(is_inserted);
 				Param *param = TranslateParamFromMapping(colid_to_param_id_map);
 				param_ids = gpdb::LAppendInt(param_ids, param->paramid);
 			}
@@ -870,17 +870,14 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 
 	// Translate arguments
 	List *args = NULL;
-	Expr *outer_expr = NULL;
-	Expr *inner_expr = NULL;
-
 	CDXLNode *outer_child_node = (*test_expr_node)[0];
 	CDXLNode *inner_child_node = (*test_expr_node)[1];
 
-	outer_expr = TranslateDXLToScalar(outer_child_node, colid_var);
+	Expr *outer_expr = TranslateDXLToScalar(outer_child_node, colid_var);
 	GPOS_ASSERT(NULL != outer_expr);
 	args = gpdb::LAppend(args, outer_expr);
 
-	inner_expr = TranslateDXLToScalar(inner_child_node, colid_var);
+	Expr *inner_expr = TranslateDXLToScalar(inner_child_node, colid_var);
 	GPOS_ASSERT(NULL != inner_expr);
 	args = gpdb::LAppend(args, inner_expr);
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -763,6 +763,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 		dxlop->GetDxlTestExpr(), slink, &test_expr_var_mapping);
 
 	const CDXLColRefArray *outer_refs = dxlop->GetDxlOuterColRefsArray();
+
 	const ULONG len = outer_refs->Size();
 
 	// Translate a copy of the translate context: the param mappings from the outer scope get copied in the constructor
@@ -870,6 +871,7 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 
 	// Translate arguments
 	List *args = NULL;
+	
 	CDXLNode *outer_child_node = (*test_expr_node)[0];
 	CDXLNode *inner_child_node = (*test_expr_node)[1];
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -716,7 +716,6 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	CDXLTranslateContext test_expr_output_ctxt(
 		m_mp, output_context->IsParentAggNode(),
 		output_context->GetColIdToParamIdMap());
-
 	List *param_ids = NIL;
 	const CDXLColRefArray *test_expr_params = dxlop->GetTestExprParams();
 	// Fill in the param mapping of the outer context and save the param ids
@@ -1961,8 +1960,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar(
 			colid_var_plstmt_map->GetOutputContext()->GetParamIdMappingElement(
 				dxlop->GetDXLColRef()->Id()))
 	{
-		// not an outer ref -> Translate var node
-
+		// not an outer ref -> Translate var nodeS
 		result_expr = (Expr *) colid_var->VarFromDXLNodeScId(dxlop);
 	}
 	else

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -871,7 +871,7 @@ CTranslatorDXLToScalar::TranslateDXLSubplanTestExprToScalar(
 
 	// Translate arguments
 	List *args = NULL;
-	
+
 	CDXLNode *outer_child_node = (*test_expr_node)[0];
 	CDXLNode *inner_child_node = (*test_expr_node)[1];
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToScalar.cpp
@@ -710,15 +710,15 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 	CDXLScalarSubPlan *dxlop =
 		CDXLScalarSubPlan::Cast(scalar_subplan_node->GetOperator());
 
-	// Generate outer context for test expression.
-	// When walking through the test expression tree, the params (inner
-	// subplan output columns) will be looked for in the outer context.
+	// When walking through the test expression tree, the test expression params.
+	// will be looked for in the output context.
+	// Generate output context for test expression params based on the outer output context.
 	CDXLTranslateContext test_expr_output_ctxt(
 		m_mp, output_context->IsParentAggNode(),
 		output_context->GetColIdToParamIdMap());
 	List *param_ids = NIL;
 	const CDXLColRefArray *test_expr_params = dxlop->GetTestExprParams();
-	// Fill in the param mapping of the outer context and save the param ids
+	// Fill in the param mapping of the output context and save the param ids
 	if (NULL != test_expr_params)
 	{
 		const ULONG size = test_expr_params->Size();
@@ -747,7 +747,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarSubplanToScalar(
 		}
 	}
 
-	// Generate var mapping to handle test expression based on the required
+	// Generate ColIdVar mapping to handle test expression based on the required
 	// output context. Test expression may contain vars from external
 	// (relative to subplan) nodes, so add their context too.
 	// We create a copy of the external mapping because we don't want to
@@ -1960,7 +1960,7 @@ CTranslatorDXLToScalar::TranslateDXLScalarIdentToScalar(
 			colid_var_plstmt_map->GetOutputContext()->GetParamIdMappingElement(
 				dxlop->GetDXLColRef()->Id()))
 	{
-		// not an outer ref -> Translate var nodeS
+		// not an outer ref -> Translate var node
 		result_expr = (Expr *) colid_var->VarFromDXLNodeScId(dxlop);
 	}
 	else

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -738,9 +738,10 @@ private:
 	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRef *colref);
 
 	// helper to build a Result expression with project list restricted to required columns
-	// and additionally fills the resulting projected columns
-	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRefSet *colrefs,
-								  CDXLColRefArray *projectedColumns = NULL);
+	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRefSet *colrefs);
+
+	// helper to build a projected DXLColRefs of Result node
+	CDXLColRefArray *GetResultProjectedColRefArray(CDXLNode *dxlProjectNode);
 
 	//	helper to build subplans from correlated LOJ
 	void BuildSubplansForCorrelatedLOJ(

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -738,7 +738,9 @@ private:
 	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRef *colref);
 
 	// helper to build a Result expression with project list restricted to required columns
-	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRefSet *colrefs);
+	// and additionally fills the resulting projected columns
+	CDXLNode *PdxlnRestrictResult(CDXLNode *dxlnode, const CColRefSet *colrefs,
+								  CDXLColRefArray *projectedColumns = NULL);
 
 	//	helper to build subplans from correlated LOJ
 	void BuildSubplansForCorrelatedLOJ(

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3244,14 +3244,14 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	// restrict the projection of the inner node.
 	// We need the "Reqd Inner Col" of CorrelatedNLJoin (pdrgpcrInner[0])
 	// and the columns from the scalar that appear in the subquery (inner part).
-	// Since the "Reqd Inner Col" always appears in the scalar (this is true
-	// for ANY/ALL subqueries), we need to define the used columns in the Test
-	// Expression that are output in the inner node.
 	CColRefSet *pcrsInner =
 		GPOS_NEW(m_mp) CColRefSet(m_mp, *pexprInner->DeriveOutputColumns());
 	CColRefSet *pcrsScalarUsed = pexprScalar->DeriveUsedColumns();
 	pcrsInner->Intersection(pcrsScalarUsed);
-	GPOS_ASSERT(pcrsInner->Size() > 0);
+	if (0 == pcrsInner->Size())
+	{
+		pcrsInner->Include((*pdrgpcrInner)[0]);
+	}
 	CDXLNode *inner_dxlnode = PdxlnRestrictResult(pdxlnInnerChild, pcrsInner);
 	pcrsInner->Release();
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3089,7 +3089,7 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 //
 //	@doc:
 //		Helper to build a Result expression with project list
-//		restricted to required columns.
+//		restricted to required columns
 //
 //---------------------------------------------------------------------------
 CDXLNode *

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3216,17 +3216,14 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 {
 	COperator *popCorrelatedJoin = pexprCorrelatedNLJoin->Pop();
 	COperator::EOperatorId op_id = popCorrelatedJoin->Eopid();
-	BOOL fCorrelatedLOJ =
-		(COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id ||
-		 COperator::EopPhysicalCorrelatedLeftOuterNLJoin == op_id);
 	GPOS_ASSERT(COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id ||
 				COperator::EopPhysicalCorrelatedNotInLeftAntiSemiNLJoin ==
 					op_id ||
-				fCorrelatedLOJ);
+				COperator::EopPhysicalCorrelatedLeftOuterNLJoin == op_id);
 
 	EdxlSubPlanType dxl_subplan_type = Edxlsubplantype(pexprCorrelatedNLJoin);
-	GPOS_ASSERT_IMP(fCorrelatedLOJ, EdxlSubPlanTypeAny == dxl_subplan_type ||
-										EdxlSubPlanTypeAll == dxl_subplan_type);
+	GPOS_ASSERT(EdxlSubPlanTypeAny == dxl_subplan_type ||
+				EdxlSubPlanTypeAll == dxl_subplan_type);
 
 	CExpression *pexprInner = (*pexprCorrelatedNLJoin)[1];
 	CExpression *pexprScalar = (*pexprCorrelatedNLJoin)[2];
@@ -3236,45 +3233,34 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 		pexprInner, NULL /*colref_array*/, pdrgpdsBaseTables,
 		pulNonGatherMotions, pfDML, false /*fRemap*/, false /*fRoot*/);
 
-	// find required column from inner child
-	CColRefSet *pcrInner = GPOS_NEW(m_mp) CColRefSet(m_mp);
-	pcrInner->Include((*pdrgpcrInner)[0]);
+	// In fact, the inner (right) part of CorrelatedNLJoin is transformed
+	// into a subquery. The scalar part of CorrelatedNLJoin is transformed
+	// into a Test Expression of the subquery.
+	// At execution, the subquery returns a tuple, and Test Expression checks
+	// the condition for returning the tuple - it acts as a filter.
+	// We do not need all the output columns of the subquery, so we need to
+	// restrict the projection of the inner node.
+	// We need the "Reqd Inner Col" of CorrelatedNLJoin (pdrgpcrInner[0])
+	// and the columns from the scalar that appear in the subquery (inner part).
+	// Since the "Reqd Inner Col" always appears in the scalar (this is true
+	// for ANY/ALL subqueries), we need to define the used columns in the Test
+	// Expression that are output in the inner node.
+	CColRefSet *pcrsInner =
+		GPOS_NEW(m_mp) CColRefSet(m_mp, *pexprInner->DeriveOutputColumns());
+	CColRefSet *pcrsScalarUsed = pexprScalar->DeriveUsedColumns();
+	pcrsInner->Intersection(pcrsScalarUsed);
+	GPOS_ASSERT(pcrsInner->Size() > 0);
+	CDXLNode *inner_dxlnode = PdxlnRestrictResult(pdxlnInnerChild, pcrsInner);
+	pcrsInner->Release();
 
-	if (fCorrelatedLOJ)
-	{
-		// Overwrite required inner column based on scalar expression.
-		// The columns contained in the scalar and the inner
-		// (intersection) are params of TestExpr if Correlated. The
-		// remaining columns of scalar are treated as vars. The vars
-		// refer to the node external to subplan.
-
-		CColRefSet *pcrsInner = pexprInner->DeriveOutputColumns();
-		CColRefSet *pcrsUsed =
-			GPOS_NEW(m_mp) CColRefSet(m_mp, *pexprScalar->DeriveUsedColumns());
-		pcrsUsed->Intersection(pcrsInner);
-		if (0 < pcrsUsed->Size())
-		{
-			// Both sides of the SubPlan test expression can come from the
-			// inner side. So we need to pass pcrsUsed instead of pcrInner into
-			// PdxlnRestrictResult()
-
-			pcrInner->Release();
-			pcrInner = pcrsUsed;
-		}
-		else
-		{
-			pcrsUsed->Release();
-		}
-	}
-
-	CDXLNode *inner_dxlnode = PdxlnRestrictResult(pdxlnInnerChild, pcrInner);
-	pcrInner->Release();
-
-	// Params for the test expression are the output columns from the
-	// projection of the inner expression. The order of the params must
-	// match the order of the columns from the projection of the inner
-	// expression. For this obtain the necessary columns directly from
-	// the projection of result node.
+	// Params for the Test Expression are the output columns from the
+	// projection of the inner Result node. The order of the params must
+	// match the order of the columns from the projection. Therefore, the
+	// params are extracted from the projection of the inner Result node after
+	// restriction.
+	// Test Expression can also contain columns that are not in the inner
+	// part - such columns are considered as Vars.
+	// Note that test_expr_params are not serialized (not displayed in the DXL file).
 	CDXLColRefArray *test_expr_params =
 		GetResultProjectedColRefArray(inner_dxlnode);
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3214,8 +3214,10 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	CDistributionSpecArray *pdrgpdsBaseTables, ULONG *pulNonGatherMotions,
 	BOOL *pfDML)
 {
+#ifdef GPOS_DEBUG
 	COperator *popCorrelatedJoin = pexprCorrelatedNLJoin->Pop();
 	COperator::EOperatorId op_id = popCorrelatedJoin->Eopid();
+#endif	// GPOS_DEBUG
 	GPOS_ASSERT(COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id ||
 				COperator::EopPhysicalCorrelatedNotInLeftAntiSemiNLJoin ==
 					op_id ||

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3089,12 +3089,14 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 //
 //	@doc:
 //		Helper to build a Result expression with project list
-//		restricted to required columns
+//		restricted to required columns. Additionally fills the
+//		resulting projected columns
 //
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
-										  const CColRefSet *colrefs)
+										  const CColRefSet *colrefs,
+										  CDXLColRefArray *projectedColumns)
 {
 	GPOS_ASSERT(NULL != dxlnode);
 	GPOS_ASSERT(NULL != colrefs);
@@ -3110,7 +3112,22 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 	}
 
 	CDXLNode *pdxlnResult = dxlnode;
-	if (1 < ulPrjElems)
+	if (1 == ulPrjElems)
+	{
+		// Fills the resulting projected column
+		CColRef *colref = colrefs->PcrFirst();
+		if (NULL != projectedColumns)
+		{
+			CMDName *mdname =
+				GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
+			IMDId *mdid = colref->RetrieveType()->MDId();
+			mdid->AddRef();
+			CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(
+				m_mp, mdname, colref->Id(), mdid, colref->TypeModifier());
+			projectedColumns->Append(dxl_colref);
+		}
+	}
+	else if (1 < ulPrjElems)
 	{
 		// restrict project list to required column
 		CDXLScalarProjList *pdxlopPrL = GPOS_NEW(m_mp) CDXLScalarProjList(m_mp);
@@ -3134,6 +3151,19 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 				CDXLNode *pdxlnPrEl = CTranslatorExprToDXLUtils::PdxlnProjElem(
 					m_mp, m_phmcrdxln, colref);
 				pdxlnProjListNew->AddChild(pdxlnPrEl);
+
+				// Fills the resulting projected columns
+				if (NULL != projectedColumns)
+				{
+					CMDName *mdname =
+						GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
+					IMDId *mdid = colref->RetrieveType()->MDId();
+					mdid->AddRef();
+					CDXLColRef *dxl_colref =
+						GPOS_NEW(m_mp) CDXLColRef(m_mp, mdname, colref->Id(),
+												  mdid, colref->TypeModifier());
+					projectedColumns->Append(dxl_colref);
+				}
 			}
 		}
 
@@ -3175,7 +3205,8 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	COperator *popCorrelatedJoin = pexprCorrelatedNLJoin->Pop();
 	COperator::EOperatorId op_id = popCorrelatedJoin->Eopid();
 	BOOL fCorrelatedLOJ =
-		(COperator::EopPhysicalCorrelatedLeftOuterNLJoin == op_id);
+		(COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id ||
+		 COperator::EopPhysicalCorrelatedLeftOuterNLJoin == op_id);
 	GPOS_ASSERT(COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id ||
 				COperator::EopPhysicalCorrelatedNotInLeftAntiSemiNLJoin ==
 					op_id ||
@@ -3197,7 +3228,6 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	CColRefSet *pcrInner = GPOS_NEW(m_mp) CColRefSet(m_mp);
 	pcrInner->Include((*pdrgpcrInner)[0]);
 
-	BOOL outerParam = false;
 	if (fCorrelatedLOJ)
 	{
 		// overwrite required inner column based on scalar expression
@@ -3208,12 +3238,12 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 		pcrsUsed->Intersection(pcrsInner);
 		if (0 < pcrsUsed->Size())
 		{
-			GPOS_ASSERT(1 == pcrsUsed->Size() || 2 == pcrsUsed->Size());
+			GPOS_ASSERT(1 == pcrsUsed->Size() || 2 == pcrsUsed->Size() ||
+						3 == pcrsUsed->Size());
 
 			// Both sides of the SubPlan test expression can come from the
 			// inner side. So we need to pass pcrsUsed instead of pcrInner into
 			// PdxlnRestrictResult()
-			outerParam = pcrsUsed->Size() > 1;
 
 			pcrInner->Release();
 			pcrInner = pcrsUsed;
@@ -3224,7 +3254,15 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 		}
 	}
 
-	CDXLNode *inner_dxlnode = PdxlnRestrictResult(pdxlnInnerChild, pcrInner);
+	// The params for the test expression are the output columns
+	// from the projection of the inner expression. The order of the
+	// params must match the order of the columns from the projection
+	// of the inner expression. For this obtain the necessary columns
+	// directly from the projection of result node.
+	CDXLColRefArray *test_expr_params = GPOS_NEW(m_mp) CDXLColRefArray(m_mp);
+
+	CDXLNode *inner_dxlnode =
+		PdxlnRestrictResult(pdxlnInnerChild, pcrInner, test_expr_params);
 	pcrInner->Release();
 	if (NULL == inner_dxlnode)
 	{
@@ -3245,7 +3283,7 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 	CDXLNode *pdxlnSubPlan = GPOS_NEW(m_mp)
 		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLScalarSubPlan(
 						   m_mp, mdid, dxl_colref_array, dxl_subplan_type,
-						   dxlnode_test_expr, outerParam));
+						   dxlnode_test_expr, test_expr_params));
 	pdxlnSubPlan->AddChild(inner_dxlnode);
 
 	// add to hashmap

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3089,14 +3089,12 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 //
 //	@doc:
 //		Helper to build a Result expression with project list
-//		restricted to required columns. Additionally fills the
-//		resulting projected columns
+//		restricted to required columns.
 //
 //---------------------------------------------------------------------------
 CDXLNode *
 CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
-										  const CColRefSet *colrefs,
-										  CDXLColRefArray *projectedColumns)
+										  const CColRefSet *colrefs)
 {
 	GPOS_ASSERT(NULL != dxlnode);
 	GPOS_ASSERT(NULL != colrefs);
@@ -3112,22 +3110,7 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 	}
 
 	CDXLNode *pdxlnResult = dxlnode;
-	if (1 == ulPrjElems)
-	{
-		// Fills the resulting projected column
-		CColRef *colref = colrefs->PcrFirst();
-		if (NULL != projectedColumns)
-		{
-			CMDName *mdname =
-				GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
-			IMDId *mdid = colref->RetrieveType()->MDId();
-			mdid->AddRef();
-			CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(
-				m_mp, mdname, colref->Id(), mdid, colref->TypeModifier());
-			projectedColumns->Append(dxl_colref);
-		}
-	}
-	else if (1 < ulPrjElems)
+	if (1 < ulPrjElems)
 	{
 		// restrict project list to required column
 		CDXLScalarProjList *pdxlopPrL = GPOS_NEW(m_mp) CDXLScalarProjList(m_mp);
@@ -3151,19 +3134,6 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 				CDXLNode *pdxlnPrEl = CTranslatorExprToDXLUtils::PdxlnProjElem(
 					m_mp, m_phmcrdxln, colref);
 				pdxlnProjListNew->AddChild(pdxlnPrEl);
-
-				// Fills the resulting projected columns
-				if (NULL != projectedColumns)
-				{
-					CMDName *mdname =
-						GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
-					IMDId *mdid = colref->RetrieveType()->MDId();
-					mdid->AddRef();
-					CDXLColRef *dxl_colref =
-						GPOS_NEW(m_mp) CDXLColRef(m_mp, mdname, colref->Id(),
-												  mdid, colref->TypeModifier());
-					projectedColumns->Append(dxl_colref);
-				}
 			}
 		}
 
@@ -3185,6 +3155,48 @@ CTranslatorExprToDXL::PdxlnRestrictResult(CDXLNode *dxlnode,
 	}
 
 	return pdxlnResult;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorExprToDXL::GetResultProjectedColRefArray
+//
+//	@doc:
+//		Helper to build an CDXLColRefArray of projected columns of Result node
+//
+//---------------------------------------------------------------------------
+CDXLColRefArray *
+CTranslatorExprToDXL::GetResultProjectedColRefArray(CDXLNode *dxlProjectNode)
+{
+	if (NULL == dxlProjectNode)
+	{
+		return NULL;
+	}
+
+	CDXLNode *pdxlnProjList = (*dxlProjectNode)[0];
+	const ULONG ulPrjElems = pdxlnProjList->Arity();
+
+	if (0 == ulPrjElems)
+	{
+		return NULL;
+	}
+
+	CDXLColRefArray *dxlColRefArray = GPOS_NEW(m_mp) CDXLColRefArray(m_mp);
+	for (ULONG ul = 0; ul < ulPrjElems; ul++)
+	{
+		CDXLNode *child_dxlnode = (*pdxlnProjList)[ul];
+		CDXLScalarProjElem *pdxlPrjElem =
+			CDXLScalarProjElem::Cast(child_dxlnode->GetOperator());
+		CColRef *colref = m_pcf->LookupColRef(pdxlPrjElem->Id());
+
+		CMDName *mdname = GPOS_NEW(m_mp) CMDName(m_mp, colref->Name().Pstr());
+		IMDId *mdid = colref->RetrieveType()->MDId();
+		mdid->AddRef();
+		CDXLColRef *dxl_colref = GPOS_NEW(m_mp) CDXLColRef(
+			m_mp, mdname, colref->Id(), mdid, colref->TypeModifier());
+		dxlColRefArray->Append(dxl_colref);
+	}
+	return dxlColRefArray;
 }
 
 //---------------------------------------------------------------------------
@@ -3230,7 +3242,11 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 
 	if (fCorrelatedLOJ)
 	{
-		// overwrite required inner column based on scalar expression
+		// Overwrite required inner column based on scalar expression.
+		// The columns contained in the scalar and the inner
+		// (intersection) are params of TestExpr if Correlated. The
+		// remaining columns of scalar are treated as vars. The vars
+		// refer to the node external to subplan.
 
 		CColRefSet *pcrsInner = pexprInner->DeriveOutputColumns();
 		CColRefSet *pcrsUsed =
@@ -3238,9 +3254,6 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 		pcrsUsed->Intersection(pcrsInner);
 		if (0 < pcrsUsed->Size())
 		{
-			GPOS_ASSERT(1 == pcrsUsed->Size() || 2 == pcrsUsed->Size() ||
-						3 == pcrsUsed->Size());
-
 			// Both sides of the SubPlan test expression can come from the
 			// inner side. So we need to pass pcrsUsed instead of pcrInner into
 			// PdxlnRestrictResult()
@@ -3254,16 +3267,17 @@ CTranslatorExprToDXL::PdxlnQuantifiedSubplan(
 		}
 	}
 
-	// The params for the test expression are the output columns
-	// from the projection of the inner expression. The order of the
-	// params must match the order of the columns from the projection
-	// of the inner expression. For this obtain the necessary columns
-	// directly from the projection of result node.
-	CDXLColRefArray *test_expr_params = GPOS_NEW(m_mp) CDXLColRefArray(m_mp);
-
-	CDXLNode *inner_dxlnode =
-		PdxlnRestrictResult(pdxlnInnerChild, pcrInner, test_expr_params);
+	CDXLNode *inner_dxlnode = PdxlnRestrictResult(pdxlnInnerChild, pcrInner);
 	pcrInner->Release();
+
+	// Params for the test expression are the output columns from the
+	// projection of the inner expression. The order of the params must
+	// match the order of the columns from the projection of the inner
+	// expression. For this obtain the necessary columns directly from
+	// the projection of result node.
+	CDXLColRefArray *test_expr_params =
+		GetResultProjectedColRefArray(inner_dxlnode);
+
 	if (NULL == inner_dxlnode)
 	{
 		GPOS_RAISE(

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
@@ -75,7 +75,6 @@ private:
 
 public:
 	// ctor/dtor
-
 	CDXLScalarSubPlan(CMemoryPool *mp, IMDId *first_col_type_mdid,
 					  CDXLColRefArray *dxl_colref_array,
 					  EdxlSubPlanType dxl_subplan_type,

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
@@ -62,7 +62,6 @@ private:
 	EdxlSubPlanType m_dxl_subplan_type;
 
 	// test expression -- not null if quantified/existential subplan
-
 	CDXLNode *m_dxlnode_test_expr;
 
 	// Test expression params array - the columns refs of the inner

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarSubPlan.h
@@ -14,6 +14,7 @@
 
 #include "gpos/base.h"
 
+#include "gpopt/base/CColRefSetIter.h"
 #include "naucrates/dxl/operators/CDXLColRef.h"
 #include "naucrates/dxl/operators/CDXLScalar.h"
 
@@ -61,20 +62,25 @@ private:
 	EdxlSubPlanType m_dxl_subplan_type;
 
 	// test expression -- not null if quantified/existential subplan
+
 	CDXLNode *m_dxlnode_test_expr;
 
-	// does test expression contain outer param
-	BOOL m_outer_param;
+	// Test expression params array - the columns refs of the inner
+	// node of the subplan.
+	// Params are not serialized, so it is not visible in DXL minidump.
+	CDXLColRefArray *m_test_expr_params;
 
 	// private copy ctor
 	CDXLScalarSubPlan(CDXLScalarSubPlan &);
 
 public:
 	// ctor/dtor
+
 	CDXLScalarSubPlan(CMemoryPool *mp, IMDId *first_col_type_mdid,
 					  CDXLColRefArray *dxl_colref_array,
 					  EdxlSubPlanType dxl_subplan_type,
-					  CDXLNode *dxlnode_test_expr, BOOL outer_param = false);
+					  CDXLNode *dxlnode_test_expr,
+					  CDXLColRefArray *test_expr_params = NULL);
 
 	virtual ~CDXLScalarSubPlan();
 
@@ -112,10 +118,11 @@ public:
 		return m_dxlnode_test_expr;
 	}
 
-	BOOL
-	FOuterParam() const
+	// return test expression params
+	CDXLColRefArray *
+	GetTestExprParams() const
 	{
-		return m_outer_param;
+		return m_test_expr_params;
 	}
 
 	// serialize operator in DXL format

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarSubPlan.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarSubPlan.cpp
@@ -34,13 +34,13 @@ CDXLScalarSubPlan::CDXLScalarSubPlan(CMemoryPool *mp,
 									 CDXLColRefArray *dxl_colref_array,
 									 EdxlSubPlanType dxl_subplan_type,
 									 CDXLNode *dxlnode_test_expr,
-									 BOOL outer_param)
+									 CDXLColRefArray *test_expr_params)
 	: CDXLScalar(mp),
 	  m_first_col_type_mdid(first_col_type_mdid),
 	  m_dxl_colref_array(dxl_colref_array),
 	  m_dxl_subplan_type(dxl_subplan_type),
 	  m_dxlnode_test_expr(dxlnode_test_expr),
-	  m_outer_param(outer_param)
+	  m_test_expr_params(test_expr_params)
 {
 	GPOS_ASSERT(EdxlSubPlanTypeSentinel > dxl_subplan_type);
 	GPOS_ASSERT_IMP(EdxlSubPlanTypeAny == dxl_subplan_type ||
@@ -60,6 +60,7 @@ CDXLScalarSubPlan::~CDXLScalarSubPlan()
 {
 	m_first_col_type_mdid->Release();
 	m_dxl_colref_array->Release();
+	CRefCount::SafeRelease(m_test_expr_params);
 	CRefCount::SafeRelease(m_dxlnode_test_expr);
 }
 

--- a/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
+++ b/src/include/gpopt/translate/CMappingColIdVarPlStmt.h
@@ -73,6 +73,12 @@ public:
 	// get the output translator context
 	CDXLTranslateContext *GetOutputContext();
 
+	// get the array of child translator contexts
+	CDXLTranslationContextArray *GetChildContexts();
+
+	// get the base table context
+	const CDXLTranslateContextBaseTable *GetBaseTableContext();
+
 	// return the context of the DXL->PlStmt translation
 	CContextDXLToPlStmt *GetDXLToPlStmtContext();
 };

--- a/src/include/gpopt/translate/CTranslatorDXLToScalar.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToScalar.h
@@ -172,21 +172,13 @@ private:
 	// translate subplan test expression
 	Expr *TranslateDXLSubplanTestExprToScalar(CDXLNode *test_expr_node,
 											  SubLinkType slink,
-											  CMappingColIdVar *colid_var,
-											  BOOL has_outer_refs,
-											  List **param_ids_list);
+											  CMappingColIdVar *colid_var);
 
 	// translate subplan parameters
 	void TranslateSubplanParams(SubPlan *sub_plan,
 								CDXLTranslateContext *dxl_translator_ctxt,
 								const CDXLColRefArray *outer_refs,
 								CMappingColIdVar *colid_var);
-
-	// translate subplan test expression parameters
-	void TranslateDXLTestExprScalarIdentToExpr(CDXLNode *child_node,
-											   Param *param,
-											   CDXLScalarIdent **ident,
-											   Expr **expr);
 
 	CHAR *GetSubplanAlias(ULONG plan_id);
 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1160,8 +1160,6 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
--- start_ignore
--- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1178,7 +1176,8 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 -- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 set optimizer_trace_fallback=on;
 set optimizer_minidump=always;
@@ -1192,8 +1191,6 @@ select * from t1 where
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
 -- Output DXL plan without unimportant properties.
--- start_ignore
--- end_ignore
 select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
 insert into t1 values (1);
@@ -1218,8 +1215,6 @@ select * from t1 where
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
--- start_ignore
--- end_ignore
 select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1159,3 +1159,57 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
+-- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
+INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
+INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
+INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Merge Key: test_tbl_t.int_t
+   ->  Sort
+         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Sort Key: test_tbl_t.int_t
+         ->  Hash Semi Join
+               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: test_tbl_t.text_t, test_tbl_t.int_t, ((hashed SubPlan 1))
+                     Hash Key: ((hashed SubPlan 1))
+                     ->  Seq Scan on public.test_tbl_t
+                           Output: test_tbl_t.text_t, test_tbl_t.int_t, (hashed SubPlan 1)
+                           SubPlan 1  (slice2; segments: 3)
+                             ->  Materialize
+                                   Output: test_tbl_d.int_d
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: test_tbl_d.int_d
+                                         ->  Seq Scan on public.test_tbl_d
+                                               Output: test_tbl_d.int_d
+               ->  Hash
+                     Output: test_tbl_p.int_p
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: test_tbl_p.int_p
+                           Hash Key: (test_tbl_p.int_p = 1)
+                           ->  Seq Scan on public.test_tbl_p
+                                 Output: test_tbl_p.int_p
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(30 rows)
+
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+ text_t | int_t 
+--------+-------
+ 0      |     0
+ 0      |     1
+(2 rows)
+
+DROP TABLE test_tbl_t;
+DROP TABLE test_tbl_d;
+DROP TABLE test_tbl_p;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1160,10 +1160,8 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-drop table if exists t1;
-drop table if exists t2;
+drop table if exists t1, t2, t3;
 NOTICE:  table "t2" does not exist, skipping
-drop table if exists t3;
 NOTICE:  table "t3" does not exist, skipping
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1' as the Greenplum Database data distribution key for this table.
@@ -1174,8 +1172,6 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 create table t3 as select i3 from (values (0), (1)) as s(i3);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i3' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set optimizer_trace_fallback=on;
-set client_min_messages='log';
 -- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
 -- of which contains a deep tree and only params (see DXL in output).
 -- The simplified  DXL is printed here because the Explain command does not display TestExpr,
@@ -1184,28 +1180,25 @@ set client_min_messages='log';
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
 -- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
--- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
--- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
 select * from t1 where
-  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
-LOG:  statement: select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
  i1 
 ----
   0
 (1 row)
 
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+-- Output DXL plan without unimportant properties.
 -- start_ignore
 -- end_ignore
-\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
-cut: '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/minidumps/*': No such file or directory
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+ERROR:  could not stat file "minidumps/dump.xml": No such file or directory
 insert into t1 values (1);
-LOG:  statement: insert into t1 values (1);
 analyze t1;
-LOG:  statement: analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1213,14 +1206,10 @@ LOG:  statement: analyze t1;
 -- The previous case contained only params (attributes contained in the
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
--- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
--- nested subplan; scan table t from outer <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
 select * from t1 where
-  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
-LOG:  statement: select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
  i1 
 ----
@@ -1228,14 +1217,12 @@ LOG:  statement: select * from t1 where
   1
 (2 rows)
 
--- start_ignore
--- end_ignore
-\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
-cut: '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/minidumps/*': No such file or directory
-\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+reset optimizer_minidump;
 reset optimizer_trace_fallback;
-drop table t1;
-drop table t2;
-drop table t3;
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+-- end_ignore
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+ERROR:  could not stat file "minidumps/dump.xml": No such file or directory
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+drop table t1,t2,t3;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1160,9 +1160,9 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+-- start_ignore
 drop table if exists t1, t2, t3;
-NOTICE:  table "t2" does not exist, skipping
-NOTICE:  table "t3" does not exist, skipping
+-- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1195,10 +1195,10 @@ reset optimizer_trace_fallback;
 -- Output DXL plan without unimportant properties.
 -- start_ignore
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
-ERROR:  could not stat file "minidumps/dump.xml": No such file or directory
-insert into t1 values (1);
-analyze t1;
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
+--insert into t1 values (1);
+--analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1214,15 +1214,13 @@ select * from t1 where
  i1 
 ----
   0
-  1
-(2 rows)
+(1 row)
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
--- Output DXL plan without unimportant properties.
 -- start_ignore
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
-ERROR:  could not stat file "minidumps/dump.xml": No such file or directory
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1159,42 +1159,45 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
--- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-SET client_min_messages='log';
-SET optimizer_trace_fallback=on;
-LOG:  statement: SET optimizer_trace_fallback=on;
-CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-LOG:  statement: CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 0);
-CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-LOG:  statement: CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 0);
-CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
-LOG:  statement: CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
-INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create table test_tbl_t as select 0 as int_t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_t' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table test_tbl_d as select 0 as int_d;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_d' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_p' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set client_min_messages='log';
+set optimizer_trace_fallback=on;
+LOG:  statement: set optimizer_trace_fallback=on;
+-- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
+-- a deep tree and only params (see minidump).
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- TestExpr and its params are not displayed in Explain output. However, the output is
+-- needed to make sure that the DXL we need is generated.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
-   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Output: test_tbl_t.int_t
    Merge Key: test_tbl_t.int_t
    ->  Sort
-         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Output: test_tbl_t.int_t
          Sort Key: test_tbl_t.int_t
          ->  Hash Semi Join
-               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Output: test_tbl_t.int_t
                Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: test_tbl_t.text_t, test_tbl_t.int_t, ((hashed SubPlan 1))
+                     Output: test_tbl_t.int_t, ((hashed SubPlan 1))
                      Hash Key: ((hashed SubPlan 1))
                      ->  Seq Scan on public.test_tbl_t
-                           Output: test_tbl_t.text_t, test_tbl_t.int_t, (hashed SubPlan 1)
+                           Output: test_tbl_t.int_t, (hashed SubPlan 1)
                            SubPlan 1  (slice2; segments: 3)
                              ->  Materialize
                                    Output: test_tbl_d.int_d
@@ -1213,44 +1216,50 @@ LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
  Settings: optimizer=off
 (30 rows)
 
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
- text_t | int_t 
---------+-------
- 0      |     0
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+ int_t 
+-------
+     0
 (1 row)
 
-INSERT INTO test_tbl_t VALUES ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 1);
-INSERT INTO test_tbl_d VALUES ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 1);
-INSERT INTO test_tbl_p VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0);
-ANALYZE test_tbl_t;
-LOG:  statement: ANALYZE test_tbl_t;
--- After adding data, the ORCA physical plan changes.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+insert into test_tbl_t values (1);
+LOG:  statement: insert into test_tbl_t values (1);
+insert into test_tbl_d values (1);
+LOG:  statement: insert into test_tbl_d values (1);
+insert into test_tbl_p values (0);
+LOG:  statement: insert into test_tbl_p values (0);
+analyze test_tbl_t;
+LOG:  statement: analyze test_tbl_t;
+-- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
+-- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
+-- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
+-- are treated as Vars. The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+-- We also need the Explain output to determine DXL.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
-   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Output: test_tbl_t.int_t
    Merge Key: test_tbl_t.int_t
    ->  Sort
-         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Output: test_tbl_t.int_t
          Sort Key: test_tbl_t.int_t
          ->  Hash Semi Join
-               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Output: test_tbl_t.int_t
                Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: test_tbl_t.text_t, test_tbl_t.int_t, ((hashed SubPlan 1))
+                     Output: test_tbl_t.int_t, ((hashed SubPlan 1))
                      Hash Key: ((hashed SubPlan 1))
                      ->  Seq Scan on public.test_tbl_t
-                           Output: test_tbl_t.text_t, test_tbl_t.int_t, (hashed SubPlan 1)
+                           Output: test_tbl_t.int_t, (hashed SubPlan 1)
                            SubPlan 1  (slice2; segments: 3)
                              ->  Materialize
                                    Output: test_tbl_d.int_d
@@ -1269,19 +1278,19 @@ LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
  Settings: optimizer=off
 (30 rows)
 
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
- text_t | int_t 
---------+-------
- 0      |     0
- 0      |     1
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+ int_t 
+-------
+     0
+     1
 (2 rows)
 
-RESET client_min_messages;
-LOG:  statement: RESET client_min_messages;
-RESET optimizer_trace_fallback;
-DROP TABLE test_tbl_t;
-DROP TABLE test_tbl_d;
-DROP TABLE test_tbl_p;
+reset client_min_messages;
+LOG:  statement: reset client_min_messages;
+reset optimizer_trace_fallback;
+drop table test_tbl_t;
+drop table test_tbl_d;
+drop table test_tbl_p;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1159,15 +1159,26 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
--- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+-- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+SET client_min_messages='log';
+SET optimizer_trace_fallback=on;
+LOG:  statement: SET optimizer_trace_fallback=on;
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
+LOG:  statement: CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
 INSERT INTO test_tbl_t VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 0);
 CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
+LOG:  statement: CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
 INSERT INTO test_tbl_d VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 0);
 CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
+LOG:  statement: CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
@@ -1203,18 +1214,27 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
 (30 rows)
 
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
  text_t | int_t 
 --------+-------
  0      |     0
 (1 row)
 
 INSERT INTO test_tbl_t VALUES ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 1);
 INSERT INTO test_tbl_d VALUES ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 1);
 INSERT INTO test_tbl_p VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0);
 ANALYZE test_tbl_t;
+LOG:  statement: ANALYZE test_tbl_t;
+-- After adding data, the ORCA physical plan changes.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
@@ -1250,13 +1270,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
 (30 rows)
 
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
  text_t | int_t 
 --------+-------
  0      |     0
  0      |     1
 (2 rows)
 
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+RESET optimizer_trace_fallback;
 DROP TABLE test_tbl_t;
 DROP TABLE test_tbl_d;
 DROP TABLE test_tbl_p;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1161,11 +1161,58 @@ drop table tl3;
 drop table tl4;
 -- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_t VALUES ('0', 0);
 CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 0);
 CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Merge Key: test_tbl_t.int_t
+   ->  Sort
+         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Sort Key: test_tbl_t.int_t
+         ->  Hash Semi Join
+               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: test_tbl_t.text_t, test_tbl_t.int_t, ((hashed SubPlan 1))
+                     Hash Key: ((hashed SubPlan 1))
+                     ->  Seq Scan on public.test_tbl_t
+                           Output: test_tbl_t.text_t, test_tbl_t.int_t, (hashed SubPlan 1)
+                           SubPlan 1  (slice2; segments: 3)
+                             ->  Materialize
+                                   Output: test_tbl_d.int_d
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                         Output: test_tbl_d.int_d
+                                         ->  Seq Scan on public.test_tbl_d
+                                               Output: test_tbl_d.int_d
+               ->  Hash
+                     Output: test_tbl_p.int_p
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: test_tbl_p.int_p
+                           Hash Key: (test_tbl_p.int_p = 1)
+                           ->  Seq Scan on public.test_tbl_p
+                                 Output: test_tbl_p.int_p
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(30 rows)
+
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+ text_t | int_t 
+--------+-------
+ 0      |     0
+(1 row)
+
+INSERT INTO test_tbl_t VALUES ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 1);
+INSERT INTO test_tbl_p VALUES ('0', 0);
+ANALYZE test_tbl_t;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
   (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
                                         QUERY PLAN                                         

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1161,7 +1161,6 @@ drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
 -- start_ignore
-drop table if exists t1, t2, t3;
 -- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1' as the Greenplum Database data distribution key for this table.
@@ -1195,10 +1194,10 @@ reset optimizer_trace_fallback;
 -- Output DXL plan without unimportant properties.
 -- start_ignore
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
---insert into t1 values (1);
---analyze t1;
+insert into t1 values (1);
+analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1214,13 +1213,14 @@ select * from t1 where
  i1 
 ----
   0
-(1 row)
+  1
+(2 rows)
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
 -- start_ignore
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1160,137 +1160,82 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-create table test_tbl_t as select 0 as int_t;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_t' as the Greenplum Database data distribution key for this table.
+drop table if exists t1;
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+drop table if exists t3;
+NOTICE:  table "t3" does not exist, skipping
+create table t1 as select 0 as i1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table test_tbl_d as select 0 as int_d;
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_d' as the Greenplum Database data distribution key for this table.
+create table t2 as select 0 as i2;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i2' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'int_p' as the Greenplum Database data distribution key for this table.
+create table t3 as select i3 from (values (0), (1)) as s(i3);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'i3' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-set client_min_messages='log';
 set optimizer_trace_fallback=on;
-LOG:  statement: set optimizer_trace_fallback=on;
--- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
--- a deep tree and only params (see minidump).
+set client_min_messages='log';
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- TestExpr and its params are not displayed in Explain output. However, the output is
--- needed to make sure that the DXL we need is generated.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)
-   Output: test_tbl_t.int_t
-   Merge Key: test_tbl_t.int_t
-   ->  Sort
-         Output: test_tbl_t.int_t
-         Sort Key: test_tbl_t.int_t
-         ->  Hash Semi Join
-               Output: test_tbl_t.int_t
-               Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: test_tbl_t.int_t, ((hashed SubPlan 1))
-                     Hash Key: ((hashed SubPlan 1))
-                     ->  Seq Scan on public.test_tbl_t
-                           Output: test_tbl_t.int_t, (hashed SubPlan 1)
-                           SubPlan 1  (slice2; segments: 3)
-                             ->  Materialize
-                                   Output: test_tbl_d.int_d
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                         Output: test_tbl_d.int_d
-                                         ->  Seq Scan on public.test_tbl_d
-                                               Output: test_tbl_d.int_d
-               ->  Hash
-                     Output: test_tbl_p.int_p
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Output: test_tbl_p.int_p
-                           Hash Key: (test_tbl_p.int_p = 1)
-                           ->  Seq Scan on public.test_tbl_p
-                                 Output: test_tbl_p.int_p
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(30 rows)
-
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
- int_t 
--------
-     0
+-- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
+-- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
+-- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+LOG:  statement: select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+ i1 
+----
+  0
 (1 row)
 
-insert into test_tbl_t values (1);
-LOG:  statement: insert into test_tbl_t values (1);
-insert into test_tbl_d values (1);
-LOG:  statement: insert into test_tbl_d values (1);
-insert into test_tbl_p values (0);
-LOG:  statement: insert into test_tbl_p values (0);
-analyze test_tbl_t;
-LOG:  statement: analyze test_tbl_t;
--- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
--- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
--- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
--- are treated as Vars. The previous case contained only params (attributes contained in the
+-- start_ignore
+-- end_ignore
+\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
+cut: '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/minidumps/*': No such file or directory
+insert into t1 values (1);
+LOG:  statement: insert into t1 values (1);
+analyze t1;
+LOG:  statement: analyze t1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
--- We also need the Explain output to determine DXL.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice4; segments: 3)
-   Output: test_tbl_t.int_t
-   Merge Key: test_tbl_t.int_t
-   ->  Sort
-         Output: test_tbl_t.int_t
-         Sort Key: test_tbl_t.int_t
-         ->  Hash Semi Join
-               Output: test_tbl_t.int_t
-               Hash Cond: (((hashed SubPlan 1)) = (test_tbl_p.int_p = 1))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: test_tbl_t.int_t, ((hashed SubPlan 1))
-                     Hash Key: ((hashed SubPlan 1))
-                     ->  Seq Scan on public.test_tbl_t
-                           Output: test_tbl_t.int_t, (hashed SubPlan 1)
-                           SubPlan 1  (slice2; segments: 3)
-                             ->  Materialize
-                                   Output: test_tbl_d.int_d
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                         Output: test_tbl_d.int_d
-                                         ->  Seq Scan on public.test_tbl_d
-                                               Output: test_tbl_d.int_d
-               ->  Hash
-                     Output: test_tbl_p.int_p
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Output: test_tbl_p.int_p
-                           Hash Key: (test_tbl_p.int_p = 1)
-                           ->  Seq Scan on public.test_tbl_p
-                                 Output: test_tbl_p.int_p
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(30 rows)
-
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
- int_t 
--------
-     0
-     1
+-- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
+-- nested subplan; scan table t from outer <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+LOG:  statement: select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+ i1 
+----
+  0
+  1
 (2 rows)
 
-reset client_min_messages;
-LOG:  statement: reset client_min_messages;
+-- start_ignore
+-- end_ignore
+\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
+cut: '/home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/minidumps/*': No such file or directory
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
 reset optimizer_trace_fallback;
-drop table test_tbl_t;
-drop table test_tbl_d;
-drop table test_tbl_p;
+drop table t1;
+drop table t2;
+drop table t3;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1235,52 +1235,52 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
--- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-SET client_min_messages='log';
-SET optimizer_trace_fallback=on;
-LOG:  statement: SET optimizer_trace_fallback=on;
-LOG:  statement: SET optimizer_trace_fallback TO 'on'  (entry db 172.17.0.2:6000 pid=16675)
-CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-LOG:  statement: CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 0);
-CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-LOG:  statement: CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 0);
-CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
-LOG:  statement: CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
-INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create table test_tbl_t as select 0 as int_t;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create table test_tbl_d as select 0 as int_d;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+set client_min_messages='log';
+set optimizer_trace_fallback=on;
+LOG:  statement: set optimizer_trace_fallback=on;
+LOG:  statement: SET optimizer_trace_fallback TO 'on'  (entry db 172.17.0.2:6000 pid=16711)
+-- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
+-- a deep tree and only params (see minidump).
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- TestExpr and its params are not displayed in Explain output. However, the output is
+-- needed to make sure that the DXL we need is generated.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
                                                                                                           QUERY PLAN                                                                                                           
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result
-   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Output: test_tbl_t.int_t
    Filter: (SubPlan 1)
    ->  Sort
-         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Output: test_tbl_t.int_t
          Sort Key: test_tbl_t.int_t
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Output: test_tbl_t.int_t
                ->  Seq Scan on public.test_tbl_t
-                     Output: test_tbl_t.text_t, test_tbl_t.int_t
+                     Output: test_tbl_t.int_t
    SubPlan 1  (slice0)
      ->  Result
-           Output: (count("outer".ColRef_0028)), (sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END))), ((test_tbl_p.int_p = 1))
+           Output: (count("outer".ColRef_0025)), (sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END))), ((test_tbl_p.int_p = 1))
            ->  GroupAggregate
-                 Output: count("outer".ColRef_0028), sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END)), ((test_tbl_p.int_p = 1)), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
+                 Output: count("outer".ColRef_0025), sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END)), ((test_tbl_p.int_p = 1)), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
                  Group Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
                  ->  Sort
-                       Output: ((test_tbl_p.int_p = 1)), (CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0028
+                       Output: ((test_tbl_p.int_p = 1)), (CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0025
                        Sort Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
                        ->  Result
-                             Output: (test_tbl_p.int_p = 1), CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END, test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0028
+                             Output: (test_tbl_p.int_p = 1), CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END, test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0025
                              ->  Nested Loop Left Join
-                                   Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, test_tbl_d.int_d, "outer".ColRef_0028
+                                   Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, test_tbl_d.int_d, "outer".ColRef_0025
                                    Join Filter: true
                                    ->  Materialize
                                          Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
@@ -1289,7 +1289,7 @@ LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
                                                ->  Seq Scan on public.test_tbl_p
                                                      Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
                                    ->  Materialize
-                                         Output: "outer".ColRef_0028, test_tbl_d.int_d
+                                         Output: "outer".ColRef_0025, test_tbl_d.int_d
                                          ->  Result
                                                Output: true, test_tbl_d.int_d
                                                ->  Result
@@ -1305,41 +1305,47 @@ LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
  Settings: optimizer=on
 (45 rows)
 
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
- text_t | int_t 
---------+-------
- 0      |     0
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+ int_t 
+-------
+     0
 (1 row)
 
-INSERT INTO test_tbl_t VALUES ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 1);
-INSERT INTO test_tbl_d VALUES ('0', 1);
-LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 1);
-INSERT INTO test_tbl_p VALUES ('0', 0);
-LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0);
-ANALYZE test_tbl_t;
-LOG:  statement: ANALYZE test_tbl_t;
--- After adding data, the ORCA physical plan changes.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+insert into test_tbl_t values (1);
+LOG:  statement: insert into test_tbl_t values (1);
+insert into test_tbl_d values (1);
+LOG:  statement: insert into test_tbl_d values (1);
+insert into test_tbl_p values (0);
+LOG:  statement: insert into test_tbl_p values (0);
+analyze test_tbl_t;
+LOG:  statement: analyze test_tbl_t;
+-- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
+-- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
+-- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
+-- are treated as Vars. The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+-- We also need the Explain output to determine DXL.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Result
-   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Output: test_tbl_t.int_t
    Filter: (SubPlan 2)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Output: test_tbl_t.int_t
          Merge Key: test_tbl_t.int_t
          ->  Sort
-               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Output: test_tbl_t.int_t
                Sort Key: test_tbl_t.int_t
                ->  Seq Scan on public.test_tbl_t
-                     Output: test_tbl_t.text_t, test_tbl_t.int_t
+                     Output: test_tbl_t.int_t
    SubPlan 2  (slice0)
      ->  Result
            Output: true
@@ -1369,20 +1375,20 @@ LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
  Settings: optimizer=on
 (38 rows)
 
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-LOG:  statement: SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
- text_t | int_t 
---------+-------
- 0      |     0
- 0      |     1
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+LOG:  statement: select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+ int_t 
+-------
+     0
+     1
 (2 rows)
 
-RESET client_min_messages;
-LOG:  statement: RESET client_min_messages;
-LOG:  statement: RESET client_min_messages  (entry db 172.17.0.2:6000 pid=16675)
-RESET optimizer_trace_fallback;
-DROP TABLE test_tbl_t;
-DROP TABLE test_tbl_d;
-DROP TABLE test_tbl_p;
+reset client_min_messages;
+LOG:  statement: reset client_min_messages;
+LOG:  statement: RESET client_min_messages  (entry db 172.17.0.2:6000 pid=16711)
+reset optimizer_trace_fallback;
+drop table test_tbl_t;
+drop table test_tbl_d;
+drop table test_tbl_p;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1236,10 +1236,8 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-drop table if exists t1;
-drop table if exists t2;
+drop table if exists t1, t2, t3;
 NOTICE:  table "t2" does not exist, skipping
-drop table if exists t3;
 NOTICE:  table "t3" does not exist, skipping
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -1247,8 +1245,6 @@ create table t2 as select 0 as i2;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table t3 as select i3 from (values (0), (1)) as s(i3);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-set optimizer_trace_fallback=on;
-set client_min_messages='log';
 -- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
 -- of which contains a deep tree and only params (see DXL in output).
 -- The simplified  DXL is printed here because the Explain command does not display TestExpr,
@@ -1257,117 +1253,384 @@ set client_min_messages='log';
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
 -- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
--- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
--- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
 select * from t1 where
-  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
-LOG:  statement: select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
  i1 
 ----
   0
 (1 row)
 
+reset optimizer_minidump;
+reset optimizer_trace_fallback;
+-- Output DXL plan without unimportant properties.
 -- start_ignore
+\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
 -- end_ignore
-\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
-<dxl:Plan Id="0" SpaceSize="0">
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="0" Alias="i1">
-<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter>
-<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-<dxl:TestExpr>
-<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-<dxl:If TypeMdid="0.16.1.0">
-<dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
-<dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-</dxl:Comparison>
-<dxl:If TypeMdid="0.16.1.0">
-<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-<dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
-</dxl:Comparison>
-<dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-</dxl:If>
-<dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-</dxl:If>
-<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
-</dxl:Comparison>
-</dxl:TestExpr>
-<dxl:ParamList>
-<dxl:Param ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ParamList>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="26" Alias="ColRef_0026">
-<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="28" Alias="ColRef_0028">
-<dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="16" Alias="?column?">
-<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:OneTimeFilter/>
-<dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-<dxl:ProjList>
-<dxl:ProjElem ColId="26" Alias="ColRef_0026">
-<dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-<dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.16.1.0"/>
-</dxl:AggFunc>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="28" Alias="ColRef_0028">
-<dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
-<dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
-</dxl:AggFunc>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="16" Alias="?column?">
-<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-</dxl:Aggregate>
-</dxl:Result>
-</dxl:SubPlan>
-</dxl:Filter>
-<dxl:OneTimeFilter/>
-<dxl:Sort SortDiscardDuplicates="false">
-<dxl:ProjList>
-<dxl:ProjElem ColId="0" Alias="i1">
-<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:SortingColumnList>
-<dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-</dxl:SortingColumnList>
-<dxl:LimitCount/>
-<dxl:LimitOffset/>
-<dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-<dxl:ProjList>
-<dxl:ProjElem ColId="0" Alias="i1">
-<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-</dxl:GatherMotion>
-</dxl:Sort>
-</dxl:Result>
-</dxl:Plan>
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+                                           xpath                                            
+--------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                         +
+ <Result>                                                                                  +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter>                                                                                  +
+ <SubPlan>                                                                                 +
+ <TestExpr>                                                                                +
+ <Comparison ComparisonOperator=\"=\">                                                     +
+ <If>                                                                                      +
+ <Comparison ComparisonOperator=\"&gt;\">                                                  +
+ <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
+ <ConstValue/>                                                                             +
+ </Comparison>                                                                             +
+ <If>                                                                                      +
+ <Comparison ComparisonOperator=\"=\">                                                     +
+ <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                             +
+ <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
+ </Comparison>                                                                             +
+ <ConstValue/>                                                                             +
+ <ConstValue/>                                                                             +
+ </If>                                                                                     +
+ <ConstValue/>                                                                             +
+ </If>                                                                                     +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
+ </Comparison>                                                                             +
+ </TestExpr>                                                                               +
+ <ParamList>                                                                               +
+ <Param ColId=\"0\" ColName=\"i1\"/>                                                       +
+ </ParamList>                                                                              +
+ <Result>                                                                                  +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                             +
+ <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                             +
+ <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <OneTimeFilter/>                                                                          +
+ <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                           +
+ <GroupingColumns>                                                                         +
+ <GroupingColumn ColId=\"8\"/>                                                             +
+ <GroupingColumn ColId=\"9\"/>                                                             +
+ <GroupingColumn ColId=\"15\"/>                                                            +
+ <GroupingColumn ColId=\"16\"/>                                                            +
+ </GroupingColumns>                                                                        +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                             +
+ <AggFunc>                                                                                 +
+ <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
+ </AggFunc>                                                                                +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                             +
+ <AggFunc>                                                                                 +
+ <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                             +
+ </AggFunc>                                                                                +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <Sort SortDiscardDuplicates=\"false\">                                                    +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                             +
+ <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+ <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <SortingColumnList>                                                                       +
+ <SortingColumn ColId=\"8\"/>                                                              +
+ <SortingColumn ColId=\"9\"/>                                                              +
+ <SortingColumn ColId=\"15\"/>                                                             +
+ <SortingColumn ColId=\"16\"/>                                                             +
+ </SortingColumnList>                                                                      +
+ <LimitCount/>                                                                             +
+ <LimitOffset/>                                                                            +
+ <Result>                                                                                  +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
+ <Comparison ComparisonOperator=\"=\">                                                     +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ <ConstValue/>                                                                             +
+ </Comparison>                                                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                             +
+ <If>                                                                                      +
+ <IsNull>                                                                                  +
+ <Comparison ComparisonOperator=\"=\">                                                     +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </Comparison>                                                                             +
+ </IsNull>                                                                                 +
+ <ConstValue/>                                                                             +
+ <ConstValue/>                                                                             +
+ </If>                                                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+ <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <OneTimeFilter/>                                                                          +
+ <NestedLoopJoin JoinType=\"Left\" IndexNestedLoopJoin=\"false\" OuterRefAsParam=\"false\">+
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+ <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <JoinFilter>                                                                              +
+ <ConstValue/>                                                                             +
+ </JoinFilter>                                                                             +
+ <Materialize Eager=\"false\">                                                             +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <SortingColumnList/>                                                                      +
+ <TableScan>                                                                               +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
+ <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
+ <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <TableDescriptor>                                                                         +
+ <Columns>                                                                                 +
+ <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>                                          +
+ <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>                                       +
+ <Column ColId=\"10\" Attno=\"-3\" ColName=\"xmin\"/>                                      +
+ <Column ColId=\"11\" Attno=\"-4\" ColName=\"cmin\"/>                                      +
+ <Column ColId=\"12\" Attno=\"-5\" ColName=\"xmax\"/>                                      +
+ <Column ColId=\"13\" Attno=\"-6\" ColName=\"cmax\"/>                                      +
+ <Column ColId=\"14\" Attno=\"-7\" ColName=\"tableoid\"/>                                  +
+ <Column ColId=\"15\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                             +
+ </Columns>                                                                                +
+ </TableDescriptor>                                                                        +
+ </TableScan>                                                                              +
+ </GatherMotion>                                                                           +
+ </Materialize>                                                                            +
+ <Materialize Eager=\"true\">                                                              +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+ <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <Result>                                                                                  +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
+ <ConstValue/>                                                                             +
+ </ProjElem>                                                                               +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <OneTimeFilter/>                                                                          +
+ <Result>                                                                                  +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter>                                                                                  +
+ <IsNotFalse>                                                                              +
+ <Comparison ComparisonOperator=\"=\">                                                     +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </Comparison>                                                                             +
+ </IsNotFalse>                                                                             +
+ </Filter>                                                                                 +
+ <OneTimeFilter/>                                                                          +
+ <Materialize Eager=\"false\">                                                             +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <SortingColumnList/>                                                                      +
+ <TableScan>                                                                               +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <TableDescriptor>                                                                         +
+ <Columns>                                                                                 +
+ <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>                                         +
+ <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>                                      +
+ <Column ColId=\"19\" Attno=\"-3\" ColName=\"xmin\"/>                                      +
+ <Column ColId=\"20\" Attno=\"-4\" ColName=\"cmin\"/>                                      +
+ <Column ColId=\"21\" Attno=\"-5\" ColName=\"xmax\"/>                                      +
+ <Column ColId=\"22\" Attno=\"-6\" ColName=\"cmax\"/>                                      +
+ <Column ColId=\"23\" Attno=\"-7\" ColName=\"tableoid\"/>                                  +
+ <Column ColId=\"24\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                             +
+ </Columns>                                                                                +
+ </TableDescriptor>                                                                        +
+ </TableScan>                                                                              +
+ </GatherMotion>                                                                           +
+ </Materialize>                                                                            +
+ </Result>                                                                                 +
+ </Result>                                                                                 +
+ </Materialize>                                                                            +
+ </NestedLoopJoin>                                                                         +
+ </Result>                                                                                 +
+ </Sort>                                                                                   +
+ </Aggregate>                                                                              +
+ </Result>                                                                                 +
+ </SubPlan>                                                                                +
+ </Filter>                                                                                 +
+ <OneTimeFilter/>                                                                          +
+ <Sort SortDiscardDuplicates=\"false\">                                                    +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <SortingColumnList>                                                                       +
+ <SortingColumn ColId=\"0\"/>                                                              +
+ </SortingColumnList>                                                                      +
+ <LimitCount/>                                                                             +
+ <LimitOffset/>                                                                            +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <SortingColumnList/>                                                                      +
+ <TableScan>                                                                               +
+ <ProjList>                                                                                +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
+ </ProjElem>                                                                               +
+ </ProjList>                                                                               +
+ <Filter/>                                                                                 +
+ <TableDescriptor>                                                                         +
+ <Columns>                                                                                 +
+ <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>                                          +
+ <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>                                       +
+ <Column ColId=\"2\" Attno=\"-3\" ColName=\"xmin\"/>                                       +
+ <Column ColId=\"3\" Attno=\"-4\" ColName=\"cmin\"/>                                       +
+ <Column ColId=\"4\" Attno=\"-5\" ColName=\"xmax\"/>                                       +
+ <Column ColId=\"5\" Attno=\"-6\" ColName=\"cmax\"/>                                       +
+ <Column ColId=\"6\" Attno=\"-7\" ColName=\"tableoid\"/>                                   +
+ <Column ColId=\"7\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                              +
+ </Columns>                                                                                +
+ </TableDescriptor>                                                                        +
+ </TableScan>                                                                              +
+ </GatherMotion>                                                                           +
+ </Sort>                                                                                   +
+ </Result>                                                                                 +
+ </Plan>"}
+(1 row)
+
 insert into t1 values (1);
-LOG:  statement: insert into t1 values (1);
 analyze t1;
-LOG:  statement: analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1375,14 +1638,10 @@ LOG:  statement: analyze t1;
 -- The previous case contained only params (attributes contained in the
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
--- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
--- nested subplan; scan table t from outer <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+set optimizer_trace_fallback=on;
+set optimizer_minidump=always;
 select * from t1 where
-  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
-LOG:  statement: select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
  i1 
 ----
@@ -1390,103 +1649,226 @@ LOG:  statement: select * from t1 where
   1
 (2 rows)
 
--- start_ignore
--- end_ignore
-\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
-<dxl:Plan Id="0" SpaceSize="0">
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="0" Alias="i1">
-<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter>
-<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-<dxl:TestExpr/>
-<dxl:ParamList>
-<dxl:Param ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-</dxl:ParamList>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="38" Alias="ColRef_0038">
-<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:OneTimeFilter/>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="16" Alias="?column?">
-<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter>
-<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-<dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
-</dxl:Comparison>
-</dxl:Filter>
-<dxl:OneTimeFilter/>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="16" Alias="?column?">
-<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-<dxl:Ident ColId="8" ColName="i3" TypeMdid="0.23.1.0"/>
-<dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-</dxl:Comparison>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="29" Alias="ColRef_0029">
-<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
-<dxl:TestExpr>
-<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
-<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
-</dxl:Comparison>
-</dxl:TestExpr>
-<dxl:ParamList/>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="17" Alias="i2">
-<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:OneTimeFilter/>
-<dxl:Result>
-<dxl:ProjList>
-<dxl:ProjElem ColId="29" Alias="ColRef_0029">
-<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-</dxl:ProjElem>
-<dxl:ProjElem ColId="17" Alias="i2">
-<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:OneTimeFilter/>
-</dxl:Result>
-</dxl:Result>
-</dxl:SubPlan>
-</dxl:ProjElem>
-</dxl:ProjList>
-<dxl:Filter/>
-<dxl:OneTimeFilter/>
-<dxl:Materialize Eager="true">
-<dxl:ProjList>
-<dxl:ProjElem ColId="8" Alias="i3">
-<dxl:Ident ColId="8" ColName="i3" TypeMdid="0.23.1.0"/>
-</dxl:ProjElem>
-</dxl:ProjList>
-</dxl:Materialize>
-</dxl:Result>
-</dxl:Result>
-</dxl:Result>
-</dxl:SubPlan>
-</dxl:Result>
-</dxl:Plan>
-\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
--- end_ignore
+reset optimizer_minidump;
 reset optimizer_trace_fallback;
-drop table t1;
-drop table t2;
-drop table t3;
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+-- end_ignore
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+                             xpath                             
+---------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                            +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                          +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter>                                                     +
+ <SubPlan>                                                    +
+ <TestExpr/>                                                  +
+ <ParamList>                                                  +
+ <Param ColId=\"0\" ColName=\"i1\"/>                          +
+ </ParamList>                                                 +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"38\" Alias=\"ColRef_0038\">                +
+ <ConstValue/>                                                +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <OneTimeFilter/>                                             +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                   +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                   +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter>                                                     +
+ <Comparison ComparisonOperator=\"=\">                        +
+ <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                +
+ <Ident ColId=\"16\" ColName=\"?column?\"/>                   +
+ </Comparison>                                                +
+ </Filter>                                                    +
+ <OneTimeFilter/>                                             +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"16\" Alias=\"?column?\">                   +
+ <Comparison ComparisonOperator=\"=\">                        +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                          +
+ <ConstValue/>                                                +
+ </Comparison>                                                +
+ </ProjElem>                                                  +
+ <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                +
+ <SubPlan>                                                    +
+ <TestExpr>                                                   +
+ <Comparison ComparisonOperator=\"=\">                        +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                          +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </Comparison>                                                +
+ </TestExpr>                                                  +
+ <ParamList/>                                                 +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                         +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <OneTimeFilter/>                                             +
+ <Result>                                                     +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                +
+ <ConstValue/>                                                +
+ </ProjElem>                                                  +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                         +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <OneTimeFilter/>                                             +
+ <Materialize Eager=\"true\">                                 +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                         +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                         +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <SortingColumnList/>                                         +
+ <TableScan>                                                  +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"17\" Alias=\"i2\">                         +
+ <Ident ColId=\"17\" ColName=\"i2\"/>                         +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <TableDescriptor>                                            +
+ <Columns>                                                    +
+ <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>            +
+ <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>         +
+ <Column ColId=\"19\" Attno=\"-3\" ColName=\"xmin\"/>         +
+ <Column ColId=\"20\" Attno=\"-4\" ColName=\"cmin\"/>         +
+ <Column ColId=\"21\" Attno=\"-5\" ColName=\"xmax\"/>         +
+ <Column ColId=\"22\" Attno=\"-6\" ColName=\"cmax\"/>         +
+ <Column ColId=\"23\" Attno=\"-7\" ColName=\"tableoid\"/>     +
+ <Column ColId=\"24\" Attno=\"-8\" ColName=\"gp_segment_id\"/>+
+ </Columns>                                                   +
+ </TableDescriptor>                                           +
+ </TableScan>                                                 +
+ </GatherMotion>                                              +
+ </Materialize>                                               +
+ </Result>                                                    +
+ </Result>                                                    +
+ </SubPlan>                                                   +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <OneTimeFilter/>                                             +
+ <Materialize Eager=\"true\">                                 +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                          +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                          +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <SortingColumnList/>                                         +
+ <TableScan>                                                  +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"8\" Alias=\"i3\">                          +
+ <Ident ColId=\"8\" ColName=\"i3\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <TableDescriptor>                                            +
+ <Columns>                                                    +
+ <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>             +
+ <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>          +
+ <Column ColId=\"10\" Attno=\"-3\" ColName=\"xmin\"/>         +
+ <Column ColId=\"11\" Attno=\"-4\" ColName=\"cmin\"/>         +
+ <Column ColId=\"12\" Attno=\"-5\" ColName=\"xmax\"/>         +
+ <Column ColId=\"13\" Attno=\"-6\" ColName=\"cmax\"/>         +
+ <Column ColId=\"14\" Attno=\"-7\" ColName=\"tableoid\"/>     +
+ <Column ColId=\"15\" Attno=\"-8\" ColName=\"gp_segment_id\"/>+
+ </Columns>                                                   +
+ </TableDescriptor>                                           +
+ </TableScan>                                                 +
+ </GatherMotion>                                              +
+ </Materialize>                                               +
+ </Result>                                                    +
+ </Result>                                                    +
+ </Result>                                                    +
+ </SubPlan>                                                   +
+ </Filter>                                                    +
+ <OneTimeFilter/>                                             +
+ <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                          +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <SortingColumnList>                                          +
+ <SortingColumn ColId=\"0\"/>                                 +
+ </SortingColumnList>                                         +
+ <Sort SortDiscardDuplicates=\"false\">                       +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                          +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <SortingColumnList>                                          +
+ <SortingColumn ColId=\"0\"/>                                 +
+ </SortingColumnList>                                         +
+ <LimitCount/>                                                +
+ <LimitOffset/>                                               +
+ <TableScan>                                                  +
+ <ProjList>                                                   +
+ <ProjElem ColId=\"0\" Alias=\"i1\">                          +
+ <Ident ColId=\"0\" ColName=\"i1\"/>                          +
+ </ProjElem>                                                  +
+ </ProjList>                                                  +
+ <Filter/>                                                    +
+ <TableDescriptor>                                            +
+ <Columns>                                                    +
+ <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>             +
+ <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>          +
+ <Column ColId=\"2\" Attno=\"-3\" ColName=\"xmin\"/>          +
+ <Column ColId=\"3\" Attno=\"-4\" ColName=\"cmin\"/>          +
+ <Column ColId=\"4\" Attno=\"-5\" ColName=\"xmax\"/>          +
+ <Column ColId=\"5\" Attno=\"-6\" ColName=\"cmax\"/>          +
+ <Column ColId=\"6\" Attno=\"-7\" ColName=\"tableoid\"/>      +
+ <Column ColId=\"7\" Attno=\"-8\" ColName=\"gp_segment_id\"/> +
+ </Columns>                                                   +
+ </TableDescriptor>                                           +
+ </TableScan>                                                 +
+ </Sort>                                                      +
+ </GatherMotion>                                              +
+ </Result>                                                    +
+ </Plan>"}
+(1 row)
+
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+drop table t1,t2,t3;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1236,9 +1236,9 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+-- start_ignore
 drop table if exists t1, t2, t3;
-NOTICE:  table "t2" does not exist, skipping
-NOTICE:  table "t3" does not exist, skipping
+-- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table t2 as select 0 as i2;
@@ -1267,370 +1267,376 @@ reset optimizer_minidump;
 reset optimizer_trace_fallback;
 -- Output DXL plan without unimportant properties.
 -- start_ignore
-\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
-                                           xpath                                            
---------------------------------------------------------------------------------------------
- {"<Plan Id=\"0\" SpaceSize=\"0\">                                                         +
- <Result>                                                                                  +
- <ProjList>                                                                                +
- <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter>                                                                                  +
- <SubPlan>                                                                                 +
- <TestExpr>                                                                                +
- <Comparison ComparisonOperator=\"=\">                                                     +
- <If>                                                                                      +
- <Comparison ComparisonOperator=\"&gt;\">                                                  +
- <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
- <ConstValue/>                                                                             +
- </Comparison>                                                                             +
- <If>                                                                                      +
- <Comparison ComparisonOperator=\"=\">                                                     +
- <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                             +
- <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
- </Comparison>                                                                             +
- <ConstValue/>                                                                             +
- <ConstValue/>                                                                             +
- </If>                                                                                     +
- <ConstValue/>                                                                             +
- </If>                                                                                     +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
- </Comparison>                                                                             +
- </TestExpr>                                                                               +
- <ParamList>                                                                               +
- <Param ColId=\"0\" ColName=\"i1\"/>                                                       +
- </ParamList>                                                                              +
- <Result>                                                                                  +
- <ProjList>                                                                                +
- <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                             +
- <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                             +
- <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <OneTimeFilter/>                                                                          +
- <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                           +
- <GroupingColumns>                                                                         +
- <GroupingColumn ColId=\"8\"/>                                                             +
- <GroupingColumn ColId=\"9\"/>                                                             +
- <GroupingColumn ColId=\"15\"/>                                                            +
- <GroupingColumn ColId=\"16\"/>                                                            +
- </GroupingColumns>                                                                        +
- <ProjList>                                                                                +
- <ProjElem ColId=\"26\" Alias=\"ColRef_0026\">                                             +
- <AggFunc>                                                                                 +
- <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
- </AggFunc>                                                                                +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"28\" Alias=\"ColRef_0028\">                                             +
- <AggFunc>                                                                                 +
- <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                             +
- </AggFunc>                                                                                +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <Sort SortDiscardDuplicates=\"false\">                                                    +
- <ProjList>                                                                                +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                                                +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                             +
- <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
- <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <SortingColumnList>                                                                       +
- <SortingColumn ColId=\"8\"/>                                                              +
- <SortingColumn ColId=\"9\"/>                                                              +
- <SortingColumn ColId=\"15\"/>                                                             +
- <SortingColumn ColId=\"16\"/>                                                             +
- </SortingColumnList>                                                                      +
- <LimitCount/>                                                                             +
- <LimitOffset/>                                                                            +
- <Result>                                                                                  +
- <ProjList>                                                                                +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                                                +
- <Comparison ComparisonOperator=\"=\">                                                     +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- <ConstValue/>                                                                             +
- </Comparison>                                                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"27\" Alias=\"ColRef_0027\">                                             +
- <If>                                                                                      +
- <IsNull>                                                                                  +
- <Comparison ComparisonOperator=\"=\">                                                     +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </Comparison>                                                                             +
- </IsNull>                                                                                 +
- <ConstValue/>                                                                             +
- <ConstValue/>                                                                             +
- </If>                                                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
- <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <OneTimeFilter/>                                                                          +
- <NestedLoopJoin JoinType=\"Left\" IndexNestedLoopJoin=\"false\" OuterRefAsParam=\"false\">+
- <ProjList>                                                                                +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
- <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <JoinFilter>                                                                              +
- <ConstValue/>                                                                             +
- </JoinFilter>                                                                             +
- <Materialize Eager=\"false\">                                                             +
- <ProjList>                                                                                +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
- <ProjList>                                                                                +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <SortingColumnList/>                                                                      +
- <TableScan>                                                                               +
- <ProjList>                                                                                +
- <ProjElem ColId=\"8\" Alias=\"i3\">                                                       +
- <Ident ColId=\"8\" ColName=\"i3\"/>                                                       +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"9\" Alias=\"ctid\">                                                     +
- <Ident ColId=\"9\" ColName=\"ctid\"/>                                                     +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"15\" Alias=\"gp_segment_id\">                                           +
- <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                           +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <TableDescriptor>                                                                         +
- <Columns>                                                                                 +
- <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>                                          +
- <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>                                       +
- <Column ColId=\"10\" Attno=\"-3\" ColName=\"xmin\"/>                                      +
- <Column ColId=\"11\" Attno=\"-4\" ColName=\"cmin\"/>                                      +
- <Column ColId=\"12\" Attno=\"-5\" ColName=\"xmax\"/>                                      +
- <Column ColId=\"13\" Attno=\"-6\" ColName=\"cmax\"/>                                      +
- <Column ColId=\"14\" Attno=\"-7\" ColName=\"tableoid\"/>                                  +
- <Column ColId=\"15\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                             +
- </Columns>                                                                                +
- </TableDescriptor>                                                                        +
- </TableScan>                                                                              +
- </GatherMotion>                                                                           +
- </Materialize>                                                                            +
- <Materialize Eager=\"true\">                                                              +
- <ProjList>                                                                                +
- <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
- <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <Result>                                                                                  +
- <ProjList>                                                                                +
- <ProjElem ColId=\"25\" Alias=\"ColRef_0025\">                                             +
- <ConstValue/>                                                                             +
- </ProjElem>                                                                               +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <OneTimeFilter/>                                                                          +
- <Result>                                                                                  +
- <ProjList>                                                                                +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter>                                                                                  +
- <IsNotFalse>                                                                              +
- <Comparison ComparisonOperator=\"=\">                                                     +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </Comparison>                                                                             +
- </IsNotFalse>                                                                             +
- </Filter>                                                                                 +
- <OneTimeFilter/>                                                                          +
- <Materialize Eager=\"false\">                                                             +
- <ProjList>                                                                                +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
- <ProjList>                                                                                +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <SortingColumnList/>                                                                      +
- <TableScan>                                                                               +
- <ProjList>                                                                                +
- <ProjElem ColId=\"17\" Alias=\"i2\">                                                      +
- <Ident ColId=\"17\" ColName=\"i2\"/>                                                      +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <TableDescriptor>                                                                         +
- <Columns>                                                                                 +
- <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>                                         +
- <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>                                      +
- <Column ColId=\"19\" Attno=\"-3\" ColName=\"xmin\"/>                                      +
- <Column ColId=\"20\" Attno=\"-4\" ColName=\"cmin\"/>                                      +
- <Column ColId=\"21\" Attno=\"-5\" ColName=\"xmax\"/>                                      +
- <Column ColId=\"22\" Attno=\"-6\" ColName=\"cmax\"/>                                      +
- <Column ColId=\"23\" Attno=\"-7\" ColName=\"tableoid\"/>                                  +
- <Column ColId=\"24\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                             +
- </Columns>                                                                                +
- </TableDescriptor>                                                                        +
- </TableScan>                                                                              +
- </GatherMotion>                                                                           +
- </Materialize>                                                                            +
- </Result>                                                                                 +
- </Result>                                                                                 +
- </Materialize>                                                                            +
- </NestedLoopJoin>                                                                         +
- </Result>                                                                                 +
- </Sort>                                                                                   +
- </Aggregate>                                                                              +
- </Result>                                                                                 +
- </SubPlan>                                                                                +
- </Filter>                                                                                 +
- <OneTimeFilter/>                                                                          +
- <Sort SortDiscardDuplicates=\"false\">                                                    +
- <ProjList>                                                                                +
- <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <SortingColumnList>                                                                       +
- <SortingColumn ColId=\"0\"/>                                                              +
- </SortingColumnList>                                                                      +
- <LimitCount/>                                                                             +
- <LimitOffset/>                                                                            +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                              +
- <ProjList>                                                                                +
- <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <SortingColumnList/>                                                                      +
- <TableScan>                                                                               +
- <ProjList>                                                                                +
- <ProjElem ColId=\"0\" Alias=\"i1\">                                                       +
- <Ident ColId=\"0\" ColName=\"i1\"/>                                                       +
- </ProjElem>                                                                               +
- </ProjList>                                                                               +
- <Filter/>                                                                                 +
- <TableDescriptor>                                                                         +
- <Columns>                                                                                 +
- <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>                                          +
- <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>                                       +
- <Column ColId=\"2\" Attno=\"-3\" ColName=\"xmin\"/>                                       +
- <Column ColId=\"3\" Attno=\"-4\" ColName=\"cmin\"/>                                       +
- <Column ColId=\"4\" Attno=\"-5\" ColName=\"xmax\"/>                                       +
- <Column ColId=\"5\" Attno=\"-6\" ColName=\"cmax\"/>                                       +
- <Column ColId=\"6\" Attno=\"-7\" ColName=\"tableoid\"/>                                   +
- <Column ColId=\"7\" Attno=\"-8\" ColName=\"gp_segment_id\"/>                              +
- </Columns>                                                                                +
- </TableDescriptor>                                                                        +
- </TableScan>                                                                              +
- </GatherMotion>                                                                           +
- </Sort>                                                                                   +
- </Result>                                                                                 +
- </Plan>"}
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+                                                                                                                xpath                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                                                                                                                   +
+                         <Result>                                                                                                                                                                                                    +
+                                 <ProjList>                                                                                                                                                                                          +
+                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                         +
+                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                                 +
+                                         </ProjElem>                                                                                                                                                                                 +
+                                 </ProjList>                                                                                                                                                                                         +
+                                 <Filter>                                                                                                                                                                                            +
+                                         <SubPlan SubPlanType=\"AnySubPlan\">                                                                                                                                                        +
+                                                 <TestExpr>                                                                                                                                                                          +
+                                                         <Comparison ComparisonOperator=\"=\">                                                                                                                                       +
+                                                                 <If>                                                                                                                                                                +
+                                                                         <Comparison ComparisonOperator=\"&gt;\">                                                                                                                    +
+                                                                                 <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                       +
+                                                                                 <ConstValue/>                                                                                                                                       +
+                                                                         </Comparison>                                                                                                                                               +
+                                                                         <If>                                                                                                                                                        +
+                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                                               +
+                                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                               +
+                                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                               +
+                                                                                 </Comparison>                                                                                                                                       +
+                                                                                 <ConstValue IsNull=\"true\"/>                                                                                                                       +
+                                                                                 <ConstValue/>                                                                                                                                       +
+                                                                         </If>                                                                                                                                                       +
+                                                                         <ConstValue/>                                                                                                                                               +
+                                                                 </If>                                                                                                                                                               +
+                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                          +
+                                                         </Comparison>                                                                                                                                                               +
+                                                 </TestExpr>                                                                                                                                                                         +
+                                                 <ParamList>                                                                                                                                                                         +
+                                                         <Param ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
+                                                 </ParamList>                                                                                                                                                                        +
+                                                 <Result>                                                                                                                                                                            +
+                                                         <ProjList>                                                                                                                                                                  +
+                                                                 <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                                       +
+                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                               +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                                 <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                                       +
+                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                                               +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                          +
+                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                  +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                         </ProjList>                                                                                                                                                                 +
+                                                         <Filter/>                                                                                                                                                                   +
+                                                         <OneTimeFilter/>                                                                                                                                                            +
+                                                         <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                                                                                             +
+                                                                 <GroupingColumns>                                                                                                                                                   +
+                                                                         <GroupingColumn ColId=\"8\"/>                                                                                                                               +
+                                                                         <GroupingColumn ColId=\"9\"/>                                                                                                                               +
+                                                                         <GroupingColumn ColId=\"15\"/>                                                                                                                              +
+                                                                         <GroupingColumn ColId=\"16\"/>                                                                                                                              +
+                                                                 </GroupingColumns>                                                                                                                                                  +
+                                                                 <ProjList>                                                                                                                                                          +
+                                                                         <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                               +
+                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
+                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
+                                                                                 </AggFunc>                                                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                               +
+                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
+                                                                                                 <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                       +
+                                                                                 </AggFunc>                                                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                  +
+                                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                         +
+                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                                 +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                                       +
+                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                               +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                             +
+                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                                     +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                 </ProjList>                                                                                                                                                         +
+                                                                 <Filter/>                                                                                                                                                           +
+                                                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                              +
+                                                                         <ProjList>                                                                                                                                                  +
+                                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                          +
+                                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                  +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                                       +
+                                                                                         <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                               +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                 +
+                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                         +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                               +
+                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                       +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                     +
+                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                             +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                                       +
+                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                               +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                         </ProjList>                                                                                                                                                 +
+                                                                         <Filter/>                                                                                                                                                   +
+                                                                         <SortingColumnList>                                                                                                                                         +
+                                                                                 <SortingColumn ColId=\"8\" SortNullsFirst=\"false\"/>                                                                                               +
+                                                                                 <SortingColumn ColId=\"9\" SortNullsFirst=\"false\"/>                                                                                               +
+                                                                                 <SortingColumn ColId=\"15\" SortNullsFirst=\"false\"/>                                                                                              +
+                                                                                 <SortingColumn ColId=\"16\" SortNullsFirst=\"false\"/>                                                                                              +
+                                                                         </SortingColumnList>                                                                                                                                        +
+                                                                         <LimitCount/>                                                                                                                                               +
+                                                                         <LimitOffset/>                                                                                                                                              +
+                                                                         <Result>                                                                                                                                                    +
+                                                                                 <ProjList>                                                                                                                                          +
+                                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                  +
+                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                               +
+                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                 </Comparison>                                                                                                                       +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                               +
+                                                                                                 <If>                                                                                                                                +
+                                                                                                         <IsNull>                                                                                                                    +
+                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                               +
+                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                         +
+                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
+                                                                                                                 </Comparison>                                                                                                       +
+                                                                                                         </IsNull>                                                                                                                   +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                 </If>                                                                                                                               +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                         +
+                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                 +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                       +
+                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                               +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                             +
+                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                     +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                               +
+                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                 </ProjList>                                                                                                                                         +
+                                                                                 <Filter/>                                                                                                                                           +
+                                                                                 <OneTimeFilter/>                                                                                                                                    +
+                                                                                 <NestedLoopJoin IndexNestedLoopJoin=\"false\" JoinType=\"Left\" OuterRefAsParam=\"false\">                                                          +
+                                                                                         <ProjList>                                                                                                                                  +
+                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                 +
+                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                               +
+                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                       +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                     +
+                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                             +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                                +
+                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                        +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                       +
+                                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                               +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                         </ProjList>                                                                                                                                 +
+                                                                                         <Filter/>                                                                                                                                   +
+                                                                                         <JoinFilter>                                                                                                                                +
+                                                                                                 <ConstValue/>                                                                                                                       +
+                                                                                         </JoinFilter>                                                                                                                               +
+                                                                                         <Materialize Eager=\"false\">                                                                                                               +
+                                                                                                 <ProjList>                                                                                                                          +
+                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                         +
+                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                 +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                       +
+                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                               +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                             +
+                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                     +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                 </ProjList>                                                                                                                         +
+                                                                                                 <Filter/>                                                                                                                           +
+                                                                                                 <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                        +
+                                                                                                         <ProjList>                                                                                                                  +
+                                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                 +
+                                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                               +
+                                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                       +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                     +
+                                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                             +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                         </ProjList>                                                                                                                 +
+                                                                                                         <Filter/>                                                                                                                   +
+                                                                                                         <SortingColumnList/>                                                                                                        +
+                                                                                                         <TableScan>                                                                                                                 +
+                                                                                                                 <ProjList>                                                                                                          +
+                                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
+                                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                       +
+                                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                               +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                             +
+                                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                     +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                 </ProjList>                                                                                                         +
+                                                                                                                 <Filter/>                                                                                                           +
+                                                                                                                 <TableDescriptor>                                                                                                   +
+                                                                                                                         <Columns>                                                                                                   +
+                                                                                                                                 <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                     +
+                                                                                                                                 <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                                  +
+                                                                                                                                 <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                             +
+                                                                                                                                 <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                        +
+                                                                                                                         </Columns>                                                                                                  +
+                                                                                                                 </TableDescriptor>                                                                                                  +
+                                                                                                         </TableScan>                                                                                                                +
+                                                                                                 </GatherMotion>                                                                                                                     +
+                                                                                         </Materialize>                                                                                                                              +
+                                                                                         <Materialize Eager=\"true\">                                                                                                                +
+                                                                                                 <ProjList>                                                                                                                          +
+                                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                               +
+                                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                       +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                        +
+                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                 </ProjList>                                                                                                                         +
+                                                                                                 <Filter/>                                                                                                                           +
+                                                                                                 <Result>                                                                                                                            +
+                                                                                                         <ProjList>                                                                                                                  +
+                                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                       +
+                                                                                                                         <ConstValue/>                                                                                               +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                +
+                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                         </ProjList>                                                                                                                 +
+                                                                                                         <Filter/>                                                                                                                   +
+                                                                                                         <OneTimeFilter/>                                                                                                            +
+                                                                                                         <Result>                                                                                                                    +
+                                                                                                                 <ProjList>                                                                                                          +
+                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                        +
+                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                 </ProjList>                                                                                                         +
+                                                                                                                 <Filter>                                                                                                            +
+                                                                                                                         <IsNotFalse>                                                                                                +
+                                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                               +
+                                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                         +
+                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
+                                                                                                                                 </Comparison>                                                                                       +
+                                                                                                                         </IsNotFalse>                                                                                               +
+                                                                                                                 </Filter>                                                                                                           +
+                                                                                                                 <OneTimeFilter/>                                                                                                    +
+                                                                                                                 <Materialize Eager=\"false\">                                                                                       +
+                                                                                                                         <ProjList>                                                                                                  +
+                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                +
+                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
+                                                                                                                                 </ProjElem>                                                                                         +
+                                                                                                                         </ProjList>                                                                                                 +
+                                                                                                                         <Filter/>                                                                                                   +
+                                                                                                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                +
+                                                                                                                                 <ProjList>                                                                                          +
+                                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
+                                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
+                                                                                                                                         </ProjElem>                                                                                 +
+                                                                                                                                 </ProjList>                                                                                         +
+                                                                                                                                 <Filter/>                                                                                           +
+                                                                                                                                 <SortingColumnList/>                                                                                +
+                                                                                                                                 <TableScan>                                                                                         +
+                                                                                                                                         <ProjList>                                                                                  +
+                                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
+                                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
+                                                                                                                                                 </ProjElem>                                                                         +
+                                                                                                                                         </ProjList>                                                                                 +
+                                                                                                                                         <Filter/>                                                                                   +
+                                                                                                                                         <TableDescriptor>                                                                           +
+                                                                                                                                                 <Columns>                                                                           +
+                                                                                                                                                         <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
+                                                                                                                                                         <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
+                                                                                                                                                         <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
+                                                                                                                                                         <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
+                                                                                                                                                 </Columns>                                                                          +
+                                                                                                                                         </TableDescriptor>                                                                          +
+                                                                                                                                 </TableScan>                                                                                        +
+                                                                                                                         </GatherMotion>                                                                                             +
+                                                                                                                 </Materialize>                                                                                                      +
+                                                                                                         </Result>                                                                                                                   +
+                                                                                                 </Result>                                                                                                                           +
+                                                                                         </Materialize>                                                                                                                              +
+                                                                                 </NestedLoopJoin>                                                                                                                                   +
+                                                                         </Result>                                                                                                                                                   +
+                                                                 </Sort>                                                                                                                                                             +
+                                                         </Aggregate>                                                                                                                                                                +
+                                                 </Result>                                                                                                                                                                           +
+                                         </SubPlan>                                                                                                                                                                                  +
+                                 </Filter>                                                                                                                                                                                           +
+                                 <OneTimeFilter/>                                                                                                                                                                                    +
+                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                                                              +
+                                         <ProjList>                                                                                                                                                                                  +
+                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                 +
+                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
+                                                 </ProjElem>                                                                                                                                                                         +
+                                         </ProjList>                                                                                                                                                                                 +
+                                         <Filter/>                                                                                                                                                                                   +
+                                         <SortingColumnList>                                                                                                                                                                         +
+                                                 <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                                                                               +
+                                         </SortingColumnList>                                                                                                                                                                        +
+                                         <LimitCount/>                                                                                                                                                                               +
+                                         <LimitOffset/>                                                                                                                                                                              +
+                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                                                                                +
+                                                 <ProjList>                                                                                                                                                                          +
+                                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                         +
+                                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                 +
+                                                         </ProjElem>                                                                                                                                                                 +
+                                                 </ProjList>                                                                                                                                                                         +
+                                                 <Filter/>                                                                                                                                                                           +
+                                                 <SortingColumnList/>                                                                                                                                                                +
+                                                 <TableScan>                                                                                                                                                                         +
+                                                         <ProjList>                                                                                                                                                                  +
+                                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                 +
+                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                         +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                         </ProjList>                                                                                                                                                                 +
+                                                         <Filter/>                                                                                                                                                                   +
+                                                         <TableDescriptor>                                                                                                                                                           +
+                                                                 <Columns>                                                                                                                                                           +
+                                                                         <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                                                                             +
+                                                                         <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                                                                          +
+                                                                         <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                                                                      +
+                                                                         <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                                                                                 +
+                                                                 </Columns>                                                                                                                                                          +
+                                                         </TableDescriptor>                                                                                                                                                          +
+                                                 </TableScan>                                                                                                                                                                        +
+                                         </GatherMotion>                                                                                                                                                                             +
+                                 </Sort>                                                                                                                                                                                             +
+                         </Result>                                                                                                                                                                                                   +
+                 </Plan>"}
 (1 row)
 
-insert into t1 values (1);
-analyze t1;
+--insert into t1 values (1);
+--analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1646,228 +1652,377 @@ select * from t1 where
  i1 
 ----
   0
-  1
-(2 rows)
+(1 row)
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
--- Output DXL plan without unimportant properties.
 -- start_ignore
-\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
-                             xpath                             
----------------------------------------------------------------
- {"<Plan Id=\"0\" SpaceSize=\"0\">                            +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"0\" Alias=\"i1\">                          +
- <Ident ColId=\"0\" ColName=\"i1\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter>                                                     +
- <SubPlan>                                                    +
- <TestExpr/>                                                  +
- <ParamList>                                                  +
- <Param ColId=\"0\" ColName=\"i1\"/>                          +
- </ParamList>                                                 +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"38\" Alias=\"ColRef_0038\">                +
- <ConstValue/>                                                +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <OneTimeFilter/>                                             +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                   +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                   +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter>                                                     +
- <Comparison ComparisonOperator=\"=\">                        +
- <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                +
- <Ident ColId=\"16\" ColName=\"?column?\"/>                   +
- </Comparison>                                                +
- </Filter>                                                    +
- <OneTimeFilter/>                                             +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"16\" Alias=\"?column?\">                   +
- <Comparison ComparisonOperator=\"=\">                        +
- <Ident ColId=\"8\" ColName=\"i3\"/>                          +
- <ConstValue/>                                                +
- </Comparison>                                                +
- </ProjElem>                                                  +
- <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                +
- <SubPlan>                                                    +
- <TestExpr>                                                   +
- <Comparison ComparisonOperator=\"=\">                        +
- <Ident ColId=\"0\" ColName=\"i1\"/>                          +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </Comparison>                                                +
- </TestExpr>                                                  +
- <ParamList/>                                                 +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"17\" Alias=\"i2\">                         +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <OneTimeFilter/>                                             +
- <Result>                                                     +
- <ProjList>                                                   +
- <ProjElem ColId=\"29\" Alias=\"ColRef_0029\">                +
- <ConstValue/>                                                +
- </ProjElem>                                                  +
- <ProjElem ColId=\"17\" Alias=\"i2\">                         +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <OneTimeFilter/>                                             +
- <Materialize Eager=\"true\">                                 +
- <ProjList>                                                   +
- <ProjElem ColId=\"17\" Alias=\"i2\">                         +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
- <ProjList>                                                   +
- <ProjElem ColId=\"17\" Alias=\"i2\">                         +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <SortingColumnList/>                                         +
- <TableScan>                                                  +
- <ProjList>                                                   +
- <ProjElem ColId=\"17\" Alias=\"i2\">                         +
- <Ident ColId=\"17\" ColName=\"i2\"/>                         +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <TableDescriptor>                                            +
- <Columns>                                                    +
- <Column ColId=\"17\" Attno=\"1\" ColName=\"i2\"/>            +
- <Column ColId=\"18\" Attno=\"-1\" ColName=\"ctid\"/>         +
- <Column ColId=\"19\" Attno=\"-3\" ColName=\"xmin\"/>         +
- <Column ColId=\"20\" Attno=\"-4\" ColName=\"cmin\"/>         +
- <Column ColId=\"21\" Attno=\"-5\" ColName=\"xmax\"/>         +
- <Column ColId=\"22\" Attno=\"-6\" ColName=\"cmax\"/>         +
- <Column ColId=\"23\" Attno=\"-7\" ColName=\"tableoid\"/>     +
- <Column ColId=\"24\" Attno=\"-8\" ColName=\"gp_segment_id\"/>+
- </Columns>                                                   +
- </TableDescriptor>                                           +
- </TableScan>                                                 +
- </GatherMotion>                                              +
- </Materialize>                                               +
- </Result>                                                    +
- </Result>                                                    +
- </SubPlan>                                                   +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <OneTimeFilter/>                                             +
- <Materialize Eager=\"true\">                                 +
- <ProjList>                                                   +
- <ProjElem ColId=\"8\" Alias=\"i3\">                          +
- <Ident ColId=\"8\" ColName=\"i3\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
- <ProjList>                                                   +
- <ProjElem ColId=\"8\" Alias=\"i3\">                          +
- <Ident ColId=\"8\" ColName=\"i3\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <SortingColumnList/>                                         +
- <TableScan>                                                  +
- <ProjList>                                                   +
- <ProjElem ColId=\"8\" Alias=\"i3\">                          +
- <Ident ColId=\"8\" ColName=\"i3\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <TableDescriptor>                                            +
- <Columns>                                                    +
- <Column ColId=\"8\" Attno=\"1\" ColName=\"i3\"/>             +
- <Column ColId=\"9\" Attno=\"-1\" ColName=\"ctid\"/>          +
- <Column ColId=\"10\" Attno=\"-3\" ColName=\"xmin\"/>         +
- <Column ColId=\"11\" Attno=\"-4\" ColName=\"cmin\"/>         +
- <Column ColId=\"12\" Attno=\"-5\" ColName=\"xmax\"/>         +
- <Column ColId=\"13\" Attno=\"-6\" ColName=\"cmax\"/>         +
- <Column ColId=\"14\" Attno=\"-7\" ColName=\"tableoid\"/>     +
- <Column ColId=\"15\" Attno=\"-8\" ColName=\"gp_segment_id\"/>+
- </Columns>                                                   +
- </TableDescriptor>                                           +
- </TableScan>                                                 +
- </GatherMotion>                                              +
- </Materialize>                                               +
- </Result>                                                    +
- </Result>                                                    +
- </Result>                                                    +
- </SubPlan>                                                   +
- </Filter>                                                    +
- <OneTimeFilter/>                                             +
- <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\"> +
- <ProjList>                                                   +
- <ProjElem ColId=\"0\" Alias=\"i1\">                          +
- <Ident ColId=\"0\" ColName=\"i1\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <SortingColumnList>                                          +
- <SortingColumn ColId=\"0\"/>                                 +
- </SortingColumnList>                                         +
- <Sort SortDiscardDuplicates=\"false\">                       +
- <ProjList>                                                   +
- <ProjElem ColId=\"0\" Alias=\"i1\">                          +
- <Ident ColId=\"0\" ColName=\"i1\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <SortingColumnList>                                          +
- <SortingColumn ColId=\"0\"/>                                 +
- </SortingColumnList>                                         +
- <LimitCount/>                                                +
- <LimitOffset/>                                               +
- <TableScan>                                                  +
- <ProjList>                                                   +
- <ProjElem ColId=\"0\" Alias=\"i1\">                          +
- <Ident ColId=\"0\" ColName=\"i1\"/>                          +
- </ProjElem>                                                  +
- </ProjList>                                                  +
- <Filter/>                                                    +
- <TableDescriptor>                                            +
- <Columns>                                                    +
- <Column ColId=\"0\" Attno=\"1\" ColName=\"i1\"/>             +
- <Column ColId=\"1\" Attno=\"-1\" ColName=\"ctid\"/>          +
- <Column ColId=\"2\" Attno=\"-3\" ColName=\"xmin\"/>          +
- <Column ColId=\"3\" Attno=\"-4\" ColName=\"cmin\"/>          +
- <Column ColId=\"4\" Attno=\"-5\" ColName=\"xmax\"/>          +
- <Column ColId=\"5\" Attno=\"-6\" ColName=\"cmax\"/>          +
- <Column ColId=\"6\" Attno=\"-7\" ColName=\"tableoid\"/>      +
- <Column ColId=\"7\" Attno=\"-8\" ColName=\"gp_segment_id\"/> +
- </Columns>                                                   +
- </TableDescriptor>                                           +
- </TableScan>                                                 +
- </Sort>                                                      +
- </GatherMotion>                                              +
- </Result>                                                    +
- </Plan>"}
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+                                                                                                                xpath                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                                                                                                                   +
+                         <Result>                                                                                                                                                                                                    +
+                                 <ProjList>                                                                                                                                                                                          +
+                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                         +
+                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                                 +
+                                         </ProjElem>                                                                                                                                                                                 +
+                                 </ProjList>                                                                                                                                                                                         +
+                                 <Filter>                                                                                                                                                                                            +
+                                         <SubPlan SubPlanType=\"AnySubPlan\">                                                                                                                                                        +
+                                                 <TestExpr>                                                                                                                                                                          +
+                                                         <Comparison ComparisonOperator=\"=\">                                                                                                                                       +
+                                                                 <If>                                                                                                                                                                +
+                                                                         <Comparison ComparisonOperator=\"&gt;\">                                                                                                                    +
+                                                                                 <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                       +
+                                                                                 <ConstValue/>                                                                                                                                       +
+                                                                         </Comparison>                                                                                                                                               +
+                                                                         <If>                                                                                                                                                        +
+                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                                               +
+                                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                               +
+                                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                               +
+                                                                                 </Comparison>                                                                                                                                       +
+                                                                                 <ConstValue IsNull=\"true\"/>                                                                                                                       +
+                                                                                 <ConstValue/>                                                                                                                                       +
+                                                                         </If>                                                                                                                                                       +
+                                                                         <ConstValue/>                                                                                                                                               +
+                                                                 </If>                                                                                                                                                               +
+                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                          +
+                                                         </Comparison>                                                                                                                                                               +
+                                                 </TestExpr>                                                                                                                                                                         +
+                                                 <ParamList>                                                                                                                                                                         +
+                                                         <Param ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
+                                                 </ParamList>                                                                                                                                                                        +
+                                                 <Result>                                                                                                                                                                            +
+                                                         <ProjList>                                                                                                                                                                  +
+                                                                 <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                                       +
+                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                               +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                                 <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                                       +
+                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                                               +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                          +
+                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                  +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                         </ProjList>                                                                                                                                                                 +
+                                                         <Filter/>                                                                                                                                                                   +
+                                                         <OneTimeFilter/>                                                                                                                                                            +
+                                                         <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                                                                                             +
+                                                                 <GroupingColumns>                                                                                                                                                   +
+                                                                         <GroupingColumn ColId=\"8\"/>                                                                                                                               +
+                                                                         <GroupingColumn ColId=\"9\"/>                                                                                                                               +
+                                                                         <GroupingColumn ColId=\"15\"/>                                                                                                                              +
+                                                                         <GroupingColumn ColId=\"16\"/>                                                                                                                              +
+                                                                 </GroupingColumns>                                                                                                                                                  +
+                                                                 <ProjList>                                                                                                                                                          +
+                                                                         <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                               +
+                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
+                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
+                                                                                 </AggFunc>                                                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                               +
+                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
+                                                                                                 <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                       +
+                                                                                 </AggFunc>                                                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                  +
+                                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                          +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                         +
+                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                                 +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                                       +
+                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                               +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                             +
+                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                                     +
+                                                                         </ProjElem>                                                                                                                                                 +
+                                                                 </ProjList>                                                                                                                                                         +
+                                                                 <Filter/>                                                                                                                                                           +
+                                                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                              +
+                                                                         <ProjList>                                                                                                                                                  +
+                                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                          +
+                                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                  +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                                       +
+                                                                                         <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                               +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                 +
+                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                         +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                               +
+                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                       +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                     +
+                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                             +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                                       +
+                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                               +
+                                                                                 </ProjElem>                                                                                                                                         +
+                                                                         </ProjList>                                                                                                                                                 +
+                                                                         <Filter/>                                                                                                                                                   +
+                                                                         <SortingColumnList>                                                                                                                                         +
+                                                                                 <SortingColumn ColId=\"8\" SortNullsFirst=\"false\"/>                                                                                               +
+                                                                                 <SortingColumn ColId=\"9\" SortNullsFirst=\"false\"/>                                                                                               +
+                                                                                 <SortingColumn ColId=\"15\" SortNullsFirst=\"false\"/>                                                                                              +
+                                                                                 <SortingColumn ColId=\"16\" SortNullsFirst=\"false\"/>                                                                                              +
+                                                                         </SortingColumnList>                                                                                                                                        +
+                                                                         <LimitCount/>                                                                                                                                               +
+                                                                         <LimitOffset/>                                                                                                                                              +
+                                                                         <Result>                                                                                                                                                    +
+                                                                                 <ProjList>                                                                                                                                          +
+                                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                  +
+                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                               +
+                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                 </Comparison>                                                                                                                       +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                               +
+                                                                                                 <If>                                                                                                                                +
+                                                                                                         <IsNull>                                                                                                                    +
+                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                               +
+                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                         +
+                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
+                                                                                                                 </Comparison>                                                                                                       +
+                                                                                                         </IsNull>                                                                                                                   +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                         <ConstValue/>                                                                                                               +
+                                                                                                 </If>                                                                                                                               +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                         +
+                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                 +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                       +
+                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                               +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                             +
+                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                     +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                               +
+                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
+                                                                                         </ProjElem>                                                                                                                                 +
+                                                                                 </ProjList>                                                                                                                                         +
+                                                                                 <Filter/>                                                                                                                                           +
+                                                                                 <OneTimeFilter/>                                                                                                                                    +
+                                                                                 <NestedLoopJoin IndexNestedLoopJoin=\"false\" JoinType=\"Left\" OuterRefAsParam=\"false\">                                                          +
+                                                                                         <ProjList>                                                                                                                                  +
+                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                 +
+                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                               +
+                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                       +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                     +
+                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                             +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                                +
+                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                        +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                       +
+                                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                               +
+                                                                                                 </ProjElem>                                                                                                                         +
+                                                                                         </ProjList>                                                                                                                                 +
+                                                                                         <Filter/>                                                                                                                                   +
+                                                                                         <JoinFilter>                                                                                                                                +
+                                                                                                 <ConstValue/>                                                                                                                       +
+                                                                                         </JoinFilter>                                                                                                                               +
+                                                                                         <Materialize Eager=\"false\">                                                                                                               +
+                                                                                                 <ProjList>                                                                                                                          +
+                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                         +
+                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                 +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                       +
+                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                               +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                             +
+                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                     +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                 </ProjList>                                                                                                                         +
+                                                                                                 <Filter/>                                                                                                                           +
+                                                                                                 <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                        +
+                                                                                                         <ProjList>                                                                                                                  +
+                                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                 +
+                                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                               +
+                                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                       +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                     +
+                                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                             +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                         </ProjList>                                                                                                                 +
+                                                                                                         <Filter/>                                                                                                                   +
+                                                                                                         <SortingColumnList/>                                                                                                        +
+                                                                                                         <TableScan>                                                                                                                 +
+                                                                                                                 <ProjList>                                                                                                          +
+                                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
+                                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                       +
+                                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                               +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                             +
+                                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                     +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                 </ProjList>                                                                                                         +
+                                                                                                                 <Filter/>                                                                                                           +
+                                                                                                                 <TableDescriptor>                                                                                                   +
+                                                                                                                         <Columns>                                                                                                   +
+                                                                                                                                 <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                     +
+                                                                                                                                 <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                                  +
+                                                                                                                                 <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                                 +
+                                                                                                                                 <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                             +
+                                                                                                                                 <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                        +
+                                                                                                                         </Columns>                                                                                                  +
+                                                                                                                 </TableDescriptor>                                                                                                  +
+                                                                                                         </TableScan>                                                                                                                +
+                                                                                                 </GatherMotion>                                                                                                                     +
+                                                                                         </Materialize>                                                                                                                              +
+                                                                                         <Materialize Eager=\"true\">                                                                                                                +
+                                                                                                 <ProjList>                                                                                                                          +
+                                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                               +
+                                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                       +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                        +
+                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                +
+                                                                                                         </ProjElem>                                                                                                                 +
+                                                                                                 </ProjList>                                                                                                                         +
+                                                                                                 <Filter/>                                                                                                                           +
+                                                                                                 <Result>                                                                                                                            +
+                                                                                                         <ProjList>                                                                                                                  +
+                                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                       +
+                                                                                                                         <ConstValue/>                                                                                               +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                +
+                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
+                                                                                                                 </ProjElem>                                                                                                         +
+                                                                                                         </ProjList>                                                                                                                 +
+                                                                                                         <Filter/>                                                                                                                   +
+                                                                                                         <OneTimeFilter/>                                                                                                            +
+                                                                                                         <Result>                                                                                                                    +
+                                                                                                                 <ProjList>                                                                                                          +
+                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                        +
+                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                +
+                                                                                                                         </ProjElem>                                                                                                 +
+                                                                                                                 </ProjList>                                                                                                         +
+                                                                                                                 <Filter>                                                                                                            +
+                                                                                                                         <IsNotFalse>                                                                                                +
+                                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                               +
+                                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                         +
+                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
+                                                                                                                                 </Comparison>                                                                                       +
+                                                                                                                         </IsNotFalse>                                                                                               +
+                                                                                                                 </Filter>                                                                                                           +
+                                                                                                                 <OneTimeFilter/>                                                                                                    +
+                                                                                                                 <Materialize Eager=\"false\">                                                                                       +
+                                                                                                                         <ProjList>                                                                                                  +
+                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                +
+                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
+                                                                                                                                 </ProjElem>                                                                                         +
+                                                                                                                         </ProjList>                                                                                                 +
+                                                                                                                         <Filter/>                                                                                                   +
+                                                                                                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                +
+                                                                                                                                 <ProjList>                                                                                          +
+                                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
+                                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
+                                                                                                                                         </ProjElem>                                                                                 +
+                                                                                                                                 </ProjList>                                                                                         +
+                                                                                                                                 <Filter/>                                                                                           +
+                                                                                                                                 <SortingColumnList/>                                                                                +
+                                                                                                                                 <TableScan>                                                                                         +
+                                                                                                                                         <ProjList>                                                                                  +
+                                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
+                                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
+                                                                                                                                                 </ProjElem>                                                                         +
+                                                                                                                                         </ProjList>                                                                                 +
+                                                                                                                                         <Filter/>                                                                                   +
+                                                                                                                                         <TableDescriptor>                                                                           +
+                                                                                                                                                 <Columns>                                                                           +
+                                                                                                                                                         <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
+                                                                                                                                                         <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
+                                                                                                                                                         <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
+                                                                                                                                                         <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
+                                                                                                                                                         <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
+                                                                                                                                                 </Columns>                                                                          +
+                                                                                                                                         </TableDescriptor>                                                                          +
+                                                                                                                                 </TableScan>                                                                                        +
+                                                                                                                         </GatherMotion>                                                                                             +
+                                                                                                                 </Materialize>                                                                                                      +
+                                                                                                         </Result>                                                                                                                   +
+                                                                                                 </Result>                                                                                                                           +
+                                                                                         </Materialize>                                                                                                                              +
+                                                                                 </NestedLoopJoin>                                                                                                                                   +
+                                                                         </Result>                                                                                                                                                   +
+                                                                 </Sort>                                                                                                                                                             +
+                                                         </Aggregate>                                                                                                                                                                +
+                                                 </Result>                                                                                                                                                                           +
+                                         </SubPlan>                                                                                                                                                                                  +
+                                 </Filter>                                                                                                                                                                                           +
+                                 <OneTimeFilter/>                                                                                                                                                                                    +
+                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                                                              +
+                                         <ProjList>                                                                                                                                                                                  +
+                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                 +
+                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
+                                                 </ProjElem>                                                                                                                                                                         +
+                                         </ProjList>                                                                                                                                                                                 +
+                                         <Filter/>                                                                                                                                                                                   +
+                                         <SortingColumnList>                                                                                                                                                                         +
+                                                 <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                                                                               +
+                                         </SortingColumnList>                                                                                                                                                                        +
+                                         <LimitCount/>                                                                                                                                                                               +
+                                         <LimitOffset/>                                                                                                                                                                              +
+                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                                                                                +
+                                                 <ProjList>                                                                                                                                                                          +
+                                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                         +
+                                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                 +
+                                                         </ProjElem>                                                                                                                                                                 +
+                                                 </ProjList>                                                                                                                                                                         +
+                                                 <Filter/>                                                                                                                                                                           +
+                                                 <SortingColumnList/>                                                                                                                                                                +
+                                                 <TableScan>                                                                                                                                                                         +
+                                                         <ProjList>                                                                                                                                                                  +
+                                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                 +
+                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                         +
+                                                                 </ProjElem>                                                                                                                                                         +
+                                                         </ProjList>                                                                                                                                                                 +
+                                                         <Filter/>                                                                                                                                                                   +
+                                                         <TableDescriptor>                                                                                                                                                           +
+                                                                 <Columns>                                                                                                                                                           +
+                                                                         <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                                                                             +
+                                                                         <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                                                                          +
+                                                                         <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                                                                          +
+                                                                         <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                                                                      +
+                                                                         <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                                                                                 +
+                                                                 </Columns>                                                                                                                                                          +
+                                                         </TableDescriptor>                                                                                                                                                          +
+                                                 </TableScan>                                                                                                                                                                        +
+                                         </GatherMotion>                                                                                                                                                                             +
+                                 </Sort>                                                                                                                                                                                             +
+                         </Result>                                                                                                                                                                                                   +
+                 </Plan>"}
 (1 row)
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1237,11 +1237,73 @@ drop table tl3;
 drop table tl4;
 -- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_t VALUES ('0', 0);
 CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 0);
 CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+                                                                                                          QUERY PLAN                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Filter: (SubPlan 1)
+   ->  Sort
+         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Sort Key: test_tbl_t.int_t
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               ->  Seq Scan on public.test_tbl_t
+                     Output: test_tbl_t.text_t, test_tbl_t.int_t
+   SubPlan 1  (slice0)
+     ->  Result
+           Output: (count("outer".ColRef_0028)), (sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END))), ((test_tbl_p.int_p = 1))
+           ->  GroupAggregate
+                 Output: count("outer".ColRef_0028), sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END)), ((test_tbl_p.int_p = 1)), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
+                 Group Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
+                 ->  Sort
+                       Output: ((test_tbl_p.int_p = 1)), (CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0028
+                       Sort Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
+                       ->  Result
+                             Output: (test_tbl_p.int_p = 1), CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END, test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0028
+                             ->  Nested Loop Left Join
+                                   Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, test_tbl_d.int_d, "outer".ColRef_0028
+                                   Join Filter: true
+                                   ->  Materialize
+                                         Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
+                                         ->  Gather Motion 3:1  (slice3; segments: 3)
+                                               Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
+                                               ->  Seq Scan on public.test_tbl_p
+                                                     Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
+                                   ->  Materialize
+                                         Output: "outer".ColRef_0028, test_tbl_d.int_d
+                                         ->  Result
+                                               Output: true, test_tbl_d.int_d
+                                               ->  Result
+                                                     Output: test_tbl_d.int_d
+                                                     Filter: ((test_tbl_t.int_t = test_tbl_d.int_d) IS NOT FALSE)
+                                                     ->  Materialize
+                                                           Output: test_tbl_d.int_d
+                                                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                                                 Output: test_tbl_d.int_d
+                                                                 ->  Seq Scan on public.test_tbl_d
+                                                                       Output: test_tbl_d.int_d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(45 rows)
+
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+ text_t | int_t 
+--------+-------
+ 0      |     0
+(1 row)
+
+INSERT INTO test_tbl_t VALUES ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 1);
+INSERT INTO test_tbl_p VALUES ('0', 0);
+ANALYZE test_tbl_t;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
   (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
                                        QUERY PLAN                                       

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1235,15 +1235,27 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
--- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+-- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+SET client_min_messages='log';
+SET optimizer_trace_fallback=on;
+LOG:  statement: SET optimizer_trace_fallback=on;
+LOG:  statement: SET optimizer_trace_fallback TO 'on'  (entry db 172.17.0.2:6000 pid=16675)
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
+LOG:  statement: CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
 INSERT INTO test_tbl_t VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 0);
 CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
+LOG:  statement: CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
 INSERT INTO test_tbl_d VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 0);
 CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
+LOG:  statement: CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
                                                                                                           QUERY PLAN                                                                                                           
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result
@@ -1294,18 +1306,27 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
 (45 rows)
 
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
  text_t | int_t 
 --------+-------
  0      |     0
 (1 row)
 
 INSERT INTO test_tbl_t VALUES ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_t VALUES ('0', 1);
 INSERT INTO test_tbl_d VALUES ('0', 1);
+LOG:  statement: INSERT INTO test_tbl_d VALUES ('0', 1);
 INSERT INTO test_tbl_p VALUES ('0', 0);
+LOG:  statement: INSERT INTO test_tbl_p VALUES ('0', 0);
 ANALYZE test_tbl_t;
+LOG:  statement: ANALYZE test_tbl_t;
+-- After adding data, the ORCA physical plan changes.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Result
@@ -1349,13 +1370,19 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
 (38 rows)
 
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+LOG:  statement: SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
  text_t | int_t 
 --------+-------
  0      |     0
  0      |     1
 (2 rows)
 
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+LOG:  statement: RESET client_min_messages  (entry db 172.17.0.2:6000 pid=16675)
+RESET optimizer_trace_fallback;
 DROP TABLE test_tbl_t;
 DROP TABLE test_tbl_d;
 DROP TABLE test_tbl_p;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1237,7 +1237,6 @@ drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
 -- start_ignore
-drop table if exists t1, t2, t3;
 -- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
@@ -1270,7 +1269,7 @@ reset optimizer_trace_fallback;
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
 \! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
-\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='   ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! python $MASTER_DATA_DIRECTORY/minidumps/script.py
@@ -1282,361 +1281,361 @@ reset optimizer_trace_fallback;
 \! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 \! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
-                                                                                                                xpath                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                                                                                                                   +
-                         <Result>                                                                                                                                                                                                    +
-                                 <ProjList>                                                                                                                                                                                          +
-                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                         +
-                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                                 +
-                                         </ProjElem>                                                                                                                                                                                 +
-                                 </ProjList>                                                                                                                                                                                         +
-                                 <Filter>                                                                                                                                                                                            +
-                                         <SubPlan SubPlanType=\"AnySubPlan\">                                                                                                                                                        +
-                                                 <TestExpr>                                                                                                                                                                          +
-                                                         <Comparison ComparisonOperator=\"=\">                                                                                                                                       +
-                                                                 <If>                                                                                                                                                                +
-                                                                         <Comparison ComparisonOperator=\"&gt;\">                                                                                                                    +
-                                                                                 <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                       +
-                                                                                 <ConstValue/>                                                                                                                                       +
-                                                                         </Comparison>                                                                                                                                               +
-                                                                         <If>                                                                                                                                                        +
-                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                                               +
-                                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                               +
-                                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                               +
-                                                                                 </Comparison>                                                                                                                                       +
-                                                                                 <ConstValue IsNull=\"true\"/>                                                                                                                       +
-                                                                                 <ConstValue/>                                                                                                                                       +
-                                                                         </If>                                                                                                                                                       +
-                                                                         <ConstValue/>                                                                                                                                               +
-                                                                 </If>                                                                                                                                                               +
-                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                          +
-                                                         </Comparison>                                                                                                                                                               +
-                                                 </TestExpr>                                                                                                                                                                         +
-                                                 <ParamList>                                                                                                                                                                         +
-                                                         <Param ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
-                                                 </ParamList>                                                                                                                                                                        +
-                                                 <Result>                                                                                                                                                                            +
-                                                         <ProjList>                                                                                                                                                                  +
-                                                                 <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                                       +
-                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                               +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                                 <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                                       +
-                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                                               +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                          +
-                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                  +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                         </ProjList>                                                                                                                                                                 +
-                                                         <Filter/>                                                                                                                                                                   +
-                                                         <OneTimeFilter/>                                                                                                                                                            +
-                                                         <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                                                                                             +
-                                                                 <GroupingColumns>                                                                                                                                                   +
-                                                                         <GroupingColumn ColId=\"8\"/>                                                                                                                               +
-                                                                         <GroupingColumn ColId=\"9\"/>                                                                                                                               +
-                                                                         <GroupingColumn ColId=\"15\"/>                                                                                                                              +
-                                                                         <GroupingColumn ColId=\"16\"/>                                                                                                                              +
-                                                                 </GroupingColumns>                                                                                                                                                  +
-                                                                 <ProjList>                                                                                                                                                          +
-                                                                         <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                               +
-                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
-                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
-                                                                                 </AggFunc>                                                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                               +
-                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
-                                                                                                 <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                       +
-                                                                                 </AggFunc>                                                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                  +
-                                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                         +
-                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                                 +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                                       +
-                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                               +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                             +
-                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                                     +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                 </ProjList>                                                                                                                                                         +
-                                                                 <Filter/>                                                                                                                                                           +
-                                                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                              +
-                                                                         <ProjList>                                                                                                                                                  +
-                                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                          +
-                                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                  +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                                       +
-                                                                                         <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                               +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                 +
-                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                         +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                               +
-                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                       +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                     +
-                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                             +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                                       +
-                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                               +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                         </ProjList>                                                                                                                                                 +
-                                                                         <Filter/>                                                                                                                                                   +
-                                                                         <SortingColumnList>                                                                                                                                         +
-                                                                                 <SortingColumn ColId=\"8\" SortNullsFirst=\"false\"/>                                                                                               +
-                                                                                 <SortingColumn ColId=\"9\" SortNullsFirst=\"false\"/>                                                                                               +
-                                                                                 <SortingColumn ColId=\"15\" SortNullsFirst=\"false\"/>                                                                                              +
-                                                                                 <SortingColumn ColId=\"16\" SortNullsFirst=\"false\"/>                                                                                              +
-                                                                         </SortingColumnList>                                                                                                                                        +
-                                                                         <LimitCount/>                                                                                                                                               +
-                                                                         <LimitOffset/>                                                                                                                                              +
-                                                                         <Result>                                                                                                                                                    +
-                                                                                 <ProjList>                                                                                                                                          +
-                                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                  +
-                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                               +
-                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                 </Comparison>                                                                                                                       +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                               +
-                                                                                                 <If>                                                                                                                                +
-                                                                                                         <IsNull>                                                                                                                    +
-                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                               +
-                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                         +
-                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
-                                                                                                                 </Comparison>                                                                                                       +
-                                                                                                         </IsNull>                                                                                                                   +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                 </If>                                                                                                                               +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                         +
-                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                 +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                       +
-                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                               +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                             +
-                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                     +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                               +
-                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                 </ProjList>                                                                                                                                         +
-                                                                                 <Filter/>                                                                                                                                           +
-                                                                                 <OneTimeFilter/>                                                                                                                                    +
-                                                                                 <NestedLoopJoin IndexNestedLoopJoin=\"false\" JoinType=\"Left\" OuterRefAsParam=\"false\">                                                          +
-                                                                                         <ProjList>                                                                                                                                  +
-                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                 +
-                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                               +
-                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                       +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                     +
-                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                             +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                                +
-                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                        +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                       +
-                                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                               +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                         </ProjList>                                                                                                                                 +
-                                                                                         <Filter/>                                                                                                                                   +
-                                                                                         <JoinFilter>                                                                                                                                +
-                                                                                                 <ConstValue/>                                                                                                                       +
-                                                                                         </JoinFilter>                                                                                                                               +
-                                                                                         <Materialize Eager=\"false\">                                                                                                               +
-                                                                                                 <ProjList>                                                                                                                          +
-                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                         +
-                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                 +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                       +
-                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                               +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                             +
-                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                     +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                 </ProjList>                                                                                                                         +
-                                                                                                 <Filter/>                                                                                                                           +
-                                                                                                 <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                        +
-                                                                                                         <ProjList>                                                                                                                  +
-                                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                 +
-                                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                               +
-                                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                       +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                     +
-                                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                             +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                         </ProjList>                                                                                                                 +
-                                                                                                         <Filter/>                                                                                                                   +
-                                                                                                         <SortingColumnList/>                                                                                                        +
-                                                                                                         <TableScan>                                                                                                                 +
-                                                                                                                 <ProjList>                                                                                                          +
-                                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
-                                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                       +
-                                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                               +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                             +
-                                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                     +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                 </ProjList>                                                                                                         +
-                                                                                                                 <Filter/>                                                                                                           +
-                                                                                                                 <TableDescriptor>                                                                                                   +
-                                                                                                                         <Columns>                                                                                                   +
-                                                                                                                                 <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                     +
-                                                                                                                                 <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                                  +
-                                                                                                                                 <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                             +
-                                                                                                                                 <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                        +
-                                                                                                                         </Columns>                                                                                                  +
-                                                                                                                 </TableDescriptor>                                                                                                  +
-                                                                                                         </TableScan>                                                                                                                +
-                                                                                                 </GatherMotion>                                                                                                                     +
-                                                                                         </Materialize>                                                                                                                              +
-                                                                                         <Materialize Eager=\"true\">                                                                                                                +
-                                                                                                 <ProjList>                                                                                                                          +
-                                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                               +
-                                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                       +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                        +
-                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                 </ProjList>                                                                                                                         +
-                                                                                                 <Filter/>                                                                                                                           +
-                                                                                                 <Result>                                                                                                                            +
-                                                                                                         <ProjList>                                                                                                                  +
-                                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                       +
-                                                                                                                         <ConstValue/>                                                                                               +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                +
-                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                         </ProjList>                                                                                                                 +
-                                                                                                         <Filter/>                                                                                                                   +
-                                                                                                         <OneTimeFilter/>                                                                                                            +
-                                                                                                         <Result>                                                                                                                    +
-                                                                                                                 <ProjList>                                                                                                          +
-                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                        +
-                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                 </ProjList>                                                                                                         +
-                                                                                                                 <Filter>                                                                                                            +
-                                                                                                                         <IsNotFalse>                                                                                                +
-                                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                               +
-                                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                         +
-                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
-                                                                                                                                 </Comparison>                                                                                       +
-                                                                                                                         </IsNotFalse>                                                                                               +
-                                                                                                                 </Filter>                                                                                                           +
-                                                                                                                 <OneTimeFilter/>                                                                                                    +
-                                                                                                                 <Materialize Eager=\"false\">                                                                                       +
-                                                                                                                         <ProjList>                                                                                                  +
-                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                +
-                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
-                                                                                                                                 </ProjElem>                                                                                         +
-                                                                                                                         </ProjList>                                                                                                 +
-                                                                                                                         <Filter/>                                                                                                   +
-                                                                                                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                +
-                                                                                                                                 <ProjList>                                                                                          +
-                                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
-                                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
-                                                                                                                                         </ProjElem>                                                                                 +
-                                                                                                                                 </ProjList>                                                                                         +
-                                                                                                                                 <Filter/>                                                                                           +
-                                                                                                                                 <SortingColumnList/>                                                                                +
-                                                                                                                                 <TableScan>                                                                                         +
-                                                                                                                                         <ProjList>                                                                                  +
-                                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
-                                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
-                                                                                                                                                 </ProjElem>                                                                         +
-                                                                                                                                         </ProjList>                                                                                 +
-                                                                                                                                         <Filter/>                                                                                   +
-                                                                                                                                         <TableDescriptor>                                                                           +
-                                                                                                                                                 <Columns>                                                                           +
-                                                                                                                                                         <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
-                                                                                                                                                         <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
-                                                                                                                                                         <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
-                                                                                                                                                         <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
-                                                                                                                                                 </Columns>                                                                          +
-                                                                                                                                         </TableDescriptor>                                                                          +
-                                                                                                                                 </TableScan>                                                                                        +
-                                                                                                                         </GatherMotion>                                                                                             +
-                                                                                                                 </Materialize>                                                                                                      +
-                                                                                                         </Result>                                                                                                                   +
-                                                                                                 </Result>                                                                                                                           +
-                                                                                         </Materialize>                                                                                                                              +
-                                                                                 </NestedLoopJoin>                                                                                                                                   +
-                                                                         </Result>                                                                                                                                                   +
-                                                                 </Sort>                                                                                                                                                             +
-                                                         </Aggregate>                                                                                                                                                                +
-                                                 </Result>                                                                                                                                                                           +
-                                         </SubPlan>                                                                                                                                                                                  +
-                                 </Filter>                                                                                                                                                                                           +
-                                 <OneTimeFilter/>                                                                                                                                                                                    +
-                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                                                              +
-                                         <ProjList>                                                                                                                                                                                  +
-                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                 +
-                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
-                                                 </ProjElem>                                                                                                                                                                         +
-                                         </ProjList>                                                                                                                                                                                 +
-                                         <Filter/>                                                                                                                                                                                   +
-                                         <SortingColumnList>                                                                                                                                                                         +
-                                                 <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                                                                               +
-                                         </SortingColumnList>                                                                                                                                                                        +
-                                         <LimitCount/>                                                                                                                                                                               +
-                                         <LimitOffset/>                                                                                                                                                                              +
-                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                                                                                +
-                                                 <ProjList>                                                                                                                                                                          +
-                                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                         +
-                                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                 +
-                                                         </ProjElem>                                                                                                                                                                 +
-                                                 </ProjList>                                                                                                                                                                         +
-                                                 <Filter/>                                                                                                                                                                           +
-                                                 <SortingColumnList/>                                                                                                                                                                +
-                                                 <TableScan>                                                                                                                                                                         +
-                                                         <ProjList>                                                                                                                                                                  +
-                                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                 +
-                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                         +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                         </ProjList>                                                                                                                                                                 +
-                                                         <Filter/>                                                                                                                                                                   +
-                                                         <TableDescriptor>                                                                                                                                                           +
-                                                                 <Columns>                                                                                                                                                           +
-                                                                         <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                                                                             +
-                                                                         <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                                                                          +
-                                                                         <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                                                                      +
-                                                                         <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                                                                                 +
-                                                                 </Columns>                                                                                                                                                          +
-                                                         </TableDescriptor>                                                                                                                                                          +
-                                                 </TableScan>                                                                                                                                                                        +
-                                         </GatherMotion>                                                                                                                                                                             +
-                                 </Sort>                                                                                                                                                                                             +
-                         </Result>                                                                                                                                                                                                   +
-                 </Plan>"}
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
+                                                            replace                                                            
+-------------------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                            +
+  <Result>                                                                                                                    +
+     <ProjList>                                                                                                               +
+        <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                   +
+           <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                +
+        </ProjElem>                                                                                                           +
+     </ProjList>                                                                                                              +
+     <Filter>                                                                                                                 +
+        <SubPlan SubPlanType=\"AnySubPlan\">                                                                                  +
+           <TestExpr>                                                                                                         +
+              <Comparison ComparisonOperator=\"=\">                                                                           +
+                 <If>                                                                                                         +
+                    <Comparison ComparisonOperator=\"&gt;\">                                                                  +
+                       <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                          +
+                       <ConstValue/>                                                                                          +
+                    </Comparison>                                                                                             +
+                    <If>                                                                                                      +
+                       <Comparison ComparisonOperator=\"=\">                                                                  +
+                          <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                       +
+                          <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                       +
+                       </Comparison>                                                                                          +
+                       <ConstValue IsNull=\"true\"/>                                                                          +
+                       <ConstValue/>                                                                                          +
+                    </If>                                                                                                     +
+                    <ConstValue/>                                                                                             +
+                 </If>                                                                                                        +
+                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                   +
+              </Comparison>                                                                                                   +
+           </TestExpr>                                                                                                        +
+           <ParamList>                                                                                                        +
+              <Param ColId=\"0\" ColName=\"i1\"/>                                                                             +
+           </ParamList>                                                                                                       +
+           <Result>                                                                                                           +
+              <ProjList>                                                                                                      +
+                 <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                +
+                    <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                             +
+                 </ProjElem>                                                                                                  +
+                 <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                +
+                    <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                             +
+                 </ProjElem>                                                                                                  +
+                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                   +
+                    <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                +
+                 </ProjElem>                                                                                                  +
+              </ProjList>                                                                                                     +
+              <Filter/>                                                                                                       +
+              <OneTimeFilter/>                                                                                                +
+              <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                                 +
+                 <GroupingColumns>                                                                                            +
+                    <GroupingColumn ColId=\"8\"/>                                                                             +
+                    <GroupingColumn ColId=\"9\"/>                                                                             +
+                    <GroupingColumn ColId=\"15\"/>                                                                            +
+                    <GroupingColumn ColId=\"16\"/>                                                                            +
+                 </GroupingColumns>                                                                                           +
+                 <ProjList>                                                                                                   +
+                    <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                             +
+                       <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                          +
+                             <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                    +
+                       </AggFunc>                                                                                             +
+                    </ProjElem>                                                                                               +
+                    <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                             +
+                       <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                          +
+                             <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                    +
+                       </AggFunc>                                                                                             +
+                    </ProjElem>                                                                                               +
+                    <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                +
+                       <Ident ColId=\"16\" ColName=\"?column?\"/>                                                             +
+                    </ProjElem>                                                                                               +
+                    <ProjElem Alias=\"i3\" ColId=\"8\">                                                                       +
+                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                                    +
+                    </ProjElem>                                                                                               +
+                    <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                     +
+                       <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                  +
+                    </ProjElem>                                                                                               +
+                    <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                           +
+                       <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                        +
+                    </ProjElem>                                                                                               +
+                 </ProjList>                                                                                                  +
+                 <Filter/>                                                                                                    +
+                 <Sort SortDiscardDuplicates=\"false\">                                                                       +
+                    <ProjList>                                                                                                +
+                       <ProjElem Alias=\"?column?\" ColId=\"16\">                                                             +
+                          <Ident ColId=\"16\" ColName=\"?column?\"/>                                                          +
+                       </ProjElem>                                                                                            +
+                       <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                          +
+                          <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                       +
+                       </ProjElem>                                                                                            +
+                       <ProjElem Alias=\"i3\" ColId=\"8\">                                                                    +
+                          <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
+                       </ProjElem>                                                                                            +
+                       <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                  +
+                          <Ident ColId=\"9\" ColName=\"ctid\"/>                                                               +
+                       </ProjElem>                                                                                            +
+                       <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                        +
+                          <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                     +
+                       </ProjElem>                                                                                            +
+                       <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                          +
+                          <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                       +
+                       </ProjElem>                                                                                            +
+                    </ProjList>                                                                                               +
+                    <Filter/>                                                                                                 +
+                    <SortingColumnList>                                                                                       +
+                       <SortingColumn ColId=\"8\" SortNullsFirst=\"false\"/>                                                  +
+                       <SortingColumn ColId=\"9\" SortNullsFirst=\"false\"/>                                                  +
+                       <SortingColumn ColId=\"15\" SortNullsFirst=\"false\"/>                                                 +
+                       <SortingColumn ColId=\"16\" SortNullsFirst=\"false\"/>                                                 +
+                    </SortingColumnList>                                                                                      +
+                    <LimitCount/>                                                                                             +
+                    <LimitOffset/>                                                                                            +
+                    <Result>                                                                                                  +
+                       <ProjList>                                                                                             +
+                          <ProjElem Alias=\"?column?\" ColId=\"16\">                                                          +
+                             <Comparison ComparisonOperator=\"=\">                                                            +
+                                <Ident ColId=\"8\" ColName=\"i3\"/>                                                           +
+                                <ConstValue/>                                                                                 +
+                             </Comparison>                                                                                    +
+                          </ProjElem>                                                                                         +
+                          <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                       +
+                             <If>                                                                                             +
+                                <IsNull>                                                                                      +
+                                   <Comparison ComparisonOperator=\"=\">                                                      +
+                                      <Ident ColId=\"0\" ColName=\"i1\"/>                                                     +
+                                      <Ident ColId=\"17\" ColName=\"i2\"/>                                                    +
+                                   </Comparison>                                                                              +
+                                </IsNull>                                                                                     +
+                                <ConstValue/>                                                                                 +
+                                <ConstValue/>                                                                                 +
+                             </If>                                                                                            +
+                          </ProjElem>                                                                                         +
+                          <ProjElem Alias=\"i3\" ColId=\"8\">                                                                 +
+                             <Ident ColId=\"8\" ColName=\"i3\"/>                                                              +
+                          </ProjElem>                                                                                         +
+                          <ProjElem Alias=\"ctid\" ColId=\"9\">                                                               +
+                             <Ident ColId=\"9\" ColName=\"ctid\"/>                                                            +
+                          </ProjElem>                                                                                         +
+                          <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                     +
+                             <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                  +
+                          </ProjElem>                                                                                         +
+                          <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                       +
+                             <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                    +
+                          </ProjElem>                                                                                         +
+                       </ProjList>                                                                                            +
+                       <Filter/>                                                                                              +
+                       <OneTimeFilter/>                                                                                       +
+                       <NestedLoopJoin IndexNestedLoopJoin=\"false\" JoinType=\"Left\" OuterRefAsParam=\"false\">             +
+                          <ProjList>                                                                                          +
+                             <ProjElem Alias=\"i3\" ColId=\"8\">                                                              +
+                                <Ident ColId=\"8\" ColName=\"i3\"/>                                                           +
+                             </ProjElem>                                                                                      +
+                             <ProjElem Alias=\"ctid\" ColId=\"9\">                                                            +
+                                <Ident ColId=\"9\" ColName=\"ctid\"/>                                                         +
+                             </ProjElem>                                                                                      +
+                             <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                  +
+                                <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                               +
+                             </ProjElem>                                                                                      +
+                             <ProjElem Alias=\"i2\" ColId=\"17\">                                                             +
+                                <Ident ColId=\"17\" ColName=\"i2\"/>                                                          +
+                             </ProjElem>                                                                                      +
+                             <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                    +
+                                <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                 +
+                             </ProjElem>                                                                                      +
+                          </ProjList>                                                                                         +
+                          <Filter/>                                                                                           +
+                          <JoinFilter>                                                                                        +
+                             <ConstValue/>                                                                                    +
+                          </JoinFilter>                                                                                       +
+                          <Materialize Eager=\"false\">                                                                       +
+                             <ProjList>                                                                                       +
+                                <ProjElem Alias=\"i3\" ColId=\"8\">                                                           +
+                                   <Ident ColId=\"8\" ColName=\"i3\"/>                                                        +
+                                </ProjElem>                                                                                   +
+                                <ProjElem Alias=\"ctid\" ColId=\"9\">                                                         +
+                                   <Ident ColId=\"9\" ColName=\"ctid\"/>                                                      +
+                                </ProjElem>                                                                                   +
+                                <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                               +
+                                   <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                            +
+                                </ProjElem>                                                                                   +
+                             </ProjList>                                                                                      +
+                             <Filter/>                                                                                        +
+                             <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                     +
+                                <ProjList>                                                                                    +
+                                   <ProjElem Alias=\"i3\" ColId=\"8\">                                                        +
+                                      <Ident ColId=\"8\" ColName=\"i3\"/>                                                     +
+                                   </ProjElem>                                                                                +
+                                   <ProjElem Alias=\"ctid\" ColId=\"9\">                                                      +
+                                      <Ident ColId=\"9\" ColName=\"ctid\"/>                                                   +
+                                   </ProjElem>                                                                                +
+                                   <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                            +
+                                      <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                         +
+                                   </ProjElem>                                                                                +
+                                </ProjList>                                                                                   +
+                                <Filter/>                                                                                     +
+                                <SortingColumnList/>                                                                          +
+                                <TableScan>                                                                                   +
+                                   <ProjList>                                                                                 +
+                                      <ProjElem Alias=\"i3\" ColId=\"8\">                                                     +
+                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                  +
+                                      </ProjElem>                                                                             +
+                                      <ProjElem Alias=\"ctid\" ColId=\"9\">                                                   +
+                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                +
+                                      </ProjElem>                                                                             +
+                                      <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                         +
+                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                      +
+                                      </ProjElem>                                                                             +
+                                   </ProjList>                                                                                +
+                                   <Filter/>                                                                                  +
+                                   <TableDescriptor>                                                                          +
+                                      <Columns>                                                                               +
+                                         <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                      +
+                                         <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                   +
+                                         <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                  +
+                                         <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                  +
+                                         <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                  +
+                                         <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                  +
+                                         <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>              +
+                                         <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>         +
+                                      </Columns>                                                                              +
+                                   </TableDescriptor>                                                                         +
+                                </TableScan>                                                                                  +
+                             </GatherMotion>                                                                                  +
+                          </Materialize>                                                                                      +
+                          <Materialize Eager=\"true\">                                                                        +
+                             <ProjList>                                                                                       +
+                                <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                 +
+                                   <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                              +
+                                </ProjElem>                                                                                   +
+                                <ProjElem Alias=\"i2\" ColId=\"17\">                                                          +
+                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                                       +
+                                </ProjElem>                                                                                   +
+                             </ProjList>                                                                                      +
+                             <Filter/>                                                                                        +
+                             <Result>                                                                                         +
+                                <ProjList>                                                                                    +
+                                   <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                              +
+                                      <ConstValue/>                                                                           +
+                                   </ProjElem>                                                                                +
+                                   <ProjElem Alias=\"i2\" ColId=\"17\">                                                       +
+                                      <Ident ColId=\"17\" ColName=\"i2\"/>                                                    +
+                                   </ProjElem>                                                                                +
+                                </ProjList>                                                                                   +
+                                <Filter/>                                                                                     +
+                                <OneTimeFilter/>                                                                              +
+                                <Result>                                                                                      +
+                                   <ProjList>                                                                                 +
+                                      <ProjElem Alias=\"i2\" ColId=\"17\">                                                    +
+                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                 +
+                                      </ProjElem>                                                                             +
+                                   </ProjList>                                                                                +
+                                   <Filter>                                                                                   +
+                                      <IsNotFalse>                                                                            +
+                                         <Comparison ComparisonOperator=\"=\">                                                +
+                                            <Ident ColId=\"0\" ColName=\"i1\"/>                                               +
+                                            <Ident ColId=\"17\" ColName=\"i2\"/>                                              +
+                                         </Comparison>                                                                        +
+                                      </IsNotFalse>                                                                           +
+                                   </Filter>                                                                                  +
+                                   <OneTimeFilter/>                                                                           +
+                                   <Materialize Eager=\"false\">                                                              +
+                                      <ProjList>                                                                              +
+                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                 +
+                                            <Ident ColId=\"17\" ColName=\"i2\"/>                                              +
+                                         </ProjElem>                                                                          +
+                                      </ProjList>                                                                             +
+                                      <Filter/>                                                                               +
+                                      <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                            +
+                                         <ProjList>                                                                           +
+                                            <ProjElem Alias=\"i2\" ColId=\"17\">                                              +
+                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                           +
+                                            </ProjElem>                                                                       +
+                                         </ProjList>                                                                          +
+                                         <Filter/>                                                                            +
+                                         <SortingColumnList/>                                                                 +
+                                         <TableScan>                                                                          +
+                                            <ProjList>                                                                        +
+                                               <ProjElem Alias=\"i2\" ColId=\"17\">                                           +
+                                                  <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
+                                               </ProjElem>                                                                    +
+                                            </ProjList>                                                                       +
+                                            <Filter/>                                                                         +
+                                            <TableDescriptor>                                                                 +
+                                               <Columns>                                                                      +
+                                                  <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
+                                                  <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
+                                                  <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
+                                                  <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
+                                                  <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
+                                                  <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
+                                                  <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
+                                                  <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
+                                               </Columns>                                                                     +
+                                            </TableDescriptor>                                                                +
+                                         </TableScan>                                                                         +
+                                      </GatherMotion>                                                                         +
+                                   </Materialize>                                                                             +
+                                </Result>                                                                                     +
+                             </Result>                                                                                        +
+                          </Materialize>                                                                                      +
+                       </NestedLoopJoin>                                                                                      +
+                    </Result>                                                                                                 +
+                 </Sort>                                                                                                      +
+              </Aggregate>                                                                                                    +
+           </Result>                                                                                                          +
+        </SubPlan>                                                                                                            +
+     </Filter>                                                                                                                +
+     <OneTimeFilter/>                                                                                                         +
+     <Sort SortDiscardDuplicates=\"false\">                                                                                   +
+        <ProjList>                                                                                                            +
+           <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                +
+              <Ident ColId=\"0\" ColName=\"i1\"/>                                                                             +
+           </ProjElem>                                                                                                        +
+        </ProjList>                                                                                                           +
+        <Filter/>                                                                                                             +
+        <SortingColumnList>                                                                                                   +
+           <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                              +
+        </SortingColumnList>                                                                                                  +
+        <LimitCount/>                                                                                                         +
+        <LimitOffset/>                                                                                                        +
+        <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                          +
+           <ProjList>                                                                                                         +
+              <ProjElem Alias=\"i1\" ColId=\"0\">                                                                             +
+                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                          +
+              </ProjElem>                                                                                                     +
+           </ProjList>                                                                                                        +
+           <Filter/>                                                                                                          +
+           <SortingColumnList/>                                                                                               +
+           <TableScan>                                                                                                        +
+              <ProjList>                                                                                                      +
+                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                          +
+                    <Ident ColId=\"0\" ColName=\"i1\"/>                                                                       +
+                 </ProjElem>                                                                                                  +
+              </ProjList>                                                                                                     +
+              <Filter/>                                                                                                       +
+              <TableDescriptor>                                                                                               +
+                 <Columns>                                                                                                    +
+                    <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                           +
+                    <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                        +
+                    <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                        +
+                    <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                        +
+                    <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                        +
+                    <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                        +
+                    <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                    +
+                    <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                               +
+                 </Columns>                                                                                                   +
+              </TableDescriptor>                                                                                              +
+           </TableScan>                                                                                                       +
+        </GatherMotion>                                                                                                       +
+     </Sort>                                                                                                                  +
+  </Result>                                                                                                                   +
+       </Plan>"}
 (1 row)
 
---insert into t1 values (1);
---analyze t1;
+insert into t1 values (1);
+analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -1652,7 +1651,8 @@ select * from t1 where
  i1 
 ----
   0
-(1 row)
+  1
+(2 rows)
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
@@ -1660,7 +1660,7 @@ reset optimizer_trace_fallback;
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
 \! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
-\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='    ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! python $MASTER_DATA_DIRECTORY/minidumps/script.py
@@ -1672,357 +1672,212 @@ reset optimizer_trace_fallback;
 \! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 \! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
-                                                                                                                xpath                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                                                                                                                   +
-                         <Result>                                                                                                                                                                                                    +
-                                 <ProjList>                                                                                                                                                                                          +
-                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                         +
-                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                                 +
-                                         </ProjElem>                                                                                                                                                                                 +
-                                 </ProjList>                                                                                                                                                                                         +
-                                 <Filter>                                                                                                                                                                                            +
-                                         <SubPlan SubPlanType=\"AnySubPlan\">                                                                                                                                                        +
-                                                 <TestExpr>                                                                                                                                                                          +
-                                                         <Comparison ComparisonOperator=\"=\">                                                                                                                                       +
-                                                                 <If>                                                                                                                                                                +
-                                                                         <Comparison ComparisonOperator=\"&gt;\">                                                                                                                    +
-                                                                                 <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                       +
-                                                                                 <ConstValue/>                                                                                                                                       +
-                                                                         </Comparison>                                                                                                                                               +
-                                                                         <If>                                                                                                                                                        +
-                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                                               +
-                                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                               +
-                                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                               +
-                                                                                 </Comparison>                                                                                                                                       +
-                                                                                 <ConstValue IsNull=\"true\"/>                                                                                                                       +
-                                                                                 <ConstValue/>                                                                                                                                       +
-                                                                         </If>                                                                                                                                                       +
-                                                                         <ConstValue/>                                                                                                                                               +
-                                                                 </If>                                                                                                                                                               +
-                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                          +
-                                                         </Comparison>                                                                                                                                                               +
-                                                 </TestExpr>                                                                                                                                                                         +
-                                                 <ParamList>                                                                                                                                                                         +
-                                                         <Param ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
-                                                 </ParamList>                                                                                                                                                                        +
-                                                 <Result>                                                                                                                                                                            +
-                                                         <ProjList>                                                                                                                                                                  +
-                                                                 <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                                       +
-                                                                         <Ident ColId=\"26\" ColName=\"ColRef_0026\"/>                                                                                                               +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                                 <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                                       +
-                                                                         <Ident ColId=\"28\" ColName=\"ColRef_0028\"/>                                                                                                               +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                          +
-                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                                  +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                         </ProjList>                                                                                                                                                                 +
-                                                         <Filter/>                                                                                                                                                                   +
-                                                         <OneTimeFilter/>                                                                                                                                                            +
-                                                         <Aggregate AggregationStrategy=\"Sorted\" StreamSafe=\"false\">                                                                                                             +
-                                                                 <GroupingColumns>                                                                                                                                                   +
-                                                                         <GroupingColumn ColId=\"8\"/>                                                                                                                               +
-                                                                         <GroupingColumn ColId=\"9\"/>                                                                                                                               +
-                                                                         <GroupingColumn ColId=\"15\"/>                                                                                                                              +
-                                                                         <GroupingColumn ColId=\"16\"/>                                                                                                                              +
-                                                                 </GroupingColumns>                                                                                                                                                  +
-                                                                 <ProjList>                                                                                                                                                          +
-                                                                         <ProjElem Alias=\"ColRef_0026\" ColId=\"26\">                                                                                                               +
-                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
-                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
-                                                                                 </AggFunc>                                                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"ColRef_0028\" ColId=\"28\">                                                                                                               +
-                                                                                 <AggFunc AggDistinct=\"false\" AggKind=\"n\">                                                                                                       +
-                                                                                                 <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                       +
-                                                                                 </AggFunc>                                                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                                  +
-                                                                                 <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                          +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                         +
-                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                                 +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                                       +
-                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                               +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                             +
-                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                                     +
-                                                                         </ProjElem>                                                                                                                                                 +
-                                                                 </ProjList>                                                                                                                                                         +
-                                                                 <Filter/>                                                                                                                                                           +
-                                                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                              +
-                                                                         <ProjList>                                                                                                                                                  +
-                                                                                 <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                          +
-                                                                                         <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                                                  +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                                       +
-                                                                                         <Ident ColId=\"27\" ColName=\"ColRef_0027\"/>                                                                                               +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                                 +
-                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                         +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                               +
-                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                                       +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                                     +
-                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                             +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                                       +
-                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                               +
-                                                                                 </ProjElem>                                                                                                                                         +
-                                                                         </ProjList>                                                                                                                                                 +
-                                                                         <Filter/>                                                                                                                                                   +
-                                                                         <SortingColumnList>                                                                                                                                         +
-                                                                                 <SortingColumn ColId=\"8\" SortNullsFirst=\"false\"/>                                                                                               +
-                                                                                 <SortingColumn ColId=\"9\" SortNullsFirst=\"false\"/>                                                                                               +
-                                                                                 <SortingColumn ColId=\"15\" SortNullsFirst=\"false\"/>                                                                                              +
-                                                                                 <SortingColumn ColId=\"16\" SortNullsFirst=\"false\"/>                                                                                              +
-                                                                         </SortingColumnList>                                                                                                                                        +
-                                                                         <LimitCount/>                                                                                                                                               +
-                                                                         <LimitOffset/>                                                                                                                                              +
-                                                                         <Result>                                                                                                                                                    +
-                                                                                 <ProjList>                                                                                                                                          +
-                                                                                         <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                                                  +
-                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                                               +
-                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                 </Comparison>                                                                                                                       +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ColRef_0027\" ColId=\"27\">                                                                                               +
-                                                                                                 <If>                                                                                                                                +
-                                                                                                         <IsNull>                                                                                                                    +
-                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                                               +
-                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                         +
-                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
-                                                                                                                 </Comparison>                                                                                                       +
-                                                                                                         </IsNull>                                                                                                                   +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                         <ConstValue/>                                                                                                               +
-                                                                                                 </If>                                                                                                                               +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                         +
-                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                                 +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                                       +
-                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                               +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                             +
-                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                                     +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                               +
-                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                                       +
-                                                                                         </ProjElem>                                                                                                                                 +
-                                                                                 </ProjList>                                                                                                                                         +
-                                                                                 <Filter/>                                                                                                                                           +
-                                                                                 <OneTimeFilter/>                                                                                                                                    +
-                                                                                 <NestedLoopJoin IndexNestedLoopJoin=\"false\" JoinType=\"Left\" OuterRefAsParam=\"false\">                                                          +
-                                                                                         <ProjList>                                                                                                                                  +
-                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                                 +
-                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                         +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                               +
-                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                                       +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                                     +
-                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                             +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                                +
-                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                        +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                                       +
-                                                                                                         <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                               +
-                                                                                                 </ProjElem>                                                                                                                         +
-                                                                                         </ProjList>                                                                                                                                 +
-                                                                                         <Filter/>                                                                                                                                   +
-                                                                                         <JoinFilter>                                                                                                                                +
-                                                                                                 <ConstValue/>                                                                                                                       +
-                                                                                         </JoinFilter>                                                                                                                               +
-                                                                                         <Materialize Eager=\"false\">                                                                                                               +
-                                                                                                 <ProjList>                                                                                                                          +
-                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                         +
-                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                                 +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                                       +
-                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                               +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                             +
-                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                                     +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                 </ProjList>                                                                                                                         +
-                                                                                                 <Filter/>                                                                                                                           +
-                                                                                                 <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                        +
-                                                                                                         <ProjList>                                                                                                                  +
-                                                                                                                 <ProjElem Alias=\"i3\" ColId=\"8\">                                                                                 +
-                                                                                                                         <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                               +
-                                                                                                                         <Ident ColId=\"9\" ColName=\"ctid\"/>                                                                       +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                                     +
-                                                                                                                         <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                             +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                         </ProjList>                                                                                                                 +
-                                                                                                         <Filter/>                                                                                                                   +
-                                                                                                         <SortingColumnList/>                                                                                                        +
-                                                                                                         <TableScan>                                                                                                                 +
-                                                                                                                 <ProjList>                                                                                                          +
-                                                                                                                         <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
-                                                                                                                                 <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                         <ProjElem Alias=\"ctid\" ColId=\"9\">                                                                       +
-                                                                                                                                 <Ident ColId=\"9\" ColName=\"ctid\"/>                                                               +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                         <ProjElem Alias=\"gp_segment_id\" ColId=\"15\">                                                             +
-                                                                                                                                 <Ident ColId=\"15\" ColName=\"gp_segment_id\"/>                                                     +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                 </ProjList>                                                                                                         +
-                                                                                                                 <Filter/>                                                                                                           +
-                                                                                                                 <TableDescriptor>                                                                                                   +
-                                                                                                                         <Columns>                                                                                                   +
-                                                                                                                                 <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                     +
-                                                                                                                                 <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                                  +
-                                                                                                                                 <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                                 +
-                                                                                                                                 <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                             +
-                                                                                                                                 <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                        +
-                                                                                                                         </Columns>                                                                                                  +
-                                                                                                                 </TableDescriptor>                                                                                                  +
-                                                                                                         </TableScan>                                                                                                                +
-                                                                                                 </GatherMotion>                                                                                                                     +
-                                                                                         </Materialize>                                                                                                                              +
-                                                                                         <Materialize Eager=\"true\">                                                                                                                +
-                                                                                                 <ProjList>                                                                                                                          +
-                                                                                                         <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                               +
-                                                                                                                 <Ident ColId=\"25\" ColName=\"ColRef_0025\"/>                                                                       +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                        +
-                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                                +
-                                                                                                         </ProjElem>                                                                                                                 +
-                                                                                                 </ProjList>                                                                                                                         +
-                                                                                                 <Filter/>                                                                                                                           +
-                                                                                                 <Result>                                                                                                                            +
-                                                                                                         <ProjList>                                                                                                                  +
-                                                                                                                 <ProjElem Alias=\"ColRef_0025\" ColId=\"25\">                                                                       +
-                                                                                                                         <ConstValue/>                                                                                               +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                                +
-                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                                        +
-                                                                                                                 </ProjElem>                                                                                                         +
-                                                                                                         </ProjList>                                                                                                                 +
-                                                                                                         <Filter/>                                                                                                                   +
-                                                                                                         <OneTimeFilter/>                                                                                                            +
-                                                                                                         <Result>                                                                                                                    +
-                                                                                                                 <ProjList>                                                                                                          +
-                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                                        +
-                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                                +
-                                                                                                                         </ProjElem>                                                                                                 +
-                                                                                                                 </ProjList>                                                                                                         +
-                                                                                                                 <Filter>                                                                                                            +
-                                                                                                                         <IsNotFalse>                                                                                                +
-                                                                                                                                 <Comparison ComparisonOperator=\"=\">                                                               +
-                                                                                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                         +
-                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
-                                                                                                                                 </Comparison>                                                                                       +
-                                                                                                                         </IsNotFalse>                                                                                               +
-                                                                                                                 </Filter>                                                                                                           +
-                                                                                                                 <OneTimeFilter/>                                                                                                    +
-                                                                                                                 <Materialize Eager=\"false\">                                                                                       +
-                                                                                                                         <ProjList>                                                                                                  +
-                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                                +
-                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
-                                                                                                                                 </ProjElem>                                                                                         +
-                                                                                                                         </ProjList>                                                                                                 +
-                                                                                                                         <Filter/>                                                                                                   +
-                                                                                                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                +
-                                                                                                                                 <ProjList>                                                                                          +
-                                                                                                                                         <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
-                                                                                                                                                 <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
-                                                                                                                                         </ProjElem>                                                                                 +
-                                                                                                                                 </ProjList>                                                                                         +
-                                                                                                                                 <Filter/>                                                                                           +
-                                                                                                                                 <SortingColumnList/>                                                                                +
-                                                                                                                                 <TableScan>                                                                                         +
-                                                                                                                                         <ProjList>                                                                                  +
-                                                                                                                                                 <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
-                                                                                                                                                         <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
-                                                                                                                                                 </ProjElem>                                                                         +
-                                                                                                                                         </ProjList>                                                                                 +
-                                                                                                                                         <Filter/>                                                                                   +
-                                                                                                                                         <TableDescriptor>                                                                           +
-                                                                                                                                                 <Columns>                                                                           +
-                                                                                                                                                         <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
-                                                                                                                                                         <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
-                                                                                                                                                         <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
-                                                                                                                                                         <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
-                                                                                                                                                         <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
-                                                                                                                                                 </Columns>                                                                          +
-                                                                                                                                         </TableDescriptor>                                                                          +
-                                                                                                                                 </TableScan>                                                                                        +
-                                                                                                                         </GatherMotion>                                                                                             +
-                                                                                                                 </Materialize>                                                                                                      +
-                                                                                                         </Result>                                                                                                                   +
-                                                                                                 </Result>                                                                                                                           +
-                                                                                         </Materialize>                                                                                                                              +
-                                                                                 </NestedLoopJoin>                                                                                                                                   +
-                                                                         </Result>                                                                                                                                                   +
-                                                                 </Sort>                                                                                                                                                             +
-                                                         </Aggregate>                                                                                                                                                                +
-                                                 </Result>                                                                                                                                                                           +
-                                         </SubPlan>                                                                                                                                                                                  +
-                                 </Filter>                                                                                                                                                                                           +
-                                 <OneTimeFilter/>                                                                                                                                                                                    +
-                                 <Sort SortDiscardDuplicates=\"false\">                                                                                                                                                              +
-                                         <ProjList>                                                                                                                                                                                  +
-                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                                 +
-                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                         +
-                                                 </ProjElem>                                                                                                                                                                         +
-                                         </ProjList>                                                                                                                                                                                 +
-                                         <Filter/>                                                                                                                                                                                   +
-                                         <SortingColumnList>                                                                                                                                                                         +
-                                                 <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                                                                               +
-                                         </SortingColumnList>                                                                                                                                                                        +
-                                         <LimitCount/>                                                                                                                                                                               +
-                                         <LimitOffset/>                                                                                                                                                                              +
-                                         <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                                                                                +
-                                                 <ProjList>                                                                                                                                                                          +
-                                                         <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                         +
-                                                                 <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                                 +
-                                                         </ProjElem>                                                                                                                                                                 +
-                                                 </ProjList>                                                                                                                                                                         +
-                                                 <Filter/>                                                                                                                                                                           +
-                                                 <SortingColumnList/>                                                                                                                                                                +
-                                                 <TableScan>                                                                                                                                                                         +
-                                                         <ProjList>                                                                                                                                                                  +
-                                                                 <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                                                 +
-                                                                         <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                                                         +
-                                                                 </ProjElem>                                                                                                                                                         +
-                                                         </ProjList>                                                                                                                                                                 +
-                                                         <Filter/>                                                                                                                                                                   +
-                                                         <TableDescriptor>                                                                                                                                                           +
-                                                                 <Columns>                                                                                                                                                           +
-                                                                         <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                                                                             +
-                                                                         <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                                                                          +
-                                                                         <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                                                                          +
-                                                                         <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                                                                      +
-                                                                         <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                                                                                 +
-                                                                 </Columns>                                                                                                                                                          +
-                                                         </TableDescriptor>                                                                                                                                                          +
-                                                 </TableScan>                                                                                                                                                                        +
-                                         </GatherMotion>                                                                                                                                                                             +
-                                 </Sort>                                                                                                                                                                                             +
-                         </Result>                                                                                                                                                                                                   +
-                 </Plan>"}
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
+                                                                    replace                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------
+ {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                             +
+   <Result>                                                                                                                                    +
+       <ProjList>                                                                                                                              +
+           <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                                 +
+               <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                             +
+           </ProjElem>                                                                                                                         +
+       </ProjList>                                                                                                                             +
+       <Filter>                                                                                                                                +
+           <SubPlan SubPlanType=\"ScalarSubPlan\">                                                                                             +
+               <TestExpr/>                                                                                                                     +
+               <ParamList>                                                                                                                     +
+                   <Param ColId=\"0\" ColName=\"i1\"/>                                                                                         +
+               </ParamList>                                                                                                                    +
+               <Result>                                                                                                                        +
+                   <ProjList>                                                                                                                  +
+                       <ProjElem Alias=\"ColRef_0038\" ColId=\"38\">                                                                           +
+                           <ConstValue/>                                                                                                       +
+                       </ProjElem>                                                                                                             +
+                   </ProjList>                                                                                                                 +
+                   <Filter/>                                                                                                                   +
+                   <OneTimeFilter/>                                                                                                            +
+                   <Result>                                                                                                                    +
+                       <ProjList>                                                                                                              +
+                           <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                          +
+                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                      +
+                           </ProjElem>                                                                                                         +
+                       </ProjList>                                                                                                             +
+                       <Filter>                                                                                                                +
+                           <Comparison ComparisonOperator=\"=\">                                                                               +
+                               <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                                                                   +
+                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                      +
+                           </Comparison>                                                                                                       +
+                       </Filter>                                                                                                               +
+                       <OneTimeFilter/>                                                                                                        +
+                       <Result>                                                                                                                +
+                           <ProjList>                                                                                                          +
+                               <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                      +
+                                   <Comparison ComparisonOperator=\"=\">                                                                       +
+                                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                                     +
+                                       <ConstValue/>                                                                                           +
+                                   </Comparison>                                                                                               +
+                               </ProjElem>                                                                                                     +
+                               <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                                                   +
+                                   <SubPlan SubPlanType=\"AnySubPlan\">                                                                        +
+                                       <TestExpr>                                                                                              +
+                                           <Comparison ComparisonOperator=\"=\">                                                               +
+                                               <Ident ColId=\"0\" ColName=\"i1\"/>                                                             +
+                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                                            +
+                                           </Comparison>                                                                                       +
+                                       </TestExpr>                                                                                             +
+                                       <ParamList/>                                                                                            +
+                                       <Result>                                                                                                +
+                                           <ProjList>                                                                                          +
+                                               <ProjElem Alias=\"i2\" ColId=\"17\">                                                            +
+                                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
+                                               </ProjElem>                                                                                     +
+                                           </ProjList>                                                                                         +
+                                           <Filter/>                                                                                           +
+                                           <OneTimeFilter/>                                                                                    +
+                                           <Result>                                                                                            +
+                                               <ProjList>                                                                                      +
+                                                   <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                               +
+                                                       <ConstValue/>                                                                           +
+                                                   </ProjElem>                                                                                 +
+                                                   <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
+                                                       <Ident ColId=\"17\" ColName=\"i2\"/>                                                    +
+                                                   </ProjElem>                                                                                 +
+                                               </ProjList>                                                                                     +
+                                               <Filter/>                                                                                       +
+                                               <OneTimeFilter/>                                                                                +
+                                               <Materialize Eager=\"true\">                                                                    +
+                                                   <ProjList>                                                                                  +
+                                                       <ProjElem Alias=\"i2\" ColId=\"17\">                                                    +
+                                                           <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
+                                                       </ProjElem>                                                                             +
+                                                   </ProjList>                                                                                 +
+                                                   <Filter/>                                                                                   +
+                                                   <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                +
+                                                       <ProjList>                                                                              +
+                                                           <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
+                                                               <Ident ColId=\"17\" ColName=\"i2\"/>                                            +
+                                                           </ProjElem>                                                                         +
+                                                       </ProjList>                                                                             +
+                                                       <Filter/>                                                                               +
+                                                       <SortingColumnList/>                                                                    +
+                                                       <TableScan>                                                                             +
+                                                           <ProjList>                                                                          +
+                                                               <ProjElem Alias=\"i2\" ColId=\"17\">                                            +
+                                                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
+                                                               </ProjElem>                                                                     +
+                                                           </ProjList>                                                                         +
+                                                           <Filter/>                                                                           +
+                                                           <TableDescriptor>                                                                   +
+                                                               <Columns>                                                                       +
+                                                                   <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
+                                                                   <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
+                                                                   <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
+                                                                   <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
+                                                                   <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
+                                                                   <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
+                                                                   <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
+                                                                   <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
+                                                               </Columns>                                                                      +
+                                                           </TableDescriptor>                                                                  +
+                                                       </TableScan>                                                                            +
+                                                   </GatherMotion>                                                                             +
+                                               </Materialize>                                                                                  +
+                                           </Result>                                                                                           +
+                                       </Result>                                                                                               +
+                                   </SubPlan>                                                                                                  +
+                               </ProjElem>                                                                                                     +
+                           </ProjList>                                                                                                         +
+                           <Filter/>                                                                                                           +
+                           <OneTimeFilter/>                                                                                                    +
+                           <Materialize Eager=\"true\">                                                                                        +
+                               <ProjList>                                                                                                      +
+                                   <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
+                                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                                     +
+                                   </ProjElem>                                                                                                 +
+                               </ProjList>                                                                                                     +
+                               <Filter/>                                                                                                       +
+                               <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                    +
+                                   <ProjList>                                                                                                  +
+                                       <ProjElem Alias=\"i3\" ColId=\"8\">                                                                     +
+                                           <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
+                                       </ProjElem>                                                                                             +
+                                   </ProjList>                                                                                                 +
+                                   <Filter/>                                                                                                   +
+                                   <SortingColumnList/>                                                                                        +
+                                   <TableScan>                                                                                                 +
+                                       <ProjList>                                                                                              +
+                                           <ProjElem Alias=\"i3\" ColId=\"8\">                                                                 +
+                                               <Ident ColId=\"8\" ColName=\"i3\"/>                                                             +
+                                           </ProjElem>                                                                                         +
+                                       </ProjList>                                                                                             +
+                                       <Filter/>                                                                                               +
+                                       <TableDescriptor>                                                                                       +
+                                           <Columns>                                                                                           +
+                                               <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                 +
+                                               <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                              +
+                                               <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                             +
+                                               <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                             +
+                                               <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                             +
+                                               <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                             +
+                                               <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                         +
+                                               <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                    +
+                                           </Columns>                                                                                          +
+                                       </TableDescriptor>                                                                                      +
+                                   </TableScan>                                                                                                +
+                               </GatherMotion>                                                                                                 +
+                           </Materialize>                                                                                                      +
+                       </Result>                                                                                                               +
+                   </Result>                                                                                                                   +
+               </Result>                                                                                                                       +
+           </SubPlan>                                                                                                                          +
+       </Filter>                                                                                                                               +
+       <OneTimeFilter/>                                                                                                                        +
+       <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                                            +
+           <ProjList>                                                                                                                          +
+               <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                             +
+                   <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                         +
+               </ProjElem>                                                                                                                     +
+           </ProjList>                                                                                                                         +
+           <Filter/>                                                                                                                           +
+           <SortingColumnList>                                                                                                                 +
+               <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                           +
+           </SortingColumnList>                                                                                                                +
+           <Sort SortDiscardDuplicates=\"false\">                                                                                              +
+               <ProjList>                                                                                                                      +
+                   <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                         +
+                       <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                     +
+                   </ProjElem>                                                                                                                 +
+               </ProjList>                                                                                                                     +
+               <Filter/>                                                                                                                       +
+               <SortingColumnList>                                                                                                             +
+                   <SortingColumn ColId=\"0\" SortNullsFirst=\"false\"/>                                                                       +
+               </SortingColumnList>                                                                                                            +
+               <LimitCount/>                                                                                                                   +
+               <LimitOffset/>                                                                                                                  +
+               <TableScan>                                                                                                                     +
+                   <ProjList>                                                                                                                  +
+                       <ProjElem Alias=\"i1\" ColId=\"0\">                                                                                     +
+                           <Ident ColId=\"0\" ColName=\"i1\"/>                                                                                 +
+                       </ProjElem>                                                                                                             +
+                   </ProjList>                                                                                                                 +
+                   <Filter/>                                                                                                                   +
+                   <TableDescriptor>                                                                                                           +
+                       <Columns>                                                                                                               +
+                           <Column Attno=\"1\" ColId=\"0\" ColName=\"i1\" ColWidth=\"4\"/>                                                     +
+                           <Column Attno=\"-1\" ColId=\"1\" ColName=\"ctid\" ColWidth=\"6\"/>                                                  +
+                           <Column Attno=\"-3\" ColId=\"2\" ColName=\"xmin\" ColWidth=\"4\"/>                                                  +
+                           <Column Attno=\"-4\" ColId=\"3\" ColName=\"cmin\" ColWidth=\"4\"/>                                                  +
+                           <Column Attno=\"-5\" ColId=\"4\" ColName=\"xmax\" ColWidth=\"4\"/>                                                  +
+                           <Column Attno=\"-6\" ColId=\"5\" ColName=\"cmax\" ColWidth=\"4\"/>                                                  +
+                           <Column Attno=\"-7\" ColId=\"6\" ColName=\"tableoid\" ColWidth=\"4\"/>                                              +
+                           <Column Attno=\"-8\" ColId=\"7\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                                         +
+                       </Columns>                                                                                                              +
+                   </TableDescriptor>                                                                                                          +
+               </TableScan>                                                                                                                    +
+           </Sort>                                                                                                                             +
+       </GatherMotion>                                                                                                                         +
+   </Result>                                                                                                                                   +
+         </Plan>"}
 (1 row)
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1236,8 +1236,6 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
--- start_ignore
--- end_ignore
 create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 create table t2 as select 0 as i2;
@@ -1251,7 +1249,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
 -- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 set optimizer_trace_fallback=on;
 set optimizer_minidump=always;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1235,3 +1235,65 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
+-- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
+INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
+INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
+INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Result
+   Output: test_tbl_t.text_t, test_tbl_t.int_t
+   Filter: (SubPlan 2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: test_tbl_t.text_t, test_tbl_t.int_t
+         Merge Key: test_tbl_t.int_t
+         ->  Sort
+               Output: test_tbl_t.text_t, test_tbl_t.int_t
+               Sort Key: test_tbl_t.int_t
+               ->  Seq Scan on public.test_tbl_t
+                     Output: test_tbl_t.text_t, test_tbl_t.int_t
+   SubPlan 2  (slice0)
+     ->  Result
+           Output: true
+           ->  Result
+                 Output: ((test_tbl_p.int_p = 1))
+                 Filter: (((SubPlan 1)) = ((test_tbl_p.int_p = 1)))
+                 ->  Result
+                       Output: (test_tbl_p.int_p = 1), (SubPlan 1)
+                       ->  Materialize
+                             Output: test_tbl_p.int_p
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   Output: test_tbl_p.int_p
+                                   ->  Seq Scan on public.test_tbl_p
+                                         Output: test_tbl_p.int_p
+                       SubPlan 1  (slice0)
+                         ->  Result
+                               Output: test_tbl_d.int_d
+                               ->  Result
+                                     Output: true, test_tbl_d.int_d
+                                     ->  Materialize
+                                           Output: test_tbl_d.int_d
+                                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                 Output: test_tbl_d.int_d
+                                                 ->  Seq Scan on public.test_tbl_d
+                                                       Output: test_tbl_d.int_d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: optimizer=on
+(38 rows)
+
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+ text_t | int_t 
+--------+-------
+ 0      |     0
+ 0      |     1
+(2 rows)
+
+DROP TABLE test_tbl_t;
+DROP TABLE test_tbl_d;
+DROP TABLE test_tbl_p;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1236,159 +1236,257 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-create table test_tbl_t as select 0 as int_t;
+drop table if exists t1;
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+drop table if exists t3;
+NOTICE:  table "t3" does not exist, skipping
+create table t1 as select 0 as i1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-create table test_tbl_d as select 0 as int_d;
+create table t2 as select 0 as i2;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
+create table t3 as select i3 from (values (0), (1)) as s(i3);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
-set client_min_messages='log';
 set optimizer_trace_fallback=on;
-LOG:  statement: set optimizer_trace_fallback=on;
-LOG:  statement: SET optimizer_trace_fallback TO 'on'  (entry db 172.17.0.2:6000 pid=16711)
--- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
--- a deep tree and only params (see minidump).
+set client_min_messages='log';
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- TestExpr and its params are not displayed in Explain output. However, the output is
--- needed to make sure that the DXL we need is generated.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-                                                                                                          QUERY PLAN                                                                                                           
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result
-   Output: test_tbl_t.int_t
-   Filter: (SubPlan 1)
-   ->  Sort
-         Output: test_tbl_t.int_t
-         Sort Key: test_tbl_t.int_t
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               Output: test_tbl_t.int_t
-               ->  Seq Scan on public.test_tbl_t
-                     Output: test_tbl_t.int_t
-   SubPlan 1  (slice0)
-     ->  Result
-           Output: (count("outer".ColRef_0025)), (sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END))), ((test_tbl_p.int_p = 1))
-           ->  GroupAggregate
-                 Output: count("outer".ColRef_0025), sum((CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END)), ((test_tbl_p.int_p = 1)), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
-                 Group Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
-                 ->  Sort
-                       Output: ((test_tbl_p.int_p = 1)), (CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END), test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0025
-                       Sort Key: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, ((test_tbl_p.int_p = 1))
-                       ->  Result
-                             Output: (test_tbl_p.int_p = 1), CASE WHEN ((test_tbl_t.int_t = test_tbl_d.int_d) IS NULL) THEN 1 ELSE 0 END, test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, "outer".ColRef_0025
-                             ->  Nested Loop Left Join
-                                   Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id, test_tbl_d.int_d, "outer".ColRef_0025
-                                   Join Filter: true
-                                   ->  Materialize
-                                         Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
-                                         ->  Gather Motion 3:1  (slice3; segments: 3)
-                                               Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
-                                               ->  Seq Scan on public.test_tbl_p
-                                                     Output: test_tbl_p.int_p, test_tbl_p.ctid, test_tbl_p.gp_segment_id
-                                   ->  Materialize
-                                         Output: "outer".ColRef_0025, test_tbl_d.int_d
-                                         ->  Result
-                                               Output: true, test_tbl_d.int_d
-                                               ->  Result
-                                                     Output: test_tbl_d.int_d
-                                                     Filter: ((test_tbl_t.int_t = test_tbl_d.int_d) IS NOT FALSE)
-                                                     ->  Materialize
-                                                           Output: test_tbl_d.int_d
-                                                           ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                 Output: test_tbl_d.int_d
-                                                                 ->  Seq Scan on public.test_tbl_d
-                                                                       Output: test_tbl_d.int_d
- Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(45 rows)
-
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
- int_t 
--------
-     0
+-- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
+-- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
+-- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+LOG:  statement: select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+ i1 
+----
+  0
 (1 row)
 
-insert into test_tbl_t values (1);
-LOG:  statement: insert into test_tbl_t values (1);
-insert into test_tbl_d values (1);
-LOG:  statement: insert into test_tbl_d values (1);
-insert into test_tbl_p values (0);
-LOG:  statement: insert into test_tbl_p values (0);
-analyze test_tbl_t;
-LOG:  statement: analyze test_tbl_t;
--- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
--- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
--- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
--- are treated as Vars. The previous case contained only params (attributes contained in the
+-- start_ignore
+-- end_ignore
+\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
+<dxl:Plan Id="0" SpaceSize="0">
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="0" Alias="i1">
+<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter>
+<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+<dxl:TestExpr>
+<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+<dxl:If TypeMdid="0.16.1.0">
+<dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
+<dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+</dxl:Comparison>
+<dxl:If TypeMdid="0.16.1.0">
+<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+<dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
+</dxl:Comparison>
+<dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+</dxl:If>
+<dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+</dxl:If>
+<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
+</dxl:Comparison>
+</dxl:TestExpr>
+<dxl:ParamList>
+<dxl:Param ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ParamList>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="26" Alias="ColRef_0026">
+<dxl:Ident ColId="26" ColName="ColRef_0026" TypeMdid="0.20.1.0"/>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="28" Alias="ColRef_0028">
+<dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="16" Alias="?column?">
+<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:OneTimeFilter/>
+<dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+<dxl:ProjList>
+<dxl:ProjElem ColId="26" Alias="ColRef_0026">
+<dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+<dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.16.1.0"/>
+</dxl:AggFunc>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="28" Alias="ColRef_0028">
+<dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+<dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.23.1.0"/>
+</dxl:AggFunc>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="16" Alias="?column?">
+<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+</dxl:Aggregate>
+</dxl:Result>
+</dxl:SubPlan>
+</dxl:Filter>
+<dxl:OneTimeFilter/>
+<dxl:Sort SortDiscardDuplicates="false">
+<dxl:ProjList>
+<dxl:ProjElem ColId="0" Alias="i1">
+<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:SortingColumnList>
+<dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+</dxl:SortingColumnList>
+<dxl:LimitCount/>
+<dxl:LimitOffset/>
+<dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+<dxl:ProjList>
+<dxl:ProjElem ColId="0" Alias="i1">
+<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+</dxl:GatherMotion>
+</dxl:Sort>
+</dxl:Result>
+</dxl:Plan>
+insert into t1 values (1);
+LOG:  statement: insert into t1 values (1);
+analyze t1;
+LOG:  statement: analyze t1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
--- We also need the Explain output to determine DXL.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Result
-   Output: test_tbl_t.int_t
-   Filter: (SubPlan 2)
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: test_tbl_t.int_t
-         Merge Key: test_tbl_t.int_t
-         ->  Sort
-               Output: test_tbl_t.int_t
-               Sort Key: test_tbl_t.int_t
-               ->  Seq Scan on public.test_tbl_t
-                     Output: test_tbl_t.int_t
-   SubPlan 2  (slice0)
-     ->  Result
-           Output: true
-           ->  Result
-                 Output: ((test_tbl_p.int_p = 1))
-                 Filter: (((SubPlan 1)) = ((test_tbl_p.int_p = 1)))
-                 ->  Result
-                       Output: (test_tbl_p.int_p = 1), (SubPlan 1)
-                       ->  Materialize
-                             Output: test_tbl_p.int_p
-                             ->  Gather Motion 3:1  (slice2; segments: 3)
-                                   Output: test_tbl_p.int_p
-                                   ->  Seq Scan on public.test_tbl_p
-                                         Output: test_tbl_p.int_p
-                       SubPlan 1  (slice0)
-                         ->  Result
-                               Output: test_tbl_d.int_d
-                               ->  Result
-                                     Output: true, test_tbl_d.int_d
-                                     ->  Materialize
-                                           Output: test_tbl_d.int_d
-                                           ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                 Output: test_tbl_d.int_d
-                                                 ->  Seq Scan on public.test_tbl_d
-                                                       Output: test_tbl_d.int_d
- Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(38 rows)
-
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-LOG:  statement: select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
- int_t 
--------
-     0
-     1
+-- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
+-- nested subplan; scan table t from outer <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+LOG:  statement: select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+ i1 
+----
+  0
+  1
 (2 rows)
 
-reset client_min_messages;
-LOG:  statement: reset client_min_messages;
-LOG:  statement: RESET client_min_messages  (entry db 172.17.0.2:6000 pid=16711)
+-- start_ignore
+-- end_ignore
+\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
+<dxl:Plan Id="0" SpaceSize="0">
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="0" Alias="i1">
+<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter>
+<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+<dxl:TestExpr/>
+<dxl:ParamList>
+<dxl:Param ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+</dxl:ParamList>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="38" Alias="ColRef_0038">
+<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:OneTimeFilter/>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="16" Alias="?column?">
+<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter>
+<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+<dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
+<dxl:Ident ColId="16" ColName="?column?" TypeMdid="0.16.1.0"/>
+</dxl:Comparison>
+</dxl:Filter>
+<dxl:OneTimeFilter/>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="16" Alias="?column?">
+<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+<dxl:Ident ColId="8" ColName="i3" TypeMdid="0.23.1.0"/>
+<dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+</dxl:Comparison>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="29" Alias="ColRef_0029">
+<dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+<dxl:TestExpr>
+<dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+<dxl:Ident ColId="0" ColName="i1" TypeMdid="0.23.1.0"/>
+<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
+</dxl:Comparison>
+</dxl:TestExpr>
+<dxl:ParamList/>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="17" Alias="i2">
+<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:OneTimeFilter/>
+<dxl:Result>
+<dxl:ProjList>
+<dxl:ProjElem ColId="29" Alias="ColRef_0029">
+<dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+</dxl:ProjElem>
+<dxl:ProjElem ColId="17" Alias="i2">
+<dxl:Ident ColId="17" ColName="i2" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:OneTimeFilter/>
+</dxl:Result>
+</dxl:Result>
+</dxl:SubPlan>
+</dxl:ProjElem>
+</dxl:ProjList>
+<dxl:Filter/>
+<dxl:OneTimeFilter/>
+<dxl:Materialize Eager="true">
+<dxl:ProjList>
+<dxl:ProjElem ColId="8" Alias="i3">
+<dxl:Ident ColId="8" ColName="i3" TypeMdid="0.23.1.0"/>
+</dxl:ProjElem>
+</dxl:ProjList>
+</dxl:Materialize>
+</dxl:Result>
+</dxl:Result>
+</dxl:Result>
+</dxl:SubPlan>
+</dxl:Result>
+</dxl:Plan>
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+-- end_ignore
 reset optimizer_trace_fallback;
-drop table test_tbl_t;
-drop table test_tbl_d;
-drop table test_tbl_p;
+drop table t1;
+drop table t2;
+drop table t3;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -617,13 +617,23 @@ drop table tl4;
 
 -- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_t VALUES ('0', 0);
 
 CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 0);
 
 CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+
+INSERT INTO test_tbl_t VALUES ('0', 1);
+INSERT INTO test_tbl_d VALUES ('0', 1);
+INSERT INTO test_tbl_p VALUES ('0', 0);
+ANALYZE test_tbl_t;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
   (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -616,42 +616,66 @@ drop table tl3;
 drop table tl4;
 
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-create table test_tbl_t as select 0 as int_t;
-create table test_tbl_d as select 0 as int_d;
-create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
-set client_min_messages='log';
-set optimizer_trace_fallback=on;
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists t3;
 
--- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
--- a deep tree and only params (see minidump).
+create table t1 as select 0 as i1;
+create table t2 as select 0 as i2;
+create table t3 as select i3 from (values (0), (1)) as s(i3);
+set optimizer_trace_fallback=on;
+set client_min_messages='log';
+
+-- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
+-- of which contains a deep tree and only params (see DXL in output).
+-- The simplified  DXL is printed here because the Explain command does not display TestExpr,
+-- but we need to check what TestExpr contains and how it is processed in the DXL to Plan
+-- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- TestExpr and its params are not displayed in Explain output. However, the output is
--- needed to make sure that the DXL we need is generated.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+-- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
 
-insert into test_tbl_t values (1);
-insert into test_tbl_d values (1);
-insert into test_tbl_p values (0);
-analyze test_tbl_t;
+-- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
+-- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+set optimizer_minidump=always;
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+-- start_ignore
+reset optimizer_minidump;
+-- end_ignore
+\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
 
--- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
--- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
--- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
--- are treated as Vars. The previous case contained only params (attributes contained in the
+insert into t1 values (1);
+analyze t1;
+-- After adding data, the ORCA physical plan changes and DXL changes too.
+-- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
+-- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
+-- in the inner <dxl:SubPlan> node. Such attributes in <dxl:TestExpr> are treated as Vars.
+-- The previous case contained only params (attributes contained in the
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
--- We also need the Explain output to determine DXL.
-explain (verbose, costs off) select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
-select * from test_tbl_t where
-  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
 
+-- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
+-- nested subplan; scan table t from outer <dxl:GatherMotion>.
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
+set optimizer_minidump=always;
+-- end_ignore
+select * from t1 where
+  (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
+-- start_ignore
+reset optimizer_minidump;
+-- end_ignore
+\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
+
+\! rm -rf $MASTER_DATA_DIRECTORY/minidumps
+-- start_ignore
 reset client_min_messages;
+-- end_ignore
 reset optimizer_trace_fallback;
-drop table test_tbl_t;
-drop table test_tbl_d;
-drop table test_tbl_p;
+drop table t1;
+drop table t2;
+drop table t3;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -616,15 +616,10 @@ drop table tl3;
 drop table tl4;
 
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-drop table if exists t1;
-drop table if exists t2;
-drop table if exists t3;
-
+drop table if exists t1, t2, t3;
 create table t1 as select 0 as i1;
 create table t2 as select 0 as i2;
 create table t3 as select i3 from (values (0), (1)) as s(i3);
-set optimizer_trace_fallback=on;
-set client_min_messages='log';
 
 -- The first query generates a DXL with <dxl:TestExpr>, the left node (inside Comparison)
 -- of which contains a deep tree and only params (see DXL in output).
@@ -635,18 +630,28 @@ set client_min_messages='log';
 -- left node is handled correctly during the DXL to Plan Statement stage.
 -- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
 
--- Removed from DXL: <dxl:Sort> inside subplan; <dxl:GroupingColumns> inside subplan;
--- some projection elements inside <dxl:Aggregate>; scan table t from <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
+
+set optimizer_trace_fallback=on;
 set optimizer_minidump=always;
--- end_ignore
 select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
--- start_ignore
 reset optimizer_minidump;
+reset optimizer_trace_fallback;
+
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
 -- end_ignore
-\! cut -b 18615-33305 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '323,344d;79,299d;68,76d;48,53d'
+
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
 
 insert into t1 values (1);
 analyze t1;
@@ -658,24 +663,28 @@ analyze t1;
 -- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
 -- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
 
--- Removed from DXL: <dxl:Materialize> inside the nested subplane; <dxl:GatherMotion> inside
--- nested subplan; scan table t from outer <dxl:GatherMotion>.
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
+
+set optimizer_trace_fallback=on;
 set optimizer_minidump=always;
--- end_ignore
 select * from t1 where
   (i1 in (select i2 from t2)) in (select i3 = 1 from t3) order by i1;
--- start_ignore
 reset optimizer_minidump;
+reset optimizer_trace_fallback;
+
+-- Output DXL plan without unimportant properties.
+-- start_ignore
+\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
 -- end_ignore
-\! cut -b 18031-26444 $MASTER_DATA_DIRECTORY/minidumps/* | sed 's/></>\n</g' | sed '/Cost\|Properties\|ValuesList/d' | sed '156,201d;121,150d;71,107d'
+
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
--- start_ignore
-reset client_min_messages;
--- end_ignore
-reset optimizer_trace_fallback;
-drop table t1;
-drop table t2;
-drop table t3;
+drop table t1,t2,t3;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -615,7 +615,9 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 
--- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+-- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+SET client_min_messages='log';
+SET optimizer_trace_fallback=on;
 CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
 INSERT INTO test_tbl_t VALUES ('0', 0);
 
@@ -626,20 +628,23 @@ CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
 INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
 
 INSERT INTO test_tbl_t VALUES ('0', 1);
 INSERT INTO test_tbl_d VALUES ('0', 1);
 INSERT INTO test_tbl_p VALUES ('0', 0);
 ANALYZE test_tbl_t;
 
+-- After adding data, the ORCA physical plan changes.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
 SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
 
+RESET client_min_messages;
+RESET optimizer_trace_fallback;
 DROP TABLE test_tbl_t;
 DROP TABLE test_tbl_d;
 DROP TABLE test_tbl_p;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -616,7 +616,9 @@ drop table tl3;
 drop table tl4;
 
 -- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+-- start_ignore
 drop table if exists t1, t2, t3;
+-- end_ignore
 create table t1 as select 0 as i1;
 create table t2 as select 0 as i2;
 create table t3 as select i3 from (values (0), (1)) as s(i3);
@@ -641,20 +643,26 @@ reset optimizer_trace_fallback;
 
 -- Output DXL plan without unimportant properties.
 -- start_ignore
-\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
 
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
 
-insert into t1 values (1);
-analyze t1;
+--insert into t1 values (1);
+--analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -672,19 +680,24 @@ select * from t1 where
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
 
--- Output DXL plan without unimportant properties.
 -- start_ignore
-\! sed 's/></>\n</g' $MASTER_DATA_DIRECTORY/minidumps/*.mdp > $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
-\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/dump.xml
+\! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
+\! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! python $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! sed -i '/Cost\|Properties\|ValuesList/d' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/TypeMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/AggMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/SortOperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/OperatorMdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/Mdid=".*"//' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
+\! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
 
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/dump.xml')));
+select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -646,7 +646,7 @@ reset optimizer_trace_fallback;
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
 \! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
-\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='   ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! python $MASTER_DATA_DIRECTORY/minidumps/script.py
@@ -659,10 +659,10 @@ reset optimizer_trace_fallback;
 \! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
 
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
 
---insert into t1 values (1);
---analyze t1;
+insert into t1 values (1);
+analyze t1;
 -- After adding data, the ORCA physical plan changes and DXL changes too.
 -- The outer <dxl:TestExpr> is empty. The second <dxl:TestExpr> (nested) does not contain a
 -- deep tree. The left node contains an attribute (Ident ColId="0") that is not present
@@ -684,7 +684,7 @@ reset optimizer_trace_fallback;
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
 \! echo "import xml.dom.minidom" > $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "dom = xml.dom.minidom.parse('$MASTER_DATA_DIRECTORY/minidumps/dump.mdp')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
-\! echo "pretty_xml = dom.toprettyxml()" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
+\! echo "pretty_xml = dom.toprettyxml(indent='    ')" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "with open('$MASTER_DATA_DIRECTORY/minidumps/pretty.xml', 'w') as file:" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! echo "\tfile.write(pretty_xml)" >> $MASTER_DATA_DIRECTORY/minidumps/script.py
 \! python $MASTER_DATA_DIRECTORY/minidumps/script.py
@@ -697,7 +697,6 @@ reset optimizer_trace_fallback;
 \! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
 
-select xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml')));
-
+select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -614,3 +614,22 @@ drop table tl1;
 drop table tl2;
 drop table tl3;
 drop table tl4;
+
+-- Check deep tree support in Test expression node when outer params are present with =ANY or IN queries
+CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
+INSERT INTO test_tbl_t VALUES ('0', 0), ('0', 1);
+
+CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
+INSERT INTO test_tbl_d VALUES ('0', 0), ('0', 1);
+
+CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
+INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+SELECT * FROM test_tbl_t WHERE
+  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 from test_tbl_p) ORDER BY int_t;
+
+DROP TABLE test_tbl_t;
+DROP TABLE test_tbl_d;
+DROP TABLE test_tbl_p;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -630,7 +630,8 @@ create table t3 as select i3 from (values (0), (1)) as s(i3);
 -- Statement stage. With the Postgres optimizer, this check does not matter.
 -- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
 -- left node is handled correctly during the DXL to Plan Statement stage.
--- Note the <Ident> with ColId 26 and 28. This appears from an internal subplan node.
+-- Рay attention to the Ident nodes with ColId 26 and 28. They appear from an internal
+-- subplan node.
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -615,36 +615,43 @@ drop table tl2;
 drop table tl3;
 drop table tl4;
 
--- Check deep tree support with params in <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
-SET client_min_messages='log';
-SET optimizer_trace_fallback=on;
-CREATE TABLE test_tbl_t (text_t text, int_t int) DISTRIBUTED BY (int_t);
-INSERT INTO test_tbl_t VALUES ('0', 0);
+-- Check support <dxl:TestExpr> node. TestExpr present with IN queries (equivalent =ANY).
+create table test_tbl_t as select 0 as int_t;
+create table test_tbl_d as select 0 as int_d;
+create table test_tbl_p as select int_p from (values (0), (1)) as s(int_p);
+set client_min_messages='log';
+set optimizer_trace_fallback=on;
 
-CREATE TABLE test_tbl_d (text_d text, int_d int) DISTRIBUTED BY (int_d);
-INSERT INTO test_tbl_d VALUES ('0', 0);
+-- The first query generates a DXL with <dxl:TestExpr>, the left node of which contains
+-- a deep tree and only params (see minidump).
+-- This testcase aims to verify that <dxl:TestExpr> with a deep tree and params in the
+-- left node is handled correctly during the DXL to Plan Statement stage.
+-- TestExpr and its params are not displayed in Explain output. However, the output is
+-- needed to make sure that the DXL we need is generated.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
 
-CREATE TABLE test_tbl_p (text_p text, int_p int) DISTRIBUTED BY (int_p);
-INSERT INTO test_tbl_p VALUES ('0', 0), ('0', 1);
+insert into test_tbl_t values (1);
+insert into test_tbl_d values (1);
+insert into test_tbl_p values (0);
+analyze test_tbl_t;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
+-- After adding data, the ORCA physical plan changes and DXL changes too. Now the left
+-- node <dxl:TestExpr> does not contain a deep tree. The left node contains an attribute
+-- that is not present in the internal <dxl:SubPlan> node. Such attributes in <dxl:TestExpr>
+-- are treated as Vars. The previous case contained only params (attributes contained in the
+-- inner <dxl:SubPlan> node). This test aims to verify that <dxl:TestExpr> with params and
+-- Vars simultaneously is handled correctly during the DXL to Plan Statement stage.
+-- We also need the Explain output to determine DXL.
+explain (verbose, costs off) select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
+select * from test_tbl_t where
+  (int_t in (select int_d from test_tbl_d)) in (select int_p = 1 from test_tbl_p) order by int_t;
 
-INSERT INTO test_tbl_t VALUES ('0', 1);
-INSERT INTO test_tbl_d VALUES ('0', 1);
-INSERT INTO test_tbl_p VALUES ('0', 0);
-ANALYZE test_tbl_t;
-
--- After adding data, the ORCA physical plan changes.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-SELECT * FROM test_tbl_t WHERE
-  (int_t IN (SELECT int_d FROM test_tbl_d)) IN (SELECT int_p = 1 FROM test_tbl_p) ORDER BY int_t;
-
-RESET client_min_messages;
-RESET optimizer_trace_fallback;
-DROP TABLE test_tbl_t;
-DROP TABLE test_tbl_d;
-DROP TABLE test_tbl_p;
+reset client_min_messages;
+reset optimizer_trace_fallback;
+drop table test_tbl_t;
+drop table test_tbl_d;
+drop table test_tbl_p;


### PR DESCRIPTION
Allow multiple params in the child nodes of \<dxl:TestExpr> (#1140)

Problem definition:
When processing a query with a subquery (example in the test), the "Attribute
number ... not found in project list" error could be output. This happened in
the DXL to Plan Statement stage because the attribute was not found in the
list of column references (CMappingColIdVar) when processing the left node of
\<dxl:TestExpr>. \<dxl:TestExpr> is part of the \<dxl:SubPlan> node and the
TestExpr acts as a filter when a tuple is returned from SubPlan at execution
(see ExecScanSubPlan()).
\<dxl:TestExpr> is processed by TranslateDXLSubplanTestExprToScalar(). The
left node was processed depending on the flag "has_outer_refs". If it was true,
the TranslateDXLTestExprScalarIdentToExpr() was called to read one \<dxl:Ident>
and then convert it to a param. If it was false, the function of handling the
DXL tree was called without taking the param into account. In our case, the
"has_outer_refs" flag was false.
"has_outer_refs" was defined at the DXL generation stage in
PdxlnQuantifiedSubplan(). The params of TestExpr are the common columns of
the scalar and the inner part of PhysicalCorrelated***NLJoin node (see the
physical plan).
As it turns out, the left node can contain more than one param, and at this
stage we need to save the list of attributes that act as TestExpr params,
because in further processing we will not be able to determine them. So
instead of a flag "has_outer_refs", we need to form a list of TestExpr params.
However, if I fixed the determination of the TestExpr params, another error
occurred - "Unsupported subplan test expression", since the left node
contained a tree, but TranslateDXLSubplanTestExprToScalar() only supported
id and cast(id). Also, this function read the TestExpr param directly from
the \<dxl:Ident> node (without using CMappingColIdVar).
Therefore, the tree processing function (TranslateDXLToScalar) is used to
process the left node of TestExpr. In order for this function to correctly
process the TestExpr params, the corresponding list of column references
(CMappingColIdVar) is initialized.

Problem summary:
The \<dxl:TestExpr> handler could output errors:
"Attribute number ... not found in project list" and "Unsupported subplan
test expression".
The first error occurred if a reference to an attribute processed as a TestExpr
param (don't confuse with subplan params \<dxl:ParamList>) was not found. This
occurred due to incorrect detection of the presence of TestExpr params
(m_outer_param flag) at the DXL generation stage in the
PdxlnQuantifiedSubplan function and the lack of adding TestExpr params to the
list of references to attributes (CMappingColIdVar) at the \<dxl:TestExpr>
transforming stage.
The second error occurred if the left node \<dxl:TestExpr> contained a tree with
the TestExpr param, since only id and cast(id) were supported (the param was
read directly from the node).
See the minidump for more information, but keep in mind that the TestExpr param
presence flag (m_outer_param) is not serialized.
Support for one param in the left node of TestExpr was added in ac6ce1a.

Possible solutions:
The "Unsupported subplan test expression" error is fixed by using the
TranslateDXLToScalar function, which allows processing the tree in the child
nodes of TestExpr (mostly the left node). But in this case, it is impossible
to get the TestExpr param (currently it is read directly from node). It is
impossible to determine whether this is a param or a Var (there are no
markers indicating this), if there is more than one attribute in the
tree - this will cause the error "Attribute number ... not found in project
list". Therefore, the TestExpr params must be obtained in a separate structure
 and added in advance to the list of references to attributes
(CMappingColIdVar). Determinating the TestExpr params and adding them to the
CMappingColIdVar before handling DXL fixes the "Attribute number ... not
found in project list" error, but since the left node may contain a tree,
this will cause the "Unsupported subplan test expression" error. Therefore,
these errors must be fixed simultaneously.

Solution:
1) Determine the necessary columns as TestExpr params at the DXL generating
stage;
2) Add references to attributes processed as TestExpr params at the DXL to
Plan Statement stage (prefilling CMappingColIdVar);
2) Add support for processing a tree with params in the left node of TestExpr.

Changes:
At the DXL generation stage (in the PdxlnQuantifiedSubplan function),
the determination of the TestExpr params for PhysicalCorrelated***NLJoin
nodes has been unified. Instead of the "has_outer_refs" flag, the presence
of TestExpr params is now determined by the array of columns -
m_test_expr_params (passed via the CDXLScalarSubPlan class, not serialized).
At the DXL to Plan Statement stage in the subplan handler, a copy of the
mapping (list of references to columns) of the subplan is created to
handle \<dxl:TestExpr>, including the TestExpr params (obtained from
m_test_expr_params). We use the copy because we do not want the TestExpr
params to be mixed with the subplan params.
In the \<dxl:TestExpr> handler, the TranslateDXLToScalar function is
used instead of TranslateDXLTestExprScalarIdentToExpr for the left node,
which allows processing trees.
For the right node \<dxl:TestExpr>, TranslateDXLToScalar is also used for
unification purposes. The TranslateDXLTestExprScalarIdentToExpr function
has been removed as unnecessary.

Ticket: ADBDEV-4603