### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/nodes/outfuncs.c

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -4979,23 +4979,14 @@ _outConstraint(StringInfo str, const Constraint *node)
 
 	WRITE_NODE_FIELD(exclusions);
 
-<<<<<<< HEAD
 	WRITE_NODE_FIELD(options);
 	WRITE_STRING_FIELD(indexname);
 	WRITE_STRING_FIELD(indexspace);
 	WRITE_BOOL_FIELD(reset_default_tblspc);
-=======
-		case CONSTR_IDENTITY:
-			appendStringInfoString(str, "IDENTITY");
-			WRITE_NODE_FIELD(options);
-			WRITE_CHAR_FIELD(generated_when);
-			break;
->>>>>>> REL_12_13
 
 	WRITE_STRING_FIELD(access_method);
 	WRITE_NODE_FIELD(where_clause);
 
-<<<<<<< HEAD
 	WRITE_NODE_FIELD(pktable);
 	WRITE_NODE_FIELD(fk_attrs);
 	WRITE_NODE_FIELD(pk_attrs);
@@ -5004,16 +4995,6 @@ _outConstraint(StringInfo str, const Constraint *node)
 	WRITE_CHAR_FIELD(fk_del_action);
 	WRITE_NODE_FIELD(old_conpfeqop);
 	WRITE_OID_FIELD(old_pktable_oid);
-=======
-		case CONSTR_CHECK:
-			appendStringInfoString(str, "CHECK");
-			WRITE_BOOL_FIELD(is_no_inherit);
-			WRITE_NODE_FIELD(raw_expr);
-			WRITE_STRING_FIELD(cooked_expr);
-			WRITE_BOOL_FIELD(skip_validation);
-			WRITE_BOOL_FIELD(initially_valid);
-			break;
->>>>>>> REL_12_13
 
 	WRITE_BOOL_FIELD(skip_validation);
 	WRITE_BOOL_FIELD(initially_valid);


### PR DESCRIPTION
Resolve conflicts in src/backend/nodes/outfuncs.c

When merging with Postgres 12, commit 19cd1cf decided (but it was not explained
why) to remove the switch case from the _outConstraint function, which led to
conflicts with commits 2f65ef5 and 1f71861, which only fixed debug output. So
this patch uses the GPDB version, discarding the incoming changes.

Ticket: ADBDEV-7238