### PR TITLE
ADBDEV-7238: Resolve conflict in src/include/pg_config.h.in

### DIFF
--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -797,13 +797,11 @@
 /* Define to 1 if you have the <winldap.h> header file. */
 #undef HAVE_WINLDAP_H
 
-<<<<<<< HEAD
 /* Define to 1 if you have the <winsock2.h> header file. */
 #undef HAVE_WINSOCK2_H
-=======
+
 /* Define to 1 if you have the `X509_get_signature_info' function. */
 #undef HAVE_X509_GET_SIGNATURE_INFO
->>>>>>> REL_12_17
 
 /* Define to 1 if you have the `X509_get_signature_nid' function. */
 #undef HAVE_X509_GET_SIGNATURE_NID


### PR DESCRIPTION
Resolve conflict in src/include/pg_config.h.in

The conflict was caused by commit a40e7b7 adding HAVE_X509_GET_SIGNATURE_INFO,
while the earlier commit a453004 had already added HAVE_WINSOCK2_H in the same
place.

Ticket: ADBDEV-7238