### PR TITLE
Replace check for Greenplum with check for fork of Greenplum

### DIFF
--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -393,7 +393,7 @@ static void postgresGetForeignUpperPaths(PlannerInfo *root,
 										 RelOptInfo *input_rel,
 										 RelOptInfo *output_rel,
 										 void *extra);
-static int greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user);
+static bool greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user);
 
 /*
  * Helper functions
@@ -7274,24 +7274,21 @@ find_em_for_rel_target(PlannerInfo *root, EquivalenceClass *ec,
 	return NULL;
 }
 
-static int
+static bool
 greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user)
 {
 	PGconn     *conn;
 	PGresult   *res;
-	int                     ret;
 
-	char *query =  "SELECT version()";
+	const char *query =
+		"SELECT FROM pg_settings WHERE name = 'gp_server_version'";
 	conn = GetConnection(server, user, false);
 
 	res = pgfdw_exec_query(conn, query);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
 		pgfdw_report_error(ERROR, res, conn, true, query);
 
-	if (PQntuples(res) == 0)
-		pgfdw_report_error(ERROR, res, conn, true, query);
-
-	ret = strstr(PQgetvalue(res, 0, 0), "Greenplum Database") ? 1 : 0;
+	bool ret = (PQntuples(res) == 1);
 
 	PQclear(res);
 	ReleaseConnection(conn);

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -393,7 +393,7 @@ static void postgresGetForeignUpperPaths(PlannerInfo *root,
 										 RelOptInfo *input_rel,
 										 RelOptInfo *output_rel,
 										 void *extra);
-static bool greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user);
+static bool gpCheckIsGP(ForeignServer *server, UserMapping *user);
 
 /*
  * Helper functions
@@ -2268,14 +2268,14 @@ postgresIsForeignRelUpdatable(Relation rel)
 		for (index = 0; index < server->num_segments; ++index)
 		{
 			rewrite_server_options(server, index);
-			if (greenplumCheckIsGreenplum(server, user))
+			if (gpCheckIsGP(server, user))
 				break;
 		}
 		if (index != server->num_segments)
 			isGreenplum = true;
 	}
 	else
-		isGreenplum = greenplumCheckIsGreenplum(server, user);
+		isGreenplum = gpCheckIsGP(server, user);
 
 	if (isGreenplum)
 		return (1 << CMD_INSERT);
@@ -7275,7 +7275,7 @@ find_em_for_rel_target(PlannerInfo *root, EquivalenceClass *ec,
 }
 
 static bool
-greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user)
+gpCheckIsGP(ForeignServer *server, UserMapping *user)
 {
 	PGconn     *conn;
 	PGresult   *res;

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -7281,7 +7281,7 @@ greenplumCheckIsGreenplum(ForeignServer *server, UserMapping *user)
 	PGresult   *res;
 
 	const char *query =
-		"SELECT FROM pg_settings WHERE name = 'gp_server_version'";
+		"SELECT FROM pg_catalog.pg_settings WHERE name = 'gp_server_version'";
 	conn = GetConnection(server, user, false);
 
 	res = pgfdw_exec_query(conn, query);

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -68,19 +68,17 @@ static bool isGPDB(void)
 	} talking_to_gpdb;
 
 	PGresult   *res;
-	char       *ver;
 
 	if (talking_to_gpdb == gpdb_yes)
 		return true;
 	else if (talking_to_gpdb == gpdb_no)
 		return false;
 
-	res = PSQLexec("select pg_catalog.version()");
+	res = PSQLexec("SELECT FROM pg_settings WHERE name = 'gp_server_version'");
 	if (!res)
 		return false;
 
-	ver = PQgetvalue(res, 0, 0);
-	if (strstr(ver, "Greenplum") != NULL)
+	if (PQntuples(res) == 1)
 	{
 		PQclear(res);
 		talking_to_gpdb = gpdb_yes;

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -74,7 +74,8 @@ static bool isGPDB(void)
 	else if (talking_to_gpdb == gpdb_no)
 		return false;
 
-	res = PSQLexec("SELECT FROM pg_settings WHERE name = 'gp_server_version'");
+	res = PSQLexec("SELECT FROM pg_catalog.pg_settings"
+				   " WHERE name = 'gp_server_version'");
 	if (!res)
 		return false;
 

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -52,13 +52,13 @@ static bool describeOneTSConfig(const char *oid, const char *nspname,
 								const char *pnspname, const char *prsname);
 static void printACLColumn(PQExpBuffer buf, const char *colname);
 static bool listOneExtensionContents(const char *extname, const char *oid);
-static bool isGPDB(void);
+static bool gpCheckIsGP(void);
 static bool isGPDB4200OrLater(void);
 static bool isGPDB5000OrLater(void);
 static bool isGPDB6000OrLater(void);
 static bool isGPDB7000OrLater(void);
 
-static bool isGPDB(void)
+static bool gpCheckIsGP(void)
 {
 	static enum
 	{
@@ -106,7 +106,7 @@ static bool isGPDB4200OrLater(void)
 {
 	bool       retValue = false;
 
-	if (isGPDB() == true)
+	if (gpCheckIsGP() == true)
 	{
 		PGresult  *result;
 
@@ -128,7 +128,7 @@ static bool isGPDB5000OrLater(void)
 {
 	bool	retValue = false;
 
-	if (isGPDB() == true)
+	if (gpCheckIsGP() == true)
 	{
 		PGresult   *res;
 
@@ -142,7 +142,7 @@ static bool isGPDB5000OrLater(void)
 static bool
 isGPDB6000OrLater(void)
 {
-	if (!isGPDB())
+	if (!gpCheckIsGP())
 		return false;		/* Not Greenplum at all. */
 
 	/* GPDB 6 is based on PostgreSQL 9.4 */
@@ -152,7 +152,7 @@ isGPDB6000OrLater(void)
 static bool
 isGPDB6000OrBelow(void)
 {
-	if (!isGPDB())
+	if (!gpCheckIsGP())
 		return false;		/* Not Greenplum at all. */
 
 	/* GPDB 6 is based on PostgreSQL 9.4 */
@@ -162,7 +162,7 @@ isGPDB6000OrBelow(void)
 static bool
 isGPDB7000OrLater(void)
 {
-	if (!isGPDB())
+	if (!gpCheckIsGP())
 		return false;		/* Not Greenplum at all. */
 
 	/* GPDB 7 is based on PostgreSQL v12 */
@@ -1751,7 +1751,7 @@ describeOneTableDetails(const char *schemaname,
 						  "LEFT JOIN pg_catalog.pg_class tc ON (c.reltoastrelid = tc.oid)\n"
 						  "WHERE c.oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "c.relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "c.relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 90400)
@@ -1770,7 +1770,7 @@ describeOneTableDetails(const char *schemaname,
 						  "LEFT JOIN pg_catalog.pg_class tc ON (c.reltoastrelid = tc.oid)\n"
 						  "WHERE c.oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "c.relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "c.relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 90100)
@@ -1789,7 +1789,7 @@ describeOneTableDetails(const char *schemaname,
 						  "LEFT JOIN pg_catalog.pg_class tc ON (c.reltoastrelid = tc.oid)\n"
 						  "WHERE c.oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "c.relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "c.relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 90000)
@@ -1807,7 +1807,7 @@ describeOneTableDetails(const char *schemaname,
 						  "LEFT JOIN pg_catalog.pg_class tc ON (c.reltoastrelid = tc.oid)\n"
 						  "WHERE c.oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "c.relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "c.relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 80400)
@@ -1824,7 +1824,7 @@ describeOneTableDetails(const char *schemaname,
 						  "LEFT JOIN pg_catalog.pg_class tc ON (c.reltoastrelid = tc.oid)\n"
 						  "WHERE c.oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "c.relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "c.relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 80200)
@@ -1836,7 +1836,7 @@ describeOneTableDetails(const char *schemaname,
 						  ", %s as relstorage "
 						  "FROM pg_catalog.pg_class WHERE oid = '%s';",
 						  /* GPDB Only:  relstorage  */
-						  (isGPDB() ? "relstorage" : "'h'"),
+						  (gpCheckIsGP() ? "relstorage" : "'h'"),
 						  oid);
 	}
 	else if (pset.sversion >= 80000)
@@ -1897,7 +1897,7 @@ describeOneTableDetails(const char *schemaname,
 		tableinfo.relam = NULL;
 
 	/* GPDB Only:  relstorage  */
-	if (pset.sversion < 120000 && isGPDB())
+	if (pset.sversion < 120000 && gpCheckIsGP())
 		tableinfo.relstorage = *(PQgetvalue(res, 0, PQfnumber(res, "relstorage")));
 	else
 		tableinfo.relstorage = 'h';
@@ -3322,7 +3322,7 @@ describeOneTableDetails(const char *schemaname,
 							 * listing them.
 							 */
 							tgdef = PQgetvalue(result, i, 1);
-							if (isGPDB() && strstr(tgdef, "RI_FKey_") != NULL)
+							if (gpCheckIsGP() && strstr(tgdef, "RI_FKey_") != NULL)
 								list_trigger = false;
 
 							break;
@@ -4570,7 +4570,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 					  gettext_noop("Owner"));
 
 	/* Show Storage type for tables */
-	if (showTables && isGPDB())
+	if (showTables && gpCheckIsGP())
 	{
 		if (isGPDB7000OrLater())
 		{


### PR DESCRIPTION
Replace check for Greenplum with check for fork of Greenplum

The purpose is to make interaction between Greengage and Greenplum clusters
possible. psql and postgres_fdw checked whether DBMS is Greenplum by analyzing 
the output of the version() function. Now they check DBMS for existence of the
'gp_server_version' GUC, which is specific for Greenplum and its forks,
for example Greengage.