### PR TITLE
ADBDEV-7019: Don't modify prepared statement by CTAS from it

### DIFF
--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -693,14 +693,6 @@ RevalidateCachedQuery(CachedPlanSource *plansource, IntoClause *intoClause)
 									   plansource->param_types,
 									   plansource->num_params);
 
-	/* GPDB: For CTAS query, set its isCTAS to be true */
-	if (intoClause)
-	{
-		Assert(list_length(tlist) == 1);
-		Query *query = (Query *) linitial(tlist);
-		query->parentStmtType = PARENTSTMTTYPE_CTAS;
-	}
-
 	/* Release snapshot if we got one */
 	if (snapshot_set)
 		PopActiveSnapshot();
@@ -785,6 +777,14 @@ RevalidateCachedQuery(CachedPlanSource *plansource, IntoClause *intoClause)
 	 */
 
 	plansource->is_valid = true;
+
+	/* GPDB: For CTAS query, set its parentStmtType to PARENTSTMTTYPE_CTAS */
+	if (intoClause)
+	{
+		Assert(list_length(tlist) == 1);
+		Query *query = (Query *) linitial(tlist);
+		query->parentStmtType = PARENTSTMTTYPE_CTAS;
+	}
 
 	/* Return transient copy of querytrees for possible use in planning */
 	return tlist;

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -201,6 +201,17 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |     SELECT * FROM road WHERE thepath = $1;                          | 
 (5 rows)
 
+-- make sure the plan is correct after CTAS
+DROP TABLE t;
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+             QUERY PLAN              
+-------------------------------------
+ Function Scan on generate_series i
+ Optimizer: Postgres query optimizer
+(2 rows)
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/expected/prepare_optimizer.out
+++ b/src/test/regress/expected/prepare_optimizer.out
@@ -205,6 +205,17 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |     SELECT * FROM road WHERE thepath = $1;                          | 
 (5 rows)
 
+-- make sure the plan is correct after CTAS
+DROP TABLE t;
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -87,6 +87,12 @@ PREPARE q7(unknown) AS
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
+-- make sure the plan is correct after CTAS
+DROP TABLE t;
+PREPARE p AS SELECT * FROM generate_series(1, 10) i;
+CREATE TEMPORARY TABLE t AS EXECUTE p;
+EXPLAIN (COSTS OFF) EXECUTE p;
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements


### PR DESCRIPTION
Don't modify prepared statement by CTAS from it

Creating a table from an execution of a prepared statement modifies the
parentStmtType attribute of the cached query of that statement, which results
in invalid plans for subsequent executions of that prepared statement. This
patch fixes the issue by marking the query as CTAS while leaving the cache
intact, namely, we now modify the parentStmtType attribute only on the copy of
the query that is subsequently used for planning, but not on the cached query
that remains for the prepared statement.

(cherry picked from commit 8b17bffc43dcfbf44b813f2f18b5c3b87c418f1b)

Changes from original commit:
1) resolved conflicts in tests
2) adapt tests output