### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/storage/lmgr/proc.c

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -986,10 +986,8 @@ ProcKill(int code, Datum arg)
 
 	Assert(MyProc != NULL);
 
-<<<<<<< HEAD
 	SIMPLE_FAULT_INJECTOR("proc_kill");
-=======
->>>>>>> REL_12_17
+
 	/* not safe if forked by system(), etc. */
 	if (MyProc->pid != (int) getpid())
 		elog(PANIC, "ProcKill() called in child process");


### PR DESCRIPTION
Resolve conflict in src/backend/storage/lmgr/proc.c

The conflict was caused by the fact that commit e2e1690 added a condition to
the beginning of the ProcKill function after the assert, while the earlier
commit efb373a had already added a fault injector to the same place.

Ticket: ADBDEV-7238