### PR TITLE
ADBDEV-6676: Adopt Postgres changes to support LLVM 18

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -18,7 +18,7 @@ RUN dnf makecache && \
     dnf -y install libicu perl-ExtUtils-Embed perl-Env perl-JSON && \
     dnf -y install perl-IPC-Run perl-Test-Base libxslt-devel openldap-devel && \
     dnf -y install python3.11-psycopg2 python3.11-pyyaml python3.11-lxml python3.11-pip && \
-    dnf -y install llvm-devel-17.0.6 clang-17.0.6 && \
+    dnf -y install llvm-devel clang && \
     dnf -y install protobuf-compiler && \
     dnf clean all && \
     #we install pytest from pypi since the version from the repository does not contain an executable file

--- a/src/backend/jit/llvm/llvmjit.c
+++ b/src/backend/jit/llvm/llvmjit.c
@@ -487,8 +487,11 @@ llvm_copy_attributes(LLVMValueRef v_from, LLVMValueRef v_to)
 	/* copy function attributes */
 	llvm_copy_attributes_at_index(v_from, v_to, LLVMAttributeFunctionIndex);
 
-	/* and the return value attributes */
-	llvm_copy_attributes_at_index(v_from, v_to, LLVMAttributeReturnIndex);
+	if (LLVMGetTypeKind(LLVMGetFunctionReturnType(v_to)) != LLVMVoidTypeKind)
+	{
+		/* and the return value attributes */
+		llvm_copy_attributes_at_index(v_from, v_to, LLVMAttributeReturnIndex);
+	}
 
 	/* and each function parameter's attribute */
 	param_count = LLVMCountParams(v_from);


### PR DESCRIPTION
See the description inside the commits.
Do not squash commits to preserve authorship.



