### PR TITLE
ADBDEV-7238: Resolve conflict in src/backend/utils/mmgr/aset.c

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -1320,7 +1320,6 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 	VALGRIND_MAKE_MEM_DEFINED(chunk, ALLOCCHUNK_PRIVATE_LEN);
 
 	oldchksize = chunk->size;
-<<<<<<< HEAD
 
 #ifdef USE_ASSERT_CHECKING
 	if (IsUnderPostmaster  && context != ErrorContext && mainthread() != 0 && !pthread_equal(main_tid, pthread_self()))
@@ -1332,8 +1331,6 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 #endif
 	}
 #endif
-=======
->>>>>>> REL_12_17
 
 #ifdef MEMORY_CONTEXT_CHECKING
 	/* Test for someone scribbling on unused space in chunk */


### PR DESCRIPTION
Resolve conflict in src/backend/utils/mmgr/aset.c

The conflict was caused by commit 463bef3 renaming the local variable oldsize
to oldchksize in the AllocSetRealloc function, while the earlier commit 6b0e52b
added a check near the same place to ensure that the function was not called
from a thread.

Ticket: ADBDEV-7238