### PR TITLE
Fix parsing history timeline file and archive recovery

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -372,12 +372,20 @@ static bool recoveryStopAfter;
  * be scanning data that was copied from an ancestor timeline when the current
  * file was created.)  During a sequential scan we do not allow this value
  * to decrease.
+ *
+ * curFileUpto: the end of the curFileTLI timeline in the history of the
+ * timeline we're recovering to (ie. recoveryTargetTLI).  We must not read the
+ * currently open file beyond this position, because it contains WAL that is
+ * not part of the history of the timeline we're recovering to.  Upon reaching
+ * that point, we need to open the file from the next timeline in the history
+ * instead.
  */
 RecoveryTargetTimeLineGoal recoveryTargetTimeLineGoal = RECOVERY_TARGET_TIMELINE_LATEST;
 TimeLineID	recoveryTargetTLIRequested = 0;
 TimeLineID	recoveryTargetTLI = 0;
 static List *expectedTLEs;
 static TimeLineID curFileTLI;
+static XLogRecPtr curFileUpto;
 
 /*
  * ProcLastRecPtr points to the start of the last XLOG record inserted by the
@@ -3777,6 +3785,9 @@ XLogFileRead(XLogSegNo segno, int emode, TimeLineID tli,
 	{
 		/* Success! */
 		curFileTLI = tli;
+		if (!expectedTLEs)
+			expectedTLEs = readTimeLineHistory(recoveryTargetTLI);
+		curFileUpto = tliSwitchPoint(curFileTLI, expectedTLEs, NULL);
 
 		/* Report recovery progress in PS display */
 		snprintf(activitymsg, sizeof(activitymsg), "recovering %s",
@@ -4613,6 +4624,8 @@ rescanLatestTimeLine(void)
 	 * between the old target and new target in pg_wal.
 	 */
 	restoreTimeLineHistoryFiles(oldtarget + 1, newtarget);
+	if (curFileTLI != 0)
+		curFileUpto = tliSwitchPoint(curFileTLI, expectedTLEs, NULL);
 
 	ereport(LOG,
 			(errmsg("new target timeline is %u",
@@ -12769,10 +12782,39 @@ XLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr, int reqLen,
 	int			emode = private->emode;
 	uint32		targetPageOff;
 	XLogSegNo	targetSegNo PG_USED_FOR_ASSERTS_ONLY;
+	XLogRecPtr	readUpto;
 	int			r;
 
 	XLByteToSeg(targetPagePtr, targetSegNo, wal_segment_size);
 	targetPageOff = XLogSegmentOffset(targetPagePtr, wal_segment_size);
+
+retry:
+	/*
+	 * If we have reached the end of the current timeline in the recovery
+	 * target timeline's history, need to switch to the file from the next
+	 * timeline.
+	 *
+	 * Note: The logic and purpose of this is similar to
+	 * XLogReadDetermineTimeline(), but we don't use the end-of-segment to
+	 * determine the next TLI like XLogReadDetermineTimeline() does.  We don't
+	 * need it because XLogFileReadAnyTLI() will try to read from the WAL
+	 * segment with the latest possible TLI.  This is more flexible than
+	 * XLogReadDetermineTimeline(), which makes it more likely that we'll make
+	 * some progress towards the recovery target, even if all the WAL is not
+	 * (yet) available.
+	 */
+	if (curFileUpto != InvalidXLogRecPtr &&
+		curFileUpto <= targetPagePtr + reqLen)
+	{
+		if (readFile >= 0)
+		{
+			close(readFile);
+			readFile = -1;
+		}
+		curFileTLI = tliOfPointInHistory(targetPagePtr + reqLen, expectedTLEs);
+		curFileUpto = tliSwitchPoint(curFileTLI, expectedTLEs, NULL);
+		readSource = XLOG_FROM_ANY;
+	}
 
 	/*
 	 * See if we need to switch to a new segment because the requested record
@@ -12814,7 +12856,6 @@ XLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr, int reqLen,
 		   (uint32) (targetRecPtr >> 32), (uint32) targetRecPtr,
 		   readSegNo, targetPageOff);
 
-retry:
 	/* See if we need to retrieve more data */
 	if (readFile < 0 ||
 		(readSource == XLOG_FROM_STREAM &&
@@ -12836,10 +12877,25 @@ retry:
 	}
 
 	/*
+	 * If the recovery target TLI changed during WaitForWALToBecomeAvailable,
+	 * the record we're looking for might not be on this file anymore.
+	 */
+	 if (curFileUpto != InvalidXLogRecPtr &&
+		 curFileUpto <= targetPagePtr + reqLen)
+		 goto retry;
+
+	/*
 	 * At this point, we have the right segment open and if we're streaming we
 	 * know the requested record is in it.
 	 */
 	Assert(readFile != -1);
+
+	/*
+	 * If we're recovering through old timelines, make sure we don't read
+	 * beyond the point where we're supposed to switch to next timeline in the
+	 * recovery target's history.
+	 */
+	readUpto = curFileUpto;
 
 	/*
 	 * If the current segment is being streamed from the primary, calculate how
@@ -12847,16 +12903,18 @@ retry:
 	 * requested record has been received, but this is for the benefit of
 	 * future calls, to allow quick exit at the top of this function.
 	 */
-	if (readSource == XLOG_FROM_STREAM)
+	if (readSource == XLOG_FROM_STREAM &&
+		(readUpto == InvalidXLogRecPtr || receivedUpto < readUpto))
 	{
-		if (((targetPagePtr) / XLOG_BLCKSZ) != (receivedUpto / XLOG_BLCKSZ))
-			readLen = XLOG_BLCKSZ;
-		else
-			readLen = XLogSegmentOffset(receivedUpto, wal_segment_size) -
-				targetPageOff;
+		readUpto = receivedUpto;
 	}
-	else
+
+	if (readUpto == InvalidXLogRecPtr ||
+		((targetPagePtr) / XLOG_BLCKSZ) != (readUpto / XLOG_BLCKSZ))
 		readLen = XLOG_BLCKSZ;
+	else
+		readLen = XLogSegmentOffset(readUpto, wal_segment_size) -
+			targetPageOff;
 
 	/* Read the requested page */
 	readOff = targetPageOff;
@@ -13064,6 +13122,9 @@ WaitForWALToBecomeAvailable(XLogRecPtr RecPtr, bool randAccess,
 						XLogRecPtr	ptr;
 						TimeLineID	tli;
 
+						if (!expectedTLEs)
+							expectedTLEs = readTimeLineHistory(recoveryTargetTLI);
+
 						if (fetching_ckpt)
 						{
 							ptr = RedoStartLSN;
@@ -13086,6 +13147,7 @@ WaitForWALToBecomeAvailable(XLogRecPtr RecPtr, bool randAccess,
 									 tli, curFileTLI);
 						}
 						curFileTLI = tli;
+						curFileUpto = tliSwitchPoint(tli, expectedTLEs, NULL);
 						RequestXLogStreaming(tli, ptr, PrimaryConnInfo,
 											 PrimarySlotName);
 						receivedUpto = 0;
@@ -13219,7 +13281,10 @@ WaitForWALToBecomeAvailable(XLogRecPtr RecPtr, bool randAccess,
 				}
 				/* Reset curFileTLI if random fetch. */
 				if (randAccess)
+				{
 					curFileTLI = 0;
+					curFileUpto = InvalidXLogRecPtr;
+				}
 
 				/*
 				 * Try to restore the file from archive, or read an existing

--- a/src/test/recovery/t/044_change_recovery_target.pl
+++ b/src/test/recovery/t/044_change_recovery_target.pl
@@ -1,0 +1,101 @@
+
+# Copyright (c) 2021-2024, PostgreSQL Global Development Group
+
+# Test that recovery server follows the right path through the WAL
+# files towards the recovery target timeline. Consider the following
+# timeline history:
+#
+#    ---S---------------------->P   TLI 1
+#                     \
+#                      -------->    TLI 2
+#
+# Standby has replayed the WALL on TLI up to point S, and is currently
+# stopped. However, it already has all the WAL from TLI 1 locally in
+# pg_wal, because it was restored from the archive or streamed from the
+# primary on TLI 1 earlier. If you now set recovery target timeline to
+# TLI 2, the standby must not replay the WAL it already has on TLI 1,
+# beyond the point where they diverged.
+#
+# This test sets up that scenario, by pausing the replay on the
+# standby.
+
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use File::Copy;
+
+my $primary1 = PostgreSQL::Test::Cluster->new('primary1');
+$primary1->init(allows_streaming => 1);
+$primary1->start;
+$primary1->backup("bkp");
+
+my $standby = PostgreSQL::Test::Cluster->new('standby');
+$standby->init_from_backup($primary1, "bkp", has_streaming => 1);
+$standby->start;
+
+# Pause the standby
+# After bump to PostgreSQL 14 or newest we should add check by executing
+# pg_get_wal_replay_pause_state(), because now there is guarantee, that recovery
+# is actually paused, but after bump to PostgreSQL 14 we should check state.
+$standby->safe_psql('postgres', "SELECT pg_wal_replay_pause()");
+
+# Make some changes in the primary. They will be streamed to the
+# standby, but not yet applied.
+$primary1->safe_psql('postgres', 'CREATE TABLE test_tab1 (t TEXT)');
+$primary1->safe_psql('postgres', 'CREATE TABLE test_tab2 (t TEXT)');
+$primary1->safe_psql('postgres',
+	"INSERT INTO test_tab1 VALUES ('both timelines')");
+$primary1->safe_psql('postgres',
+	"INSERT INTO test_tab2 VALUES ('both timelines')");
+
+# Create timeline 2 at this point
+my $primary2 = PostgreSQL::Test::Cluster->new('primary2');
+$primary2->init_from_backup($primary1, "bkp", has_streaming => 1);
+$primary2->start;
+$primary1->wait_for_catchup($primary2, 'replay', $primary1->lsn('flush'));
+$primary2->promote;
+
+# Make some changes on both timelines
+$primary1->safe_psql('postgres',
+	"INSERT INTO test_tab1 VALUES ('TLI 1 only')");
+
+$primary2->safe_psql('postgres',
+	"INSERT INTO test_tab2 VALUES ('TLI 2 only')");
+
+# Stop the standby, and re-point it to TLI 2 (primary2).
+$standby->stop;
+my $primary2_connstr = $primary2->connstr;
+$standby->append_conf('postgresql.conf',
+	"primary_conninfo = '$primary2_connstr'");
+$standby->append_conf('postgresql.conf',
+	"recovery_target_timeline = 2");
+
+# Copy the history file. Otherwise, the standby will just error out
+# with "FATAL: recovery target timeline 2 does not exist"
+#
+# XXX: Perhaps it should try to connect to the primary and fetch the
+# history file from there instead of erroring out. But it doesn't do
+# that today.
+copy($primary2->data_dir . '/pg_wal/00000002.history',
+	$standby->data_dir . '/pg_wal/00000002.history')
+  or BAIL_OUT("could not copy 00000002.history");
+
+# Check that it recovers correctly to TLI 2 when started up.
+$standby->start;
+$primary2->wait_for_catchup($standby, 'replay', $primary2->lsn('flush'));
+
+my $result =
+  $standby->safe_psql('postgres', "SELECT * FROM test_tab1");
+is( $result, qq(both timelines),
+		"changes on TLI 1 are *not* on standby");
+
+$result =
+  $standby->safe_psql('postgres', "SELECT * FROM test_tab2");
+is( $result, qq(both timelines
+TLI 2 only),
+		"all changes on TLI 2 are on the standby");
+
+done_testing();

--- a/src/test/recovery/t/050_check_recovery_backup.pl
+++ b/src/test/recovery/t/050_check_recovery_backup.pl
@@ -1,0 +1,155 @@
+use strict;
+use warnings;
+use File::Basename qw(basename dirname);
+use File::Compare;
+use File::Path qw(rmtree);
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Set umask so test directories and files are created with default permissions
+umask(0077);
+
+my $tempdir = PostgreSQL::Test::Utils::tempdir;
+my $basebackupdir1 = $tempdir . '/basebackup1';
+my $basebackupdir2 = $tempdir . '/basebackup2';
+my $archivedir =  $tempdir . '/archive';
+
+my $primary = PostgreSQL::Test::Cluster->new('primary');
+my $standby = PostgreSQL::Test::Cluster->new('standby');
+
+sub create_backup_primary
+{
+	my ($backup_dir, $restore_point) = @_;
+
+	print("Running: create_backup_primary: '$restore_point'\n");
+
+	$primary->command_ok([ 'rm', '-rf', $backup_dir ],
+		"clear directory for backup '$backup_dir'");
+	mkdir($backup_dir);
+
+	$primary->command_ok([ 'pg_basebackup', '--target-gp-dbid', 2, '-D', "$backup_dir", '-p', $primary->port, '--verbose' ],
+		'pg_basebackup runs');
+	ok(-f "$backup_dir/PG_VERSION", "backup was created at '$backup_dir'");
+
+	$primary->safe_psql('test_db', "SELECT pg_create_restore_point('$restore_point')");
+}
+
+sub restore_backup_primary
+{
+	my ($backup_dir, $restore_options, $label) = @_;
+	my $primary_pgdata = $primary->data_dir;
+
+	print("Running: restore_backup_primary: '$restore_options' '$label'\n");
+
+	$primary->command_ok([ 'rm', '-rf', $primary_pgdata ],
+		"'$label': rm primary pgdata");
+	$primary->command_ok([ 'cp', '-r', $backup_dir, $primary_pgdata ],
+		"'$label': copy basebackup to primary");
+
+	# configure recovery
+	$primary->set_recovery_mode;
+	open my $conf, '>', "$primary_pgdata/postgresql.auto.conf";
+	print $conf "recovery_target_action = 'promote'\n";
+	print $conf "restore_command = 'cp -v $archivedir/%f $primary_pgdata/%p'\n";
+	print $conf "$restore_options\n";
+	close $conf;
+	$primary->start;
+}
+
+sub wait_recovery_and_switch_wal_primary
+{
+	my ($label) = @_;
+
+	print("Running: wait_recovery_and_switch_wal_primary: '$label'\n");
+
+	$primary->poll_query_until('test_db', "SELECT true FROM pg_switch_wal()")
+		or die "'$label': Timed out while waiting for switch WAL after recovery";
+}
+
+sub restore_backup_standby
+{
+	my ($backup_dir, $restore_point, $primary_host, $primary_port, $label) = @_;
+
+	my $standby_pgdata = $standby->data_dir;
+	my $standby_port = $standby->port;
+
+	$standby->command_ok([ 'rm', '-rf', $standby_pgdata ],
+		"'$label': rm standby pgdata");
+	$standby->command_ok([ 'cp', '-r', $backup_dir, $standby_pgdata ],
+		"'$label': copy basebackup to standby");
+
+	$standby->set_recovery_mode;
+	open my $conf, '>', "$standby_pgdata/postgresql.auto.conf";
+	print $conf "recovery_target_action = 'shutdown'\n";
+	print $conf "restore_command = 'cp -v $archivedir/%f $standby_pgdata/%p'\n";
+	print $conf "recovery_target_name = '$restore_point'\n";
+	close $conf;
+	$standby->adjust_conf('postgresql.conf', 'port', $standby_port);
+	$standby->start(fail_ok => 1);
+
+	$standby->wait_for_log('database system is shut down');
+
+	# configure primary connection with replication slot
+	unlink "$standby_pgdata/recovery.signal";
+	unlink "$standby_pgdata/postgresql.auto.conf";
+	$standby->set_standby_mode;
+	open $conf, '>', "$standby_pgdata/postgresql.auto.conf";
+	print $conf "primary_conninfo = 'port=$primary_port host=$primary_host'\n";
+	print $conf "primary_slot_name = 'internal_wal_replication_slot'\n";
+	close $conf;
+
+	$standby->_update_pid(0);
+	$standby->start;
+}
+
+mkdir($archivedir);
+
+# Initialize primary
+$primary->init(allows_streaming => 1, extra => ['--data-checksums']);
+$primary->append_conf("postgresql.conf", "archive_mode = 'on'");
+$primary->append_conf("postgresql.conf", "archive_command = 'cp -v %p $archivedir/'");
+$primary->start;
+$primary->safe_psql('postgres', 'CREATE DATABASE test_db');
+$primary->safe_psql('test_db', 'CREATE TABLE test AS SELECT generate_series(1,10)');
+$primary->safe_psql('postgres', 'CREATE ROLE postgres WITH LOGIN REPLICATION');
+
+# Steps at primary below are needed to generate non-linear history of timelines
+
+create_backup_primary($basebackupdir1, 'backup_label1');
+$primary->stop('smart');
+restore_backup_primary($basebackupdir1, "recovery_target_name = 'backup_label1'\nrecovery_target_timeline = 'current'", '001 -> 012');
+wait_recovery_and_switch_wal_primary('001 -> 012');
+
+create_backup_primary($basebackupdir2, 'backup_label2');
+$primary->stop('smart');
+restore_backup_primary($basebackupdir2, "recovery_target_name = 'backup_label2'\nrecovery_target_timeline = 'current'", '012 -> 013');
+wait_recovery_and_switch_wal_primary('012 -> 013');
+
+$primary->stop('smart');
+restore_backup_primary($basebackupdir2, "recovery_target_name = 'backup_label2'\nrecovery_target_timeline = 'current'", '012 -> 023');
+wait_recovery_and_switch_wal_primary('012 -> 023');
+
+$primary->stop('smart');
+restore_backup_primary($basebackupdir1, "recovery_target_name = 'backup_label1'\nrecovery_target_timeline = 'current'", '101 -> 112');
+wait_recovery_and_switch_wal_primary('101 -> 112');
+
+$primary->stop('smart');
+restore_backup_primary($basebackupdir2, "recovery_target_name = 'backup_label2'\nrecovery_target_timeline = 'current'", '112 -> 113');
+wait_recovery_and_switch_wal_primary('112 -> 113');
+
+$primary->stop('smart');
+restore_backup_primary($basebackupdir1, "recovery_target_name = 'backup_label1'\nrecovery_target_timeline = 'current'", '101 -> 114');
+
+# wait for end of recovery and create replication slot
+$primary->poll_query_until('test_db', "SELECT true")
+  or die "Timed out while waiting for creating replication slot after recovery";
+$primary->safe_psql('test_db', "SELECT pg_create_physical_replication_slot('internal_wal_replication_slot')");
+
+restore_backup_standby($basebackupdir1, 'backup_label1', $primary->host, $primary->port, '301 -> 312');
+
+# After restart standby did not start because of error (now, it should start correctly)
+$standby->restart;
+
+done_testing();


### PR DESCRIPTION
Don't read past current TLI during archive recovery

If you set the recovery target timeline, the recovery would not
correctly follow the timeline history to reach that timeline, if a
local WAL segment had more WAL records on one of the older
timelines. Fix that by not reading WAL past the switchpoint in the
timeline history.

This case came up with pg_rewind: if you call pg_rewind on a server
that is a direct ancestor of the source, it exits with "no rewind
required" and does nothing. However, if the target had already
streamed WAL past the point of divergence, and just hadn't applied it
yet, when you start it up it will follow the original timeline, not
the one you tried to rewind to. This commit alone doesn't fix that,
because the server still won't know that it's supposed to follow the
other timeline. But this at least fixes the similar case when you have
set the recovery target timeline explicitly.

Discussion: https://www.postgresql.org/message-id/18575-1b9b3b60e2a480de%40postgresql.org

Original patch has been simply modified to correctly apply to our fork:
1) File xlogrecovery.c was renamed to xlog.c
2) Variable flushedUpto was renamed to receivedUpto
3) Callback wait_for_replay_catchup($primary2) was changed to
wait_for_catchup($primary2, 'replay', $primary1->lsn('flush'))

---

 Add test for check replication after recovery
    
 This commit adds new test to check correctness of standby's recovery. Standby
 should correctly connect to the primary's replication slot after recovery.

---
This PR should be rebased to preserve authorship.
