### PR TITLE
ADBDEV-4610: Fix Orca's planning of a correlated subplan that has distinct or union all

### DIFF
--- a/.abi-check/6.27.1_arenadata60/postgres.symbols.ignore
+++ b/.abi-check/6.27.1_arenadata60/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -234,7 +234,8 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	{EopttraceDoNotEnforceCorrelatedExecution,
 	 &optimizer_donot_enforce_subplans,
 	 false,	 // m_negate_param
-	 GPOS_WSZ_LIT("Do not try to enforce correlated execution in the optimizer")},
+	 GPOS_WSZ_LIT(
+		 "Do not try to enforce correlated execution in the optimizer")},
 
 	{EopttraceForceExpandedMDQAs, &optimizer_force_expanded_distinct_aggs,
 	 false,	 // m_negate_param

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -234,7 +234,7 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	{EopttraceDoNotEnforceCorrelatedExecution,
 	 &optimizer_donot_enforce_subplans,
 	 false,	 // m_negate_param
-	 GPOS_WSZ_LIT("Enforce correlated execution in the optimizer")},
+	 GPOS_WSZ_LIT("Do not try to enforce correlated execution in the optimizer")},
 
 	{EopttraceForceExpandedMDQAs, &optimizer_force_expanded_distinct_aggs,
 	 false,	 // m_negate_param

--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -231,6 +231,11 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT("Enforce correlated execution in the optimizer")},
 
+	{EopttraceDoNotEnforceCorrelatedExecution,
+	 &optimizer_donot_enforce_subplans,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT("Enforce correlated execution in the optimizer")},
+
 	{EopttraceForceExpandedMDQAs, &optimizer_force_expanded_distinct_aggs,
 	 false,	 // m_negate_param
 	 GPOS_WSZ_LIT(

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedInSubqueryWithUnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedInSubqueryWithUnionAll.mdp
@@ -1,0 +1,717 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment>
+    <![CDATA[
+create table t1 (a int, b int) distributed by (a);
+create table t2 (a int, b int) distributed by (a);
+
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+
+insert into t2 values(0,0);
+insert into t2 values(3,3);
+
+set optimizer_donot_enforce_subplans = on;
+
+explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Append
+                 ->  Result
+                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on t2
+                                         Filter: (0 = b)
+                 ->  Result
+                       Filter: (0 = "outer".?column?)
+                       ->  Result
+                             ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000"
+              DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000"
+              MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000"
+                  LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18"
+              ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10"
+              BroadcastThreshold="100000" EnforceConstraintsOnDML="false"
+              PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"
+              SkewFactor="0"/>
+      <dxl:TraceFlags
+              Value="102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,103045,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.482898.1.0.1" Name="b" Width="4.000000"
+              NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000"
+              ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.482898.1.0.0" Name="a" Width="4.000000"
+              NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000"
+              ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="true" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="1"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="true" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="8"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="true" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="4"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq"
+              ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="true" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="4"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="true" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="6"
+              PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT"
+              ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="false" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="4"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true"
+              IsHashable="true" IsMergeJoinable="false" IsComposite="false"
+              IsTextRelated="false" IsFixedLength="true" Length="4"
+              PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true"
+              HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.482898.1.0" Name="t2" Rows="1.000000"
+              RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq"
+              ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="6.482898.1.0" Name="t2" IsTemporary="false"
+              HasOids="false" StorageType="Heap" DistributionPolicy="Hash"
+              DistributionColumns="1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false"
+                  ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0"
+                  Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0"
+                  Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.482895.1.0.1" Name="b" Width="4.000000"
+              NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000"
+              ColStatsMissing="false"/>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true"
+              HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.482895.1.0" Name="t1" Rows="1.000000"
+              RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.482895.1.0" Name="t1" IsTemporary="false"
+              HasOids="false" StorageType="Heap" DistributionPolicy="Hash"
+              DistributionColumns="1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false"
+                  ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false"
+                  ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0"
+                  Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0"
+                  Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="11">
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UnionAll InputColumns="11;20" CastAcrossInputs="false">
+            <dxl:Columns>
+              <dxl:Column ColId="11" Attno="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+            <dxl:LogicalSelect>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:Or>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="6.482898.1.0" TableName="t2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="a"
+                            TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="b"
+                            TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid"
+                            TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin"
+                            TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin"
+                            TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax"
+                            TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax"
+                            TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid"
+                            TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id"
+                            TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:LogicalSelect>
+            <dxl:LogicalProject>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="20" Alias="?column?">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:LogicalConstTable>
+                <dxl:Columns>
+                  <dxl:Column ColId="19" Attno="1" ColName=""
+                          TypeMdid="0.16.1.0"/>
+                </dxl:Columns>
+                <dxl:ConstTuple>
+                  <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ConstTuple>
+              </dxl:LogicalConstTable>
+            </dxl:LogicalProject>
+          </dxl:UnionAll>
+        </dxl:SubqueryAny>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.482895.1.0" TableName="t1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"
+                      ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"
+                      ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid"
+                      TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin"
+                      TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin"
+                      TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax"
+                      TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax"
+                      TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid"
+                      TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id"
+                      TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.492188" Rows="1.000000"
+                  Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter>
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+            <dxl:TestExpr/>
+            <dxl:ParamList>
+              <dxl:Param ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ParamList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000311" Rows="2.000000"
+                        Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Append IsTarget="false" IsZapped="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000311"
+                          Rows="2.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000265"
+                            Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="b">
+                      <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Or>
+                      <dxl:Comparison ComparisonOperator="="
+                              OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                      </dxl:Comparison>
+                      <dxl:Comparison ComparisonOperator="="
+                              OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Or>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000166"
+                              Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="a">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="b">
+                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000158"
+                                Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="a">
+                          <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="b">
+                          <dxl:Ident ColId="10" ColName="b"
+                                  TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000069"
+                                  Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="9" Alias="a">
+                            <dxl:Ident ColId="9" ColName="a"
+                                    TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="10" Alias="b">
+                            <dxl:Ident ColId="10" ColName="b"
+                                    TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="="
+                                  OperatorMdid="0.96.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                            <dxl:Ident ColId="10" ColName="b"
+                                    TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="6.482898.1.0" TableName="t2">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="a"
+                                    TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="b"
+                                    TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid"
+                                    TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin"
+                                    TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin"
+                                    TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax"
+                                    TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax"
+                                    TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid"
+                                    TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="17" Attno="-8"
+                                    ColName="gp_segment_id" TypeMdid="0.23.1.0"
+                                    ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:GatherMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000038"
+                            Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="19" Alias="?column?">
+                      <dxl:Ident ColId="19" ColName="?column?"
+                              TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="="
+                            OperatorMdid="0.96.1.0">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                      <dxl:Ident ColId="19" ColName="?column?"
+                              TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005"
+                              Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001"
+                                Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="18" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Result>
+              </dxl:Append>
+            </dxl:Result>
+          </dxl:SubPlan>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000"
+                    Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000"
+                      Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.482895.1.0" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"
+                        ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"
+                        ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid"
+                        TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin"
+                        TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin"
+                        TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax"
+                        TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax"
+                        TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid"
+                        TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id"
+                        TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:GatherMotion>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1187,9 +1187,6 @@ CUtils::PexprLogicalCorrelatedQuantifiedApply(
 	if (COperator::EopLogicalSelect != pexprRight->Pop()->Eopid())
 	{
 		// quantified comparison was pushed down, we create a dummy comparison here
-		GPOS_ASSERT(
-			!CUtils::HasOuterRefs(pexprRight) &&
-			"unexpected outer references in inner child of Semi Apply expression ");
 		pexprScalar->Release();
 		pexprScalar = PexprScalarConstBool(mp, true /*value*/);
 	}

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSubqueryUnnest.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSubqueryUnnest.cpp
@@ -68,6 +68,13 @@ CXformSubqueryUnnest::PexprSubqueryUnnest(CMemoryPool *mp, CExpression *pexpr,
 		return NULL;
 	}
 
+	if (GPOS_FTRACE(EopttraceDoNotEnforceCorrelatedExecution) &&
+		fEnforceCorrelatedApply)
+	{
+		// do not try to enforce correlated apply
+		return NULL;
+	}
+
 	// extract components
 	CExpression *pexprOuter = (*pexpr)[0];
 	CExpression *pexprScalar = (*pexpr)[1];

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -231,6 +231,8 @@ enum EOptTraceFlag
 	// Keep locks on partition children during planning
 	EopttraceKeepPartitionChildrenLocks = 103045,
 
+	EopttraceDoNotEnforceCorrelatedExecution = 103046,
+
 	///////////////////////////////////////////////////////
 	///////////////////// statistics flags ////////////////
 	//////////////////////////////////////////////////////

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CSubqueryTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CSubqueryTest.cpp
@@ -79,6 +79,7 @@ const CHAR *rgszSubqueryFileNames[] = {
 	"../data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp",
 	"../data/dxl/minidump/Subquery-AnyAllAggregates.mdp",
 	"../data/dxl/minidump/Join-With-Subq-Preds-2.mdp",
+	"../data/dxl/minidump/CorrelatedInSubqueryWithUnionAll.mdp",
 };
 
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -416,6 +416,7 @@ bool		optimizer_penalize_skew;
 bool		optimizer_prune_computed_columns;
 bool		optimizer_push_requirements_from_consumer_to_producer;
 bool		optimizer_enforce_subplans;
+bool		optimizer_donot_enforce_subplans;
 bool		optimizer_use_external_constant_expression_evaluation_for_ints;
 bool		optimizer_apply_left_outer_to_union_all_disregarding_stats;
 bool		optimizer_remove_order_below_dml;
@@ -2752,6 +2753,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enforce_subplans,
+		false,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_donot_enforce_subplans", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enforce do not correlated execution in the optimizer"),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_donot_enforce_subplans,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -544,6 +544,7 @@ extern bool optimizer_penalize_skew;
 extern bool optimizer_prune_computed_columns;
 extern bool optimizer_push_requirements_from_consumer_to_producer;
 extern bool optimizer_enforce_subplans;
+extern bool optimizer_donot_enforce_subplans;
 extern bool optimizer_apply_left_outer_to_union_all_disregarding_stats;
 extern bool optimizer_use_external_constant_expression_evaluation_for_ints;
 extern bool optimizer_remove_order_below_dml;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -410,6 +410,7 @@
 		"optimizer_enable_replicated_table",
 		"optimizer_enable_right_outer_join",
 		"optimizer_enforce_subplans",
+		"optimizer_donot_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",
 		"optimizer_extract_dxl_stats",

--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -564,3 +564,66 @@ select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (s
 (1 row)
 
 drop table t1;
+-- Test that ORCA can build a plan for a query with a subquery that contains union all or distinct.
+-- start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+-- end_ignore
+create table t1 (a int, b int) distributed by (a);
+create table t2 (a int, b int) distributed by (a);
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t2 values(0,0);
+insert into t2 values(3,3);
+set optimizer_donot_enforce_subplans = on;
+explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on t1
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Append
+                 ->  Result
+                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                   ->  Seq Scan on t2
+                 ->  Result
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
+ a | b 
+---+---
+ 2 | 2
+ 1 | 1
+(2 rows)
+
+explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on t1
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
+ a | b 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+reset optimizer_donot_enforce_subplans;
+drop table t1;
+drop table t2;

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -557,3 +557,79 @@ select count(*) from ( values :lots_of_values ) as b(a) where b.a % 100000 in (s
 (1 row)
 
 drop table t1;
+-- Test that ORCA can build a plan for a query with a subquery that contains union all or distinct.
+-- start_ignore
+drop table if exists t1;
+NOTICE:  table "t1" does not exist, skipping
+drop table if exists t2;
+NOTICE:  table "t2" does not exist, skipping
+-- end_ignore
+create table t1 (a int, b int) distributed by (a);
+create table t2 (a int, b int) distributed by (a);
+insert into t1 values(1,1);
+insert into t1 values(2,2);
+insert into t2 values(0,0);
+insert into t2 values(3,3);
+set optimizer_donot_enforce_subplans = on;
+explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  Append
+                 ->  Result
+                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on t2
+                                         Filter: (0 = b)
+                 ->  Result
+                       Filter: (0 = "outer".?column?)
+                       ->  Result
+                             ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
+
+select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
+ a | b 
+---+---
+ 2 | 2
+ 1 | 1
+(2 rows)
+
+explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1
+   SubPlan 1  (slice0)
+     ->  Result
+           ->  GroupAggregate
+                 Group Key: t2.b
+                 ->  Sort
+                       Sort Key: t2.b
+                       ->  Result
+                             Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                             ->  Materialize
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         ->  Seq Scan on t2
+                                               Filter: (0 = b)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
+ a | b 
+---+---
+ 2 | 2
+ 1 | 1
+(2 rows)
+
+reset optimizer_donot_enforce_subplans;
+drop table t1;
+drop table t2;


### PR DESCRIPTION
Fix Orca's planning of a correlated subplan that has distinct or union all (#1246)

For correlated subqueries in any/in/exists expressions, ORCA tries to build an
uncorrelated plan, but if it fails, it builds a correlated one. The
XformSelect2Apply transformation creates two versions of the expression with
CLogicalLeftSemiApplyIn and CLogicalLeftSemiCorrelatedApplyIn. For both
expressions, the XformLeftSemiApply2LeftSemiJoin transformation is applied, in
which an attempt is made to decorrelate the subquery, which, if failed, leads to
the decoration of the subquery by the Result node with the true constant. For
CLogicalLeftSemiApplyIn, this happens in the
PexprLogicalCorrelatedQuantifiedApply method. If there is no filter at the top
of the expression, then the Result node with the constant true is added. In this
place, there was an assert that checked the presence of external parameters. But
the presence of external parameters in this place is to be expected.

Fix this problem by removing the assert, as the presence of external parameters
in this location is expected. Also add a new GUC that controls the
XformSelect2Apply transformation in order not to generate a correlated
CLogicalLeftSemiCorrelatedApplyIn expression; this is necessary for tests.