### PR TITLE
ADBDEV-7126: Remove obsolete Xerces-related code and comments in GPDB 6

### DIFF
--- a/config/orca.m4
+++ b/config/orca.m4
@@ -1,6 +1,6 @@
 # PGAC_CHECK_ORCA_XERCES
 # ---------------------
-# Check if the Greenplum patched version of Xerces-C is found
+# Check if the Xerces-C library is found
 AC_DEFUN([PGAC_CHECK_ORCA_XERCES],
 [
 AC_CHECK_LIB(xerces-c, strnicmp, [],

--- a/src/backend/gporca/cmake/FindXerces.cmake
+++ b/src/backend/gporca/cmake/FindXerces.cmake
@@ -1,5 +1,4 @@
 # Module to find Xerces-C.
-# We specifically try to find the Greenplum patched version of Xerces.
 
 find_path(XERCES_INCLUDE_DIR xercesc/sax2/DefaultHandler.hpp)
 
@@ -11,13 +10,5 @@ set(XERCES_INCLUDE_DIRS ${XERCES_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Xerces DEFAULT_MSG
                                   XERCES_LIBRARY XERCES_INCLUDE_DIR)
-
-if (XERCES_FOUND)
-  # Check for patched Xerces. DOMImplementationList is a subclass of XMemory in
-  # the Greenplum version of Xerces, but not (yet) in upstream.
-  set(CMAKE_REQUIRED_INCLUDES
-      "${XERCES_INCLUDE_DIRS} ${CMAKE_REQUIRED_INCLUDES}")
-  include(CheckCXXSourceCompiles)
-endif()
 
 mark_as_advanced(XERCES_INCLUDE_DIR XERCES_LIBRARY)


### PR DESCRIPTION
This patch removes outdated Xerces-related checks from CMake, which were
likely left mistakenly (see commit 021de9a38b). Additionally, it removes
references to the patched Xerces from the autoconf macro (see commit
0b3b421).

This cleanup should have been done earlier (see commit 431a01f), but it was
missed at that time.