### PR TITLE
Remove generation of USE_ORCA define

### DIFF
--- a/configure
+++ b/configure
@@ -7905,9 +7905,7 @@ if test "${enable_orca+set}" = set; then :
   enableval=$enable_orca;
   case $enableval in
     yes)
-
-$as_echo "#define USE_ORCA 1" >>confdefs.h
-
+      :
       ;;
     no)
       :
@@ -7919,8 +7917,6 @@ $as_echo "#define USE_ORCA 1" >>confdefs.h
 
 else
   enable_orca=yes
-
-$as_echo "#define USE_ORCA 1" >>confdefs.h
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -787,9 +787,7 @@ PGAC_ARG_BOOL(enable, cassert, no, [enable assertion checks (for debugging)],
 #
 # Enable GPORCA optimizer
 #
-PGAC_ARG_BOOL(enable, orca, yes, [disable ORCA optimizer],
-              [AC_DEFINE([USE_ORCA], 1,
-                         [Define to 1 to build with Greenplum ORCA optimizer. (--enable-orca)])])
+PGAC_ARG_BOOL(enable, orca, yes, [disable ORCA optimizer])
 AC_MSG_RESULT([checking whether to build with ORCA... $enable_orca])
 AC_SUBST(enable_orca)
 

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -1017,9 +1017,6 @@
 /* Define to use OpenSSL for random number generation */
 #undef USE_OPENSSL_RANDOM
 
-/* Define to 1 to build with Greenplum ORCA optimizer. (--enable-orca) */
-#undef USE_ORCA
-
 /* Define to 1 to build with PAM support. (--with-pam) */
 #undef USE_PAM
 


### PR DESCRIPTION
Remove generation of USE_ORCA define

USE_ORCA define is no longer used. This patch removes generation of this define.
File 'configure.in' is modified manually. Other files are re-generated by
'autoconf' and 'autoheader' tools.