### PR TITLE
ADBDEV-4605: Solve inconsistency between our fork and upstream in handling LASJ-NOTIN

### DIFF
--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -667,10 +667,11 @@ splitJoinQualExpr(List *joinqual, List **inner_join_keys_p, List **outer_join_ke
 				break;
 
 			case T_Const:
+			case T_DistinctExpr:
 				/*
-				 * Constant expressions do not need to be splitted into left and
-				 * right as they don't need to be considered for NULL value special
-				 * cases
+				 * Distinct and constant expressions do not need to be
+				 * splitted into left and right as they don't need to be
+				 * considered for NULL value special cases
 				 */
 				break;
 

--- a/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -3,25 +3,6 @@
      CREATE TABLE foo(a INT);
      CREATE TABLE bar(b INT);
      EXPLAIN SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);
-
-     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356704383.34 rows=1 width=4)
-       ->  Result  (cost=0.00..1356704383.34 rows=1 width=4)
-             Filter: (SubPlan 2)
-             ->  Seq Scan on foo  (cost=0.00..1356704383.32 rows=334 width=5)
-             SubPlan 2
-               ->  Result  (cost=0.00..1324044.59 rows=1000 width=9)
-                     ->  Materialize  (cost=0.00..1324044.58 rows=1000 width=8)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324044.57 rows=1000 width=8)
-                                 ->  Seq Scan on bar  (cost=0.00..1324044.43 rows=334 width=8)
-                                       SubPlan 1
-                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                               ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=4)
-                                                     ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                                                           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=4)
-     Optimizer: Pivotal Optimizer (GPORCA)
-    (16 rows)
-
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -341,10 +322,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="230">
+    <dxl:Plan Id="0" SpaceSize="28">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.218383" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.000493" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -353,209 +334,22 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Result>
+        <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.218369" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.000479" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
-              <dxl:TestExpr>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:TestExpr>
-              <dxl:ParamList/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.172338" Rows="3000.000000" Width="9"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="8" Alias="b">
-                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="16" Alias="a">
-                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.172338" Rows="3000.000000" Width="9"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="b">
-                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="a">
-                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.163338" Rows="3000.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="8" Alias="b">
-                        <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="16" Alias="a">
-                        <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.155338" Rows="3000.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="8" Alias="b">
-                          <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="16" Alias="a">
-                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.012138" Rows="1000.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="8" Alias="b">
-                            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="16" Alias="a">
-                            <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                              <dxl:TestExpr/>
-                              <dxl:ParamList/>
-                              <dxl:Materialize Eager="false">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000294" Rows="3.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="16" Alias="a">
-                                    <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000290" Rows="3.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="16" Alias="a">
-                                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:Limit>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="16" Alias="a">
-                                        <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="16" Alias="a">
-                                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:TableScan>
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
-                                        </dxl:Properties>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="16" Alias="a">
-                                            <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                        <dxl:Filter/>
-                                        <dxl:TableDescriptor Mdid="6.377090.1.0" TableName="foo">
-                                          <dxl:Columns>
-                                            <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                            <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                            <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                          </dxl:Columns>
-                                        </dxl:TableDescriptor>
-                                      </dxl:TableScan>
-                                    </dxl:GatherMotion>
-                                    <dxl:LimitCount>
-                                      <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                      </dxl:Cast>
-                                    </dxl:LimitCount>
-                                    <dxl:LimitOffset>
-                                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                                    </dxl:LimitOffset>
-                                  </dxl:Limit>
-                                </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:SubPlan>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.012138" Rows="1000.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="8" Alias="b">
-                              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.377093.1.0" TableName="bar">
-                            <dxl:Columns>
-                              <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Result>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:SubPlan>
-          </dxl:Filter>
-          <dxl:OneTimeFilter/>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2155.207402" Rows="1000.000000" Width="5"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="4"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -576,7 +370,174 @@
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-        </dxl:Result>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="3.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000463" Rows="3.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000409" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:JoinFilter>
+                <dxl:Assert ErrorCode="P0003">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="16" Alias="a">
+                      <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:AssertConstraintList>
+                    <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
+                        <dxl:Ident ColId="29" ColName="row_number" TypeMdid="0.20.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:Comparison>
+                    </dxl:AssertConstraint>
+                  </dxl:AssertConstraintList>
+                  <dxl:Window PartitionColumns="">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="29" Alias="row_number">
+                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="a">
+                        <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Limit>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="16" Alias="a">
+                          <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="16" Alias="a">
+                            <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="16" Alias="a">
+                              <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.377090.1.0" TableName="foo">
+                            <dxl:Columns>
+                              <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                              <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                              <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                      <dxl:LimitCount>
+                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:Cast>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
+                    <dxl:WindowKeyList>
+                      <dxl:WindowKey>
+                        <dxl:SortingColumnList/>
+                      </dxl:WindowKey>
+                    </dxl:WindowKeyList>
+                  </dxl:Window>
+                </dxl:Assert>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="b">
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="b">
+                        <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="b">
+                          <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="6.377093.1.0" TableName="bar">
+                        <dxl:Columns>
+                          <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-1.mdp
@@ -322,10 +322,13 @@
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Not>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:IsDistinctFrom>
               </dxl:Not>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="6.32780.1.1" TableName="x">

--- a/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AntiSemiJoin2Select-2.mdp
@@ -322,10 +322,13 @@
             </dxl:ProjList>
             <dxl:Filter>
               <dxl:Not>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:IsDistinctFrom OperatorMdid="0.91.1.0">
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:IsDistinctFrom>
               </dxl:Not>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="6.32780.1.1" TableName="x">

--- a/src/backend/gporca/data/dxl/minidump/LASJ-Not-In-Force-Broadcast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LASJ-Not-In-Force-Broadcast.mdp
@@ -1130,7 +1130,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.034640" Rows="40.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.035815" Rows="100.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1141,7 +1141,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.034044" Rows="40.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.034324" Rows="100.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-NOT-IN-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-NOT-IN-Subquery.mdp
@@ -534,7 +534,7 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
     <dxl:Plan Id="0" SpaceSize="24">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.014692" Rows="30.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.115021" Rows="30.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -554,7 +554,7 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.012903" Rows="30.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.113232" Rows="30.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -579,7 +579,7 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
               </dxl:ParamList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.010349" Rows="27.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.110678" Rows="27.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="18" Alias="i">
@@ -593,9 +593,9 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
                   </dxl:Comparison>
                 </dxl:Filter>
                 <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.009757" Rows="27.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.044878" Rows="3000.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="18" Alias="i">
@@ -605,13 +605,69 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
                       <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:JoinFilter>
+                  <dxl:Filter>
+                    <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
+                      <dxl:TestExpr>
+                        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:TestExpr>
+                      <dxl:ParamList/>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000863" Rows="26.953361" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="27" Alias="i">
+                            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000827" Rows="26.953361" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="27" Alias="i">
+                              <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000184" Rows="8.984454" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="27" Alias="i">
+                                <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                                <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="c">
+                              <dxl:Columns>
+                                <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:SubPlan>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
                   <dxl:Materialize Eager="true">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
@@ -668,58 +724,7 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i not in (
                       </dxl:TableScan>
                     </dxl:BroadcastMotion>
                   </dxl:Materialize>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000863" Rows="26.953361" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="27" Alias="i">
-                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000827" Rows="26.953361" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="27" Alias="i">
-                          <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000184" Rows="8.984454" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="27" Alias="i">
-                            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                            <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="c">
-                          <dxl:Columns>
-                            <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
+                </dxl:Result>
               </dxl:Result>
             </dxl:SubPlan>
           </dxl:Filter>

--- a/src/backend/gporca/data/dxl/minidump/NotInToLASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NotInToLASJ.mdp
@@ -325,7 +325,7 @@
     <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="883119.052225" Rows="1.200000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="883119.052260" Rows="3.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -336,7 +336,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="883119.052207" Rows="1.200000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="883119.052216" Rows="3.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-LASJ.mdp
@@ -851,7 +851,7 @@
     <dxl:Plan Id="0" SpaceSize="18">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.011537" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.011587" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -869,7 +869,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.011536" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.011586" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="ColRef_0026">
@@ -880,7 +880,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.011500" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.011550" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -896,7 +896,7 @@
             <dxl:Filter/>
             <dxl:HashJoin JoinType="LeftAntiSemiJoinNotIn">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.011500" Rows="19.200000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.011550" Rows="48.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2NotInWhereLOJ.mdp
@@ -135,6 +135,22 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.91.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.16.1.0"/>
+        <dxl:RightType Mdid="0.16.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.60.1.0"/>
+        <dxl:Commutator Mdid="0.91.1.0"/>
+        <dxl:InverseOp Mdid="0.85.1.0"/>
+        <dxl:HashOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7124.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.424.1.0"/>
+          <dxl:Opfamily Mdid="0.2222.1.0"/>
+          <dxl:Opfamily Mdid="0.7124.1.0"/>
+          <dxl:Opfamily Mdid="0.10002.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.531.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.25.1.0"/>
         <dxl:RightType Mdid="0.25.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-Limit1.mdp
@@ -308,7 +308,7 @@
     <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.000299" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000329" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1605,6 +1605,7 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 
 	BOOL fSuccess = true;
 	BOOL fUseCorrelated = false;
+	CExpression *pexprInnerSelect = nullptr;
 	CExpression *pexprPredicate = nullptr;
 	CExpression *pexprInner = (*pexprSubquery)[0];
 	COperator::EOperatorId eopidSubq = pexprSubquery->Pop()->Eopid();
@@ -1640,11 +1641,13 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 		}
 	}
 
-	// generate a select with the inverse predicate as the selection predicate
-	// TODO: Handle the case where pexprInversePred == NULL
 	CExpression *pexprInversePred =
 		CXformUtils::PexprInversePred(mp, pexprSubquery);
+	// generate a select with the inverse predicate as the selection predicate
+	// TODO: Handle the case where pexprInversePred == NULL
 	pexprPredicate = pexprInversePred;
+	pexprInnerSelect =
+		CUtils::PexprLogicalSelect(mp, pexprInner, pexprPredicate);
 
 	if (EsqctxtValue == esqctxt)
 	{
@@ -1665,8 +1668,11 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 			}
 		}
 
-		CExpression *pexprInnerSelect = PexprInnerSelect(
+		CExpression *pexprNewInnerSelect = PexprInnerSelect(
 			mp, colref, pexprInner, pexprPredicate, &fUseNotNullOptimization);
+
+		pexprInnerSelect->Release();
+		pexprInnerSelect = pexprNewInnerSelect;
 
 		if (!fUseCorrelated)
 		{
@@ -1682,10 +1688,6 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 				mp, pexprOuter, pexprSubquery, esqctxt, ppexprNewOuter,
 				ppexprResidualScalar);
 		}
-
-		// cleanup
-		pexprInner->Release();
-		pexprPredicate->Release();
 	}
 	else
 	{
@@ -1694,7 +1696,7 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 		*ppexprResidualScalar = CUtils::PexprScalarConstBool(mp, true);
 		*ppexprNewOuter =
 			CUtils::PexprLogicalApply<CLogicalLeftAntiSemiApplyNotIn>(
-				mp, pexprOuter, pexprInner, colref, eopidSubq, pexprPredicate);
+				mp, pexprOuter, pexprInnerSelect, colref, eopidSubq);
 	}
 
 	return fSuccess;

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1646,8 +1646,6 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 	// generate a select with the inverse predicate as the selection predicate
 	// TODO: Handle the case where pexprInversePred == NULL
 	pexprPredicate = pexprInversePred;
-	pexprInnerSelect =
-		CUtils::PexprLogicalSelect(mp, pexprInner, pexprPredicate);
 
 	if (EsqctxtValue == esqctxt)
 	{
@@ -1668,11 +1666,8 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 			}
 		}
 
-		CExpression *pexprNewInnerSelect = PexprInnerSelect(
+		pexprInnerSelect = PexprInnerSelect(
 			mp, colref, pexprInner, pexprPredicate, &fUseNotNullOptimization);
-
-		pexprInnerSelect->Release();
-		pexprInnerSelect = pexprNewInnerSelect;
 
 		if (!fUseCorrelated)
 		{
@@ -1688,10 +1683,35 @@ CSubqueryHandler::FRemoveAllSubquery(CExpression *pexprOuter,
 				mp, pexprOuter, pexprSubquery, esqctxt, ppexprNewOuter,
 				ppexprResidualScalar);
 		}
+		pexprInner->Release();
+		pexprPredicate->Release();
 	}
 	else
 	{
 		GPOS_ASSERT(EsqctxtFilter == esqctxt);
+
+		// check that inner row in filter is nullable
+		CColRefSet *pcrsNotNullInner = GPOS_NEW(mp) CColRefSet(mp);
+		pcrsNotNullInner->Include(pexprInner->DeriveNotNullColumns());
+		CColRefSet *pcrsUsedInner = GPOS_NEW(mp) CColRefSet(mp);
+		pcrsUsedInner->Include(colref);
+		pcrsUsedInner->Intersection(pexprPredicate->DeriveUsedColumns());
+		pcrsNotNullInner->Intersection(pcrsUsedInner);
+		BOOL fInnerUsesNullableCol =
+			pcrsNotNullInner->Size() != pcrsUsedInner->Size();
+		pcrsNotNullInner->Release();
+		pcrsUsedInner->Release();
+
+		if (fInnerUsesNullableCol)
+		{
+			pexprInnerSelect = CUtils::PexprLogicalSelect(
+				mp, pexprInner, CUtils::PexprIsNotFalse(mp, pexprPredicate));
+		}
+		else
+		{
+			pexprInnerSelect =
+				CUtils::PexprLogicalSelect(mp, pexprInner, pexprPredicate);
+		}
 
 		*ppexprResidualScalar = CUtils::PexprScalarConstBool(mp, true);
 		*ppexprNewOuter =

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -1223,30 +1223,6 @@ CSubqueryHandler::FCreateCorrelatedApplyForQuantifiedSubquery(
 		CScalarSubqueryQuantified::PopConvert(pexprSubquery->Pop());
 	CColRef *colref = const_cast<CColRef *>(popSubquery->Pcr());
 
-	// If subq is SubqueryAll and scalar child is a subquery then it must be
-	// treated in "Value" context. For example:
-	//
-	//   SELECT * FROM foo WHERE (SELECT a FROM foo limit 1) = ALL(SELECT b FROM bar);
-	//
-	//   +--CScalarSubqueryAll(=)["b" (8)]
-	//      |--CLogicalGet "bar" ("bar"),
-	//      +--CScalarSubquery["a" (16)]
-	//         +--CLogicalLimit <empty> global
-	//            |--CLogicalGet "foo" ("foo"),
-	//            |--CScalarConst (0)
-	//            +--CScalarCast
-	//               +--CScalarConst (1)
-	//
-	// "Value" context signals FGenerateCorrelatedApplyForScalarSubquery() to
-	// generate a left outer apply as opposed to an inner apply. This is
-	// necessary in order to avoid incorrectly filtering out non-matching rows
-	// which are required to correctly determine the ALL_SUBLINK result.
-	if ((*pexprSubquery)[1]->Pop()->Eopid() == COperator::EopScalarSubquery &&
-		eopidSubq == COperator::EopScalarSubqueryAll)
-	{
-		esqctxt = EsqctxtValue;
-	}
-
 	// build subquery quantified comparison
 	CExpression *pexprResult = nullptr;
 	CSubqueryHandler sh(mp, true /* fEnforceCorrelatedApply */);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2354,6 +2354,10 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 		{
 			CExpression *pexprEquality = nullptr;
 			CExpression *pexprFalse = nullptr;
+
+			// LASJ with Not-In in GPDB returns nothing, if a NULL was
+			// produced by the inner-outer tuple match. So, we should
+			// check NOT NULL for the inner and outer sides only for LASJ.
 			if (FExtractEquality(
 					pexprPred, &pexprEquality,
 					&pexprFalse) &&	 // extracted equality expression
@@ -2365,12 +2369,17 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 				CPhysicalJoin::FHashJoinCompatible(
 					pexprEquality, pexprOuter,
 					pexprInner) &&	// equality is hash-join compatible
-				!CUtils::FUsesNullableCol(
-					mp, pexprEquality,
-					pexprInner) &&	// equality uses an inner NOT NULL column
-				!CUtils::FUsesNullableCol(
-					mp, pexprEquality,
-					pexprOuter))  // equality uses an outer NOT NULL column
+				((COperator::EopLogicalLeftAntiSemiJoin ==
+					  pexpr->Pop()->Eopid() &&
+				  !CUtils::FUsesNullableCol(
+					  mp, pexprEquality,
+					  pexprInner) &&  // equality uses an inner NOT NULL column
+				  !CUtils::FUsesNullableCol(
+					  mp, pexprEquality,
+					  pexprOuter)  // equality uses an outer NOT NULL column
+				  ) ||
+				 (COperator::EopLogicalLeftAntiSemiJoinNotIn ==
+				  pexpr->Pop()->Eopid())))
 			{
 				pexprEquality->AddRef();
 				pdrgpexprNew->Append(pexprEquality);

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -62,7 +62,7 @@ SemiJoinDPE InSubqWithPrjListReturnSet LeftSemiJoinWithRepOuterTab LeftSemiJoinC
 
 CAntiSemiJoinTest:
 AntiSemiJoin2Select-1 AntiSemiJoin2Select-2 NOT-IN-NotNullBoth NOT-IN-NullInner NOT-IN-NullOuter
-Correlated-AntiSemiJoin CorrelatedAntiSemiJoin-True Correlated-LASJ-With-Outer-Col
+Correlated-AntiSemiJoin CorrelatedAntiSemiJoin-True Correlated-LASJ-With-Outer-Col NotInToLASJ
 Correlated-LASJ-With-Outer-Const Correlated-LASJ-With-Outer-Expr LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds
 LASJ-Not-In-Force-Broadcast;
 

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -62,7 +62,7 @@ SemiJoinDPE InSubqWithPrjListReturnSet LeftSemiJoinWithRepOuterTab LeftSemiJoinC
 
 CAntiSemiJoinTest:
 AntiSemiJoin2Select-1 AntiSemiJoin2Select-2 NOT-IN-NotNullBoth NOT-IN-NullInner NOT-IN-NullOuter
-Correlated-AntiSemiJoin CorrelatedAntiSemiJoin-True Correlated-LASJ-With-Outer-Col NotInToLASJ
+Correlated-AntiSemiJoin CorrelatedAntiSemiJoin-True Correlated-LASJ-With-Outer-Col
 Correlated-LASJ-With-Outer-Const Correlated-LASJ-With-Outer-Expr LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds
 LASJ-Not-In-Force-Broadcast;
 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -957,18 +957,17 @@ SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t
 -- Test for unexpected NLJ qual
 --
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
-                                                                                                                                                       QUERY PLAN                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=0.00..882688.14 rows=1 width=1)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
    Join Filter: true
-   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-         Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: ((1 > x) IS DISTINCT FROM false)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(8 rows)
 
 --
 -- Test for wrong results in window functions under joins #1

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -330,19 +330,19 @@ select c1 from t1 where c1 > 6 and c1 not in
 --
 explain select c1 from t1,t2 where c1 not in 
 	(select c3 from t3) and c1 = c2;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
-   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
-         Hash Cond: (t2.c2 = t1.c1)
-         ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-         ->  Hash  (cost=862.00..862.00 rows=2 width=4)
-               ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=2 width=4)
-                     Hash Cond: (t1.c1 = t3.c3)
-                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                 ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=5 width=4)
+   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..1293.00 rows=2 width=4)
+         Hash Cond: (t1.c1 = t3.c3)
+         ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+               Hash Cond: (t1.c1 = t2.c2)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                     ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
  Settings:  optimizer=on
  Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
 (13 rows)
@@ -885,26 +885,27 @@ select c1 from t1 where c1 <>all (select c2 from t2);
 --q34
 --
 explain select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
-                                                                                                                                                                       QUERY PLAN                                                                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1765379.01 rows=4 width=4)
-   ->  Seq Scan on t1  (cost=0.00..1765379.01 rows=2 width=4)
-         Filter: (SubPlan 1)
-         SubPlan 1
-           ->  Result  (cost=0.00..862.00 rows=1 width=1)
-                 Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                 ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
-                       ->  Result  (cost=0.00..862.00 rows=2 width=8)
-                             ->  Materialize  (cost=0.00..862.00 rows=2 width=4)
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-                                         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                               Hash Cond: (t2.c2 = t1n.c1n)
-                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-                                               ->  Hash  (cost=431.00..431.00 rows=7 width=4)
-                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                           ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+                                                                                                                                                                    QUERY PLAN                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1765379.24 rows=10 width=4)
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
+   SubPlan 1
+     ->  Result  (cost=0.00..862.00 rows=1 width=1)
+           Filter: ((CASE WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (t2.c2 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (t1.c1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (t1.c1 > t2.c2) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+           ->  Aggregate  (cost=0.00..862.00 rows=1 width=16)
+                 ->  Result  (cost=0.00..862.00 rows=5 width=8)
+                       ->  Materialize  (cost=0.00..862.00 rows=5 width=4)
+                             ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=5 width=4)
+                                   ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=2 width=4)
+                                         Hash Cond: (t2.c2 = t1n.c1n)
+                                         ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                         ->  Hash  (cost=431.00..431.00 rows=7 width=4)
+                                               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                                     ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(17 rows)
+(18 rows)
 
 select c1 from t1 where c1 <=all (select c2 from t2 where c2 not in (select c1n from t1n));
  c1 

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -5558,18 +5558,17 @@ set optimizer_metadata_caching to off;
 insert into tbl_z select i from generate_series(1,100) i;
 -- plan with no relsize collection
 explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
-                                                                                                                                                       QUERY PLAN                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..882688.07 rows=1 width=1)
    Join Filter: true
-   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-         Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: ((1 > x) IS DISTINCT FROM false)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(8 rows)
 
 set gp_enable_relsize_collection = on;
 -- plan with relsize collection


### PR DESCRIPTION
Solve inconsistency between our fork and upstream in handling LASJ-NOTIN

This patch changes the approach for handling LASJ-NOTIN in GPORCA. Our fork of GPDB 6 uses approach by Denis Smirnov <sd@arenadata.io>, however upstream chose to use a different approach. Previously in GPDB 7 upstream's approach was used, this patch changes it to our approach instead.

The main difference between approaches lies in how NULL values are handled for inner queries of LASJ-NOTIN operator. Our approach is to add a "distinct from false" operator on top of the join condition (see 90afebcd9404a87ab1c4e95b17a6f6a2734b4d63). Upstream's approach is to instead move the join condition above LASJ-NOTIN as a filter (see ee9dc5d21c7e2f4b38dfa80900f56ff518047acf). This approach has several issues like invalidating attribute ids (which would require a separate fix), and also being a duplicate of an already existing transformation made by CXformUtils::FProcessGPDBAntiSemiHashJoin. Also, our approach is optimized to the same simple form as upstream's when it is possible.

---

Note: Do not squash to preserve authorship