### PR TITLE
ADBDEV-6685: Remove the old libxerces installation from the ABI tests

### DIFF
--- a/.github/workflows/greenplum-abi-tests.yml
+++ b/.github/workflows/greenplum-abi-tests.yml
@@ -93,19 +93,6 @@ jobs:
           sudo apt install -y libuv1-dev libpam0g-dev libldap-dev libipc-run-perl abi-dumper
           sudo ln -fs python2 /usr/bin/python
 
-        # FIXME: The next lines is only needed for the current pass of the ABI
-        # tests and should be removed after merging README.ubuntu.bash changes
-        # into the base branch.
-      - name: Build libxerces 3.1.2
-        if: ${{matrix.ref == '6.27.1_arenadata58' }}
-        run: |
-          wget https://github.com/arenadata/gp-xerces/archive/refs/tags/v3.1.2-p1.tar.gz
-          tar -xzf v3.1.2-p1.tar.gz
-          pushd gp-xerces-3.1.2-p1
-          ./configure
-          make -j`nproc` && sudo make install
-          popd
-
       - name: Build Greenplum
         run: |
           ## TODO: Since abi-dumper requires debug info and it's hard to inject CFLAGS via the script for


### PR DESCRIPTION
Remove the old libxerces installation from the ABI tests

Old libxerces was kept in ABI tests to not break them for baseline version.
Now that the baseline was also updated to not use old libxerces, we can remove
this.