### PR TITLE
ADBDEV-6277: Fix GUC sync leaving broken temp tables (#1193)

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1651,7 +1651,9 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 			/* if some guc can not restore successful
 			 * we can not keep alive gang anymore.
 			 */
-			DisconnectAndDestroyAllGangs(false);
+			DisconnectAndDestroyAllGangs(true);
+			GpResetSessionIfNeeded();
+			GpDropTempTables();
 			/*
 			 * when qe elog an error, qd will use ReThrowError to
 			 * re throw the error, the errordata_stack_depth will ++,

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -153,3 +153,38 @@ RESET
 (4 rows)
 4q: ... <quitting>
 
+-- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
+1: create temp table sync_temp_table(a int) distributed by (a);
+CREATE TABLE
+-- Cause panic on segment from another session
+2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: create function my_function() returns void as $$ begin end; $$ language plpgsql;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (seg0 192.168.0.101:6002 pid=347506)
+2q: ... <quitting>
+-- Attempting to change GUC
+!\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+-- Query to execute GUC sync (GUC sync fails, query succeeds)
+1: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+-- Should fail with "relation does not exist"
+1: select * from sync_temp_table;
+ERROR:  relation "sync_temp_table" does not exist
+LINE 1: select * from sync_temp_table;
+                      ^
+
+!\retcode gpconfig -r log_min_messages;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+1q: ... <quitting>


### PR DESCRIPTION
Fix GUC sync leaving broken temp tables (#1193)

Before this patch, if an error happened during GUC sync (for example a segment was disconnected) the gang was destroyed but the session wasn't reset, so temporary tables weren't cleaned up. This left a temporary table left on coordinator, but not on segments, resulting in segment errors. This patch fixes this by enabling session reset for errors during GUC syncs.

Changes from original commit:
1. Replace CheckForResetSession with equivalent GpResetSessionIfNeeded and GpDropTempTables.
2. Fix test output.

Ticket: ADBDEV-6277
(cherry picked from commit 6fe7e5316590c563c3d134777f5e93899372a317)

---

Note: Do not squash to preserve authorship