### PR TITLE
ADBDEV-7223: Resolve conflicts in src/include/pg_config.h.win32

### DIFF
--- a/src/include/pg_config.h.win32
+++ b/src/include/pg_config.h.win32
@@ -687,11 +687,7 @@
 #define PACKAGE_NAME "Greenplum Database"
 
 /* Define to the full name and version of this package. */
-<<<<<<< HEAD
 #define PACKAGE_STRING "Greenplum Database 7.0.0-beta"
-=======
-#define PACKAGE_STRING "PostgreSQL 12.13"
->>>>>>> REL_12_13
 
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "12.13"


### PR DESCRIPTION
Resolve conflicts in src/include/pg_config.h.win32

Conflict caused by version string.

Ticket: ADBDEV-7223