### PR TITLE
ADBDEV-7233: Resolve conflicts in src/backend/executor/nodeWindowAgg.c

### DIFF
--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -44,7 +44,6 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
-#include "optimizer/optimizer.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_oper.h"

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -43,11 +43,8 @@
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-<<<<<<< HEAD
-=======
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
->>>>>>> REL_12_17
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_oper.h"


### PR DESCRIPTION
Resolve conflicts in src/backed/executir/nodeWindowAgg.c

Conflict is caused by additional #include's in GPDB near Postgres's #include's.
optimizer.h is already included below.