### PR TITLE
ADBDEV-5473: Truncate temporary relation files before unlink

### DIFF
--- a/src/test/regress/input/tablespace.source
+++ b/src/test/regress/input/tablespace.source
@@ -354,4 +354,28 @@ INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
 DROP TABLE t;
 \! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
 
+-- Enable gp_inject_fault extension.
+-- This extension will be used in test below to force flushing of all dirty
+-- pages by the bg writer process.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Start with a clean state (no dirty buffers) by performing a checkpoint.
+-- It will also protect from a random timed checkpoint during the test, that could lead to not stable test result.
+CHECKPOINT;
+-- Force flushing all dirty pages by the bg writer process.
+SELECT gp_inject_fault_infinite('bg_buffer_sync_default_logic', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+
+-- Checking that the temp heap table doesn't leave non-zero files.
+CREATE TEMP TABLE t(a int, b int) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+-- Wait while the bg writer process flushes the data.
+-- Check that fault_in_background_writer_main occured at least twice to ensure
+-- one full loop of the bg writer process is done.
+SELECT gp_inject_fault('fault_in_background_writer_main', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+SELECT gp_wait_until_triggered_fault('fault_in_background_writer_main', 2, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+SELECT gp_inject_fault('fault_in_background_writer_main', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+
+SELECT gp_inject_fault('bg_buffer_sync_default_logic', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+
 DROP TABLESPACE testspace;

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -753,4 +753,61 @@ INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
 DROP TABLE t;
 \! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
 size: 0
+-- Enable gp_inject_fault extension.
+-- This extension will be used in test below to force flushing of all dirty
+-- pages by the bg writer process.
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- Start with a clean state (no dirty buffers) by performing a checkpoint.
+-- It will also protect from a random timed checkpoint during the test, that could lead to not stable test result.
+CHECKPOINT;
+-- Force flushing all dirty pages by the bg writer process.
+SELECT gp_inject_fault_infinite('bg_buffer_sync_default_logic', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- Checking that the temp heap table doesn't leave non-zero files.
+CREATE TEMP TABLE t(a int, b int) TABLESPACE testspace;
+INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
+-- Wait while the bg writer process flushes the data.
+-- Check that fault_in_background_writer_main occured at least twice to ensure
+-- one full loop of the bg writer process is done.
+SELECT gp_inject_fault('fault_in_background_writer_main', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+SELECT gp_wait_until_triggered_fault('fault_in_background_writer_main', 2, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+SELECT gp_inject_fault('fault_in_background_writer_main', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+DROP TABLE t;
+\! find /proc/[0-9]*/fd -lname '@testtablespace@*(deleted)' -exec stat -Lc '%s' {} \; 2>/dev/null | awk 'BEGIN {sum=0} {sum += $1} END {print "size:",  sum}';
+size: 0
+SELECT gp_inject_fault('bg_buffer_sync_default_logic', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
 DROP TABLESPACE testspace;


### PR DESCRIPTION
Truncate temporary relation files before unlink (#1147)

Problem description:
After the drop of a temporary heap relation, disk space was not released to the OS for several minutes. The expected behavior is immediate disk space release.

Root cause:
Background writer process kept file descriptors of the relation open until the next checkpoint. The next checkpoint occurred after a timeout, which could be up to CheckPointTimeout seconds (300 by default). Only temporary relations suffered from it, because in mdunlinkfork segment files were truncated for all non-temporary relations.

Fix:
The mdunlinkfork function was changed to call do_truncate on all segment files for all relations, including temporary.

No changes from original commit.
Ticket: ADBDEV-5473

(cherry picked from commit d622b980ce2b0eb3c2fa63b8c4f1ec29d7c01930)

---

Note: Do not squash to preserve authorship
