### PR TITLE
ADBDEV-7251: Fix tests in an iterative approach

### DIFF
--- a/src/test/regress/expected/inherit.out
+++ b/src/test/regress/expected/inherit.out
@@ -1855,51 +1855,91 @@ update inhpar set
   (f3, f2[4])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),
   (f2[5], f2[6]) = (select 'x', 'y' from int4_tbl limit 1)
 from onek p2 where inhpar.f1 = p2.unique1;
-                                                                                                     QUERY PLAN                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                               QUERY PLAN                                                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.inhpar
    Update on public.inhpar
    Update on public.inhcld
-   InitPlan 2 (returns $4,$5)
+   InitPlan 2 (returns $4,$5)  (slice1)
      ->  Limit
            Output: 'x'::text, 'y'::text
-           ->  Seq Scan on public.int4_tbl int4_tbl_1
+           ->  Gather Motion 3:1  (slice2; segments: 3)
                  Output: 'x'::text, 'y'::text
-   InitPlan 4 (returns $10,$11)
+                 ->  Limit
+                       Output: 'x'::text, 'y'::text
+                       ->  Seq Scan on public.int4_tbl
+                             Output: 'x'::text, 'y'::text
+   InitPlan 4 (returns $10,$11)  (slice3)
      ->  Limit
            Output: 'x'::text, 'y'::text
-           ->  Seq Scan on public.int4_tbl int4_tbl_3
+           ->  Gather Motion 3:1  (slice4; segments: 3)
                  Output: 'x'::text, 'y'::text
-   ->  Merge Join
-         Output: $12, (((((inhpar.f2[1] := $13)[2] := $4)[3] := $5)[4] := $15)[5] := $10)[6] := $11, $14, (SubPlan 1 (returns $2,$3)), NULL::record, (SubPlan 3 (returns $8,$9)), NULL::record, inhpar.ctid, p2.ctid
-         Merge Cond: (p2.unique1 = inhpar.f1)
-         ->  Index Scan using onek_unique1 on public.onek p2
-               Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
-         ->  Sort
-               Output: inhpar.f2, inhpar.ctid, inhpar.f1
-               Sort Key: inhpar.f1
-               ->  Seq Scan on public.inhpar
-                     Output: inhpar.f2, inhpar.ctid, inhpar.f1
-         SubPlan 1 (returns $2,$3)
-           ->  Limit
-                 Output: (p2.unique2), (p2.stringu1)
-                 ->  Seq Scan on public.int4_tbl
-                       Output: p2.unique2, p2.stringu1
-         SubPlan 3 (returns $8,$9)
-           ->  Limit
-                 Output: (p2.unique2), (p2.stringu1)
-                 ->  Seq Scan on public.int4_tbl int4_tbl_2
-                       Output: p2.unique2, p2.stringu1
-   ->  Hash Join
-         Output: $16, (((((inhcld.f2[1] := $17)[2] := $4)[3] := $5)[4] := $19)[5] := $10)[6] := $11, $18, (SubPlan 1 (returns $2,$3)), NULL::record, (SubPlan 3 (returns $8,$9)), NULL::record, inhcld.ctid, p2.ctid
-         Hash Cond: (inhcld.f1 = p2.unique1)
-         ->  Seq Scan on public.inhcld
-               Output: inhcld.f2, inhcld.ctid, inhcld.f1
-         ->  Hash
-               Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
-               ->  Seq Scan on public.onek p2
-                     Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
-(42 rows)
+                 ->  Limit
+                       Output: 'x'::text, 'y'::text
+                       ->  Seq Scan on public.int4_tbl int4_tbl_1
+                             Output: 'x'::text, 'y'::text
+   ->  Explicit Redistribute Motion 3:3  (slice5; segments: 3)
+         Output: ($12), ((((((inhpar.f2[1] := ($13)::text)[2] := $4)[3] := $5)[4] := ($15)::text)[5] := $10)[6] := $11), ($14), ((SubPlan 1 (returns $2,$3) (copy 5))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 6))), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid, (DMLAction)
+         ->  Split
+               Output: ($12), ((((((inhpar.f2[1] := ($13)::text)[2] := $4)[3] := $5)[4] := ($15)::text)[5] := $10)[6] := $11), ($14), ((SubPlan 1 (returns $2,$3) (copy 5))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 6))), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid, DMLAction
+               ->  Merge Join
+                     Output: $12, (((((inhpar.f2[1] := $13)[2] := $4)[3] := $5)[4] := $15)[5] := $10)[6] := $11, $14, (SubPlan 1 (returns $2,$3) (copy 5)), NULL::record, (SubPlan 3 (returns $8,$9) (copy 6)), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid
+                     Merge Cond: (inhpar.f1 = p2.unique1)
+                     ->  Sort
+                           Output: inhpar.f2, inhpar.ctid, inhpar.gp_segment_id, inhpar.f1
+                           Sort Key: inhpar.f1
+                           ->  Seq Scan on public.inhpar
+                                 Output: inhpar.f2, inhpar.ctid, inhpar.gp_segment_id, inhpar.f1
+                     ->  Index Scan using onek_unique1 on public.onek p2
+                           Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                     SubPlan 1 (returns $2,$3) (copy 5)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_2
+                     SubPlan 3 (returns $8,$9) (copy 6)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_3
+   ->  Explicit Redistribute Motion 3:3  (slice8; segments: 3)
+         Output: ($16), ((((((inhcld.f2[1] := ($17)::text)[2] := $4)[3] := $5)[4] := ($19)::text)[5] := $10)[6] := $11), ($18), ((SubPlan 1 (returns $2,$3) (copy 7))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 8))), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid, (DMLAction)
+         ->  Split
+               Output: ($16), ((((((inhcld.f2[1] := ($17)::text)[2] := $4)[3] := $5)[4] := ($19)::text)[5] := $10)[6] := $11), ($18), ((SubPlan 1 (returns $2,$3) (copy 7))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 8))), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid, DMLAction
+               ->  Hash Join
+                     Output: $16, (((((inhcld.f2[1] := $17)[2] := $4)[3] := $5)[4] := $19)[5] := $10)[6] := $11, $18, (SubPlan 1 (returns $2,$3) (copy 7)), NULL::record, (SubPlan 3 (returns $8,$9) (copy 8)), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid
+                     Hash Cond: (inhcld.f1 = p2.unique1)
+                     ->  Seq Scan on public.inhcld
+                           Output: inhcld.f2, inhcld.ctid, inhcld.gp_segment_id, inhcld.f1
+                     ->  Hash
+                           Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                           ->  Index Scan using onek_unique1 on public.onek p2
+                                 Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                     SubPlan 1 (returns $2,$3) (copy 7)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice9; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_4
+                     SubPlan 3 (returns $8,$9) (copy 8)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice10; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_5
+ Optimizer: Postgres-based planner
+ Settings: enable_bitmapscan = 'off', enable_mergejoin = 'on', enable_seqscan = 'off', optimizer = 'off'
+(82 rows)
 
 update inhpar set
   (f1, f2[1])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1835,6 +1835,116 @@ reset enable_indexscan;
 reset enable_bitmapscan;
 rollback;
 --
+-- Check handling of MULTIEXPR SubPlans in inherited updates
+--
+create table inhpar(f1 int, f2 text[], f3 int);
+insert into inhpar select generate_series(1,10);
+create table inhcld() inherits(inhpar);
+insert into inhcld select generate_series(11,10000);
+vacuum analyze inhcld;
+vacuum analyze inhpar;
+explain (verbose, costs off)
+update inhpar set
+  (f1, f2[1])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),
+  (f2[2], f2[3]) = (select 'x', 'y' from int4_tbl limit 1),
+  (f3, f2[4])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),
+  (f2[5], f2[6]) = (select 'x', 'y' from int4_tbl limit 1)
+from onek p2 where inhpar.f1 = p2.unique1;
+                                                                                                                                               QUERY PLAN                                                                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.inhpar
+   Update on public.inhpar
+   Update on public.inhcld
+   InitPlan 2 (returns $4,$5)  (slice1)
+     ->  Limit
+           Output: 'x'::text, 'y'::text
+           ->  Gather Motion 3:1  (slice2; segments: 3)
+                 Output: 'x'::text, 'y'::text
+                 ->  Limit
+                       Output: 'x'::text, 'y'::text
+                       ->  Seq Scan on public.int4_tbl
+                             Output: 'x'::text, 'y'::text
+   InitPlan 4 (returns $10,$11)  (slice3)
+     ->  Limit
+           Output: 'x'::text, 'y'::text
+           ->  Gather Motion 3:1  (slice4; segments: 3)
+                 Output: 'x'::text, 'y'::text
+                 ->  Limit
+                       Output: 'x'::text, 'y'::text
+                       ->  Seq Scan on public.int4_tbl int4_tbl_1
+                             Output: 'x'::text, 'y'::text
+   ->  Explicit Redistribute Motion 3:3  (slice5; segments: 3)
+         Output: ($12), ((((((inhpar.f2[1] := ($13)::text)[2] := $4)[3] := $5)[4] := ($15)::text)[5] := $10)[6] := $11), ($14), ((SubPlan 1 (returns $2,$3) (copy 5))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 6))), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid, (DMLAction)
+         ->  Split
+               Output: ($12), ((((((inhpar.f2[1] := ($13)::text)[2] := $4)[3] := $5)[4] := ($15)::text)[5] := $10)[6] := $11), ($14), ((SubPlan 1 (returns $2,$3) (copy 5))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 6))), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid, DMLAction
+               ->  Merge Join
+                     Output: $12, (((((inhpar.f2[1] := $13)[2] := $4)[3] := $5)[4] := $15)[5] := $10)[6] := $11, $14, (SubPlan 1 (returns $2,$3) (copy 5)), NULL::record, (SubPlan 3 (returns $8,$9) (copy 6)), NULL::record, inhpar.ctid, inhpar.gp_segment_id, p2.ctid
+                     Merge Cond: (inhpar.f1 = p2.unique1)
+                     ->  Sort
+                           Output: inhpar.f2, inhpar.ctid, inhpar.gp_segment_id, inhpar.f1
+                           Sort Key: inhpar.f1
+                           ->  Seq Scan on public.inhpar
+                                 Output: inhpar.f2, inhpar.ctid, inhpar.gp_segment_id, inhpar.f1
+                     ->  Index Scan using onek_unique1 on public.onek p2
+                           Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                     SubPlan 1 (returns $2,$3) (copy 5)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice6; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_2
+                     SubPlan 3 (returns $8,$9) (copy 6)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice7; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_3
+   ->  Explicit Redistribute Motion 3:3  (slice8; segments: 3)
+         Output: ($16), ((((((inhcld.f2[1] := ($17)::text)[2] := $4)[3] := $5)[4] := ($19)::text)[5] := $10)[6] := $11), ($18), ((SubPlan 1 (returns $2,$3) (copy 7))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 8))), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid, (DMLAction)
+         ->  Split
+               Output: ($16), ((((((inhcld.f2[1] := ($17)::text)[2] := $4)[3] := $5)[4] := ($19)::text)[5] := $10)[6] := $11), ($18), ((SubPlan 1 (returns $2,$3) (copy 7))), NULL::record, ((SubPlan 3 (returns $8,$9) (copy 8))), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid, DMLAction
+               ->  Hash Join
+                     Output: $16, (((((inhcld.f2[1] := $17)[2] := $4)[3] := $5)[4] := $19)[5] := $10)[6] := $11, $18, (SubPlan 1 (returns $2,$3) (copy 7)), NULL::record, (SubPlan 3 (returns $8,$9) (copy 8)), NULL::record, inhcld.ctid, inhcld.gp_segment_id, p2.ctid
+                     Hash Cond: (inhcld.f1 = p2.unique1)
+                     ->  Seq Scan on public.inhcld
+                           Output: inhcld.f2, inhcld.ctid, inhcld.gp_segment_id, inhcld.f1
+                     ->  Hash
+                           Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                           ->  Index Scan using onek_unique1 on public.onek p2
+                                 Output: p2.unique2, p2.stringu1, p2.ctid, p2.unique1
+                     SubPlan 1 (returns $2,$3) (copy 7)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice9; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_4
+                     SubPlan 3 (returns $8,$9) (copy 8)
+                       ->  Limit
+                             Output: (p2.unique2), (p2.stringu1)
+                             ->  Result
+                                   Output: p2.unique2, p2.stringu1
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice10; segments: 3)
+                                               ->  Seq Scan on public.int4_tbl int4_tbl_5
+ Optimizer: Postgres-based planner
+ Settings: enable_bitmapscan = 'off', enable_mergejoin = 'on', enable_seqscan = 'off'
+(82 rows)
+
+update inhpar set
+  (f1, f2[1])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),
+  (f2[2], f2[3]) = (select 'x', 'y' from int4_tbl limit 1),
+  (f3, f2[4])    = (select p2.unique2, p2.stringu1 from int4_tbl limit 1),
+  (f2[5], f2[6]) = (select 'x', 'y' from int4_tbl limit 1)
+from onek p2 where inhpar.f1 = p2.unique1;
+drop table inhpar cascade;
+NOTICE:  drop cascades to table inhcld
+--
 -- Check handling of a constant-null CHECK constraint
 --
 create table cnullparent (f1 int);

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -3070,7 +3070,6 @@ referencing new table as new_table
 for each statement execute function convslot_trig2();
 ERROR:  Triggers for statements are not yet supported
 update convslot_test_parent set col1 = col1 || '1';
-NOTICE:  trigger = but_trigger, new table = (11,tutu), (31,tutu)
 create function convslot_trig3()
 returns trigger
 language plpgsql
@@ -3103,18 +3102,20 @@ partition by range (id);
 create table convslot_test_part (val int, id int not null);
 alter table convslot_test_parent
   attach partition convslot_test_part for values from (1) to (1000);
+ERROR:  distribution policy for "convslot_test_part" must be the same as that for "convslot_test_parent"
 create function convslot_trig4() returns trigger as
 $$begin raise exception 'BOOM!'; end$$ language plpgsql;
 create trigger convslot_test_parent_update
     after update on convslot_test_parent
     referencing old table as old_rows new table as new_rows
     for each statement execute procedure convslot_trig4();
+ERROR:  Triggers for statements are not yet supported
 insert into convslot_test_parent (id, val) values (1, 2);
+ERROR:  no partition of relation "convslot_test_parent" found for row  (seg1 172.18.0.8:7003 pid=22252)
+DETAIL:  Partition key of the failing row contains (id) = (1).
 begin;
 savepoint svp;
 update convslot_test_parent set val = 3;  -- error expected
-ERROR:  BOOM!
-CONTEXT:  PL/pgSQL function convslot_trig4() line 1 at RAISE
 rollback to savepoint svp;
 rollback;
 drop table convslot_test_parent;

--- a/src/test/regress/expected/triggers.out
+++ b/src/test/regress/expected/triggers.out
@@ -3098,11 +3098,11 @@ drop function convslot_trig3();
 -- Bug #17607: variant of above in which trigger function raises an error;
 -- we don't see any ill effects unless trigger tuple requires mapping
 create table convslot_test_parent (id int primary key, val int)
-partition by range (id);
-create table convslot_test_part (val int, id int not null);
+distributed by (id) partition by range (id);
+create table convslot_test_part (val int, id int not null)
+distributed by (id);
 alter table convslot_test_parent
   attach partition convslot_test_part for values from (1) to (1000);
-ERROR:  distribution policy for "convslot_test_part" must be the same as that for "convslot_test_parent"
 create function convslot_trig4() returns trigger as
 $$begin raise exception 'BOOM!'; end$$ language plpgsql;
 create trigger convslot_test_parent_update
@@ -3111,8 +3111,6 @@ create trigger convslot_test_parent_update
     for each statement execute procedure convslot_trig4();
 ERROR:  Triggers for statements are not yet supported
 insert into convslot_test_parent (id, val) values (1, 2);
-ERROR:  no partition of relation "convslot_test_parent" found for row  (seg1 172.18.0.8:7003 pid=22252)
-DETAIL:  Partition key of the failing row contains (id) = (1).
 begin;
 savepoint svp;
 update convslot_test_parent set val = 3;  -- error expected

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -463,27 +463,6 @@ SELECT a, b FROM base_tbl_hist;
  10 | 
 (2 rows)
 
--- it's still updatable if we add a DO ALSO rule
-CREATE TABLE base_tbl_hist(ts timestamptz default now(), a int, b text);
-CREATE RULE base_tbl_log AS ON INSERT TO rw_view1 DO ALSO
-  INSERT INTO base_tbl_hist(a,b) VALUES(new.a, new.b);
-SELECT table_name, is_updatable, is_insertable_into
-  FROM information_schema.views
- WHERE table_name = 'rw_view1';
- table_name | is_updatable | is_insertable_into 
-------------+--------------+--------------------
- rw_view1   | YES          | YES
-(1 row)
-
--- Check behavior with DEFAULTs (bug #17633)
-INSERT INTO rw_view1 VALUES (9, DEFAULT), (10, DEFAULT);
-SELECT a, b FROM base_tbl_hist;
- a  | b 
-----+---
-  9 | 
- 10 | 
-(2 rows)
-
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to view rw_view1
 DROP TABLE base_tbl_hist;

--- a/src/test/regress/sql/triggers.sql
+++ b/src/test/regress/sql/triggers.sql
@@ -2440,9 +2440,10 @@ drop function convslot_trig3();
 -- we don't see any ill effects unless trigger tuple requires mapping
 
 create table convslot_test_parent (id int primary key, val int)
-partition by range (id);
+distributed by (id) partition by range (id);
 
-create table convslot_test_part (val int, id int not null);
+create table convslot_test_part (val int, id int not null)
+distributed by (id);
 
 alter table convslot_test_parent
   attach partition convslot_test_part for values from (1) to (1000);


### PR DESCRIPTION
Fix tests in an iterative approach

After fixing all conflicts, three regression tests failed:

1) the triggers test failed because new tests were added to it without taking
into account the features of the GPDB, which still does not support
statement-level triggers

2) the inherit test failed because a new test was added to it, the output of
which for the GPDB is significantly different from vanilla postgres

3) the updatable_views test failed because it duplicated the output

Ticket: ADBDEV-7251