### PR TITLE
ADBDEV-7233: Resolve conflicts in src/backend/utils/ruleutils.c

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -10687,58 +10687,7 @@ get_from_clause_item(Node *jtnode, Query *query, deparse_context *context)
 		}
 
 		/* Print the relation alias, if needed */
-<<<<<<< HEAD
-		printalias = false;
-		if (rte->alias != NULL)
-		{
-			/* Always print alias if user provided one */
-			printalias = true;
-		}
-		else if (colinfo->printaliases)
-		{
-			/* Always print alias if we need to print column aliases */
-			printalias = true;
-		}
-		else if (rte->rtekind == RTE_RELATION)
-		{
-			/*
-			 * No need to print alias if it's same as relation name (this
-			 * would normally be the case, but not if set_rtable_names had to
-			 * resolve a conflict).
-			 */
-			if (strcmp(refname, get_relation_name(rte->relid)) != 0)
-				printalias = true;
-		}
-		else if (rte->rtekind == RTE_FUNCTION || rte->rtekind == RTE_TABLEFUNCTION)
-		{
-			/*
-			 * For a function RTE, always print alias.  This covers possible
-			 * renaming of the function and/or instability of the
-			 * FigureColname rules for things that aren't simple functions.
-			 * Note we'd need to force it anyway for the columndef list case.
-			 */
-			printalias = true;
-		}
-		else if (rte->rtekind == RTE_VALUES)
-		{
-			/* Alias is syntactically required for VALUES */
-			printalias = true;
-		}
-		else if (rte->rtekind == RTE_CTE)
-		{
-			/*
-			 * No need to print alias if it's same as CTE name (this would
-			 * normally be the case, but not if set_rtable_names had to
-			 * resolve a conflict).
-			 */
-			if (strcmp(refname, rte->ctename) != 0)
-				printalias = true;
-		}
-		if (printalias)
-			appendStringInfo(buf, " %s", quote_identifier(refname));
-=======
 		get_rte_alias(rte, varno, false, context);
->>>>>>> REL_12_17
 
 		/* Print the column definitions or aliases, if needed */
 		if (rtfunc1 && rtfunc1->funccolnames != NIL)
@@ -10906,7 +10855,7 @@ get_rte_alias(RangeTblEntry *rte, int varno, bool use_as,
 		if (strcmp(refname, get_relation_name(rte->relid)) != 0)
 			printalias = true;
 	}
-	else if (rte->rtekind == RTE_FUNCTION)
+	else if (rte->rtekind == RTE_FUNCTION || rte->rtekind == RTE_TABLEFUNCTION)
 	{
 		/*
 		 * For a function RTE, always print alias.  This covers possible


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/ruleutils.c

This was caused by commit 3dd287c14facd5ee17e386175752a75ce16a1daa conflicting
with GPDB's initial code dump. GPDB additionally handles RTE_TABLEFUNCTION
case, so added it to the function added by Postgres's commit.