### PR TITLE
ADBDEV-7223: Resolve conflicts in the src/include/libpq/hba.h

### DIFF
--- a/src/include/libpq/hba.h
+++ b/src/include/libpq/hba.h
@@ -134,12 +134,8 @@ extern bool load_ident(void);
 extern void hba_getauthmethod(hbaPort *port);
 extern int	check_usermap(const char *usermap_name,
 						  const char *pg_role, const char *auth_user,
-<<<<<<< HEAD
-						  bool case_sensitive);
-extern bool check_same_host_or_net(SockAddr *raddr, IPCompareMethod method);
-=======
 						  bool case_insensitive);
->>>>>>> REL_12_13
+extern bool check_same_host_or_net(SockAddr *raddr, IPCompareMethod method);
 extern bool pg_isblank(const char c);
 
 #endif							/* HBA_H */


### PR DESCRIPTION
Resolve conflicts in the src/include/libpq/hba.h

Conflict caused because Postgres renamed parameter from `case_sensitive` to `case_insensitive`, see commit c1dd5a8aedc7184d9a013721960813f7ace156ab.

Ticket: ADBDEV-7223
