### PR TITLE
ADBDEV-7239-2: Resolve conflicts in xlog.c

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -2155,13 +2155,7 @@ AdvanceXLInsertBuffer(XLogRecPtr upto, bool opportunistic)
 	XLogRecPtr	NewPageEndPtr = InvalidXLogRecPtr;
 	XLogRecPtr	NewPageBeginPtr;
 	XLogPageHeader NewPage;
-<<<<<<< HEAD
-#ifdef WAL_DEBUG
-	int			npages = 0;
-#endif
-=======
 	int			npages pg_attribute_unused() = 0;
->>>>>>> REL_12_13
 
 	LWLockAcquire(WALBufMappingLock, LW_EXCLUSIVE);
 


### PR DESCRIPTION
Commit f38a0bde21776f6a8e92b73645c3d54764c85459 replaced ifdef with
`__attribute__((unused))` for the debug variable.