### PR TITLE
Resolve conflicts in the src/backend/commands/foreigncmds.c

### DIFF
--- a/src/backend/commands/foreigncmds.c
+++ b/src/backend/commands/foreigncmds.c
@@ -502,10 +502,6 @@ static Oid
 lookup_fdw_handler_func(DefElem *handler)
 {
 	Oid			handlerOid;
-<<<<<<< HEAD
-=======
-	Oid			funcargtypes[1] = {0};	/* dummy */
->>>>>>> REL_12_17
 
 	if (handler == NULL || handler->arg == NULL)
 		return InvalidOid;


### PR DESCRIPTION
The variable changed in f06e1711d2e64aa6f56fe7aee49d56ea085ed002 was deleted by
the newer commit 907d4d07e614cf80b8401a7801263f62be7d9d64