### PR TITLE
ADBDEV-6963: Use DWARF4 for ABI tests

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -94,7 +94,9 @@ jobs:
         run: |
           pushd gpdb_src
           CC='gcc -m64' \
-          CFLAGS='-Og -g3 -Wno-maybe-uninitialized' LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
+          CXXFLAGS='-O0' \
+          CFLAGS='-gdwarf-4 -Og -g3 -Wno-maybe-uninitialized' \
+          LDFLAGS='-Wl,--enable-new-dtags -Wl,--export-dynamic' \
           ./configure --with-gssapi --enable-orafce --enable-ic-proxy --enable-orca --with-libxml \
                       --with-uuid=e2fs --with-pgport=5432 --enable-tap-tests --enable-debug-extensions \
                       --with-perl --with-python --with-openssl --with-pam --with-ldap --disable-rpath \


### PR DESCRIPTION
Use DWARF4 for ABI tests

Previous patch did not account that `abi-dumper` utility does not accept DWARF5
debug info. This patch adds `-gdwarf4` option to `CFLAGS` to make sure debug
info can be read, and `-O0` to `CXXFLAGS` to speed up the build process.