### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/access/gist/gistxlog.c

### DIFF
--- a/src/backend/access/gist/gistxlog.c
+++ b/src/backend/access/gist/gistxlog.c
@@ -81,13 +81,7 @@ gistRedoPageUpdateRecord(XLogReaderState *record)
 		char	   *begin;
 		char	   *data;
 		Size		datalen;
-<<<<<<< HEAD
-#ifdef USE_ASSERT_CHECKING
-		int			ninserted = 0;
-#endif
-=======
 		int			ninserted PG_USED_FOR_ASSERTS_ONLY = 0;
->>>>>>> REL_12_13
 
 		data = begin = XLogRecGetBlockData(record, 0, &datalen);
 


### PR DESCRIPTION
Resolve conflicts in src/backend/access/gist/gistxlog.c

Commit 14c8d26 fixed set but unused variables with if-defs, while the usual
upstream practice in such cases is to simply mute such warnings, see commit
f38a0bd. To reduce future conflicts, this patch uses the upstream version.

Ticket: ADBDEV-7238