### PR TITLE
ADBDEV-6987: Fix assert when using append optimized tables with GIN index

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -342,7 +342,7 @@ ginPostingListDecodeAllSegments(GinPostingList *segment, int len, int *ndecoded_
 		}
 
 		/* copy the first item */
-		Assert(OffsetNumberIsValid(ItemPointerGetOffsetNumber(&segment->first)));
+		Assert(ItemPointerIsValid(&segment->first));
 		Assert(ndecoded == 0 || ginCompareItemPointers(&segment->first, &result[ndecoded - 1]) > 0);
 		result[ndecoded] = segment->first;
 		ndecoded++;

--- a/src/test/regress/expected/appendonly_with_gin_index.out
+++ b/src/test/regress/expected/appendonly_with_gin_index.out
@@ -5,17 +5,30 @@ create table users(
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 -- And I have a large amount of data in the table
 insert into users
-  select to_tsvector(md5(random()::text))
-  from generate_series(1, 6000) i;
-insert into users values ('John');
+  select to_tsvector( md5(random()::text))
+  from generate_series(1, 60000) i;
+insert into users values (to_tsvector('John'));
 -- When I create a GIN index on users
-set gp_debug_linger=1;
 CREATE INDEX users_search_idx ON users USING gin (first_name);
-reset gp_debug_linger;
+-- Orca performs seq scan in this case, so disable Orca.
+set optimizer = 0;
 -- Then I should be able to query the table
-select * from users where first_name = 'John';
+select * from users where first_name @@ to_tsquery('John');
  first_name 
 ------------
- 'John'
+ 'john':1
 (1 row)
 
+explain (costs off) select * from users where first_name @@ to_tsquery('John');
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on users
+         Recheck Cond: (first_name @@ '''john'''::tsquery)
+         ->  Bitmap Index Scan on users_search_idx
+               Index Cond: (first_name @@ '''john'''::tsquery)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+drop table users;
+reset optimizer;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -55,7 +55,7 @@ test: create_misc create_operator
 # These depend on the above two
 test: create_index create_view
 # Depends on things setup for create_index
-test: gp_gin_index
+test: gp_gin_index appendonly_with_gin_index
 
 test: inherit
 

--- a/src/test/regress/sql/appendonly_with_gin_index.sql
+++ b/src/test/regress/sql/appendonly_with_gin_index.sql
@@ -5,15 +5,20 @@ create table users(
 
 -- And I have a large amount of data in the table
 insert into users
-  select to_tsvector(md5(random()::text))
-  from generate_series(1, 6000) i;
+  select to_tsvector( md5(random()::text))
+  from generate_series(1, 60000) i;
 
-insert into users values ('John');
+insert into users values (to_tsvector('John'));
 
 -- When I create a GIN index on users
-set gp_debug_linger=1;
 CREATE INDEX users_search_idx ON users USING gin (first_name);
-reset gp_debug_linger;
+
+-- Orca performs seq scan in this case, so disable Orca.
+set optimizer = 0;
 
 -- Then I should be able to query the table
-select * from users where first_name = 'John';
+select * from users where first_name @@ to_tsquery('John');
+explain (costs off) select * from users where first_name @@ to_tsquery('John');
+
+drop table users;
+reset optimizer;


### PR DESCRIPTION
Fix assert when using append optimized tables with GIN index (#1241)

Using an AO table with a GIN index could cause an assert in the debug build.
The triggered assert (OffsetNumberIsValid) checks the offset (ip_posid) in the
tuple address (ItemPointerData), indirectly checking the correctness of
GinPostingList decompression. Decompression can be performed, for example,
when inserting data into an AO table with a GIN index or starting a vacuum.
The offset range is checked as for a Heap table. The correct range is 1..8192
with a BLCKSZ of 32768 bytes (see MaxOffsetNumber).
However, in AO tables, the TID offset (ip_posid) is calculated differently,
this led to the assert.

In a Heap table, ip_posid means the ItemIdData number inside the PageHeader
structure. ip_posid for Heap tables is calculated by PageGetMaxOffsetNumber()
macro, for example during insertion. ip_posid can take the value 1..8192 with
BLCKSZ size 32768 bytes.

For AO tables ip_posid is calculated as the value of the lower 16 bits of the
segfile row in AOTupleIdInit() and can take the value 1..32768. What could
cause the assert.

A larger range of ip_posid with AO tuples does not cause problems in the GIN
index, since the full tuple address (ItemPointerData) is used during
processing.

This commit weakens the offset range check (ip_posid) in the assert at the
GinPostingList decompression stage so that AO tables with GIN index can be
processed in the build with asserts.

Changes:
Only the ItemPointerIsValid() check is left;
The appendonly_with_gin_index test has been added to the parallel_schedule;
In the test query, the data volume has been increased and the search condition
has been rewritten so that the GIN index works.

(cherry picked from commit 2a8c1fc)
Changes from original: modified output.

Ticket: ADBDEV-6987

----------

Commits in the PR shouldn't be squashed to preserve authorship.