### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/storage/ipc/ipc.c

### DIFF
--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -103,10 +103,8 @@ static int	on_proc_exit_index,
 void
 proc_exit(int code)
 {
-<<<<<<< HEAD
 	pqsignal(SIGALRM, SIG_IGN);
-=======
->>>>>>> REL_12_17
+
 	/* not safe if forked by system(), etc. */
 	if (MyProcPid != (int) getpid())
 		elog(PANIC, "proc_exit() called in child process");


### PR DESCRIPTION
Resolve conflict in src/backend/storage/ipc/ipc.c

The conflict was caused by the fact that commit e2e1690 added a condition at
the very beginning of the proc_exit function, while the earlier commit 6b0e52b
had already added ignoring the signal there.

Ticket: ADBDEV-7238