### PR TITLE
ADBDEV-7238: Resolve conflict in contrib/hstore/Makefile

### DIFF
--- a/contrib/hstore/Makefile
+++ b/contrib/hstore/Makefile
@@ -15,12 +15,8 @@ PGFILEDESC = "hstore - key/value pair data type"
 
 HEADERS = hstore.h
 
-<<<<<<< HEAD
-REGRESS = hstore
-REGRESS_OPTS += --init-file=$(top_builddir)/src/test/regress/init_file
-=======
 REGRESS = hstore hstore_utf8
->>>>>>> REL_12_17
+REGRESS_OPTS += --init-file=$(top_builddir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config


### PR DESCRIPTION
Resolve conflict in contrib/hstore/Makefile

The conflict was caused by commit edf1de6 adding a new hstore_utf8 test, while
the earlier commit 8ad51a0 added options.

Ticket: ADBDEV-7238