### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/utils/mmgr/slab.c

### DIFF
--- a/src/backend/utils/mmgr/slab.c
+++ b/src/backend/utils/mmgr/slab.c
@@ -57,12 +57,9 @@
 #include "utils/gp_alloc.h"
 #include "lib/ilist.h"
 
-<<<<<<< HEAD
-=======
 
 #define Slab_BLOCKHDRSZ	MAXALIGN(sizeof(SlabBlock))
 
->>>>>>> REL_12_13
 /*
  * SlabContext is a specialized implementation of MemoryContext.
  */


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/mmgr/slab.c

The patch fixes a small conflict with commit f249f10 due to empty lines.

Ticket: ADBDEV-7238