### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/optimizer/path/joinpath.c

### DIFF
--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -24,15 +24,12 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
 #include "optimizer/planmain.h"
-<<<<<<< HEAD
+#include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "utils/lsyscache.h"
 
 #include "executor/nodeHash.h"                  /* ExecHashRowSize() */
 #include "cdb/cdbpath.h"                        /* cdbpath_rows() */
-=======
-#include "optimizer/restrictinfo.h"
->>>>>>> REL_12_17
 
 /* Hook for plugins to get control in add_paths_to_joinrel() */
 set_join_pathlist_hook_type set_join_pathlist_hook = NULL;
@@ -375,8 +372,8 @@ add_paths_to_joinrel(PlannerInfo *root,
 	 * permissions as, give the FDW a chance to push down joins.
 	 */
 	if (joinrel->fdwroutine &&
-<<<<<<< HEAD
-		joinrel->fdwroutine->GetForeignJoinPaths)
+		joinrel->fdwroutine->GetForeignJoinPaths &&
+		consider_join_pushdown)
 	{
 		if(joinrel->exec_location != FTEXECLOCATION_ALL_SEGMENTS ||
 		   !joinrel->fdwroutine->IsMPPPlanNeeded || joinrel->fdwroutine->IsMPPPlanNeeded() == 0)
@@ -386,13 +383,6 @@ add_paths_to_joinrel(PlannerInfo *root,
 													 jointype, &extra);
 		}
 	}
-=======
-		joinrel->fdwroutine->GetForeignJoinPaths &&
-		consider_join_pushdown)
-		joinrel->fdwroutine->GetForeignJoinPaths(root, joinrel,
-												 outerrel, innerrel,
-												 jointype, &extra);
->>>>>>> REL_12_17
 
 	/*
 	 * 6. Finally, give extensions a chance to manipulate the path list.  They


### PR DESCRIPTION
Resolve conflicts in src/backend/optimizer/path/joinpath.c

The first conflict was caused by commit 9edf72a adding an include
optimizer/restrictinfo.h, while the earlier commit 9628a33 had already added an
include optimizer/tlist.h to the same place.

The second conflict was caused by commit 9edf72a adding consider_join_pushdown
to the condition, while the earlier GPDB-specific commit b7617ac had added more
conditions just below.

Ticket: ADBDEV-7238