### PR TITLE
Partial revert "Decouple Orca from Explain component"

### DIFF
--- a/.abi-check/7.2.0_arenadata7/postgres.types.ignore
+++ b/.abi-check/7.2.0_arenadata7/postgres.types.ignore
@@ -1,1 +1,0 @@
-struct PlannedStmt

--- a/gpcontrib/orca/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/gpcontrib/orca/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -219,7 +219,7 @@ CTranslatorDXLToPlStmt::GetPlannedStmtFromDXL(const CDXLNode *dxlnode,
 
 	// assemble planned stmt
 	PlannedStmt *planned_stmt = MakeNode(PlannedStmt);
-	planned_stmt->plannerName = "GPORCA";
+	planned_stmt->planGen = PLANGEN_OPTIMIZER;
 
 	planned_stmt->rtable = m_dxl_to_plstmt_context->GetRTableEntriesList();
 	planned_stmt->subplans = m_dxl_to_plstmt_context->GetSubplanEntriesList();

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -889,10 +889,10 @@ ExplainPrintPlan(ExplainState *es, QueryDesc *queryDesc)
 	 * If requested, include information about GUC parameters with values that
 	 * don't match the built-in defaults.
 	 */
-	if (queryDesc->plannedstmt->plannerName == NULL)
+	if (queryDesc->plannedstmt->planGen == PLANGEN_PLANNER)
 		ExplainPropertyStringInfo("Optimizer", es, "Postgres-based planner");
 	else
-		ExplainPropertyStringInfo("Optimizer", es, "%s", queryDesc->plannedstmt->plannerName);
+		ExplainPropertyStringInfo("Optimizer", es, "GPORCA");
 
 	ExplainPrintSettings(es);
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -103,6 +103,7 @@ _copyPlannedStmt(const PlannedStmt *from)
 	PlannedStmt *newnode = makeNode(PlannedStmt);
 
 	COPY_SCALAR_FIELD(commandType);
+	COPY_SCALAR_FIELD(planGen);
 	COPY_SCALAR_FIELD(queryId);
 	COPY_SCALAR_FIELD(hasReturning);
 	COPY_SCALAR_FIELD(hasModifyingCTE);
@@ -150,7 +151,6 @@ _copyPlannedStmt(const PlannedStmt *from)
 	COPY_NODE_FIELD(copyIntoClause);
 	COPY_NODE_FIELD(refreshClause);
 	COPY_SCALAR_FIELD(metricsQueryType);
-	COPY_STRING_FIELD(plannerName);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -338,6 +338,7 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_NODE_TYPE("PLANNEDSTMT");
 
 	WRITE_ENUM_FIELD(commandType, CmdType);
+	WRITE_ENUM_FIELD(planGen, PlanGenerator);
 	WRITE_UINT64_FIELD(queryId);
 	WRITE_BOOL_FIELD(hasReturning);
 	WRITE_BOOL_FIELD(hasModifyingCTE);
@@ -392,7 +393,6 @@ _outPlannedStmt(StringInfo str, const PlannedStmt *node)
 	WRITE_NODE_FIELD(copyIntoClause);
 	WRITE_NODE_FIELD(refreshClause);
 	WRITE_INT_FIELD(metricsQueryType);
-	WRITE_STRING_FIELD(plannerName);
 }
 
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2408,6 +2408,7 @@ _readPlannedStmt(void)
 	READ_LOCALS(PlannedStmt);
 
 	READ_ENUM_FIELD(commandType, CmdType);
+	READ_ENUM_FIELD(planGen, PlanGenerator);
 	READ_UINT64_FIELD(queryId);
 	READ_BOOL_FIELD(hasReturning);
 	READ_BOOL_FIELD(hasModifyingCTE);
@@ -2460,7 +2461,6 @@ _readPlannedStmt(void)
 	READ_NODE_FIELD(copyIntoClause);
 	READ_NODE_FIELD(refreshClause);
 	READ_INT_FIELD(metricsQueryType);
-	READ_STRING_FIELD(plannerName);
 
 	READ_DONE();
 }

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -40,6 +40,12 @@ typedef struct DirectDispatchInfo
 	bool		haveProcessedAnyCalculations;
 } DirectDispatchInfo;
 
+typedef enum PlanGenerator
+{
+	PLANGEN_PLANNER,			/* plan produced by the planner*/
+	PLANGEN_OPTIMIZER,			/* plan produced by the optimizer*/
+} PlanGenerator;
+
 /* DML Actions */
 typedef enum DMLAction
 {
@@ -69,6 +75,8 @@ typedef struct PlannedStmt
 	NodeTag		type;
 
 	CmdType		commandType;	/* select|insert|update|delete|utility */
+
+	PlanGenerator	planGen;		/* optimizer generation */
 
 	uint64		queryId;		/* query identifier (copied from Query) */
 
@@ -148,13 +156,6 @@ typedef struct PlannedStmt
  	 * GPDB: whether a query is a SPI inner query for extension usage 
  	 */
 	int8		metricsQueryType;
-
-	/*
-	 * If the plan is done by an extension, the field below should contain
-	 * the name of the extension planner. Should be NULL if planning is done
-	 * by Postgres planner.
-	 */
-	const char	*plannerName;
 } PlannedStmt;
 
 /*


### PR DESCRIPTION
Partial revert "Decouple Orca from Explain component (#1124)"

This partially reverts commit bf2cc5abaa2a35f77b489a87e0c35c2f7f5d220a.

Only changes in 'PlannedStmt' structure are reverted. It is done to preserve
binary compatibility, as 'PlannedStmt' is used widely across various extensions.
