### PR TITLE
ADBDEV-5519 Fix "unable to login" error when server uses tset

### DIFF
--- a/gpMgmt/bin/lib/pexpect/pxssh.py
+++ b/gpMgmt/bin/lib/pexpect/pxssh.py
@@ -265,7 +265,7 @@ class pxssh (spawn):
         # This does not distinguish between a remote server 'password' prompt
         # and a local ssh 'passphrase' prompt (for unlocking a private key).
         spawn._spawn(self, cmd)
-        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT, "(?i)connection closed by remote host"], timeout=login_timeout)
+        i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type\?", TIMEOUT, "(?i)connection closed by remote host"], timeout=login_timeout)
 
         # First phase
         if i==0:
@@ -273,13 +273,13 @@ class pxssh (spawn):
             # This is what you get if SSH does not have the remote host's
             # public key stored in the 'known_hosts' cache.
             self.sendline("yes")
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type\?", TIMEOUT])
         if i==2: # password or passphrase
             self.sendline(password)
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type\?", TIMEOUT])
         if i==4:
             self.sendline(terminal_type)
-            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type", TIMEOUT])
+            i = self.expect(["(?i)are you sure you want to continue connecting", original_prompt, "(?i)(?:password)|(?:passphrase for key)", "(?i)permission denied", "(?i)terminal type\?", TIMEOUT])
 
         # Second phase
         if i==0:


### PR DESCRIPTION
Fix "unable to login" error when server uses tset (#1176)

gpssh utility uses pexpect library to establish ssh connection and run commands
in the session. The login procedure uses the pxssh login function, which
sends ssh connection request and via expect mechanism looks for specific pattern
matches in the ssh output. Pattern search is needed to send credentials, answer
the various prompts. Before creating a connection and logging in gpssh empties
the TERM environment variable. Because of that some scripts, which are run
during remote shell startup (e.x. /etc/profile, ~/.bash_profile, etc.), may
throw an error that they can't identify the terminal type, or return
'Terminal type?' prompt in order to ask user about the terminal type he uses
locally, or both. The login function from pxssh.py is ready to process such
situation, because we can see a '(?i)terminal type' pattern in the expect call.
However, sometimes the output containing 'Terminal type?' prompt can be
interpreted ambiguously, because the 'terminal type' pattern can be met several
times (e.x. the tset command can print the error "tset: unknown terminal type
unknown" and ask for the terminal type right after it). This ambiguity may lead
to gpssh fail.

This patch changes the terminal type pattern in pxssh.py login function by
adding the '?' character to the pattern. Because 'Terminal type?' prompt is
quite widespread in the shell startup scripts, the proposed changes are
sufficient to cover vast variety of cases.

(cherry picked from commit 28e921e)


----------

Commits in the PR shouldn't be squashed to preserve authorship.