### PR TITLE
ADBDEV-7030: Fix creating table by EXPLAIN ANALYZE CTAS from prepared statement

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -412,13 +412,6 @@ ExplainOneQuery(Query *query, IntoClause *into, ExplainState *es,
 		INSTR_TIME_SET_CURRENT(planduration);
 		INSTR_TIME_SUBTRACT(planduration, planstart);
 
-		/*
-		 * GPDB_92_MERGE_FIXME: it really should be an optimizer's responsibility
-		 * to correctly set the into-clause and into-policy of the PlannedStmt.
-		 */
-		if (into != NULL)
-			plan->intoClause = copyObject(into);
-
 		/* run it (if needed) and produce output */
 		ExplainOnePlan(plan, into, es, queryString, params, &planduration, 0);
 	}
@@ -537,7 +530,16 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 	 * AS, we'd better use the appropriate tuple receiver.
 	 */
 	if (into)
+	{
 		dest = CreateIntoRelDestReceiver(into);
+
+		/*
+		 * GPDB_92_MERGE_FIXME: it really should be an optimizer's responsibility
+		 * to correctly set the into-clause and into-policy of the PlannedStmt.
+		 */
+		if (into != NULL)
+			plannedstmt->intoClause = copyObject(into);
+	}
 	else
 		dest = None_Receiver;
 

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -135,22 +135,22 @@ CREATE TEMPORARY TABLE q5_prep_results AS EXECUTE q5(200, 'DTAAAA');
 SELECT * FROM q5_prep_results;
  unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
 ---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
-     200 |    9441 |   0 |    0 |   0 |      0 |       0 |      200 |         200 |       200 |      200 |   0 |    1 | SHAAAA   | DZNAAA   | HHHHxx
+    5229 |    6407 |   1 |    1 |   9 |      9 |      29 |      229 |        1229 |       229 |     5229 |  58 |   59 | DTAAAA   | LMJAAA   | VVVVxx
+    5905 |    9537 |   1 |    1 |   5 |      5 |       5 |      905 |        1905 |       905 |     5905 |  10 |   11 | DTAAAA   | VCOAAA   | HHHHxx
+    7257 |    1895 |   1 |    1 |   7 |     17 |      57 |      257 |        1257 |      2257 |     7257 | 114 |  115 | DTAAAA   | XUCAAA   | VVVVxx
+    7933 |    4514 |   1 |    1 |   3 |     13 |      33 |      933 |        1933 |      2933 |     7933 |  66 |   67 | DTAAAA   | QRGAAA   | OOOOxx
+    8609 |    5918 |   1 |    1 |   9 |      9 |       9 |      609 |         609 |      3609 |     8609 |  18 |   19 | DTAAAA   | QTIAAA   | OOOOxx
+    9961 |    2058 |   1 |    1 |   1 |      1 |      61 |      961 |        1961 |      4961 |     9961 | 122 |  123 | DTAAAA   | EBDAAA   | OOOOxx
      497 |    9092 |   1 |    1 |   7 |     17 |      97 |      497 |         497 |       497 |      497 | 194 |  195 | DTAAAA   | SLNAAA   | AAAAxx
     1173 |    6699 |   1 |    1 |   3 |     13 |      73 |      173 |        1173 |      1173 |     1173 | 146 |  147 | DTAAAA   | RXJAAA   | VVVVxx
     1849 |    8143 |   1 |    1 |   9 |      9 |      49 |      849 |        1849 |      1849 |     1849 |  98 |   99 | DTAAAA   | FBMAAA   | VVVVxx
     2525 |      64 |   1 |    1 |   5 |      5 |      25 |      525 |         525 |      2525 |     2525 |  50 |   51 | DTAAAA   | MCAAAA   | AAAAxx
+     200 |    9441 |   0 |    0 |   0 |      0 |       0 |      200 |         200 |       200 |      200 |   0 |    1 | SHAAAA   | DZNAAA   | HHHHxx
     3201 |    7309 |   1 |    1 |   1 |      1 |       1 |      201 |        1201 |      3201 |     3201 |   2 |    3 | DTAAAA   | DVKAAA   | HHHHxx
     3877 |    4060 |   1 |    1 |   7 |     17 |      77 |      877 |        1877 |      3877 |     3877 | 154 |  155 | DTAAAA   | EAGAAA   | AAAAxx
     4553 |    4113 |   1 |    1 |   3 |     13 |      53 |      553 |         553 |      4553 |     4553 | 106 |  107 | DTAAAA   | FCGAAA   | HHHHxx
-    5229 |    6407 |   1 |    1 |   9 |      9 |      29 |      229 |        1229 |       229 |     5229 |  58 |   59 | DTAAAA   | LMJAAA   | VVVVxx
-    5905 |    9537 |   1 |    1 |   5 |      5 |       5 |      905 |        1905 |       905 |     5905 |  10 |   11 | DTAAAA   | VCOAAA   | HHHHxx
     6581 |    4686 |   1 |    1 |   1 |      1 |      81 |      581 |         581 |      1581 |     6581 | 162 |  163 | DTAAAA   | GYGAAA   | OOOOxx
-    7257 |    1895 |   1 |    1 |   7 |     17 |      57 |      257 |        1257 |      2257 |     7257 | 114 |  115 | DTAAAA   | XUCAAA   | VVVVxx
-    7933 |    4514 |   1 |    1 |   3 |     13 |      33 |      933 |        1933 |      2933 |     7933 |  66 |   67 | DTAAAA   | QRGAAA   | OOOOxx
-    8609 |    5918 |   1 |    1 |   9 |      9 |       9 |      609 |         609 |      3609 |     8609 |  18 |   19 | DTAAAA   | QTIAAA   | OOOOxx
     9285 |    8469 |   1 |    1 |   5 |      5 |      85 |      285 |        1285 |      4285 |     9285 | 170 |  171 | DTAAAA   | TNMAAA   | HHHHxx
-    9961 |    2058 |   1 |    1 |   1 |      1 |      61 |      961 |        1961 |      4961 |     9961 | 122 |  123 | DTAAAA   | EBDAAA   | OOOOxx
 (16 rows)
 
 -- ensure EXPLAIN ANALYZE CTAS from prepared statement creates table
@@ -159,15 +159,19 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
 CREATE TEMPORARY TABLE t AS EXECUTE p;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Redistribute Motion 1:3  (slice1; segments: 1) (actual rows=1 loops=1)
-   Hash Key: 1
-   ->  Result (actual rows=1 loops=1)
-   (slice0)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
-   (slice1)    Executor memory: 42K bytes (seg0).
+ Result (actual rows=1 loops=1)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
+         ->  Result (actual rows=1 loops=1)
+               ->  Result (actual rows=1 loops=1)
+                     One-Time Filter: (gp_execution_segment() = 1)
+                     ->  Result (actual rows=1 loops=1)
+                           ->  Result (actual rows=1 loops=1)
+   (slice0)    Executor memory: 92K bytes avg x 3 workers, 92K bytes max (seg0).
+   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution time: 6.053 ms
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 4.031 ms
+(12 rows)
 
 SELECT * FROM t;
  i 

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -1,3 +1,12 @@
+-- start_matchsubs
+-- m/Execution time: \d+\.\d+ ms/
+-- s/Execution time: \d+\.\d+ ms/Execution time: ##.### ms/
+-- s/Executor memory: (\d+)\w bytes \(seg\d+\)\./Executor memory: (#####)K bytes (seg#)./
+-- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
+-- m/Memory used:  \d+\w?B/
+-- s/Memory used:  \d+\w?B/Memory used: ###B/
+-- end_matchsubs
+
 -- Regression tests for prepareable statements. We query the content
 -- of the pg_prepared_statements view as prepared statements are
 -- created and removed.
@@ -61,6 +70,13 @@ PREPARE q5(int, text) AS
 	ORDER BY unique1;
 CREATE TEMPORARY TABLE q5_prep_results AS EXECUTE q5(200, 'DTAAAA');
 SELECT * FROM q5_prep_results;
+
+-- ensure EXPLAIN ANALYZE CTAS from prepared statement creates table
+PREPARE p AS SELECT 1 i;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+SELECT * FROM t;
+DEALLOCATE p;
 
 -- unknown or unspecified parameter types: should succeed
 PREPARE q6 AS


### PR DESCRIPTION
Fix creating table by EXPLAIN ANALYZE CTAS from prepared statement (#1214)

When creating a table from a select statement, GPDB uses the following hack.
The intorel_initplan function is called in InitPlan before ExecutorRun in
ExecCreateTableAs so that the table is created earlier, otherwise the current
MPP framework will fail. This only happens if the queryDesc->plannedstmt
structure has the intoClause field filled in. For EXPLAIN ANALYZE CTAS from a
prepared statement, this field was forgotten to be filled in, the
intorel_initplan function was not called, the table was not created, and the
custom DestReceiver DR_intorel was not initialized correctly. This patch solves
these problems by correctly setting the intoClause field of the plannedstmt
structure in the ExplainOnePlan function, before calling the ExecutorStart
function, which later calls InitPlan, which then calls intorel_initplan.

Ticket: ADBDEV-7030
(cherry picked from commit 7b908315de85f1671b6733fbe6aadb4f2cfcface)

Changes from original commit:
1) rework solution to provide more correct assignment with copy object
2) removed unnecessary changes in intorel_startup_dummy function
3) matchsubs were added to tests, becasuse 6X doesn't support SUMMARY OFF
   option in EXPLAIN
4) missed output for ORCA was added, because now it includes plan