### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/catalog/pg_proc.c

### DIFF
--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -1081,14 +1081,9 @@ function_parse_error_transpose(const char *prosrc)
 	}
 
 	/* We can get the original query text from the active portal (hack...) */
-<<<<<<< HEAD
-	/* Assert(ActivePortal && PortalGetStatus(ActivePortal) == PORTAL_ACTIVE); */
-	queryText = ActivePortal->sourceText;
-=======
 	if (ActivePortal && ActivePortal->status == PORTAL_ACTIVE)
 	{
 		const char *queryText = ActivePortal->sourceText;
->>>>>>> REL_12_13
 
 		/* Try to locate the prosrc in the original text */
 		newerrposition = match_prosrc_to_query(prosrc, queryText,


### PR DESCRIPTION
Resolve conflicts in src/backend/catalog/pg_proc.c

The conflict was due to the assert being commented out in GPDB. For the change
itself, see the detailed description in commit d9ffccf.

Ticket: ADBDEV-7238