### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/access/brin/brin_tuple.c

### DIFF
--- a/src/backend/access/brin/brin_tuple.c
+++ b/src/backend/access/brin/brin_tuple.c
@@ -370,7 +370,6 @@ brin_form_placeholder_tuple(BrinDesc *brdesc, BlockNumber blkno, Size *size)
 	rettuple->bt_blkno = blkno;
 	rettuple->bt_info = hoff;
 	rettuple->bt_info |= BRIN_NULLS_MASK | BRIN_PLACEHOLDER_MASK | BRIN_EMPTY_RANGE_MASK;
-<<<<<<< HEAD
 
 	bitP = ((bits8 *) ((char *) rettuple + SizeOfBrinTuple)) - 1;
 	bitmask = HIGHBIT;
@@ -417,8 +416,6 @@ brin_form_empty_tuple(BrinDesc *brdesc, BlockNumber blkno, Size *size)
 	rettuple->bt_blkno = blkno;
 	rettuple->bt_info = hoff;
 	rettuple->bt_info |= BRIN_NULLS_MASK | BRIN_EMPTY_RANGE_MASK;
-=======
->>>>>>> REL_12_17
 
 	bitP = ((bits8 *) ((char *) rettuple + SizeOfBrinTuple)) - 1;
 	bitmask = HIGHBIT;


### PR DESCRIPTION
Resolve conflict in src/backend/access/brin/brin_tuple.c

The conflict was caused by commit d78a66d adding usage of the new mask
BRIN_EMPTY_RANGE_MASK to the brin_form_placeholder_tuple function, while the
earlier GPDB-specific commit a442c05 added a similar brin_form_empty_tuple
function below for ao/co tables.

Ticket: ADBDEV-7238