### PR TITLE
Use gporca.mk for compilation settings of gpos 'common' src files

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/attributes.h
+++ b/src/backend/gporca/libgpos/include/gpos/attributes.h
@@ -1,6 +1,16 @@
 #ifndef GPOS_attributes_H
 #define GPOS_attributes_H
 
+#ifdef USE_CMAKE
+#define GPOS_FORMAT_ARCHETYPE printf
+#else
+#include "pg_config.h"
+#define GPOS_FORMAT_ARCHETYPE PG_PRINTF_ATTRIBUTE
+#endif
+
+#define GPOS_ATTRIBUTE_PRINTF(f, a) \
+	__attribute__((format(GPOS_FORMAT_ARCHETYPE, f, a)))
+
 #ifdef __GNUC__
 #define GPOS_UNUSED __attribute__((unused))
 #else

--- a/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/clibwrapper.h
@@ -91,7 +91,8 @@ INT Vswprintf(WCHAR *wcstr, SIZE_T max_len, const WCHAR *format,
 			  VA_LIST vaArgs);
 
 // format string
-INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs);
+INT Vsnprintf(CHAR *src, SIZE_T size, const CHAR *format, VA_LIST vaArgs)
+	GPOS_ATTRIBUTE_PRINTF(3, 0);
 
 // return string describing error number
 void Strerror_r(INT errnum, CHAR *buf, SIZE_T buf_len);

--- a/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CStringStatic.h
@@ -11,6 +11,7 @@
 #ifndef GPOS_CStringStatic_H
 #define GPOS_CStringStatic_H
 
+#include "gpos/attributes.h"
 #include "gpos/base.h"
 #include "gpos/common/clibwrapper.h"
 
@@ -102,10 +103,11 @@ public:
 	void AppendBuffer(const CHAR *buf);
 
 	// appends a formatted string
-	void AppendFormat(const CHAR *format, ...);
+	void AppendFormat(const CHAR *format, ...) GPOS_ATTRIBUTE_PRINTF(2, 3);
 
 	// appends a formatted string based on passed va list
-	void AppendFormatVA(const CHAR *format, VA_LIST va_args);
+	void AppendFormatVA(const CHAR *format, VA_LIST va_args)
+		GPOS_ATTRIBUTE_PRINTF(2, 0);
 
 	// appends wide character string
 	void AppendConvert(const WCHAR *wc_str);

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/io/CFileTest.cpp
@@ -250,19 +250,18 @@ CFileTest::Unittest_MkTmpFile(CHAR *szTmpDir, CHAR *szTmpFile)
 	GPOS_ASSERT(NULL != szTmpDir);
 	GPOS_ASSERT(NULL != szTmpFile);
 
-	CStringStatic strTmpDir(szTmpDir, GPOS_FILE_NAME_BUF_SIZE);
-	CStringStatic strTmpFile(szTmpFile, GPOS_FILE_NAME_BUF_SIZE);
-
-	const CHAR szDir[GPOS_FILE_NAME_BUF_SIZE] = "/tmp/CFileTest.XXXXXX";
-	const CHAR szFile[GPOS_FILE_NAME_BUF_SIZE] = "/CFileTest_file.txt";
+	CHAR szDir[] = "/tmp/CFileTest.XXXXXX";
+	const CHAR szFile[] = "/CFileTest_file.txt";
 
 	// create unique temporary directory name under /tmp
-	strTmpDir.AppendFormat(szDir);
-	ioutils::CreateTempDir(szTmpDir);
+	ioutils::CreateTempDir(szDir);
+
+	// copy the temporary directory name into szTmpDir
+	CStringStatic strTmpDir(szTmpDir, GPOS_FILE_NAME_BUF_SIZE, szDir);
+	CStringStatic strTmpFile(szTmpFile, GPOS_FILE_NAME_BUF_SIZE);
 
 	// unique temporary file name
-	strTmpFile.AppendFormat(szTmpDir);
-	strTmpFile.AppendFormat(szFile);
+	strTmpFile.AppendFormat("%s%s", szDir, szFile);
 }
 
 

--- a/src/backend/gporca/libgpos/src/common/Makefile
+++ b/src/backend/gporca/libgpos/src/common/Makefile
@@ -8,12 +8,7 @@ subdir = src/backend/gporca/libgpos/src/common
 top_builddir = ../../../../../..
 include $(top_builddir)/src/Makefile.global
 
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpos/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpopt/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libnaucrates/include $(CPPFLAGS)
-override CPPFLAGS := -I$(top_builddir)/src/backend/gporca/libgpdbcost/include $(CPPFLAGS)
-# FIXME: Would be better to include gporca.mk, but hitting a warning
-override CXXFLAGS := -Wno-variadic-macros -fno-omit-frame-pointer $(CXXFLAGS)
+include $(top_builddir)/src/backend/gporca/gporca.mk
 
 OBJS        = CAutoTimer.o \
               CBitSet.o \


### PR DESCRIPTION
Use gporca.mk for compilation settings of gpos 'common' src files

Problem description:
Src files in 'common' folder of libgpos part of Orca used own compilation
settings instead of those defined in 'gporca.mk' file. These settings were not
so strict as in 'gporca.mk'. Also, they duplicated part of 'gporca.mk'.

Fix:
Include 'gporca.mk' in the makefile of 'common' folder instead of using own
settings.

------------------

This change requires prior 
 - cherry-pick of 2be1f2b2bf6d9f319a15f9476ddc19de2a5b01c8, otherwise compilation fails due to warning '[-Werror=suggest-attribute=format]' for several gpos functions.
 - cherry-pick of 58c3ea9ca96df9d0c6e9f8d67f4ab3e73b93a8d2, otherwise compilation of orca unit tests fails.

So, do NOT squash the commits.