### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/postmaster/postmaster.c

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2378,9 +2378,6 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 
 	if (proto == CANCEL_REQUEST_CODE || proto == FINISH_REQUEST_CODE)
 	{
-<<<<<<< HEAD
-		processCancelRequest(port, buf, proto);
-=======
 		if (len != sizeof(CancelRequestPacket))
 		{
 			ereport(COMMERROR,
@@ -2388,8 +2385,7 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 					 errmsg("invalid length of startup packet")));
 			return STATUS_ERROR;
 		}
-		processCancelRequest(port, buf);
->>>>>>> REL_12_17
+		processCancelRequest(port, buf, proto);
 		/* Not really an error, but we don't want to proceed further */
 		return STATUS_ERROR;
 	}


### PR DESCRIPTION
Resolve conflict in src/backend/postmaster/postmaster.c

The conflict was caused by commit e75b5c8 adding a rejection to cancel a
request if the length is incorrect, while the earlier commit 6b0e52b just below
added a third argument to the processCancelRequest function call.

Ticket: ADBDEV-7238