### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/access/brin/brin.c

### DIFF
--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -895,11 +895,8 @@ brinbuildCallback(Relation index,
 		if (has_nulls && !(col->bv_hasnulls || col->bv_allnulls))
 			col->bv_hasnulls = true;
 	}
-<<<<<<< HEAD
 	/* GPDB: Additional accounting in the build state for AO/CO relations */
 	state->bs_aoHasDataTuple = true;
-=======
->>>>>>> REL_12_17
 
 	/*
 	 * After updating summaries for all the keys, mark it as not empty.


### PR DESCRIPTION
Resolve conflict in src/backend/access/brin/brin.c

The conflict was caused by commit d78a66d adding the bt_empty_range mark at the
end of the brinbuildCallback function, while the earlier GPDB-specific commit
c5a4334 added the bs_aoHasDataTuple mark at the same place in the same function
for ao/co tables.

Ticket: ADBDEV-7238