### PR TITLE
ADBDEV-7238: Resolve conflicts in src/backend/storage/buffer/bufmgr.c

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -3351,15 +3351,9 @@ FlushRelationBuffers(Relation rel)
 	int			i;
 	BufferDesc *bufHdr;
 
-<<<<<<< HEAD
-	/* Open rel at the smgr level if not already done */
-	RelationOpenSmgr(rel);
-
 	if (!RelationUsesBufferManager(rel))
 		return;
 
-=======
->>>>>>> REL_12_17
 	if (RelationUsesLocalBuffers(rel))
 	{
 		for (i = 0; i < NLocBuffer; i++)
@@ -3424,15 +3418,9 @@ FlushRelationBuffers(Relation rel)
 			(buf_state & (BM_VALID | BM_DIRTY)) == (BM_VALID | BM_DIRTY))
 		{
 			PinBuffer_Locked(bufHdr);
-<<<<<<< HEAD
 			AcquireContentLock(bufHdr, LW_SHARED);
-			FlushBuffer(bufHdr, rel->rd_smgr);
-			ReleaseContentLock(bufHdr);
-=======
-			LWLockAcquire(BufferDescriptorGetContentLock(bufHdr), LW_SHARED);
 			FlushBuffer(bufHdr, RelationGetSmgr(rel));
-			LWLockRelease(BufferDescriptorGetContentLock(bufHdr));
->>>>>>> REL_12_17
+			ReleaseContentLock(bufHdr);
 			UnpinBuffer(bufHdr, true);
 		}
 		else

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -658,7 +658,7 @@ RelationGetSmgr(Relation rel)
  * that do not use shared/local buffers.
  */
 #define RelationUsesBufferManager(relation) \
-	((relation)->rd_smgr->smgr_which == SMGR_MD)
+	(RelationGetSmgr(relation)->smgr_which == SMGR_MD)
 
 /*
  * RelationUsesTempNamespace


### PR DESCRIPTION
Resolve conflicts in src/backend/storage/buffer/bufmgr.c

The first conflict was caused by commit e21856f removing the call to
RelationOpenSmgr in the FlushRelationBuffers function, while the earlier commit
19cd1cf added a check right after that call.

The second conflict was caused by commit e21856f replacing RelationOpenSmgr
with RelationGetSmgr in the FlushRelationBuffers function, while the earlier
commit 6b0e52b replaced the locks around the same place with protected ones.

This patch also adds the use of the RelationGetSmgr function to the
RelationUsesBufferManager macro.

Ticket: ADBDEV-7238