### PR TITLE
[ADBDEV-5482] Add removing temp schemas for tests

### DIFF
--- a/src/test/isolation2/sql/autovacuum-temp-table.sql
+++ b/src/test/isolation2/sql/autovacuum-temp-table.sql
@@ -61,3 +61,8 @@
 1: alter system reset autovacuum_naptime;
 1: alter system reset autovacuum_vacuum_threshold;
 1: !\retcode gpstop -u;
+-- start_ignore
+-- After error, temp schemas may still exist at segments
+-- Let's remove all such temporary schemas for inactive connections
+! psql -d isolation2test -f ../regress/sql/remove_temp_schemas.sql;
+-- end_ignore

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -114,6 +114,11 @@ select wait_until_all_segments_synchronized();
 -- verify no segment is down after recovery
 select count(*) from gp_segment_configuration where status = 'd';
 
+-- start_ignore
+-- After error, temp schemas may still exist at segments
+-- Let's remove all such temporary schemas for inactive connections
+! psql -d isolation2test -f ../regress/sql/remove_temp_schemas.sql;
+-- end_ignore
 !\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 !\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 !\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;

--- a/src/test/isolation2/sql/orphan_temp_table.sql
+++ b/src/test/isolation2/sql/orphan_temp_table.sql
@@ -60,3 +60,8 @@
 -- there shouldn't be any temporary namespaces left after the session quits
 5: SELECT count(*) FROM pg_namespace where (nspname like '%pg_temp_%' or nspname like '%pg_toast_temp_%') and oid > 16386;
 5q:
+-- start_ignore
+-- After error, temp schemas may still exist at segments
+-- Let's remove all such temporary schemas for inactive connections
+! psql -d isolation2test -f ../regress/sql/remove_temp_schemas.sql;
+-- end_ignore

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -827,3 +827,8 @@ SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration;
 -- Apply settings
 \! gpstop -u;
 --- end_ignore
+-- start_ignore
+-- After error, temp schemas may still exist at segments
+-- Let's remove all such temporary schemas for inactive connections
+\i sql/remove_temp_schemas.sql
+-- end_ignore

--- a/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
+++ b/src/test/regress/sql/not_out_of_shmem_exit_slots.sql
@@ -174,3 +174,8 @@ SET debug_dtm_action_target=protocol;
 SET debug_dtm_action_protocol=commit_prepared;
 SET debug_dtm_action=fail_begin_command;
 DROP TABLE foo_stg;
+-- start_ignore
+-- After error, temp schemas may still exist at segments
+-- Let's remove all such temporary schemas for inactive connections
+\i sql/remove_temp_schemas.sql
+-- end_ignore

--- a/src/test/regress/sql/remove_temp_schemas.sql
+++ b/src/test/regress/sql/remove_temp_schemas.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION gp_execute_on_server(content int, query text)
+returns text language C as '$libdir/regress.so', 'gp_execute_on_server';
+
+DO $$
+DECLARE
+	schema_rec record;
+BEGIN
+	FOR schema_rec IN
+		SELECT nspname, gp_segment_id
+		FROM (
+			SELECT nspname, gp_segment_id
+			FROM gp_dist_random('pg_namespace')
+			UNION
+			SELECT nspname, gp_segment_id
+			FROM pg_namespace
+		) n
+		LEFT JOIN pg_stat_activity ON
+			sess_id = regexp_replace(nspname, 'pg(_toast)?_temp_', '')::int
+		WHERE sess_id is null AND nspname ~ '^pg(_toast)?_temp_[1-9]{1}[0-9]*'
+	LOOP
+		IF schema_rec.gp_segment_id = -1 then
+			EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE', schema_rec.nspname);
+		ELSE
+		PERFORM gp_execute_on_server(schema_rec.gp_segment_id,
+				format('DROP SCHEMA IF EXISTS %I CASCADE', schema_rec.nspname));
+		END IF;
+	END LOOP;
+END $$;
+
+DROP function gp_execute_on_server(content int, query text);


### PR DESCRIPTION
Add removing temp schemas for tests

Some regression and isolation2 tests use temp tables. Some of these tests
generate error: "Any temporary tables for this session have been dropped because
the gang was disconnected". At such case temporary schemas will not be removed
at coordinator and segment with error.

gpcheckcat removes such temporary schemas. If gpcheckcat found temporary
schemas, it prints "Found and dropped 42 unbound temporary schemas". But
gpcheckcat can not remove temporary schema if it was created at session, which
is active now. After restarting a cluster, gpcheckcat may acquire the same
session number as the temporary schema and be unable to delete it. If gpcheckcat
does not remove such temporary schema, it will get result in an error, because
this schema does not exist for some segments.

This patch adds removing temporary schemas for regression tests
(not_out_of_shmem_exit_slots, alter_db_set_tablespace) and isolation2 test
(fts_errors).

Cherry-picked from: ab27121a8dee8b14f7c0e0579de0a538334caee9

Original commit adds the temprorary schema deletion function and cleans
up temp schemas in specific regress and isolation2 tests. This commit
complements the tests list and slightly changes the comments in those tests
for 7X. Additionally, the remove_temp_schemas script has been changed in order
to handle the case when coordinator has not the temp schema while
a segment has. It wouldn't be superfluous to notice that regexp in the
query filters out schemas like pg_temp_01, since shemas with id starting with
'0' serve utility purposes.