### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/executor/nodeWindowAgg.c

### DIFF
--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -43,11 +43,8 @@
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-<<<<<<< HEAD
-=======
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
->>>>>>> REL_12_17
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_oper.h"


### PR DESCRIPTION
Resolve conflict in src/backend/executor/nodeWindowAgg.c

The conflict was caused by the fact that commit ac55abd added an include
optimizer/clauses.h, while the earlier commit f09346a had already replaced the
same include with optimizer/optimizer.h.

Ticket: ADBDEV-7238