### PR TITLE
ADBDEV-6856: Implement gprebalance cleanup handler

### DIFF
--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -399,7 +399,7 @@ def main(options, args, parser):
         if options.clean:
             gprebalance.remove_status_file()
             gprebalance.cleanup_schema()
-            gprebalance.cleanup_plan()
+            gprebalance.cleanup_directory()
             logger.info('Cleanup Finished.  exiting...')
             sys.exit(0)
 

--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -438,9 +438,6 @@ def main(options, args, parser):
     except KeyboardInterrupt:
         sys.exit('\nUser Interrupted')
     finally:
-        gprebalance.remove_status_file()
-        gprebalance.cleanup_schema()
-        gprebalance.cleanup_plan()
         gprebalance.shutdown()
         remove_pid_file(get_coordinatordatadir())
 

--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -443,6 +443,7 @@ def main(options, args, parser):
     finally:
         gprebalance.remove_status_file()
         gprebalance.cleanup_schema()
+        gprebalance.cleanup_plan()
         gprebalance.shutdown()
         remove_pid_file(get_coordinatordatadir())
 

--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -396,6 +396,13 @@ def main(options, args, parser):
 
         gprebalance_file_status = gprebalance.get_state_from_file()
 
+        if options.clean:
+            gprebalance.remove_status_file()
+            gprebalance.cleanup_schema()
+            gprebalance.cleanup_plan()
+            logger.info('Cleanup Finished.  exiting...')
+            sys.exit(0)
+
         from gprebalance_modules.rebalance_status import RebalanceStatus  # nopep8
 
         if gprebalance_db_status == RebalanceStatus.COMPLETED:

--- a/gpMgmt/bin/gprebalance_modules/rebalance.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance.py
@@ -314,7 +314,15 @@ class GPRebalance:
         self.logger.info('Dropping rebalance schema')
         self.statusManager.cleanup_schema()
 
+    def cleanup_plan(self):
+        self.logger.info('Dropping rebalance plan')
+        datadir = self.options.coordinator_data_directory + CONF_DIR
+        plan_file = os.path.join(datadir, "plan.pkl")
+        if os.path.exists(plan_file):
+            os.unlink(plan_file)
+
     def remove_status_file(self):
+        self.logger.info('Dropping status file')
         if self.statusManager:
             self.statusManager.remove_all()
 

--- a/gpMgmt/bin/gprebalance_modules/rebalance.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance.py
@@ -318,12 +318,11 @@ class GPRebalance:
         self.logger.info('Dropping rebalance schema')
         self.statusManager.cleanup_schema()
 
-    def cleanup_plan(self):
-        self.logger.info('Dropping rebalance plan')
+    def cleanup_directory(self):
+        self.logger.info('Dropping rebalance directory')
         datadir = self.options.coordinator_data_directory + CONF_DIR
-        plan_file = os.path.join(datadir, "plan.pkl")
-        if os.path.exists(plan_file):
-            os.unlink(plan_file)
+        cmd = RemoveDirectory("Dropping rebalance directory", datadir)
+        cmd.run(validateAfter=True)
 
     def remove_status_file(self):
         self.logger.info('Dropping status file')

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -194,7 +194,6 @@ class SingleMoveCommand(SQLCommand):
                     self.logger.info("Removing old segment's tablespace datadir (dbidi = %d): %s",
                                      self.segment.dbid, tblspdir)
                     cmd.run(validateAfter=True)
-            os.unlink(filename)
             status_conn.close()
 
         except Exception as ex:

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -92,14 +92,8 @@ class SingleMoveCommand(SQLCommand):
          self.conf_dir, self.needs_switch) = step_details
 
         self.move_error = False
-        self.filename = None
 
         SQLCommand.__init__(self, name)
-
-    def __del__(self):
-        if self.filename is not None:
-            if os.path.exists(self.filename):
-                os.unlink(self.filename)
 
     def write_gprecoverseg_config(self):
         filename = self.conf_dir + FILENAME + "dbid" + str(self.segment.dbid)
@@ -125,14 +119,14 @@ class SingleMoveCommand(SQLCommand):
             StatusManager.record_move(status_conn, self.move, self.segment,
                                       segsize, datetime.datetime.now())
 
-            self.filename = self.write_gprecoverseg_config()
+            filename = self.write_gprecoverseg_config()
             log_file = os.path.join(self.conf_dir,
                                     f"gprecoverseg_dbid{self.segment.dbid}_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
                                     )
 
             # Prepare command arguments
             cmd_args = [
-                '-i', self.filename,
+                '-i', filename,
                 '-B', '1',
                 '-v', '-a'
             ]
@@ -195,6 +189,7 @@ class SingleMoveCommand(SQLCommand):
                     self.logger.info("Removing old segment's tablespace datadir (dbidi = %d): %s",
                                      self.segment.dbid, tblspdir)
                     cmd.run(validateAfter=True)
+            os.unlink(filename)
             status_conn.close()
 
         except Exception as ex:

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -4,6 +4,7 @@ import multiprocessing
 import time
 from collections import defaultdict
 import pickle
+import shutil
 from typing import List, Dict, Optional, Set, Tuple
 from enum import Enum
 from gprebalance_modules.rebalance_plan import Move, Plan  # nopep8
@@ -355,12 +356,18 @@ class RebalanceExecutor:
         self.statusManager = statusManager
         self.options = options
         self.dburl = dburl
+        self.to_delete = []
         segids = []
         for m in plan.moves:
             segids.append(m.segid)
         self.segmentSizes = self.estimateSegmentSizes(segids)
         self.resources = self.initializeHostResources(plan.moves)
         self.queue = None
+
+    def __del__(self):
+        for to_delete in self.to_delete:
+            self.logger.info(f"removing {to_delete}")
+            shutil.rmtree(to_delete)
 
     def initializeHostResources(self, moves: List[Move]):
         resources = {}
@@ -436,11 +443,13 @@ class RebalanceExecutor:
                 sourceSeg.address, [sourceSeg.datadir])
             segmentSizes[segid] = SegmentSize(
                 source_data_dir_usage[sourceSeg.datadir], None)
+            self.to_delete.append(sourceSeg.datadir)
         for segid, tblspace_dirs in tablespaces.items():
             sourceSeg = self.segmentMap[segid]
             source_tblsps_usage = self._disk_usage(
                 sourceSeg.address, tblspace_dirs)
             segmentSizes[segid].source_tablespace_usage = source_tblsps_usage
+            self.to_delete.extend(tblspace_dirs)
 
         return segmentSizes
 

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -4,7 +4,6 @@ import multiprocessing
 import time
 from collections import defaultdict
 import pickle
-import shutil
 from typing import List, Dict, Optional, Set, Tuple
 from enum import Enum
 from gprebalance_modules.rebalance_plan import Move, Plan  # nopep8
@@ -392,18 +391,12 @@ class RebalanceExecutor:
         self.statusManager = statusManager
         self.options = options
         self.dburl = dburl
-        self.to_delete = []
         segids = []
         for m in plan.moves:
             segids.append(m.segid)
         self.segmentSizes = self.estimateSegmentSizes(segids)
         self.resources = self.initializeHostResources(plan.moves)
         self.queue = None
-
-    def __del__(self):
-        for to_delete in self.to_delete:
-            self.logger.info(f"removing {to_delete}")
-            shutil.rmtree(to_delete)
 
     def initializeHostResources(self, moves: List[Move]):
         resources = {}
@@ -479,13 +472,11 @@ class RebalanceExecutor:
                 sourceSeg.address, [sourceSeg.datadir])
             segmentSizes[segid] = SegmentSize(
                 source_data_dir_usage[sourceSeg.datadir], None)
-            self.to_delete.append(sourceSeg.datadir)
         for segid, tblspace_dirs in tablespaces.items():
             sourceSeg = self.segmentMap[segid]
             source_tblsps_usage = self._disk_usage(
                 sourceSeg.address, tblspace_dirs)
             segmentSizes[segid].source_tablespace_usage = source_tblsps_usage
-            self.to_delete.extend(tblspace_dirs)
 
         return segmentSizes
 

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -92,8 +92,14 @@ class SingleMoveCommand(SQLCommand):
          self.conf_dir, self.needs_switch) = step_details
 
         self.move_error = False
+        self.filename = None
 
         SQLCommand.__init__(self, name)
+
+    def __del__(self):
+        if self.filename is not None:
+            if os.path.exists(self.filename):
+                os.unlink(self.filename)
 
     def write_gprecoverseg_config(self):
         filename = self.conf_dir + FILENAME + "dbid" + str(self.segment.dbid)
@@ -116,7 +122,7 @@ class SingleMoveCommand(SQLCommand):
             self.logger.error(ex.__str__().strip())
             return
 
-        filename = self.write_gprecoverseg_config()
+        self.filename = self.write_gprecoverseg_config()
         log_file = os.path.join(self.conf_dir,
                                 f"gprecoverseg_dbid{self.segment.dbid}_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
                                 )
@@ -125,7 +131,7 @@ class SingleMoveCommand(SQLCommand):
 
         # Prepare command arguments
         cmd_args = [
-            '-i', filename,
+            '-i', self.filename,
             '-B', '1',
             '-v', '-a'
         ]


### PR DESCRIPTION
Implement gprebalance cleanup handler

This patch implements the --clean option of the gprebalance utility. It cleans
the status-file, the gprebalance schema in the database, and completely removes
the rebalance directory from the coordinator.