### PR TITLE
ADBDEV-6183: Disable GUC gp_log_stack_trace_lines by default (#1187)

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1696,7 +1696,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_log_stack_trace_lines,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Disable GUC gp_log_stack_trace_lines by default (#1187)

Gpdb uses addr2line to add file names and line numbers to the stack trace. But
addr2line can use a large amount of memory, the consumption of which we cannot
control, which can lead to OOM on the entire host.
This behavior is controlled by GUC gp_log_stack_trace_lines which is true by
default.

This patch changes the default value for gp_log_stack_trace_lines to false so as
not to run addr2line every time the stack is logged.

(cherry picked from commit e828be5)

---
This PR should be rebased to preserve authorship.