### PR TITLE
Fix gpfdist work with OpenSSL 3.0

### DIFF
--- a/gpAux/gpdemo/generate_certs.sh
+++ b/gpAux/gpdemo/generate_certs.sh
@@ -5,13 +5,13 @@ key="server.key"
 cert="server.crt"
 
 # create the csr
-openssl req -new -passin pass:password -passout pass:password -text -out $csr 2>&1 <<-EOF
+openssl req -new -verify -passin pass:password -passout pass:password -text -out $csr 2>&1 <<-EOF
 US
 California
 Palo Alto
 Pivotal
 GPDB
-127.0.0.1
+localhost
 gpdb@127.0.0.1
 .
 .
@@ -29,10 +29,10 @@ chmod og-rwx ${key}
 
 mkdir -p certificate/gpfdists
 
-cp server.key certificate/gpfdists/server.key
-cp server.crt certificate/gpfdists/server.crt
-cp server.key certificate/gpfdists/client.key
-cp server.crt certificate/gpfdists/client.crt
-cp server.crt certificate/gpfdists/root.crt
+cp $key certificate/gpfdists/server.key
+cp $cert certificate/gpfdists/server.crt
+cp $key certificate/gpfdists/client.key
+cp $cert certificate/gpfdists/client.crt
+cp $cert certificate/gpfdists/root.crt
 
 rm -f server.* privkey.pem

--- a/gpAux/gpdemo/generate_certs.sh
+++ b/gpAux/gpdemo/generate_certs.sh
@@ -5,7 +5,7 @@ key="server.key"
 cert="server.crt"
 
 # create the csr
-openssl req -new -verify -passin pass:password -passout pass:password -text -out $csr 2>&1 <<-EOF
+openssl req -new -passin pass:password -passout pass:password -text -out $csr 2>&1 <<-EOF
 US
 California
 Palo Alto

--- a/src/bin/gpfdist/regress/input/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/input/gpfdist_ssl.source
@@ -82,7 +82,7 @@ INSERT INTO tbl_on_heap VALUES
 ('ccc','twoc','shpits','2011-06-01 12:30:30',23,732,834567,45.67,789.123,7.12345,123.456789 );
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -90,7 +90,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 $max_tls >/dev/null 2>&1;ret=$?;
+curl -H "X-GP-PROTO: 1" https://localhost:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 $max_tls >/dev/null 2>&1;ret=$?;
 if [ $ret -ne 35 ];then
     echo "success";
 else
@@ -110,7 +110,7 @@ CREATE TABLE tbl_on_heap2 (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -124,7 +124,7 @@ CREATE TABLE tbl_on_heap (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -137,7 +137,7 @@ CREATE TABLE tbl_on_heap (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdist://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -150,7 +150,7 @@ CREATE TABLE tbl_on_heap (
             n5 numeric, n6 real, n7 double precision);
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdist://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 DROP TABLE IF EXISTS tbl_on_heap;
 
@@ -162,7 +162,7 @@ select * from gpfdist_ssl_not_matching_start;
 -- gpfdist_ssl case 6
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
 SET verify_gpfdists_cert=off; 
@@ -180,7 +180,7 @@ SET verify_gpfdists_cert=on;
 
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 
 SELECT * FROM tbl;

--- a/src/bin/gpfdist/regress/output/gpfdist_ssl.source
+++ b/src/bin/gpfdist/regress/output/gpfdist_ssl.source
@@ -69,7 +69,7 @@ INSERT INTO tbl_on_heap VALUES
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  foreign table "tbl" does not exist, skipping
 CREATE WRITABLE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl SELECT * FROM tbl_on_heap;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -84,7 +84,7 @@ SELECT * FROM tbl_on_heap ORDER BY s1;
 CREATE EXTERNAL WEB TABLE curl_with_tls12 (x text)
 execute E'
 curl --help | grep tls-max >/dev/null 2>&1;ret=$?;if [ $ret -eq 0 ];then max_tls="--tls-max 1.2";fi;
-curl -H "X-GP-PROTO: 1" https://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 $max_tls >/dev/null 2>&1;ret=$?;
+curl -H "X-GP-PROTO: 1" https://localhost:7070/gpfdist_ssl/tbl2.tbl -vk --cert @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.crt --key @abs_srcdir@/data/gpfdist_ssl/certs_matching/client.key --tlsv1.2 $max_tls >/dev/null 2>&1;ret=$?;
 if [ $ret -ne 35 ];then
     echo "success";
 else
@@ -112,7 +112,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 DROP EXTERNAL TABLE IF EXISTS tbl2;
 NOTICE:  foreign table "tbl2" does not exist, skipping
 CREATE EXTERNAL TABLE tbl2 (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap2 SELECT * FROM tbl2;
 SELECT * FROM tbl_on_heap2 ORDER BY s1;
@@ -134,7 +134,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl2.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdists://localhost:7070/gpfdist_ssl/tbl2.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
 SELECT * FROM tbl_on_heap ORDER BY s1;
@@ -165,10 +165,10 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdist://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 INSERT INTO tbl_on_heap SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. effective url: http://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. error code = 104 (Connection reset by peer)  (seg1 slice1 172.17.0.2:25433 pid=59561)
+ERROR:  connection with gpfdist failed for gpfdist://localhost:7070/gpfdist_ssl/tbl1.tbl. effective url: http://localhost:7070/gpfdist_ssl/tbl1.tbl. error code = 104 (Connection reset by peer)  (seg1 slice1 172.17.0.2:25433 pid=59561)
 SELECT * FROM tbl_on_heap ORDER BY s1;
  s1 | s2 | s3 | dt | n1 | n2 | n3 | n4 | n5 | n6 | n7 
 ----+----+----+----+----+----+----+----+----+----+----
@@ -184,7 +184,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 's1' a
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl','gpfdist://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl','gpfdist://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 ERROR:  URI protocols must be the same for all data sources
 HINT:  Available protocols are 'http', 'file', 'gpfdist' and 'gpfdists'
@@ -207,10 +207,10 @@ select * from gpfdist_ssl_not_matching_start;
 DROP EXTERNAL TABLE IF EXISTS tbl;
 NOTICE:  foreign table "tbl" does not exist, skipping
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl. effective url: https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl.  (seg0 slice1 172.17.0.2:25432 pid=59537)
+ERROR:  connection with gpfdist failed for gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl. effective url: https://localhost:7070/gpfdist_ssl/tbl1.tbl.  (seg0 slice1 172.17.0.2:25432 pid=59537)
 DETAIL:  SSL certificate problem: self signed certificate
 SET verify_gpfdists_cert=off; 
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
@@ -246,10 +246,10 @@ select * from gpfdist_ssl_start_no_ca_verify;
 -- end_ignore
 DROP EXTERNAL TABLE IF EXISTS tbl;
 CREATE EXTERNAL TABLE tbl (s1 text, s2 text, s3 text, dt timestamp,n1 smallint, n2 integer, n3 bigint, n4 decimal, n5 numeric, n6 real, n7 double precision)
-LOCATION ('gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl')
+LOCATION ('gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl')
 FORMAT 'TEXT' (DELIMITER '|' );
 SELECT * FROM tbl;
-ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 localhost:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
@@ -364,7 +364,7 @@ select * from gpfdist_ssl_start_no_ca_verify;
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 localhost:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 -- end_ignore
@@ -518,7 +518,7 @@ client.crt client.key root.crt.bak server.crt server.key
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 127.0.0.1:7000 pid=23827)
+ERROR:  could not open CA certificate file root.crt: No such file or directory  (seg0 slice1 localhost:7000 pid=23827)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 -- end_ignore
@@ -544,13 +544,13 @@ client.crt.bak client.key.bak root.crt.bak server.crt server.key
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 \! bash change_cert.bash gpfdist_replace_root
 Generating a RSA private key
@@ -574,13 +574,13 @@ select * from gpfdist_ssl_start_ca_verify;
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; SSL certificate problem: self signed certificate  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 \! bash change_cert.bash recover_gpdb_root
 client.crt.bak client.key.bak root.crt server.crt server.key
@@ -588,13 +588,13 @@ client.crt.bak client.key.bak root.crt server.crt server.key
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 127.0.0.1:7000 pid=1504)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure  (seg0 slice1 localhost:7000 pid=1504)
 -- start_ignore
 \! bash change_cert.bash recover_gpdb_client
 client.crt client.key root.crt server.crt server.key
@@ -602,13 +602,13 @@ client.crt client.key root.crt server.crt server.key
 SET verify_gpfdists_cert=on;
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 127.0.0.1:7000 pid=19723)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 localhost:7000 pid=19723)
 -- start_ignore
 SET verify_gpfdists_cert=off;
 WARNING:  verify_gpfdists_cert=off. Greenplum Database will stop validating the gpfdists SSL certificate for connections between segments and gpfdists
 -- end_ignore
 SELECT * FROM tbl;
-ERROR:  connection with gpfdist failed for "gpfdists://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://127.0.0.1:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 127.0.0.1:7000 pid=19723)
+ERROR:  connection with gpfdist failed for "gpfdists://localhost:7070/gpfdist_ssl/tbl1.tbl", effective url: "https://localhost:7070/gpfdist_ssl/tbl1.tbl": ; error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca  (seg0 slice1 localhost:7000 pid=19723)
 -- start_ignore
 select * from gpfdist_ssl_stop;
       x      


### PR DESCRIPTION
Fix gpfdist work with OpenSSL 3.0

OpenSSL 3.0 does not allow to use self-signed certificates with IP address as
host. Adding alternative IP address or hostname requires to generate
certificates via config file ('-config' option). All additional IPs or hosts
should be written in the "alt_names" section.

To avoid generating config file for OpenSSL script uses "localhost" instead of
127.0.0.1.

Patch changes host "127.0.0.1" to "localhost" in gpfdist's ssl test and in the
generate_certs.sh script. Such changes successfully work with openssl 1.1.1.