### PR TITLE
Fix using multiple references to DML CTE

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2032,6 +2032,19 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 			((Query *) cte->ctequery)->commandType != CMD_SELECT)
 			elog(ERROR, "Too much references to non-SELECT CTE");
 
+		/*
+		 * For non-select CTE It is important to check, that there is only one
+		 * reference. If such CTE is used more than one times from another CTE,
+		 * cterefcount will be more than one. But if non-select CTE is used one
+		 * time from another CTE and another CTE is used more than one time, we
+		 * will get situation: non-select CTE has cterefcount == 1, but used more
+		 * times. To check it, update cterefcount, and at the next iteration we
+		 * correctly check such cases. And it does not matter, how much CTE
+		 * between non-select CTE and the last select.
+		 */
+		if (((Query *) cte->ctequery)->commandType != CMD_SELECT)
+			cte->cterefcount++;
+
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 
 		/*

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -2023,27 +2023,28 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	if (!root->config->gp_cte_sharing || cte->cterefcount == 1)
 	{
-		/*
-		 * If plan sharing is disabled, we avoid performing DML inside CTE for
-		 * each reference. It'll cause duplicated DML operations or mutation
-		 * errors during cdbparallelize().
-		 */
-		if (cte->cterefcount > 1 &&
-			((Query *) cte->ctequery)->commandType != CMD_SELECT)
-			elog(ERROR, "Too much references to non-SELECT CTE");
-
-		/*
-		 * For non-select CTE It is important to check, that there is only one
-		 * reference. If such CTE is used more than one times from another CTE,
-		 * cterefcount will be more than one. But if non-select CTE is used one
-		 * time from another CTE and another CTE is used more than one time, we
-		 * will get situation: non-select CTE has cterefcount == 1, but used more
-		 * times. To check it, update cterefcount, and at the next iteration we
-		 * correctly check such cases. And it does not matter, how much CTE
-		 * between non-select CTE and the last select.
-		 */
 		if (((Query *) cte->ctequery)->commandType != CMD_SELECT)
+		{
+			/*
+			 * If plan sharing is disabled, we avoid performing DML inside CTE for
+			 * each reference. It'll cause duplicated DML operations or mutation
+			 * errors during cdbparallelize().
+			 */
+			if (cte->cterefcount > 1)
+				elog(ERROR, "Too much references to non-SELECT CTE");
+
+			/*
+			 * For non-select CTE it is important to check, that there is only one
+			 * reference. If such CTE is used more than one times from another CTE,
+			 * cterefcount will be more than one. But if non-select CTE is used one
+			 * time from another CTE and another CTE is used more than one time, we
+			 * will get situation: non-select CTE has cterefcount == 1, but used more
+			 * times. To check it, update cterefcount, and at the next iteration we
+			 * correctly check such cases. And it does not matter, how much CTE
+			 * between non-select CTE and the last select.
+			 */
 			cte->cterefcount++;
+		}
 
 		PlannerConfig *config = CopyPlannerConfig(root->config);
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -38,6 +38,7 @@
 #include "optimizer/restrictinfo.h"
 #include "optimizer/var.h"
 #include "optimizer/planshare.h"
+#include "optimizer/subselect.h"
 #include "parser/parse_clause.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteManip.h"
@@ -2023,27 +2024,16 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	if (!root->config->gp_cte_sharing || cte->cterefcount == 1)
 	{
-		if (((Query *) cte->ctequery)->commandType != CMD_SELECT)
+		/*
+		 * If plan sharing is disabled, we avoid performing DML inside CTE for
+		 * multi reference and recursive cases. Otherwise, it'll cause
+		 * duplicated DML operations.
+		 */
+		if ((cte->cterefcount > 1 || cte->cterecursive) &&
+			(((Query *) cte->ctequery)->commandType != CMD_SELECT ||
+			cte_contains_dml(cte->ctequery, cteroot)))
 		{
-			/*
-			 * If plan sharing is disabled, we avoid performing DML inside CTE for
-			 * each reference. It'll cause duplicated DML operations or mutation
-			 * errors during cdbparallelize().
-			 */
-			if (cte->cterefcount > 1)
-				elog(ERROR, "Too much references to non-SELECT CTE");
-
-			/*
-			 * For non-select CTE it is important to check, that there is only one
-			 * reference. If such CTE is used more than one times from another CTE,
-			 * cterefcount will be more than one. But if non-select CTE is used one
-			 * time from another CTE and another CTE is used more than one time, we
-			 * will get situation: non-select CTE has cterefcount == 1, but used more
-			 * times. To check it, update cterefcount, and at the next iteration we
-			 * correctly check such cases. And it does not matter, how much CTE
-			 * between non-select CTE and the last select.
-			 */
-			cte->cterefcount++;
+			elog(ERROR, "Too much references to non-SELECT CTE");
 		}
 
 		PlannerConfig *config = CopyPlannerConfig(root->config);

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -51,4 +51,6 @@ extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);
 extern bool QueryHasDistributedRelation(Query *q, bool recursive);
 
+extern bool cte_contains_dml(Node *ctequery, PlannerInfo *root);
+
 #endif   /* SUBSELECT_H */

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2284,6 +2284,7 @@ WITH e AS (
  Optimizer: Postgres query optimizer
 (39 rows)
 
+RESET gp_cte_sharing;
 DROP TABLE d;
 DROP TABLE r;
 -- Test planner not pushing down quals to non-SELECT queries inside CTE. There
@@ -2329,7 +2330,6 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
-SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2329,6 +2329,7 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
+SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i
@@ -2347,6 +2348,26 @@ with cte as (
     returning i
 ) select count(*) from cte where i < (select avg(i) from cte);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    insert into with_dml
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+create table with_dml_repl (i int, j int) distributed replicated;
+explain (costs off)
+with cte as (
+    insert into with_dml_repl
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+drop table with_dml_repl;
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
 -- queries contain modifying CTEs, because Greenplum cannot have two writer
 -- segworker groups, and during execution an error is thrown. Showing

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2367,6 +2367,16 @@ cte2 as (
     select * from cte)
 select * from cte2 a join cte2 b using (i);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with recursive cte as (
+    select 1 as i from with_dml where with_dml.j = 2
+    union all
+    select cte2.i from cte join cte2 using(i)),
+cte2 as (
+    insert into with_dml_repl select i, i * 100 from generate_series(1,5) i
+    returning *
+) select * from cte;
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
 drop table with_dml_repl;
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
 -- queries contain modifying CTEs, because Greenplum cannot have two writer

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2287,6 +2287,7 @@ WITH e AS (
  Optimizer: Pivotal Optimizer (GPORCA)
 (41 rows)
 
+RESET gp_cte_sharing;
 DROP TABLE d;
 DROP TABLE r;
 -- Test planner not pushing down quals to non-SELECT queries inside CTE. There
@@ -2332,7 +2333,6 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
-SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2332,6 +2332,7 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
+SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i
@@ -2350,6 +2351,26 @@ with cte as (
     returning i
 ) select count(*) from cte where i < (select avg(i) from cte);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with cte as (
+    insert into with_dml
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+create table with_dml_repl (i int, j int) distributed replicated;
+explain (costs off)
+with cte as (
+    insert into with_dml_repl
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+drop table with_dml_repl;
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
 -- queries contain modifying CTEs, because Greenplum cannot have two writer
 -- segworker groups, and during execution an error is thrown. Showing

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2370,6 +2370,16 @@ cte2 as (
     select * from cte)
 select * from cte2 a join cte2 b using (i);
 ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
+explain (costs off)
+with recursive cte as (
+    select 1 as i from with_dml where with_dml.j = 2
+    union all
+    select cte2.i from cte join cte2 using(i)),
+cte2 as (
+    insert into with_dml_repl select i, i * 100 from generate_series(1,5) i
+    returning *
+) select * from cte;
+ERROR:  Too much references to non-SELECT CTE (allpaths.c:2043)
 drop table with_dml_repl;
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
 -- queries contain modifying CTEs, because Greenplum cannot have two writer

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -444,6 +444,7 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
+SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i
@@ -459,6 +460,24 @@ with cte as (
     delete from with_dml where i > 0
     returning i
 ) select count(*) from cte where i < (select avg(i) from cte);
+explain (costs off)
+with cte as (
+    insert into with_dml
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+create table with_dml_repl (i int, j int) distributed replicated;
+explain (costs off)
+with cte as (
+    insert into with_dml_repl
+        select i, i * 2 from generate_series(1,5) i
+        returning *),
+cte2 as (
+    select * from cte)
+select * from cte2 a join cte2 b using (i);
+drop table with_dml_repl;
 
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose
 -- queries contain modifying CTEs, because Greenplum cannot have two writer

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -422,6 +422,7 @@ WITH e AS (
 ), h AS (
     SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
 ) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
+RESET gp_cte_sharing;
 DROP TABLE d;
 DROP TABLE r;
 
@@ -444,7 +445,6 @@ select count(*) c from with_dml;
 
 -- Test one cannot use DML CTE if multiple CTE references found.
 -- Otherwise it will cause duplicated DML operations or planner errors.
-SET gp_cte_sharing TO off;
 explain (costs off)
 with cte as (
     insert into with_dml select i, i * 100 from generate_series(1,5) i

--- a/src/test/regress/sql/with_clause.sql
+++ b/src/test/regress/sql/with_clause.sql
@@ -477,6 +477,15 @@ with cte as (
 cte2 as (
     select * from cte)
 select * from cte2 a join cte2 b using (i);
+explain (costs off)
+with recursive cte as (
+    select 1 as i from with_dml where with_dml.j = 2
+    union all
+    select cte2.i from cte join cte2 using(i)),
+cte2 as (
+    insert into with_dml_repl select i, i * 100 from generate_series(1,5) i
+    returning *
+) select * from cte;
 drop table with_dml_repl;
 
 -- Greenplum fails to execute SELECT INTO and CREATE TABLE AS statements, whose


### PR DESCRIPTION
```
Fix using multiple references to DML CTE

Commit 20537e17098e824f6296366478821ada8e98b67e forbids multiple using DML CTE.
But if DML CTE is used one time in another CTE and such CTE is used more than
one time, the check from the commit above will not work, because the cterefcount
field contains 1 (and it is correct). And there is the another case, where DML
CTE is used at recursive CTE.

Patch adds check for such cases by using walker to find multiple reference to
DML CTE.


Co-authored-by: Alexander Kondakov <a.kondakov@arenadata.io>
```