### PR TITLE
ADBDEV-6811 Throw out fault injector code blocks for release builds

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -78,6 +78,7 @@ RUN wget https://ftp.postgresql.org/pub/dev/pg_bsd_indent-1.3.tar.gz && \
     rm -r pg_bsd_indent*
 
 WORKDIR /home/gpadmin
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
 
 FROM base as build
 
@@ -88,7 +89,6 @@ RUN mkdir /home/gpadmin/bin_gpdb
 ENV TARGET_OS_VERSION=7
 ENV TARGET_OS=centos
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend" 
 
 # Compile with running mocking tests
 RUN bash /home/gpadmin/gpdb_src/concourse/scripts/compile_gpdb.bash

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -36,6 +36,7 @@ RUN set -eux; \
     $adb_python3_bin -m pip cache purge
 
 WORKDIR /home/gpadmin
+ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
 
 FROM base as build
 
@@ -45,7 +46,6 @@ RUN mkdir /home/gpadmin/bin_gpdb
 
 ENV TARGET_OS=ubuntu
 ENV OUTPUT_ARTIFACT_DIR=bin_gpdb
-ENV CONFIGURE_FLAGS="--enable-debug-extensions --with-gssapi --enable-cassert --enable-debug --enable-depend"
 # Use python3.9 to compile into GPDB's plpython3u
 ENV PYTHON3=$adb_python3_bin
 

--- a/configure
+++ b/configure
@@ -3321,7 +3321,9 @@ if test "${enable_debug_extensions+set}" = set; then :
   enableval=$enable_debug_extensions;
   case $enableval in
     yes)
-      :
+
+$as_echo "#define FAULT_INJECTOR 1" >>confdefs.h
+
       ;;
     no)
       :

--- a/configure.in
+++ b/configure.in
@@ -209,8 +209,8 @@ AC_SUBST(enable_gpfdist)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL(enable, debug-extensions, yes,
-              [exclude debug extensions in gpcontrib],
+PGAC_ARG_BOOL(enable, debug-extensions, no,
+              [include debug extensions in gpcontrib],
               [AC_DEFINE([FAULT_INJECTOR], 1,
                          [Define to 1 to build with fault injector. (--enable-debug-extensions)])])
 AC_SUBST(enable_debug_extensions)

--- a/configure.in
+++ b/configure.in
@@ -209,10 +209,10 @@ AC_SUBST(enable_gpfdist)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL (enable, debug-extensions, yes,
+PGAC_ARG_BOOL(enable, debug-extensions, yes,
               [exclude debug extensions in gpcontrib],
               [AC_DEFINE([FAULT_INJECTOR], 1,
-                         [Define to 1 to build with fault injector. (--enable-faultinjector)])])
+                         [Define to 1 to build with fault injector. (--enable-debug-extensions)])])
 AC_SUBST(enable_debug_extensions)
 
 #

--- a/configure.in
+++ b/configure.in
@@ -209,8 +209,10 @@ AC_SUBST(enable_gpfdist)
 #
 # include debug extensions in gpcontrib
 #
-PGAC_ARG_BOOL(enable, debug-extensions, no,
-              [include debug extensions in gpcontrib])
+PGAC_ARG_BOOL (enable, debug-extensions, yes,
+              [exclude debug extensions in gpcontrib],
+              [AC_DEFINE([FAULT_INJECTOR], 1,
+                         [Define to 1 to build with fault injector. (--enable-faultinjector)])])
 AC_SUBST(enable_debug_extensions)
 
 #

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -473,7 +473,9 @@ lookup_agg_hash_entry(AggState *aggstate,
 	if (SIMPLE_FAULT_INJECTOR("force_hashagg_stream_hashtable") == FaultInjectorTypeSkip)
 		if (((Agg *) aggstate->ss.ps.plan)->streaming)
 			return NULL;
+
 #endif
+
 	if (p_isnew != NULL)
 		*p_isnew = false;
 

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -469,10 +469,11 @@ lookup_agg_hash_entry(AggState *aggstate,
    
 	Assert(mt_bind != NULL);
 
+#ifdef FAULT_INJECTOR
 	if (SIMPLE_FAULT_INJECTOR("force_hashagg_stream_hashtable") == FaultInjectorTypeSkip)
 		if (((Agg *) aggstate->ss.ps.plan)->streaming)
 			return NULL;
-
+#endif
 	if (p_isnew != NULL)
 		*p_isnew = false;
 

--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -473,7 +473,6 @@ lookup_agg_hash_entry(AggState *aggstate,
 	if (SIMPLE_FAULT_INJECTOR("force_hashagg_stream_hashtable") == FaultInjectorTypeSkip)
 		if (((Agg *) aggstate->ss.ps.plan)->streaming)
 			return NULL;
-
 #endif
 
 	if (p_isnew != NULL)

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -340,8 +340,10 @@ void FtsLoop()
 		probe_requested = false;
 		skipFtsProbe = false;
 
+#ifdef FAULT_INJECTOR
 		if (SIMPLE_FAULT_INJECTOR("fts_probe") == FaultInjectorTypeSkip)
 			skipFtsProbe = true;
+#endif			
 
 		if (skipFtsProbe || !has_mirrors)
 		{

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -343,7 +343,7 @@ void FtsLoop()
 #ifdef FAULT_INJECTOR
 		if (SIMPLE_FAULT_INJECTOR("fts_probe") == FaultInjectorTypeSkip)
 			skipFtsProbe = true;
-#endif			
+#endif
 
 		if (skipFtsProbe || !has_mirrors)
 		{

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2467,6 +2467,7 @@ gpdb::RunStaticPartitionSelection(PartitionSelector *ps)
 	return NULL;
 }
 
+#ifdef FAULT_INJECTOR
 FaultInjectorType_e
 gpdb::InjectFaultInOptTasks(const char *fault_name)
 {
@@ -2478,6 +2479,7 @@ gpdb::InjectFaultInOptTasks(const char *fault_name)
 	GP_WRAP_END;
 	return FaultInjectorTypeNotSpecified;
 }
+#endif
 
 gpos::ULONG
 gpdb::CountLeafPartTables(Oid rel_oid)

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -677,8 +677,10 @@ Node *EvalConstExpressions(Node *node);
 // static partition selection given a PartitionSelector node
 SelectedParts *RunStaticPartitionSelection(PartitionSelector *ps);
 
+#ifdef FAULT_INJECTOR
 // simple fault injector used by COptTasks.cpp to inject GPDB fault
 FaultInjectorType_e InjectFaultInOptTasks(const char *fault_name);
+#endif
 
 // return the number of leaf partition for a given table oid
 gpos::ULONG CountLeafPartTables(Oid oidRelation);

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -61,6 +61,9 @@
    (--enable-thread-safety) */
 #undef ENABLE_THREAD_SAFETY
 
+/* Define to 1 to build with fault injector. (--enable-debug-extensions) */
+#undef FAULT_INJECTOR
+
 /* Define to nothing if C supports flexible array members, and to 1 if it does
    not. That way, with a declaration like `struct s { int n; double
    d[FLEXIBLE_ARRAY_MEMBER]; };', the struct hack can be used with pre-C99

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -286,17 +286,6 @@
 /* #define WAL_DEBUG */
 
 /*
- * Enable debugging print statements for B-tree related operations; see
- * also log_btree_build_stats GUC var.
- */
-/* #define BTREE_BUILD_STATS */
-
-/*
- * Enable injecting faults.
- */
-#define FAULT_INJECTOR 1
-
-/*
  * Enable tracing of resource consumption during sort operations;
  * see also the trace_sort GUC var.  For 8.1 this is enabled by default.
  */

--- a/src/include/utils/faultinjector.h
+++ b/src/include/utils/faultinjector.h
@@ -9,7 +9,7 @@
 #ifndef FAULTINJECTOR_H
 #define FAULTINJECTOR_H
 
-#include "pg_config_manual.h"
+#include "pg_config.h"
 
 #define FAULTINJECTOR_MAX_SLOTS	16
 


### PR DESCRIPTION
Exclude fault injector test code for release build. It shall provide better
performance by removing test only code with consequent simplifying of functions
and avoid running sub-optimal test code.

This commit is based on 7.x commit 4111340abfd7355df127ce50aa264cfcb9ae024c

Move the setting of the CONFIGURE_FLAGS environment variable to a first stage of
image building so that its value passes through into the container.

Co-authored-by: Hao Wu <gfphoenix78@gmail.com>