### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/commands/schemacmds.c

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -71,7 +71,6 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 	AclResult	aclresult;
 	ObjectAddress address;
 	StringInfoData pathbuf;
-<<<<<<< HEAD
 	bool		shouldDispatch = (Gp_role == GP_ROLE_DISPATCH && 
 								  !IsBootstrapProcessingMode());
 
@@ -93,8 +92,6 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 		InitTempTableNamespace();
 		return InvalidOid;
 	}
-=======
->>>>>>> REL_12_17
 
 	GetUserIdAndSecContext(&saved_uid, &save_sec_context);
 


### PR DESCRIPTION
Resolve conflict in src/backend/commands/schemacmds.c

The conflict was caused by commit 78119a0 adding a local variable pathbuf to
the CreateSchemaCommand function, while there was GPDB-specific code next to
that code.

Ticket: ADBDEV-7238