### PR TITLE
ADBDEV-7016: Don't modify prepared statement by CTAS from it

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -704,14 +704,6 @@ RevalidateCachedQuery(CachedPlanSource *plansource,
 									   plansource->num_params,
 									   queryEnv);
 
-	/* GPDB: For CTAS query, set its isCTAS to be true */
-	if (intoClause)
-	{
-		Assert(list_length(tlist) == 1);
-		Query *query = (Query *) linitial(tlist);
-		query->parentStmtType = PARENTSTMTTYPE_CTAS;
-	}
-
 	/* Release snapshot if we got one */
 	if (snapshot_set)
 		PopActiveSnapshot();
@@ -803,6 +795,14 @@ RevalidateCachedQuery(CachedPlanSource *plansource,
 	 */
 
 	plansource->is_valid = true;
+
+	/* GPDB: For CTAS query, set its parentStmtType to PARENTSTMTTYPE_CTAS */
+	if (intoClause)
+	{
+		Assert(list_length(tlist) == 1);
+		Query *query = (Query *) linitial(tlist);
+		query->parentStmtType = PARENTSTMTTYPE_CTAS;
+	}
 
 	/* Return transient copy of querytrees for possible use in planning */
 	return tlist;

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -212,6 +212,7 @@ PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
 CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
 ERROR:  prepared statement is not a SELECT
 -- make sure the plan is correct after CTAS
+DROP TABLE t;
 PREPARE p AS SELECT * FROM generate_series(1, 10) i;
 CREATE TEMPORARY TABLE t AS EXECUTE p;
 EXPLAIN (COSTS OFF) EXECUTE p;

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -192,6 +192,16 @@ ERROR:  prepared statement is not a SELECT
 PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
 CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
 ERROR:  prepared statement is not a SELECT
+-- make sure the plan is correct after CTAS
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+             QUERY PLAN             
+------------------------------------
+ Function Scan on generate_series i
+ Optimizer: Postgres-based planner
+(2 rows)
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -222,6 +222,7 @@ INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
 ERROR:  prepared statement is not a SELECT
 -- make sure the plan is correct after CTAS
+DROP TABLE t;
 PREPARE p AS SELECT * FROM generate_series(1, 10) i;
 CREATE TEMPORARY TABLE t AS EXECUTE p;
 EXPLAIN (COSTS OFF) EXECUTE p;

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -200,6 +200,16 @@ CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
 ERROR:  prepared statement is not a SELECT
+-- make sure the plan is correct after CTAS
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+            QUERY PLAN            
+----------------------------------
+ Function Scan on generate_series
+ Optimizer: GPORCA
+(2 rows)
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -99,6 +99,7 @@ PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
 CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
 
 -- make sure the plan is correct after CTAS
+DROP TABLE t;
 PREPARE p AS SELECT * FROM generate_series(1, 10) i;
 CREATE TEMPORARY TABLE t AS EXECUTE p;
 EXPLAIN (COSTS OFF) EXECUTE p;

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -91,6 +91,11 @@ CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_update;
 PREPARE prepared_delete AS DELETE FROM simple_table WHERE a = 1 RETURNING *;
 CREATE TEMPORARY TABLE t2 AS EXECUTE prepared_delete;
 
+-- make sure the plan is correct after CTAS
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements


### PR DESCRIPTION
Don't modify prepared statement by CTAS from it

Creating a table from an execution of a prepared statement modifies the
parentStmtType attribute of the cached query of that statement, which results
in invalid plans for subsequent executions of that prepared statement. This
patch fixes the issue by marking the query as CTAS while leaving the cache
intact, namely, we now modify the parentStmtType attribute only on the copy of
the query that is subsequently used for planning, but not on the cached query
that remains for the prepared statement.