### PR TITLE
ADBDEV-7238: Resolve conflict in src/test/isolation/isolation_schedule

### DIFF
--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -133,9 +133,9 @@ test: partition-key-update-3
 test: partition-key-update-4
 test: plpgsql-toast
 test: truncate-conflict
-<<<<<<< HEAD
 #test: serializable-parallel
 #test: serializable-parallel-2
+#test: serializable-parallel-3
 
 #test: prepared-transactions
 
@@ -146,8 +146,3 @@ test: ao-repeatable-read-vacuum
 
 test: ao-insert-eof create_index_hot udf-insert-deadlock heap-repeatable-read ao-repeatable-read
 test: vacuum-ao-concurrent-drop
-=======
-test: serializable-parallel
-test: serializable-parallel-2
-test: serializable-parallel-3
->>>>>>> REL_12_17


### PR DESCRIPTION
Resolve conflict in src/test/isolation/isolation_schedule

The conflict was caused by the fact that commit afa122e added a new test
serializable-parallel-3, while the earlier commit 19cd1cf had already disabled
the two previous tests.

Ticket: ADBDEV-7238