### PR TITLE
Resolve conflicts in the src/backend/jit/llvm/llvmjit_expr.c

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -161,17 +161,6 @@ llvm_compile_expr(ExprState *state)
 
 	LLVMPositionBuilderAtEnd(b, entry);
 
-<<<<<<< HEAD
-	v_tmpvaluep = LLVMBuildStructGEP(b, v_state,
-									 FIELDNO_EXPRSTATE_RESVALUE,
-									 "v.state.resvalue");
-	v_tmpisnullp = LLVMBuildStructGEP(b, v_state,
-									  FIELDNO_EXPRSTATE_RESNULL,
-									  "v.state.resnull");
-	v_parent = l_load_struct_gep(b, v_state,
-								 FIELDNO_EXPRSTATE_PARENT,
-								 "v.state.parent");
-=======
 	v_tmpvaluep = l_struct_gep(b,
 							   StructExprState,
 							   v_state,
@@ -182,7 +171,9 @@ llvm_compile_expr(ExprState *state)
 								v_state,
 								FIELDNO_EXPRSTATE_RESNULL,
 								"v.state.resnull");
->>>>>>> REL_12_17
+	v_parent = l_load_struct_gep(b, v_state,
+								 FIELDNO_EXPRSTATE_PARENT,
+								 "v.state.parent");
 
 	/* build global slots */
 	v_scanslot = l_load_struct_gep(b,


### PR DESCRIPTION
Commit 15ddc9725eb73d97a16652c7c90d993302773544 was in conflict with
GPDB-specific code. GPDB specific code does not require edits as it already uses
the correct LLVM functions.