### PR TITLE
ADBDEV-7020: Fix DISTRIBUTED BY support for CTAS from prepared statement

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -462,9 +462,13 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 		ExecutorFinish(queryDesc);
 		ExecutorEnd(queryDesc);
 
-		if (into->distributedBy &&
-			((DistributedBy *)(into->distributedBy))->ptype == POLICYTYPE_REPLICATED)
-			queryDesc->es_processed /= ((DistributedBy *)(into->distributedBy))->numsegments;
+		if (into->distributedBy)
+		{
+			Assert(IsA(into->distributedBy, GpPolicy));
+
+			if (((GpPolicy *)(into->distributedBy))->ptype == POLICYTYPE_REPLICATED)
+				queryDesc->es_processed /= ((GpPolicy *)(into->distributedBy))->numsegments;
+		}
 
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -11612,7 +11612,7 @@ ExecuteStmt: EXECUTE name execute_param_clause
 					$$ = (Node *) n;
 				}
 			| CREATE OptTemp TABLE create_as_target AS
-				EXECUTE name execute_param_clause opt_with_data
+				EXECUTE name execute_param_clause opt_with_data OptDistributedBy
 				{
 					CreateTableAsStmt *ctas = makeNode(CreateTableAsStmt);
 					ExecuteStmt *n = makeNode(ExecuteStmt);
@@ -11624,6 +11624,7 @@ ExecuteStmt: EXECUTE name execute_param_clause
 					ctas->is_select_into = false;
 					/* cram additional flags into the IntoClause */
 					$4->rel->relpersistence = $2;
+					ctas->into->distributedBy = $10;
 					$4->skipData = !($9);
 					$$ = (Node *) ctas;
 				}

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -784,6 +784,12 @@ RevalidateCachedQuery(CachedPlanSource *plansource, IntoClause *intoClause)
 		Assert(list_length(tlist) == 1);
 		Query *query = (Query *) linitial(tlist);
 		query->parentStmtType = PARENTSTMTTYPE_CTAS;
+
+		if (intoClause->distributedBy)
+		{
+			Assert(IsA(intoClause->distributedBy, GpPolicy));
+			query->intoPolicy = (GpPolicy *)intoClause->distributedBy;
+		}
 	}
 
 	/* Return transient copy of querytrees for possible use in planning */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -205,7 +205,7 @@ typedef struct Query
 
 	/*
 	 * MPP: Used only on QD. Don't serialize. Holds the result distribution
-	 * policy for SELECT ... INTO and set operations.
+	 * policy for SELECT ... INTO, CTAS, CTAE and set operations.
 	 */
 	struct GpPolicy *intoPolicy;
 

--- a/src/interfaces/ecpg/preproc/check_rules.pl
+++ b/src/interfaces/ecpg/preproc/check_rules.pl
@@ -39,8 +39,8 @@ my %replace_line = (
 	'ExecuteStmtEXECUTEnameexecute_param_clause' =>
 	  'EXECUTE prepared_name execute_param_clause execute_rest',
 
-'ExecuteStmtCREATEOptTempTABLEcreate_as_targetASEXECUTEnameexecute_param_clause'
-	  => 'CREATE OptTemp TABLE create_as_target AS EXECUTE prepared_name execute_param_clause',
+'ExecuteStmtCREATEOptTempTABLEcreate_as_targetASEXECUTEnameexecute_param_clauseOptDistributedBy'
+	  => 'CREATE OptTemp TABLE create_as_target AS EXECUTE prepared_name execute_param_clause OptDistributedBy',
 
 	'PrepareStmtPREPAREnameprep_type_clauseASPreparableStmt' =>
 	  'PREPARE prepared_name prep_type_clause AS PreparableStmt');

--- a/src/interfaces/ecpg/preproc/parse.pl
+++ b/src/interfaces/ecpg/preproc/parse.pl
@@ -102,8 +102,8 @@ my %replace_line = (
 	  'RETURNING target_list opt_ecpg_into',
 	'ExecuteStmtEXECUTEnameexecute_param_clause' =>
 	  'EXECUTE prepared_name execute_param_clause execute_rest',
-'ExecuteStmtCREATEOptTempTABLEcreate_as_targetASEXECUTEnameexecute_param_clause'
-	  => 'CREATE OptTemp TABLE create_as_target AS EXECUTE prepared_name execute_param_clause',
+'ExecuteStmtCREATEOptTempTABLEcreate_as_targetASEXECUTEnameexecute_param_clauseDistributedBy'
+	  => 'CREATE OptTemp TABLE create_as_target AS EXECUTE prepared_name execute_param_clause DistributedBy',
 	'PrepareStmtPREPAREnameprep_type_clauseASPreparableStmt' =>
 	  'PREPARE prepared_name prep_type_clause AS PreparableStmt',
 	'var_nameColId' => 'ECPGColId',);

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -106,30 +106,88 @@ select distkey, distclass from gp_distribution_policy where localoid = 'distpol3
 (1 row)
 
 -- MPP-7268: CTAS produces incorrect distribution.
-drop table if exists foo;
-NOTICE:  table "foo" does not exist, skipping
-drop table if exists bar;
-NOTICE:  table "bar" does not exist, skipping
-create table foo (a varchar(15), b int) distributed by (b);
-create table bar as select * from foo distributed by (b);
-select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
- distkey | distclass 
----------+-----------
- 2       | 10027
-(1 row)
+create table foo (a int, b bool, c text, d date) distributed by (a);
+prepare bar as select * from foo;
+create table foo_by_a as select * from foo distributed by (a);
+create table bar_by_a as execute bar distributed by (a);
+create table foo_by_b as select * from foo distributed by (b);
+create table bar_by_b as execute bar distributed by (b);
+create table foo_by_c as select * from foo distributed by (c);
+create table bar_by_c as execute bar distributed by (c);
+create table foo_by_d as select * from foo distributed by (d);
+create table bar_by_d as execute bar distributed by (d);
+create table foo_by_ab as select * from foo distributed by (a, b);
+create table bar_by_ab as execute bar distributed by (a, b);
+create table foo_by_bc as select * from foo distributed by (b, c);
+create table bar_by_bc as execute bar distributed by (b, c);
+create table foo_by_cd as select * from foo distributed by (c, d);
+create table bar_by_cd as execute bar distributed by (c, d);
+create table foo_by_abc as select * from foo distributed by (a, b, c);
+create table bar_by_abc as execute bar distributed by (a, b, c);
+create table foo_by_bcd as select * from foo distributed by (b, c, d);
+create table bar_by_bcd as execute bar distributed by (b, c, d);
+create table foo_rand as select * from foo distributed randomly;
+create table bar_rand as execute bar distributed randomly;
+create table foo_repl as select * from foo distributed replicated;
+create table bar_repl as execute bar distributed replicated;
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid::regclass::name in (
+   'foo', 'foo', 'foo_by_a', 'bar_by_a',  'foo_by_b', 'bar_by_b', 'foo_by_c',
+   'bar_by_c', 'foo_by_d', 'bar_by_d', 'foo_by_ab', 'bar_by_ab', 'foo_by_bc',
+   'bar_by_bc', 'foo_by_cd', 'bar_by_cd', 'foo_by_abc', 'bar_by_abc',
+   'foo_by_bcd', 'bar_by_bcd', 'foo_rand', 'bar_rand', 'foo_repl', 'bar_repl'
+) order by 1;
+  localoid  | policytype | numsegments | distkey |     distclass     
+------------+------------+-------------+---------+-------------------
+ bar_by_a   | p          |           3 | 1       | 10027
+ bar_by_ab  | p          |           3 | 1 2     | 10027 10057
+ bar_by_abc | p          |           3 | 1 2 3   | 10027 10057 10043
+ bar_by_b   | p          |           3 | 2       | 10057
+ bar_by_bc  | p          |           3 | 2 3     | 10057 10043
+ bar_by_bcd | p          |           3 | 2 3 4   | 10057 10043 10019
+ bar_by_c   | p          |           3 | 3       | 10043
+ bar_by_cd  | p          |           3 | 3 4     | 10043 10019
+ bar_by_d   | p          |           3 | 4       | 10019
+ bar_rand   | p          |           3 |         | 
+ bar_repl   | r          |           3 |         | 
+ foo        | p          |           3 | 1       | 10027
+ foo_by_a   | p          |           3 | 1       | 10027
+ foo_by_ab  | p          |           3 | 1 2     | 10027 10057
+ foo_by_abc | p          |           3 | 1 2 3   | 10027 10057 10043
+ foo_by_b   | p          |           3 | 2       | 10057
+ foo_by_bc  | p          |           3 | 2 3     | 10057 10043
+ foo_by_bcd | p          |           3 | 2 3 4   | 10057 10043 10019
+ foo_by_c   | p          |           3 | 3       | 10043
+ foo_by_cd  | p          |           3 | 3 4     | 10043 10019
+ foo_by_d   | p          |           3 | 4       | 10019
+ foo_rand   | p          |           3 |         | 
+ foo_repl   | r          |           3 |         | 
+(23 rows)
 
-drop table if exists foo;
-drop table if exists bar;
-create table foo (a int, b varchar(15)) distributed by (b);
-create table bar as select * from foo distributed by (b);
-select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
- distkey | distclass 
----------+-----------
- 2       | 10043
-(1 row)
-
-drop table if exists foo;
-drop table if exists bar;
+deallocate bar;
+drop table foo;
+drop table foo_by_a;
+drop table bar_by_a;
+drop table foo_by_b;
+drop table bar_by_b;
+drop table foo_by_c;
+drop table bar_by_c;
+drop table foo_by_d;
+drop table bar_by_d;
+drop table foo_by_ab;
+drop table bar_by_ab;
+drop table foo_by_bc;
+drop table bar_by_bc;
+drop table foo_by_cd;
+drop table bar_by_cd;
+drop table foo_by_abc;
+drop table bar_by_abc;
+drop table foo_by_bcd;
+drop table bar_by_bcd;
+drop table foo_rand;
+drop table bar_rand;
+drop table foo_repl;
+drop table bar_repl;
 CREATE TABLE foo (
 col_with_default numeric DEFAULT 0,
 col_with_default_drop_default character varying(30) DEFAULT 'test1',

--- a/src/test/regress/sql/gp_create_table.sql
+++ b/src/test/regress/sql/gp_create_table.sql
@@ -72,20 +72,100 @@ select distkey, distclass from gp_distribution_policy where localoid = 'distpol3
 
 
 -- MPP-7268: CTAS produces incorrect distribution.
+-- start_ignore
 drop table if exists foo;
 drop table if exists bar;
-create table foo (a varchar(15), b int) distributed by (b);
-create table bar as select * from foo distributed by (b);
-select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
+drop table if exists foo_by_a;
+drop table if exists bar_by_a;
+drop table if exists foo_by_b;
+drop table if exists bar_by_b;
+drop table if exists foo_by_c;
+drop table if exists bar_by_c;
+drop table if exists foo_by_d;
+drop table if exists bar_by_d;
+drop table if exists foo_by_ab;
+drop table if exists bar_by_ab;
+drop table if exists foo_by_bc;
+drop table if exists bar_by_bc;
+drop table if exists foo_by_cd;
+drop table if exists bar_by_cd;
+drop table if exists foo_by_abc;
+drop table if exists bar_by_abc;
+drop table if exists foo_by_bcd;
+drop table if exists bar_by_bcd;
+drop table if exists foo_rand;
+drop table if exists bar_rand;
+drop table if exists foo_repl;
+drop table if exists bar_repl;
+-- end_ignore
+create table foo (a int, b bool, c text, d date) distributed by (a);
+prepare bar as select * from foo;
 
-drop table if exists foo;
-drop table if exists bar;
-create table foo (a int, b varchar(15)) distributed by (b);
-create table bar as select * from foo distributed by (b);
-select distkey, distclass from gp_distribution_policy where localoid='bar'::regclass;
+create table foo_by_a as select * from foo distributed by (a);
+create table bar_by_a as execute bar distributed by (a);
 
-drop table if exists foo;
-drop table if exists bar;
+create table foo_by_b as select * from foo distributed by (b);
+create table bar_by_b as execute bar distributed by (b);
+
+create table foo_by_c as select * from foo distributed by (c);
+create table bar_by_c as execute bar distributed by (c);
+
+create table foo_by_d as select * from foo distributed by (d);
+create table bar_by_d as execute bar distributed by (d);
+
+create table foo_by_ab as select * from foo distributed by (a, b);
+create table bar_by_ab as execute bar distributed by (a, b);
+
+create table foo_by_bc as select * from foo distributed by (b, c);
+create table bar_by_bc as execute bar distributed by (b, c);
+
+create table foo_by_cd as select * from foo distributed by (c, d);
+create table bar_by_cd as execute bar distributed by (c, d);
+
+create table foo_by_abc as select * from foo distributed by (a, b, c);
+create table bar_by_abc as execute bar distributed by (a, b, c);
+
+create table foo_by_bcd as select * from foo distributed by (b, c, d);
+create table bar_by_bcd as execute bar distributed by (b, c, d);
+
+create table foo_rand as select * from foo distributed randomly;
+create table bar_rand as execute bar distributed randomly;
+
+create table foo_repl as select * from foo distributed replicated;
+create table bar_repl as execute bar distributed replicated;
+
+select localoid::regclass::name, policytype, numsegments, distkey, distclass
+from gp_distribution_policy where localoid::regclass::name in (
+   'foo', 'foo', 'foo_by_a', 'bar_by_a',  'foo_by_b', 'bar_by_b', 'foo_by_c',
+   'bar_by_c', 'foo_by_d', 'bar_by_d', 'foo_by_ab', 'bar_by_ab', 'foo_by_bc',
+   'bar_by_bc', 'foo_by_cd', 'bar_by_cd', 'foo_by_abc', 'bar_by_abc',
+   'foo_by_bcd', 'bar_by_bcd', 'foo_rand', 'bar_rand', 'foo_repl', 'bar_repl'
+) order by 1;
+
+deallocate bar;
+drop table foo;
+drop table foo_by_a;
+drop table bar_by_a;
+drop table foo_by_b;
+drop table bar_by_b;
+drop table foo_by_c;
+drop table bar_by_c;
+drop table foo_by_d;
+drop table bar_by_d;
+drop table foo_by_ab;
+drop table bar_by_ab;
+drop table foo_by_bc;
+drop table bar_by_bc;
+drop table foo_by_cd;
+drop table bar_by_cd;
+drop table foo_by_abc;
+drop table bar_by_abc;
+drop table foo_by_bcd;
+drop table bar_by_bcd;
+drop table foo_rand;
+drop table bar_rand;
+drop table foo_repl;
+drop table bar_repl;
 
 CREATE TABLE foo (
 col_with_default numeric DEFAULT 0,


### PR DESCRIPTION
Fix DISTRIBUTED BY support for CTAS from prepared statement

SQL command to create a table from a prepared statement execution did not work
with explicit distribution specification.

This patch adds:

1) support for explicit distribution specification in the parser of such a
   command (as well as in the generation of corresponding ECPG commands)

2) extracting the target list from the prepared statement

3) saving the specified distribution via distributedBy attribute of the
   IntoClause structure

(cherry picked from commit aebcde70d8655c44e85eeff6f01c65763d624d28)

Changes from original commit:
1) resolved conflicts
2) adapt tests output and added more test cases to best coverage
3) exclude unsupported in 6X syntax CREATE TABLE IF NOT EXISTS AS EXECUTE