### PR TITLE
Add support for target cols with functional dependency on grouping ones to ORCA

### DIFF
--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -833,6 +833,70 @@ ConstraintSetParentConstraint(Oid childConstrId,
 	table_close(constrRel, RowExclusiveLock);
 }
 
+/*
+ * get_constraint_relation_oids
+ *		Find the IDs of the relations to which a constraint refers.
+ */
+void
+get_constraint_relation_oids(Oid constraint_oid, Oid *conrelid, Oid *confrelid)
+{
+	HeapTuple	tup;
+	Form_pg_constraint con;
+
+	tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(constraint_oid));
+	if (!HeapTupleIsValid(tup)) /* should not happen */
+		elog(ERROR, "cache lookup failed for constraint %u", constraint_oid);
+	con = (Form_pg_constraint) GETSTRUCT(tup);
+	*conrelid = con->conrelid;
+	*confrelid = con->confrelid;
+	ReleaseSysCache(tup);
+}
+
+/*
+ * get_constraint_relation_columns
+ *		Find the columns of the relations to which a constraint refers.
+ *		Returns the list of found columns.
+ */
+List *
+get_constraint_relation_columns(Oid constraint_oid)
+{
+	List	   *conkeys_list = NIL;
+	HeapTuple	tp = SearchSysCache1(CONSTROID, ObjectIdGetDatum(constraint_oid));
+
+	if (HeapTupleIsValid(tp))
+	{
+		bool		is_null;
+		Relation	pg_constraint = heap_open(ConstraintRelationId, AccessShareLock);
+		Datum		adatum = heap_getattr(tp,
+										  Anum_pg_constraint_conkey,
+										  RelationGetDescr(pg_constraint),
+										  &is_null);
+
+		if (is_null)
+			elog(LOG, "null conkey for constraint %u", constraint_oid);
+		else
+		{
+			Datum	   *conkeys;
+			int			num_conkeys = 0;
+
+			deconstruct_array(DatumGetArrayTypeP(adatum),
+							  INT2OID, 2, true, 's',
+							  &conkeys, NULL, &num_conkeys);
+
+			for (int i = 0; i < num_conkeys; i++)
+			{
+				AttrNumber	attnum = DatumGetInt16(conkeys[i]);
+
+				conkeys_list = list_append_unique_int(conkeys_list, attnum);
+			}
+		}
+
+		heap_close(pg_constraint, AccessShareLock);
+		ReleaseSysCache(tp);
+	}
+
+	return conkeys_list;
+}
 
 /*
  * get_relation_constraint_oid

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -35,13 +35,19 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 extern "C" {
 #include "catalog/pg_collation.h"
+#include "catalog/pg_constraint.h"
 #include "catalog/pg_inherits.h"
 #include "foreign/fdwapi.h"
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/subselect.h"
+#include "optimizer/tlist.h"
 #include "parser/parse_agg.h"
+#include "parser/parse_clause.h"
+#include "parser/parse_oper.h"
 #include "storage/lmgr.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
 }
 #pragma GCC diagnostic pop
 
@@ -2699,6 +2705,74 @@ gpdb::IsTypeRange(Oid typid)
 	}
 	GP_WRAP_END;
 	return false;
+}
+
+TargetEntry *
+gpdb::GetSortGroupRefTle(Index sortref, List *targetlist)
+{
+	GP_WRAP_START;
+	{
+		return get_sortgroupref_tle(sortref, targetlist);
+	}
+	GP_WRAP_END;
+	return NULL;
+}
+
+bool
+gpdb::ListMemberInt(List *list, int datum)
+{
+	GP_WRAP_START;
+	{
+		return list_member_int(list, datum);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
+void
+gpdb::GetSortGroupOperators(Oid argtype, bool need_lt, bool need_eq,
+							bool need_gt, Oid *lt_opr, Oid *eq_opr, Oid *gt_opr,
+							bool *hashable)
+{
+	GP_WRAP_START;
+	{
+		get_sort_group_operators(argtype, need_lt, need_eq, need_gt, lt_opr,
+								 eq_opr, gt_opr, hashable);
+	}
+	GP_WRAP_END;
+}
+
+Index
+gpdb::AssignSortGroupRef(TargetEntry *tle, List *tlist)
+{
+	GP_WRAP_START;
+	{
+		return assignSortGroupRef(tle, tlist);
+	}
+	GP_WRAP_END;
+	return 0;
+}
+
+void
+gpdb::GetConstraintRelationOids(Oid constraint_oid, Oid *conrelid,
+								Oid *confrelid)
+{
+	GP_WRAP_START;
+	{
+		get_constraint_relation_oids(constraint_oid, conrelid, confrelid);
+	}
+	GP_WRAP_END;
+}
+
+List *
+gpdb::GetConstraintRelationColumns(Oid constraint_oid)
+{
+	GP_WRAP_START;
+	{
+		return get_constraint_relation_columns(constraint_oid);
+	}
+	GP_WRAP_END;
+	return NIL;
 }
 
 char *

--- a/src/include/catalog/pg_constraint.h
+++ b/src/include/catalog/pg_constraint.h
@@ -256,6 +256,9 @@ extern void DeconstructFkConstraintRow(HeapTuple tuple, int *numfks,
 									   AttrNumber *conkey, AttrNumber *confkey,
 									   Oid *pf_eq_oprs, Oid *pp_eq_oprs, Oid *ff_eq_oprs);
 
+extern void get_constraint_relation_oids(Oid constraint_oid, Oid *conrelid, Oid *confrelid);
+extern List *get_constraint_relation_columns(Oid constraint_oid);
+
 extern bool check_functional_grouping(Oid relid,
 									  Index varno, Index varlevelsup,
 									  List *grouping_columns,

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -655,6 +655,27 @@ TargetEntry *FlatCopyTargetEntry(TargetEntry *src_tle);
 
 bool IsTypeRange(Oid typid);
 
+// find the targetlist entry by its ressortgroupref
+TargetEntry *GetSortGroupRefTle(Index sortref, List *targetlist);
+
+// return true if the integer 'datum' is a member of the list
+bool ListMemberInt(List *list, int datum);
+
+// get default sorting/grouping operators for type
+void GetSortGroupOperators(Oid argtype, bool need_lt, bool need_eq,
+						   bool need_gt, Oid *lt_opr, Oid *eq_opr, Oid *gt_opr,
+						   bool *hashable);
+
+// assign the targetentry an unused ressortgroupref, if it doesn't already have one.
+Index AssignSortGroupRef(TargetEntry *tle, List *tlist);
+
+// find the IDs of the relations to which a constraint refers
+void GetConstraintRelationOids(Oid constraint_oid, Oid *conrelid,
+							   Oid *confrelid);
+
+// find the columns of the relations to which a constraint refers
+List *GetConstraintRelationColumns(Oid constraint_oid);
+
 char *GetRelAmName(Oid reloid);
 
 IndexAmRoutine *GetIndexAmRoutineFromAmHandler(Oid am_handler);

--- a/src/test/regress/expected/functional_deps.out
+++ b/src/test/regress/expected/functional_deps.out
@@ -1168,7 +1168,7 @@ SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c
 (50 rows)
 
 SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c; -- falls back to Postgres-based planner yet
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
@@ -1638,7 +1638,7 @@ SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
@@ -1747,7 +1747,7 @@ SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a));
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0

--- a/src/test/regress/expected/functional_deps_optimizer.out
+++ b/src/test/regress/expected/functional_deps_optimizer.out
@@ -1169,6 +1169,8 @@ SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c
 
 SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
 GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
@@ -1639,6 +1641,8 @@ ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in 
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
 SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0
@@ -1748,6 +1752,8 @@ ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in 
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
 SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  a  |   b   | c 
 ----+-------+---
   1 | text1 | 0

--- a/src/test/regress/expected/functional_deps_optimizer.out
+++ b/src/test/regress/expected/functional_deps_optimizer.out
@@ -1168,7 +1168,7 @@ SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c
 (50 rows)
 
 SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c; -- falls back to Postgres-based planner yet
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
  a  |   b   | c 
@@ -1640,7 +1640,7 @@ SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  a  |   b   | c 
@@ -1751,7 +1751,7 @@ SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a));
 ERROR:  column "test_table1.c" must appear in the GROUP BY clause or be used in an aggregate function
 LINE 1: SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((...
                      ^
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: nested grouping set
  a  |   b   | c 

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2374,7 +2374,7 @@ insert into dqa_unique select i%3, i%5, i%7, i%9 from generate_series(1, 10) i;
 analyze dqa_unique;
 explain(verbose on, costs off) select count(distinct a), count(distinct d), c from dqa_unique group by a, b;
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Finalize HashAggregate
@@ -2406,7 +2406,7 @@ DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect nor
 
 select count(distinct a), count(distinct d), c from dqa_unique group by a, b;
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Multiple Distinct Qualified Aggregates are disabled in the optimizer
  count | count | c 
 -------+-------+---
      1 |     1 | 5

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -453,7 +453,7 @@ select a, d, grouping(a,b,c)
   from gstest3
  group by grouping sets ((a,b), (a,c));
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | d | grouping 
 ---+---+----------
  1 | 1 |        1
@@ -1613,7 +1613,7 @@ select a, d, grouping(a,b,c)
   from gstest3
  group by grouping sets ((a,b), (a,c));
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
  a | d | grouping 
 ---+---+----------
  1 | 1 |        1
@@ -1627,7 +1627,7 @@ explain (costs off)
     from gstest3
    group by grouping sets ((a,b), (a,c));
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Grouping function with multiple arguments
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -76,8 +76,6 @@ create temp table gstest2 (a int primary key, b int, c int, d int, v int);
 insert into gstest2 values (1, 1, 1, 1, 1);
 insert into gstest2 values (2, 2, 2, 2, 1);
 select d from gstest2 group by grouping sets ((a,b), (a));
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Query-to-DXL Translation: No attribute entry found due to incorrect normalization of query
  d 
 ---
  2

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -1,5 +1,8 @@
 -- from http://www.depesz.com/index.php/2010/04/19/getting-unique-elements/
 
+-- Enable logs that allow to show GPORCA failed to produce a plan
+SET optimizer_trace_fallback = on;
+
 CREATE TEMP TABLE articles (
     id int CONSTRAINT articles_pkey PRIMARY KEY,
     keywords text,
@@ -210,3 +213,168 @@ EXECUTE foo;
 ALTER TABLE articles DROP CONSTRAINT articles_pkey RESTRICT;
 
 EXECUTE foo;  -- fail
+
+-- start_ignore
+DROP TABLE IF EXISTS test_table1;
+DROP TABLE IF EXISTS test_table2;
+DROP TABLE IF EXISTS test_table3;
+-- end_ignore
+
+CREATE TABLE test_table1 (a int PRIMARY KEY, b text, c int);
+INSERT INTO test_table1 VALUES
+(1, 'text1', 0),
+(2, 'text2', 1),
+(3, 'text3', 0),
+(4, 'text4', 1),
+(5, 'text0', 0),
+(6, 'text1', 1),
+(7, 'text2', 0),
+(8, 'text3', 1),
+(9, 'text4', 0),
+(10, 'text0', 1),
+(11, 'text1', 0),
+(12, 'text2', 1),
+(13, 'text3', 0),
+(14, 'text4', 1),
+(15, 'text0', 0),
+(16, 'text1', 1),
+(17, 'text2', 0),
+(18, 'text3', 1),
+(19, 'text4', 0),
+(20, 'text0', 1),
+(21, 'text1', 0),
+(22, 'text2', 1),
+(23, 'text3', 0),
+(24, 'text4', 1),
+(25, 'text0', 0);
+
+CREATE TABLE test_table2 (a int, b text, c int, CONSTRAINT id_t2 PRIMARY KEY(a,c));
+INSERT INTO test_table2 VALUES
+(1, 'text|1|-1|', -1),
+(1, 'text|1|1|',   1),
+(2, 'text|2|-1|', -1),
+(2, 'text|2|1|',   1),
+(3, 'text|3|-1|', -1),
+(3, 'text|3|1|',   1),
+(4, 'text|4|-1|', -1),
+(4, 'text|4|1|',   1),
+(5, 'text|5|-1|', -1),
+(5, 'text|5|1|',   1);
+
+CREATE TABLE test_table3 (a int PRIMARY KEY, b text, c int);
+INSERT INTO test_table3 VALUES
+(1, 't3-text1', 0),
+(2, 't3-text2', 1),
+(3, 't3-text3', 0),
+(4, 't3-text4', 1),
+(5, 't3-text0', 0),
+(6, 't3-text1', 1),
+(7, 't3-text2', 0),
+(8, 't3-text3', 1),
+(9, 't3-text4', 0),
+(10, 't3-text0', 1);
+
+-- Check simple group by clause
+SELECT a, b FROM test_table1 GROUP BY a ORDER BY a;
+SELECT a, b, c FROM test_table1 GROUP BY a, a > 1 ORDER BY a;
+SELECT a, b, c FROM test_table1 GROUP BY a, b ORDER BY a;
+-- Check grouping sets
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a)) ORDER BY a;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a, b;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b)) ORDER BY a, b;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, b), (a), (a,c)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a, a), ()) ORDER BY a, b, c; -- fail
+-- Check rollup
+SELECT a, b, c FROM test_table1 GROUP BY ROLLUP (a,b,c) ORDER BY a, b, c;
+-- Check expressions in target list
+SELECT a, b, c, 1+(a+c)*2 AS exp_ac FROM test_table1 GROUP BY a ORDER BY a, b, c, exp_ac;
+SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY a ORDER BY a;
+SELECT 1+(a+c)*2 AS exp_ac_1, 100+(a+c)*2 AS exp_ac_2 FROM test_table1 GROUP BY a ORDER BY exp_ac_1;
+SELECT 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
+-- Check together with aggregate functions in target list
+SELECT count(*) AS cnt, 1+(a+c)*2 AS exp_ac, a FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY a;
+-- Check with grouping function in target list
+SELECT grouping(a) AS g_a, a, b FROM test_table1 GROUP BY GROUPING SETS ((a)) ORDER BY a;
+SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ()) ORDER BY avg_c;
+-- Check aggregate functions in ORDER BY clause
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) ORDER BY avg(c), a, b;
+-- Check aggregate functions in HAVING clause
+SELECT a, b FROM test_table1 GROUP BY GROUPING SETS ((a), (a,b)) HAVING avg(c) > 0 ORDER BY avg(c), a, b;
+-- Check grouping functions in HAVING clause
+SELECT grouping(a) AS g_a, a, avg(c) as avg_c FROM test_table1 GROUP BY ROLLUP (a) HAVING grouping(a) = 0 ORDER BY a, avg_c;
+SELECT 1+(a+c)*2 AS exp_ac_1, b, grouping(b) AS g_b FROM test_table1 GROUP BY a, b HAVING grouping(b) = 0 ORDER BY exp_ac_1, b;
+SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 GROUP BY GROUPING SETS ((a), (b), ())
+	HAVING  grouping(a) = 1 AND grouping(b) = 1 ORDER BY avg_c;
+-- Check sub-query
+SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t;
+SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
+SELECT (SELECT c) FROM test_table1 GROUP BY a ORDER BY a;
+SELECT b, (SELECT c FROM (SELECT c) AS alias_test_table1) FROM test_table1 GROUP BY a ORDER BY a;
+-- Check cases with primary key consisting of more than 1 column
+SELECT a, b, c FROM test_table2 GROUP BY a, c ORDER BY a, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c), (a)) ORDER BY a, c; -- fail
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, count(*) AS cnt, a, avg(c) FROM test_table2 GROUP BY GROUPING SETS ((a, c), () ) ORDER BY a, c;
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS (a, c, (a, c) ) ORDER BY g_a, g_c, a, c; -- fail
+SELECT grouping(a) AS g_a, grouping(c) AS g_c, a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a, c) ) ORDER BY g_a, g_c, a, c;
+-- Check cases with join and grouping by primary key of one of the tables
+SELECT l.a, l.b, count(r.b) AS cnt FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+-- Plus check expressions with aggregate functions 
+SELECT l.a, l.b, count(r.b) + avg(r.a) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+SELECT l.a, l.b, count(r.b) + avg(l.a) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+SELECT l.a, l.b, count(r.b) + avg(l.c) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+SELECT l.a, l.b, count(r.b) + avg(r.a) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+-- Plus check aggregate functions with expression as parameters
+SELECT l.a, l.b, avg(r.a + l.c) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+SELECT l.a, l.b, avg(r.a + r.c) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+SELECT l.a, l.b, avg(l.a + l.c) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+-- Plus check both cases above together
+SELECT l.a, l.b, avg(r.a + l.c) + count(r.b) AS agg_expr FROM test_table1 AS l JOIN test_table2 AS r ON l.a=r.a GROUP BY l.a ORDER BY l.a;
+-- Check cases with join of 2 tables on their primary key
+SELECT l.a, l.b, r.a, r.b FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY l.a, r.a ORDER BY l.a;
+SELECT grouping(l.a) AS g_l_a, grouping(r.a) AS g_r_a, grouping(r.c) AS g_r_c, l.a, r.a, r.c
+	FROM test_table1 AS l JOIN test_table3 AS r ON l.a=r.a GROUP BY GROUPING SETS ((l.a, r.a), (r.c), ()) ORDER BY l.a, r.c;
+
+-- Checking for ungrouped columns in TargetList
+
+-- grouping expression and GROUP BY
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()), a ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
+
+-- only grouping expression
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (a,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a), GROUPING SETS (b,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (b), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (a,()), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (a),a)),
+		                                 GROUPING SETS (b,()) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS (GROUPING SETS (GROUPING SETS (b),a)),
+		                                 GROUPING SETS (b,()); -- fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(c))) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), GROUPING SETS ((a),(b)), GROUPING SETS ((a),())); --fail
+SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b), ROLLUP(a)); -- fail
+
+-- composite Primary Key
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c),()), a, c ORDER BY a, b, c;
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS ((a,c), GROUPING SETS (a,c)); -- fail
+SELECT a, b, c FROM test_table2 GROUP BY GROUPING SETS (a,c), GROUPING SETS (a,()) ORDER BY a, b, c; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a; -- fail
+SELECT a, b, c FROM test_table2 GROUP BY ROLLUP (a,c), a, c ORDER BY a, b, c;
+
+DROP TABLE test_table1;
+DROP TABLE test_table2;
+DROP TABLE test_table3;
+
+RESET optimizer_trace_fallback;
+RESET optimizer;

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -309,7 +309,7 @@ SELECT grouping(a) AS g_a, grouping(b) AS g_b, avg(c) AS avg_c FROM test_table1 
 -- Check sub-query
 SELECT * FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t;
 SELECT sub_t.a, sub_t.b, sub_t.c FROM (SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a), (a,c)) ORDER BY a, c) AS sub_t 
-GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c;
+GROUP BY GROUPING SETS ((sub_t.a, sub_t.b, sub_t.c), ()) ORDER BY sub_t.a, sub_t.b, sub_t.c; -- falls back to Postgres-based planner yet
 SELECT (SELECT c) FROM test_table1 GROUP BY a ORDER BY a;
 SELECT b, (SELECT c FROM (SELECT c) AS alias_test_table1) FROM test_table1 GROUP BY a ORDER BY a;
 -- Check cases with primary key consisting of more than 1 column
@@ -343,9 +343,9 @@ SELECT a, b, c FROM test_table1 GROUP BY GROUPING SETS ((a),(b),()), a ORDER BY 
 SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b),()) ORDER BY a, b, c;
 SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b),()); -- fail
 SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),()); -- fail
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), ROLLUP (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
 SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), ROLLUP (a)); -- fail
-SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c;
+SELECT a, b, c FROM test_table1 GROUP BY a, GROUPING SETS ((a),(b), CUBE (a)) ORDER BY a, b, c; -- falls back to Postgres-based planner yet
 SELECT a, b, c FROM test_table1 GROUP BY b, GROUPING SETS ((a),(b), CUBE (a)); -- fail
 
 -- only grouping expression


### PR DESCRIPTION
Add support for target cols with functional dependency on grouping ones to ORCA

Problem description: ORCA fails to handle queries with columns in the target
list, not listed in GROUP BY clause, if grouping is done by a primary key
(meaning that these columns have a functional dependency on grouping columns).
In such a case, it falls back to the standard planner. Expected behavior - ORCA
generates a plan for a query with columns in target list, if these columns have
a functional dependency on columns in GROUP BY list.

Root cause: Function CQueryMutators::ShouldFallback during query normalization
finds out that there is a target list entry, that is not a grouping column, and
it triggers fallback to the standard planner.

Fix: All columns from the target list with functional dependency on grouping
columns are added explicitly to group by clause at the query normalization stage
(at start of groupby normalization, before checking if fallback is required)
before the translation to DXL. It requires the following steps:
1) Extract such columns from target list expressions, and if they do not have a
relevant target list entry, add resjunk target list entries for them.
2) Store current unique target list entry references in groupClause - they will
be required at step 4.
3) Update all grouping sets that contain the primary key - add the functionally
dependent columns from the target list.
4) Update arguments of GROUPING functions (based on target list entry references
stored on step 2 and updated target list entry references), because they could
be shifted after step 3.

Plus, new test cases were added to the functional_deps test.

(cherry picked from commit https://github.com/arenadata/gpdb/commit/b1373f861107592c4ff0792e01f60b3843d44e44)

Changes comparing to the original commit:
1. Usage of 'grouping()' function with a column that is not in a grouping sets
is now declined on the parser stage (even if the column has a functional
dependency on the column in the grouping set). So the part related to the
adjustment of the 'grouping()' function arguments is removed (steps 2 and 4 of
algorithm).
2. Functions 'GetSortGroupClauseExpr()', 'LAppendUniqueInt()' and
'LAppendUnique()' are not needed anymore, so they are removed from the patch.
3. Function 'get_constraint_relation_oids()' was removed at some point between
6x and 7x versions, but the patch uses it. So this function is brought back.
4. Internals of 'groupClause' field of the Query structure has changed
significantly comparing to 6x. Now it is a plain list of SortGroupClause nodes.
The structure of the GROUP BY statement is now defined by 'groupingSets' field
in the Query structure. Therefore, now the patch mutates not 'groupClause'
field, but 'groupingSets' field. And missing SortGroupClause node is simply
added to 'groupClause' list. The mutator and 'GroupingListContainsPrimaryKey()'
functions has been updated to work with 'groupingSets'.
5. After this change some old tests stopped to fallback to the standard planner 
(which is an expected consequence of the patch). Some old tests started to 
fallback with a different reason (as previous reason is fixed with this patch).
All answer files for such tests were updated accordingly.
6. Tests were aligned with changes in 6a737f538abebbc602b8585632a2b1a8a0b99e39,
as it is the expected behavior after PostgreSQL 9.5.
7. Some newly added with the patch test cases fallback to standard planner on 7x
due to different reason (for ex. "GPORCA does not support the following feature:
nested grouping set"). These cases are left untouched, as they are reproduced
even without target cols with functional dependency, so it is out of scope of
the patch. Only optimizer answer file is updated.

For item 6:
Co-authored-by: Aleksandr Kopytov <a.kopytov@arenadata.io>