### PR TITLE
ADBDEV-7233: Resolve conflicts in src/backend/utils/misc/guc.c

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -9498,68 +9498,8 @@ get_explain_guc_options(int *num)
 			 !is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_ALL_SETTINGS)))
 			continue;
 
-<<<<<<< HEAD
 		/* skip GUC variables that match the built-in default */
 		if (!is_guc_modified(conf))
-=======
-		/* return only options that are different from their boot values */
-		modified = false;
-
-		switch (conf->vartype)
-		{
-			case PGC_BOOL:
-				{
-					struct config_bool *lconf = (struct config_bool *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_INT:
-				{
-					struct config_int *lconf = (struct config_int *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_REAL:
-				{
-					struct config_real *lconf = (struct config_real *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			case PGC_STRING:
-				{
-					struct config_string *lconf = (struct config_string *) conf;
-
-					if (lconf->boot_val == NULL &&
-						*lconf->variable == NULL)
-						modified = false;
-					else if (lconf->boot_val == NULL ||
-							 *lconf->variable == NULL)
-						modified = true;
-					else
-						modified = (strcmp(lconf->boot_val, *(lconf->variable)) != 0);
-				}
-				break;
-
-			case PGC_ENUM:
-				{
-					struct config_enum *lconf = (struct config_enum *) conf;
-
-					modified = (lconf->boot_val != *(lconf->variable));
-				}
-				break;
-
-			default:
-				elog(ERROR, "unexpected GUC type: %d", conf->vartype);
-		}
-
-		if (!modified)
->>>>>>> REL_12_17
 			continue;
 
 		/* OK, report it */


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/misc/guc.c

Conflict was caused by GPDB commit bd7453030e9542dbac2241923ee18b83af35528d
moving code into is_guc_modified function. Relevant Postgres's commit
65810fc6d0f6ccd3166713b9ec2f856be535383f was already applied.