### PR TITLE
Delete temporary files for tests gpfdist2 and gpfdist2_compress

### DIFF
--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -23,6 +23,15 @@ CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152
 -- select * from check_ps;
 -- select * from check_env;
 
+-- Helper to remove the output files
+DROP EXTERNAL WEB TABLE IF EXISTS clean_out_files;
+CREATE EXTERNAL WEB TABLE clean_out_files (x text)
+EXECUTE E'(rm -f @abs_srcdir@/data/gpfdist2/lineitem.tbl.out.zst @abs_srcdir@/data/gpfdist2/test_quote.csv)'
+on SEGMENT 0
+FORMAT 'text';
+
+SELECT * FROM clean_out_files;
+
 -- end_ignore
 
 

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -32,6 +32,8 @@ FORMAT 'text';
 
 SELECT * FROM clean_out_files;
 
+DROP EXTERNAL WEB TABLE clean_out_files;
+
 -- end_ignore
 
 

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -34,6 +34,8 @@ FORMAT 'text';
 
 SELECT * FROM clean_out_files;
 
+DROP EXTERNAL WEB TABLE clean_out_files;
+
 -- end_ignore
 
 --- test 1 using a little file

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -24,6 +24,16 @@ FORMAT 'text' (delimiter '|');
 -- start_ignore
 select * from gpfdist2_stop;
 select * from gpfdist2_start;
+
+-- Helper to remove the output files
+DROP EXTERNAL WEB TABLE IF EXISTS clean_out_files;
+CREATE EXTERNAL WEB TABLE clean_out_files (x text)
+EXECUTE E'( rm -f @abs_srcdir@/data/gpfdist2/lineitem.tbl.w)'
+on SEGMENT 0
+FORMAT 'text';
+
+SELECT * FROM clean_out_files;
+
 -- end_ignore
 
 --- test 1 using a little file


### PR DESCRIPTION
This patch adds cleanup of temporary files used for gpfdist tests.

Tests gpfdist2 and gpfdist2_compress does not clear temporary files used to
check writable external tables. Those files are appended by the next test run 
using same source tree, and results does not match.

It's not a problem in CI, where docker image built with a clean directory, but
can be a problem on a developer's machine, if tests run more than once.