### PR TITLE
ADBDEV-7238: Resolve conflicts in src/test/subscription/t/100_bugs.pl

### DIFF
--- a/src/test/subscription/t/100_bugs.pl
+++ b/src/test/subscription/t/100_bugs.pl
@@ -1,15 +1,9 @@
 # Tests for various bugs found over time
 use strict;
 use warnings;
-<<<<<<< HEAD
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-=======
-use PostgresNode;
-use TestLib;
-use Test::More tests => 7;
->>>>>>> REL_12_17
 
 # Bug #15114
 
@@ -186,9 +180,6 @@ is( $node_subscriber->safe_psql(
 $node_publisher->stop('fast');
 $node_subscriber->stop('fast');
 
-<<<<<<< HEAD
-done_testing();
-=======
 # The bug was that when the REPLICA IDENTITY FULL is used with dropped or
 # generated columns, we fail to apply updates and deletes
 my $node_publisher_d_cols = get_new_node('node_publisher_d_cols');
@@ -253,4 +244,5 @@ is( $node_subscriber_d_cols->safe_psql(
 
 $node_publisher_d_cols->stop('fast');
 $node_subscriber_d_cols->stop('fast');
->>>>>>> REL_12_17
+
+done_testing();


### PR DESCRIPTION
Resolve conflicts in src/test/subscription/t/100_bugs.pl

The first conflict was caused by commit dfa774f adding this new test, while
this test was already cherry-picked earlier, and commits a3de0a6 and 8e2409f
already made fixes to it.

The second conflict was caused by commit 0f2d4ad adding new tests to the end of
the file, while commit 8e2409f previously added done_testing to the end of the
same file.

Ticket: ADBDEV-7238