### PR TITLE
ADBDEV-6950: Don't recycle WAL when receiving archival report in archive_mode always

### DIFF
--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -1368,7 +1368,7 @@ ProcessArchivalReport(void)
 
 	elog(DEBUG2, "received archival report from primary: %s", primary_last_archived);
 
-	if (wal_sender_archiving_status_interval <= 0)
+	if (wal_sender_archiving_status_interval <= 0 || XLogArchiveMode == ARCHIVE_MODE_ALWAYS)
 		return;
 
 	/* Check that the wal filename reported by primary looks valid */

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -1895,7 +1895,7 @@ WalSndComputeSleeptime(TimestampTz now)
 	}
 
 	/* If archiving is enabled, send a status report to the client */
-	if (XLogArchivingStatusReportingActive() && XLogArchiveMode != ARCHIVE_MODE_ALWAYS)
+	if (XLogArchivingStatusReportingActive())
 	{
 		/*
 		 * If we requested an update from pgstat, poll every
@@ -3505,7 +3505,7 @@ WalSndKeepaliveIfNecessary(void)
 	/*
 	 * Send an archival status message, if necessary.
 	 */
-	if (XLogArchivingStatusReportingActive() && XLogArchiveMode != ARCHIVE_MODE_ALWAYS)
+	if (XLogArchivingStatusReportingActive())
 		WalSndArchivalReportIfNecessary(GetCurrentTimestamp());
 
 	/*

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -1895,7 +1895,7 @@ WalSndComputeSleeptime(TimestampTz now)
 	}
 
 	/* If archiving is enabled, send a status report to the client */
-	if (XLogArchivingStatusReportingActive())
+	if (XLogArchivingStatusReportingActive() && XLogArchiveMode != ARCHIVE_MODE_ALWAYS)
 	{
 		/*
 		 * If we requested an update from pgstat, poll every
@@ -3505,7 +3505,7 @@ WalSndKeepaliveIfNecessary(void)
 	/*
 	 * Send an archival status message, if necessary.
 	 */
-	if (XLogArchivingStatusReportingActive())
+	if (XLogArchivingStatusReportingActive() && XLogArchiveMode != ARCHIVE_MODE_ALWAYS)
 		WalSndArchivalReportIfNecessary(GetCurrentTimestamp());
 
 	/*

--- a/src/test/recovery/t/123_streaming_and_archiving_with_archive_mode_always.pl
+++ b/src/test/recovery/t/123_streaming_and_archiving_with_archive_mode_always.pl
@@ -5,67 +5,65 @@ use TestLib;
 use Test::More tests => 8;
 use File::Copy;
 
-# Initialize master node with WAL archiving setup
+# Initialize the master node with WAL archiving configured
 my $node_master = get_new_node('master');
 $node_master->init(has_archiving => 1, allows_streaming => 1);
-
-$node_master->append_conf('postgresql.conf', "archive_command = 'exit 1'");
+# Set wal_sender_archiving_status_interval to a small value so that the master sends the report quickly
 $node_master->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 50ms');
 $node_master->start;
 my $master_archive = $node_master->archive_dir;
 my $master_data = $node_master->data_dir;
-
-# Take backup
+# Set the archive_command to an incorrect value, causing archiving to fail
+$node_master->safe_psql('postgres', "ALTER SYSTEM SET archive_command = 'exit 1'; SELECT pg_reload_conf();");
+# Make a backup copy
 $node_master->backup('my_backup');
-
-# Initialize the standby node
+# Initialize the standby node. It will inherit archive_command and wal_sender_archiving_status_interval from the master node
 my $node_standby = get_new_node('standby');
 $node_standby->init_from_backup($node_master, 'my_backup', has_streaming => 1);
+# Set archive_mode to always
 $node_standby->append_conf('postgresql.conf', 'archive_mode = always');
 my $standby_archive = $node_standby->archive_dir;
 my $standby_data = $node_standby->data_dir;
 $node_standby->start;
-
-$node_master->safe_psql('postgres', "CREATE TABLE test1 AS SELECT generate_series(1,10) AS x;");
-
+# Generate some data
+$node_master->safe_psql('postgres', "CREATE TABLE test AS SELECT generate_series(1,10);");
+# Remember current WAL segment
 my $walfile = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());");
+# Switch WAL segment and make checkpoint
 $node_master->safe_psql('postgres', "SELECT pg_switch_xlog(); CHECKPOINT;");
-
+# Remember another WAL segment
 my $walfile2 = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());");
-
-# After switching wal, the current wal file will be marked as ready to be archived on the master. But this wal file
-# won't get archived because of the incorrect archive_command
+# After the WAL switch, the current WAL file will be marked as ready to be archived on master.
+# But this WAL file will not be archived due to the incorrect archive_command
 my $walfile_ready = "pg_xlog/archive_status/$walfile.ready";
 my $walfile_done = "pg_xlog/archive_status/$walfile.done";
-
 # Wait for the standby to catch up
-$node_master->wait_for_catchup($node_standby, 'write',
-	$node_master->lsn('insert'));
-
+$node_master->wait_for_catchup($node_standby, 'write', $node_master->lsn('insert'));
 # Wait for archive failure
-$node_master->poll_query_until('postgres', "SELECT failed_count > 0 FROM pg_stat_archiver", 't') or die "Timed out while waiting for archiving to fail";
-
+$node_master->poll_query_until('postgres', "SELECT failed_count > 0 FROM pg_stat_archiver", 't')
+    or die "Timed out while waiting for archiving to fail";
+# .ready files exist on master and standby for the remembered WAL segment
 ok( -f "$master_data/$walfile_ready", ".ready file exists on master for WAL segment $walfile");
 ok( -f "$standby_data/$walfile_ready", ".ready file exists on standby for WAL segment $walfile");
-
+# .done files do not exist on master and standby for remembered WAL segment
 ok( !-f "$master_data/$walfile_done", ".done file does not exist on master for WAL segment $walfile");
 ok( !-f "$standby_data/$walfile_done", ".done file does not exist on standby for WAL segment $walfile");
-
-# Make WAL archiving work again for master by resetting the archive_command
-$node_master->safe_psql('postgres', "ALTER SYSTEM SET archive_command = 'echo %p && cp %p $master_archive/%f'; SELECT pg_reload_conf();");
-
+# Make WAL archiving work again for master by resetting archive_command
+$node_master->safe_psql('postgres', "ALTER SYSTEM RESET archive_command; SELECT pg_reload_conf();");
 # Force the archiver process to wake up and start archiving
 $node_master->safe_psql('postgres', "SELECT pg_switch_xlog();");
-
-# Check if master has .done file created for the archived segment and also that the file gets uploaded to the archive
+# Wait until master creates a .done file for the archived segment
 wait_until_file_exists("$master_data/$walfile_done", ".done file to exist on master for WAL segment $walfile");
-
+# The .ready file should no longer be on master
 ok( !-f "$master_data/$walfile_ready", ".ready file does not exist for WAL segment $walfile");
-
+# Wait for master to load the WAL segment into the archive.
 wait_until_file_exists("$master_archive/$walfile", "$walfile to be archived by the master");
-
-run_cmd_until(["grep", "sending archival report: $walfile2", $node_master->logfile], "sending archival report: $walfile2") or die "Timed out while waiting for sending archival report: $walfile2";
-
+# Wait until master sends an archiving notification to standby.
+run_cmd_until(["grep", "sending archival report: $walfile2", $node_master->logfile], "sending archival report: $walfile2")
+    or die "Timed out while waiting for sending archival report: $walfile2";
+# The .ready file should still be on standby.
 ok( -f "$standby_data/$walfile_ready", ".ready file exists on standby for WAL segment $walfile");
+# The .done file should still not be on standby.
 ok( !-f "$standby_data/$walfile_done", ".done file does not exist on standby for WAL segment $walfile");
+# Standby has not loaded the WAL segment into the archive yet.
 ok( !-f "$standby_archive/$walfile", "$walfile does not exist in standby's archive");

--- a/src/test/recovery/t/123_streaming_and_archiving_with_archive_mode_always.pl
+++ b/src/test/recovery/t/123_streaming_and_archiving_with_archive_mode_always.pl
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 8;
+use File::Copy;
+
+# Initialize master node with WAL archiving setup
+my $node_master = get_new_node('master');
+$node_master->init(has_archiving => 1, allows_streaming => 1);
+
+$node_master->append_conf('postgresql.conf', "archive_command = 'exit 1'");
+$node_master->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 50ms');
+$node_master->start;
+my $master_archive = $node_master->archive_dir;
+my $master_data = $node_master->data_dir;
+
+# Take backup
+$node_master->backup('my_backup');
+
+# Initialize the standby node
+my $node_standby = get_new_node('standby');
+$node_standby->init_from_backup($node_master, 'my_backup', has_streaming => 1);
+$node_standby->append_conf('postgresql.conf', 'archive_mode = always');
+my $standby_archive = $node_standby->archive_dir;
+my $standby_data = $node_standby->data_dir;
+$node_standby->start;
+
+$node_master->safe_psql('postgres', "CREATE TABLE test1 AS SELECT generate_series(1,10) AS x;");
+
+my $walfile = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());");
+$node_master->safe_psql('postgres', "SELECT pg_switch_xlog(); CHECKPOINT;");
+
+my $walfile2 = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());");
+
+# After switching wal, the current wal file will be marked as ready to be archived on the master. But this wal file
+# won't get archived because of the incorrect archive_command
+my $walfile_ready = "pg_xlog/archive_status/$walfile.ready";
+my $walfile_done = "pg_xlog/archive_status/$walfile.done";
+
+# Wait for the standby to catch up
+$node_master->wait_for_catchup($node_standby, 'write',
+	$node_master->lsn('insert'));
+
+# Wait for archive failure
+$node_master->poll_query_until('postgres', "SELECT failed_count > 0 FROM pg_stat_archiver", 't') or die "Timed out while waiting for archiving to fail";
+
+ok( -f "$master_data/$walfile_ready", ".ready file exists on master for WAL segment $walfile");
+ok( -f "$standby_data/$walfile_ready", ".ready file exists on standby for WAL segment $walfile");
+
+ok( !-f "$master_data/$walfile_done", ".done file does not exist on master for WAL segment $walfile");
+ok( !-f "$standby_data/$walfile_done", ".done file does not exist on standby for WAL segment $walfile");
+
+# Make WAL archiving work again for master by resetting the archive_command
+$node_master->safe_psql('postgres', "ALTER SYSTEM SET archive_command = 'echo %p && cp %p $master_archive/%f'; SELECT pg_reload_conf();");
+
+# Force the archiver process to wake up and start archiving
+$node_master->safe_psql('postgres', "SELECT pg_switch_xlog();");
+
+# Check if master has .done file created for the archived segment and also that the file gets uploaded to the archive
+wait_until_file_exists("$master_data/$walfile_done", ".done file to exist on master for WAL segment $walfile");
+
+ok( !-f "$master_data/$walfile_ready", ".ready file does not exist for WAL segment $walfile");
+
+wait_until_file_exists("$master_archive/$walfile", "$walfile to be archived by the master");
+
+run_cmd_until(["grep", "sending archival report: $walfile2", $node_master->logfile], "sending archival report: $walfile2") or die "Timed out while waiting for sending archival report: $walfile2";
+
+ok( -f "$standby_data/$walfile_ready", ".ready file exists on standby for WAL segment $walfile");
+ok( !-f "$standby_data/$walfile_done", ".done file does not exist on standby for WAL segment $walfile");
+ok( !-f "$standby_archive/$walfile", "$walfile does not exist in standby's archive");


### PR DESCRIPTION
Don't recycle WAL when receiving archival report in archive_mode always

Commit 4f2db19 added the following functionality. If
wal_sender_archiving_status_interval GUC was set, the primary would
periodically (by default, every 10 seconds) notify its standby about the latest
WAL segment sent to the archive. At the same time, the standby would mark all
old WAL segments as archived (.done), regardless of the archiving mode, upon
receiving such a notification. As a result, the WAL segment could be reused and
overwritten (or even deleted!), in parallel with archiving from the standby,
which could lead to a broken WAL segment getting into the archive. A similar
problem was fixed in commit 4b818bd, but not for the notification case, so this
patch solves this problem exactly for this case. Namely, upon receiving a
notification from the primary, it does not mark WAL segments as archived
(.done) in the always archiving mode.