### PR TITLE
ADBDEV-6835: Fix modified GUCs when starting a new slice

### DIFF
--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1354,7 +1354,7 @@ process_startup_options(Port *port, bool am_superuser)
 			char *name = NULL;
 			char *val = NULL;
 			ParseLongOption(av[i], &name, &val);
-			SetConfigOption(name, val, gucctx, PGC_S_SESSION);
+			SetConfigOption(name, val, gucctx, PGC_S_TEST);
 		}
 		pfree(av);
 	}

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1354,6 +1354,12 @@ process_startup_options(Port *port, bool am_superuser)
 			char *name = NULL;
 			char *val = NULL;
 			ParseLongOption(av[i], &name, &val);
+			/*
+			 * The PGC_S_TEST source is used to allow some GUCs, such as
+			 * default_tablespace, temp_tablespaces, and
+			 * temp_spill_files_tablespaces, to issue a notice instead of an
+			 * error on invalid values ​​when starting a new slice.
+			 */
 			SetConfigOption(name, val, gucctx, PGC_S_TEST);
 		}
 		pfree(av);

--- a/src/test/regress/input/default_tablespace.source
+++ b/src/test/regress/input/default_tablespace.source
@@ -77,3 +77,11 @@ drop database database_with_tablespace;
 
 drop tablespace some_default_tablespace;
 drop tablespace some_database_tablespace;
+
+-- ensure modified GUCs when starting a new slice does not error
+create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+set default_tablespace to some_default_tablespace;
+drop tablespace some_default_tablespace;
+create table table_under_database_with_default_tablespace (a int);
+insert into table_under_database_with_default_tablespace select random() from generate_series(1, 10);
+drop table table_under_database_with_default_tablespace;

--- a/src/test/regress/output/default_tablespace.source
+++ b/src/test/regress/output/default_tablespace.source
@@ -111,3 +111,10 @@ drop database database_for_default_tablespace;
 drop database database_with_tablespace;
 drop tablespace some_default_tablespace;
 drop tablespace some_database_tablespace;
+-- ensure modified GUCs when starting a new slice does not error
+create tablespace some_default_tablespace location '@testtablespace@_default_tablespace';
+set default_tablespace to some_default_tablespace;
+drop tablespace some_default_tablespace;
+create table table_under_database_with_default_tablespace (a int);
+insert into table_under_database_with_default_tablespace select random() from generate_series(1, 10);
+drop table table_under_database_with_default_tablespace;


### PR DESCRIPTION
Fix modified GUCs when starting a new slice

The commit fe973d0 added installation of modified GUCs when starting a new
slice. However, it was not taken into account that some GUCs, for example,
default_tablespace, temp_tablespaces and temp_spill_files_tablespaces, cannot
contain invalid values ​​for a new connection, although this does not cause
problems for the current connection. This patch fixes an issue by using the
PGC_S_TEST option instead of PGC_S_SESSION when setting modified GUCs when
starting a new slice.