### PR TITLE
ADBDEV-6936 Avoid reusing timeline for interrupted promotion

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -905,7 +905,8 @@ static MemoryContext walDebugCxt = NULL;
 
 static void readRecoverySignalFile(void);
 static void validateRecoveryParameters(void);
-static void exitArchiveRecovery(TimeLineID endTLI, XLogRecPtr endOfLog);
+static void exitArchiveRecovery(void);
+static void XLogInitNewTimeline(TimeLineID endTLI, XLogRecPtr endOfLog);
 static bool recoveryStopsBefore(XLogReaderState *record);
 static bool recoveryStopsAfter(XLogReaderState *record);
 static void recoveryPausesHere(void);
@@ -5620,24 +5621,12 @@ validateRecoveryParameters(void)
  * Exit archive-recovery state
  */
 static void
-exitArchiveRecovery(TimeLineID endTLI, XLogRecPtr endOfLog)
+exitArchiveRecovery(void)
 {
-	char		xlogfname[MAXFNAMELEN];
-	XLogSegNo	endLogSegNo;
-	XLogSegNo	startLogSegNo;
-
-	/* we always switch to a new timeline after archive recovery */
-	Assert(endTLI != ThisTimeLineID);
-
 	/*
 	 * We are no longer in archive recovery state.
 	 */
 	InArchiveRecovery = false;
-
-	/*
-	 * Update min recovery point one last time.
-	 */
-	UpdateMinRecoveryPoint(InvalidXLogRecPtr, true);
 
 	/*
 	 * If the ending log segment is still open, close it (to avoid problems on
@@ -5648,6 +5637,46 @@ exitArchiveRecovery(TimeLineID endTLI, XLogRecPtr endOfLog)
 		close(readFile);
 		readFile = -1;
 	}
+
+	/*
+	 * Remove the signal files out of the way, so that we don't accidentally
+	 * re-enter archive recovery mode in a subsequent crash.
+	 */
+	if (standby_signal_file_found)
+		durable_unlink(STANDBY_SIGNAL_FILE, FATAL);
+
+	if (recovery_signal_file_found)
+		durable_unlink(RECOVERY_SIGNAL_FILE, FATAL);
+
+	/*
+	 * Response to FTS probes after this point will not indicate that we are a
+	 * mirror because the am_mirror flag is set based on existence of
+	 * RECOVERY_COMMAND_FILE.  New libpq connections to the postmaster should
+	 * no longer return CAC_MIRROR_READY as response because we are no longer a
+	 * mirror.
+	 */
+	ResetMirrorReadyFlag();
+	ereport(LOG,
+			(errmsg("archive recovery complete")));
+}
+
+/*
+ * Initialize the first WAL segment on new timeline.
+ */
+static void
+XLogInitNewTimeline(TimeLineID endTLI, XLogRecPtr endOfLog)
+{
+	char		xlogfname[MAXFNAMELEN];
+	XLogSegNo	endLogSegNo;
+	XLogSegNo	startLogSegNo;
+
+	/* we always switch to a new timeline after archive recovery */
+	Assert(endTLI != ThisTimeLineID);
+
+	/*
+	 * Update min recovery point one last time.
+	 */
+	UpdateMinRecoveryPoint(InvalidXLogRecPtr, true);
 
 	/*
 	 * Calculate the last segment on the old timeline, and the first segment
@@ -5700,27 +5729,6 @@ exitArchiveRecovery(TimeLineID endTLI, XLogRecPtr endOfLog)
 	 */
 	XLogFileName(xlogfname, ThisTimeLineID, startLogSegNo, wal_segment_size);
 	XLogArchiveCleanup(xlogfname);
-
-	/*
-	 * Remove the signal files out of the way, so that we don't accidentally
-	 * re-enter archive recovery mode in a subsequent crash.
-	 */
-	if (standby_signal_file_found)
-		durable_unlink(STANDBY_SIGNAL_FILE, FATAL);
-
-	if (recovery_signal_file_found)
-		durable_unlink(RECOVERY_SIGNAL_FILE, FATAL);
-
-	/*
-	 * Response to FTS probes after this point will not indicate that we are a
-	 * mirror because the am_mirror flag is set based on existence of
-	 * RECOVERY_COMMAND_FILE.  New libpq connections to the postmaster should
-	 * no longer return CAC_MIRROR_READY as response because we are no longer a
-	 * mirror.
-	 */
-	ResetMirrorReadyFlag();
-	ereport(LOG,
-			(errmsg("archive recovery complete")));
 }
 
 /*
@@ -7960,12 +7968,11 @@ StartupXLOG(void)
 			snprintf(reason, sizeof(reason), "no recovery target specified");
 
 		/*
-		 * We are now done reading the old WAL.  Turn off archive fetching if
-		 * it was active, and make a writable copy of the last WAL segment.
-		 * (Note that we also have a copy of the last block of the old WAL in
-		 * readBuf; we will use that below.)
+		 * Make a writable copy of the last WAL segment.  (Note that we also
+		 * have a copy of the last block of the old WAL in
+		 * endOfRecovery->lastPage; we will use that below.)
 		 */
-		exitArchiveRecovery(EndOfLogTLI, EndOfLog);
+		XLogInitNewTimeline(EndOfLogTLI, EndOfLog);
 
 		/*
 		 * Write the timeline history file, and have it archived. After this
@@ -8139,6 +8146,8 @@ StartupXLOG(void)
 
 	if (ArchiveRecoveryRequested)
 	{
+		exitArchiveRecovery();
+
 		/*
 		 * And finally, execute the recovery_end_command, if any.
 		 */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8080,6 +8080,8 @@ StartupXLOG(void)
 	UpdateFullPageWrites();
 	LocalXLogInsertAllowed = -1;
 
+	SIMPLE_FAULT_INJECTOR("before_persisting_new_tli");
+
 	if (InRecovery)
 	{
 		/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -905,7 +905,6 @@ static MemoryContext walDebugCxt = NULL;
 
 static void readRecoverySignalFile(void);
 static void validateRecoveryParameters(void);
-static void exitArchiveRecovery(void);
 static void XLogInitNewTimeline(TimeLineID endTLI, XLogRecPtr endOfLog);
 static bool recoveryStopsBefore(XLogReaderState *record);
 static bool recoveryStopsAfter(XLogReaderState *record);
@@ -5618,49 +5617,6 @@ validateRecoveryParameters(void)
 }
 
 /*
- * Exit archive-recovery state
- */
-static void
-exitArchiveRecovery(void)
-{
-	/*
-	 * We are no longer in archive recovery state.
-	 */
-	InArchiveRecovery = false;
-
-	/*
-	 * If the ending log segment is still open, close it (to avoid problems on
-	 * Windows with trying to rename or delete an open file).
-	 */
-	if (readFile >= 0)
-	{
-		close(readFile);
-		readFile = -1;
-	}
-
-	/*
-	 * Remove the signal files out of the way, so that we don't accidentally
-	 * re-enter archive recovery mode in a subsequent crash.
-	 */
-	if (standby_signal_file_found)
-		durable_unlink(STANDBY_SIGNAL_FILE, FATAL);
-
-	if (recovery_signal_file_found)
-		durable_unlink(RECOVERY_SIGNAL_FILE, FATAL);
-
-	/*
-	 * Response to FTS probes after this point will not indicate that we are a
-	 * mirror because the am_mirror flag is set based on existence of
-	 * RECOVERY_COMMAND_FILE.  New libpq connections to the postmaster should
-	 * no longer return CAC_MIRROR_READY as response because we are no longer a
-	 * mirror.
-	 */
-	ResetMirrorReadyFlag();
-	ereport(LOG,
-			(errmsg("archive recovery complete")));
-}
-
-/*
  * Initialize the first WAL segment on new timeline.
  */
 static void
@@ -7856,6 +7812,25 @@ StartupXLOG(void)
 	record = ReadRecord(xlogreader, LastRec, PANIC, false);
 	EndOfLog = EndRecPtr;
 
+	if (ArchiveRecoveryRequested)
+	{
+		/*
+		 * We are no longer in archive recovery state.
+		 */
+		Assert(InArchiveRecovery);
+		InArchiveRecovery = false;
+
+		/*
+		 * If the ending log segment is still open, close it (to avoid problems on
+		 * Windows with trying to rename or delete an open file).
+		 */
+		if (readFile >= 0)
+		{
+			close(readFile);
+			readFile = -1;
+		}
+	}
+
 	/*
 	 * EndOfLogTLI is the TLI in the filename of the XLOG segment containing
 	 * the end-of-log. It could be different from the timeline that EndOfLog
@@ -7931,8 +7906,6 @@ StartupXLOG(void)
 	{
 		char		reason[200];
 		char		recoveryPath[MAXPGPATH];
-
-		Assert(InArchiveRecovery);
 
 		ThisTimeLineID = findNewestTimeLine(recoveryTargetTLI) + 1;
 		ereport(LOG,
@@ -8146,7 +8119,26 @@ StartupXLOG(void)
 
 	if (ArchiveRecoveryRequested)
 	{
-		exitArchiveRecovery();
+		/*
+		 * Remove the signal files out of the way, so that we don't accidentally
+		 * re-enter archive recovery mode in a subsequent crash.
+		 */
+		if (standby_signal_file_found)
+			durable_unlink(STANDBY_SIGNAL_FILE, FATAL);
+
+		if (recovery_signal_file_found)
+			durable_unlink(RECOVERY_SIGNAL_FILE, FATAL);
+
+		/*
+		 * Response to FTS probes after this point will not indicate that we are a
+		 * mirror because the am_mirror flag is set based on existence of
+		 * RECOVERY_COMMAND_FILE.  New libpq connections to the postmaster should
+		 * no longer return CAC_MIRROR_READY as response because we are no longer a
+		 * mirror.
+		 */
+		ResetMirrorReadyFlag();
+		ereport(LOG,
+				(errmsg("archive recovery complete")));
 
 		/*
 		 * And finally, execute the recovery_end_command, if any.

--- a/src/test/isolation2/sql/fts_doublefault.sql
+++ b/src/test/isolation2/sql/fts_doublefault.sql
@@ -26,6 +26,10 @@ select gp_request_fts_probe_scan();
 -1U: create table last_timestamp as select time from gp_configuration_history order by time desc limit 1;
 
 -- stop primary in order to promote mirror for content 0
+-- start_ignore
+create EXTENSION if not exists gp_inject_fault;
+SELECT gp_inject_fault('before_persisting_new_tli', 'suspend', 5);
+-- end_ignore
 select pg_ctl((select datadir from gp_segment_configuration c
                where c.role='p' and c.content=0), 'stop');
 
@@ -34,6 +38,9 @@ select gp_request_fts_probe_scan();
 -- primary is down, and mirror has now been promoted to primary. Verify
 -1U: select wait_until_segments_are_down(1);
 -1U: select dbid, description from gp_configuration_history where time > (select time from last_timestamp) order by time;
+-- start_ignore
+select pg_sleep(5);
+-- end_ignore
 
 -- stop acting primary in order to trigger double fault for content 0
 select pg_ctl((select datadir from gp_segment_configuration c


### PR DESCRIPTION
Each Postgres instance (that GPDB segments are) should use own timeline
to exclude WAL segment names interference if derived from the common
ancestor. When we derive the new instance from backup or promote a
replica, the Postgres searches the next free timeline number to identify
the given reincarnation. Postgres persists information about selected
timeline in the Checkpoint record or associates it with End of Recovery
record in the controldata. Also, it remembers switch point to the
history file. These two entities helps the Postgres to handle timeline
switch in case of failure and consequent recovery. But Postgres used to
remove signal files earlier than persisting new timeline info. As a
result, the Postgres had no way to remember about promotion or to try
again, if something goes wrong soon. So, Postgres carried out the common
crash recovery and continued the previous timeline. As a result, the
instance may overwrite next WAL segments and push it to the archive with
the same name with unpredictable results depending on archive_command
implementation. But even without archiving, possible presence of this
orphaned timeline in the history file may lead to unexpected error
during the next replica switching because LSN of such switch point is
before latest checkpoint record created on the reused timeline.

The optimal solution is to retry interrupted promotion. FTS is ready to
do it, at least. To achieve this goal and fall into archive recovery
again, we should delay removing signal files until we persist the new
timeline information. The only insignificant negative outcome for this
approach is possible assignment of the one more timeline identity, if
we fall right after history file creation.