### PR TITLE
Fix error "External planner is not registered"

### DIFF
--- a/contrib/pg_stat_statements/sql/disable_pg_stat_statements.sql
+++ b/contrib/pg_stat_statements/sql/disable_pg_stat_statements.sql
@@ -1,4 +1,4 @@
 -- start_ignore
-\! gpconfig -r shared_preload_libraries;
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_remove(string_to_array(current_setting('shared_preload_libraries'), ','), 'pg_stat_statements'), ',')" postgres)"
 \! gpstop -raq -M fast;
 -- end_ignore

--- a/contrib/pg_stat_statements/sql/enable_pg_stat_statements.sql
+++ b/contrib/pg_stat_statements/sql/enable_pg_stat_statements.sql
@@ -1,4 +1,4 @@
 -- start_ignore
-\! gpconfig -c shared_preload_libraries -v 'pg_stat_statements';
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'pg_stat_statements'), ',')" postgres)"
 \! gpstop -raq -M fast;
 -- end_ignore


### PR DESCRIPTION
Fix error "External planner is not registered"

Problem description:
Tests for 'pg_stat_statements', launched with 'optimizer=on', failed with error:
"FATAL:  External planner is not registered".

Root cause:
Setup and teardown steps of 'pg_stat_statements' configured values of
'shared_preload_libraries' without taking into account its previous value. Thus,
it was set to 'pg_stat_statements' at test start, and to empty string after the
tests. And 'orca' lib was lost. It caused the error.

Fix:
Now setup and teardown steps take into account previous value of
'shared_preload_libraries'. 
