### PR TITLE
ADBDEV-6941: Make GPDB 7 ABI tests use Ubuntu

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -74,7 +74,6 @@ jobs:
             repo: ${{ github.repository }}
             ref: ${{ github.sha }}
 
-    steps:
       ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
       ## 'Exuberant Ctags'.
       - name: Install universal-ctags
@@ -84,6 +83,7 @@ jobs:
           sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
           which ctags
 
+    steps:
       - name: Download Greenplum source code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -61,7 +61,6 @@ jobs:
   abi-dump:
     needs: abi-dump-setup
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb7-rocky8-build
     strategy:
       matrix:
         name:
@@ -76,47 +75,49 @@ jobs:
             ref: ${{ github.sha }}
 
     steps:
-      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
-      ## 'Exuberant Ctags'.
-      - name: Install universal-ctags.
-        run: |
-          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
-          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
-          cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
-          which ctags
-
       - name: Download Greenplum source code
         uses: actions/checkout@v3
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ matrix.ref }}
           submodules: recursive
-          fetch-depth: 0 # Specify '0' to fetch all history for all branches and tags.
+          fetch-depth: 1
           path: gpdb_src
 
-      - name: Install abi-dumper
+      - name: Install dependencies and abi-dumper
         run: |
-          yum install -y epel-release
-          yum install -y abi-dumper
+          sudo gpdb_src/README.Ubuntu.bash
+          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
+          sudo ln -fs python2 /usr/bin/python
+
+      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
+      ## 'Exuberant Ctags'.
+      - name: Install universal-ctags
+        run: |
+          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
+          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
+          sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
+          which ctags
 
       - name: Build Greenplum
         run: |
-          ## TODO: Since abi-dumper requires debug info and it's hard to inject CFLAGS via the script for
-          ## releasing Greenplum, we have to manually configure it here. Probably we can improve it in future.
           pushd gpdb_src
           CC='gcc -m64' \
           CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
-          ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
-                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
-                      --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
-                      --with-libraries="" --disable-rpath \
+          ./configure --with-gssapi --enable-orafce --enable-ic-proxy --enable-orca --with-libxml \
+                      --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --enable-debug-extensions \
+                      --enable-debug --with-perl --with-python --with-openssl --with-pam --with-ldap \
+                      --with-includes="" --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
                       --mandir=/usr/local/greenplum-db-devel/man
-          make -j`nproc` && make install
+          sudo make -j`nproc` install
 
       - name: Dump ABI
         run: |
-          abi-dumper -lver ${{ matrix.ref }} -skip-cxx -public-headers /usr/local/greenplum-db-devel/include/${{ needs.abi-dump-setup.outputs.ABI_HEADERS }} -o postgres-${{ matrix.ref }}.abi /usr/local/greenplum-db-devel/bin/postgres
+          abi-dumper -lver ${{ matrix.ref }} -skip-cxx \
+                     -public-headers /usr/local/greenplum-db-devel/include/${{ needs.abi-dump-setup.outputs.ABI_HEADERS }} \
+                     -o postgres-${{ matrix.ref }}.abi \
+                     /usr/local/greenplum-db-devel/bin/postgres
 
       - name: Upload ABI files
         uses: actions/upload-artifact@v3
@@ -129,7 +130,6 @@ jobs:
       - abi-dump-setup
       - abi-dump
     runs-on: ubuntu-latest
-    container: gcr.io/data-gpdb-public-images/gpdb7-rocky8-build
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v3
@@ -151,9 +151,7 @@ jobs:
 
       - name: Install abi-compliance-checker and report viewer (lynx)
         run: |
-          yum install -y epel-release
-          yum install -y abi-compliance-checker
-          yum install -y --enablerepo=powertools lynx
+          sudo apt install -y abi-compliance-checker lynx
 
       - name: Compare ABI
         run: |

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -74,15 +74,6 @@ jobs:
             repo: ${{ github.repository }}
             ref: ${{ github.sha }}
 
-      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
-      ## 'Exuberant Ctags'.
-      - name: Install universal-ctags
-        run: |
-          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
-          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
-          sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
-          which ctags
-
     steps:
       - name: Download Greenplum source code
         uses: actions/checkout@v3
@@ -96,7 +87,7 @@ jobs:
       - name: Install dependencies and abi-dumper
         run: |
           sudo gpdb_src/README.Ubuntu.bash
-          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
+          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl universal-ctags abi-dumper
           sudo ln -fs python2 /usr/bin/python
 
       - name: Build Greenplum

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -74,6 +74,7 @@ jobs:
             repo: ${{ github.repository }}
             ref: ${{ github.sha }}
 
+    steps:
       ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
       ## 'Exuberant Ctags'.
       - name: Install universal-ctags
@@ -83,7 +84,6 @@ jobs:
           sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
           which ctags
 
-    steps:
       - name: Download Greenplum source code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -97,8 +97,8 @@ jobs:
           CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
           ./configure --with-gssapi --enable-orafce --enable-ic-proxy --enable-orca --with-libxml \
                       --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --enable-debug-extensions \
-                      --with-perl --with-python --with-openssl --with-pam --with-ldap
-                      --with-includes="" --with-libraries="" --disable-rpath \
+                      --with-perl --with-python --with-openssl --with-pam --with-ldap --disable-rpath \
+                      --with-includes="" --with-libraries="" \
                       --prefix=/usr/local/greenplum-db-devel \
                       --mandir=/usr/local/greenplum-db-devel/man
           sudo make -j`nproc` install

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies and abi-dumper
         run: |
           sudo gpdb_src/README.Ubuntu.bash
-          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl universal-ctags abi-dumper
+          sudo apt install -y libuv1-dev libpam0g-dev libldap-dev libipc-run-perl universal-ctags abi-dumper
           sudo ln -fs python2 /usr/bin/python
 
       - name: Build Greenplum
@@ -95,10 +95,10 @@ jobs:
           pushd gpdb_src
           CC='gcc -m64' \
           CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
-          ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
-                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
-                      --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
-                      --with-libraries="" --disable-rpath \
+          ./configure --with-gssapi --enable-orafce --enable-ic-proxy --enable-orca --with-libxml \
+                      --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --enable-debug-extensions \
+                      --with-perl --with-python --with-openssl --with-pam --with-ldap
+                      --with-includes="" --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
                       --mandir=/usr/local/greenplum-db-devel/man
           sudo make -j`nproc` install

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -95,10 +95,10 @@ jobs:
           pushd gpdb_src
           CC='gcc -m64' \
           CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
-          ./configure --with-gssapi --enable-orafce --enable-ic-proxy --enable-orca --with-libxml \
-                      --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --enable-debug-extensions \
-                      --enable-debug --with-perl --with-python --with-openssl --with-pam --with-ldap \
-                      --with-includes="" --with-libraries="" --disable-rpath \
+          ./configure --with-quicklz --disable-gpperfmon --with-gssapi --enable-mapreduce --enable-orafce --enable-ic-proxy \
+                      --enable-orca --with-libxml --with-pythonsrc-ext --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests \
+                      --enable-debug-extensions --with-perl --with-python --with-openssl --with-pam --with-ldap --with-includes="" \
+                      --with-libraries="" --disable-rpath \
                       --prefix=/usr/local/greenplum-db-devel \
                       --mandir=/usr/local/greenplum-db-devel/man
           sudo make -j`nproc` install

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   abi-dump-setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       BASELINE_REF: ${{ steps.vars.outputs.BASELINE_REF }}
       BASELINE_VERSION: ${{ steps.vars.outputs.BASELINE_VERSION }}
@@ -60,7 +60,7 @@ jobs:
 
   abi-dump:
     needs: abi-dump-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         name:
@@ -87,17 +87,8 @@ jobs:
       - name: Install dependencies and abi-dumper
         run: |
           sudo gpdb_src/README.Ubuntu.bash
-          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
+          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl universal-ctags abi-dumper
           sudo ln -fs python2 /usr/bin/python
-
-      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
-      ## 'Exuberant Ctags'.
-      - name: Install universal-ctags
-        run: |
-          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
-          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
-          sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
-          which ctags
 
       - name: Build Greenplum
         run: |
@@ -129,7 +120,7 @@ jobs:
     needs:
       - abi-dump-setup
       - abi-dump
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download baseline
         uses: actions/download-artifact@v3

--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -74,6 +74,15 @@ jobs:
             repo: ${{ github.repository }}
             ref: ${{ github.sha }}
 
+      ## FIXME: abi-dumper requires 'Universal Ctags' but the package manager only provides
+      ## 'Exuberant Ctags'.
+      - name: Install universal-ctags
+        run: |
+          wget 'https://github.com/universal-ctags/ctags-nightly-build/releases/download/2023.07.05%2Bafdae39c0c2e508d113cbc570f4635b96159840c/uctags-2023.07.05-linux-x86_64.tar.xz'
+          tar -xf uctags-2023.07.05-linux-x86_64.tar.xz
+          sudo cp uctags-2023.07.05-linux-x86_64/bin/* /usr/bin/
+          which ctags
+
     steps:
       - name: Download Greenplum source code
         uses: actions/checkout@v3
@@ -87,7 +96,7 @@ jobs:
       - name: Install dependencies and abi-dumper
         run: |
           sudo gpdb_src/README.Ubuntu.bash
-          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl universal-ctags abi-dumper
+          sudo apt install -y wget libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
           sudo ln -fs python2 /usr/bin/python
 
       - name: Build Greenplum


### PR DESCRIPTION
Make GPDB 7 ABI tests use Ubuntu

Previosly, the source was still built on Rocky Linux 8. This patch forces the
workflow to use Ubuntu 22.04 and adjusts it accordingly.
