### PR TITLE
Resolve conflicts in the Perl tests

### DIFF
--- a/src/bin/scripts/t/011_clusterdb_all.pl
+++ b/src/bin/scripts/t/011_clusterdb_all.pl
@@ -1,15 +1,9 @@
 use strict;
 use warnings;
 
-<<<<<<< HEAD
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-=======
-use PostgresNode;
-use TestLib;
-use Test::More tests => 4;
->>>>>>> REL_12_17
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -24,9 +18,6 @@ $node->issues_sql_like(
 	qr/statement: CLUSTER.*statement: CLUSTER/s,
 	'cluster all databases');
 
-<<<<<<< HEAD
-done_testing();
-=======
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
@@ -39,4 +30,5 @@ $node->command_ok([ 'clusterdb', '-a' ],
 # invalid database in 010_clusterdb.pl as well.
 $node->command_fails([ 'clusterdb', '-d', 'regression_invalid'],
   'clusterdb cannot target invalid database');
->>>>>>> REL_12_17
+
+done_testing();

--- a/src/bin/scripts/t/050_dropdb.pl
+++ b/src/bin/scripts/t/050_dropdb.pl
@@ -1,15 +1,9 @@
 use strict;
 use warnings;
 
-<<<<<<< HEAD
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
-=======
-use PostgresNode;
-use TestLib;
-use Test::More tests => 12;
->>>>>>> REL_12_17
 
 program_help_ok('dropdb');
 program_version_ok('dropdb');
@@ -28,9 +22,6 @@ $node->issues_sql_like(
 $node->command_fails([ 'dropdb', 'nonexistent' ],
 	'fails with nonexistent database');
 
-<<<<<<< HEAD
-done_testing();
-=======
 # check that invalid database can be dropped with dropdb
 $node->safe_psql(
 	'postgres', q(
@@ -39,4 +30,5 @@ $node->safe_psql(
 ));
 $node->command_ok([ 'dropdb', 'regression_invalid' ],
   'invalid database can be dropped');
->>>>>>> REL_12_17
+
+done_testing();

--- a/src/bin/scripts/t/091_reindexdb_all.pl
+++ b/src/bin/scripts/t/091_reindexdb_all.pl
@@ -1,13 +1,8 @@
 use strict;
 use warnings;
 
-<<<<<<< HEAD
 use PostgreSQL::Test::Cluster;
 use Test::More;
-=======
-use PostgresNode;
-use Test::More tests => 4;
->>>>>>> REL_12_17
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -20,9 +15,6 @@ $node->issues_sql_like(
 	qr/statement: REINDEX.*statement: REINDEX/s,
 	'reindex all databases');
 
-<<<<<<< HEAD
-done_testing();
-=======
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
@@ -35,4 +27,5 @@ $node->command_ok([ 'reindexdb', '-a' ],
 # invalid database in 090_reindexdb.pl as well.
 $node->command_fails([ 'reindexdb', '-d', 'regression_invalid'],
   'reindexdb cannot target invalid database');
->>>>>>> REL_12_17
+
+done_testing();

--- a/src/bin/scripts/t/101_vacuumdb_all.pl
+++ b/src/bin/scripts/t/101_vacuumdb_all.pl
@@ -1,13 +1,8 @@
 use strict;
 use warnings;
 
-<<<<<<< HEAD
 use PostgreSQL::Test::Cluster;
 use Test::More;
-=======
-use PostgresNode;
-use Test::More tests => 4;
->>>>>>> REL_12_17
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
@@ -18,9 +13,6 @@ $node->issues_sql_like(
 	qr/statement: VACUUM.*statement: VACUUM/s,
 	'vacuum all databases');
 
-<<<<<<< HEAD
-done_testing();
-=======
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
@@ -33,4 +25,5 @@ $node->command_ok([ 'vacuumdb', '-a' ],
 # invalid database in 010_vacuumdb.pl as well.
 $node->command_fails([ 'vacuumdb', '-d', 'regression_invalid'],
   'vacuumdb cannot target invalid database');
->>>>>>> REL_12_17
+
+done_testing();


### PR DESCRIPTION
Resolve conflicts in the:
1. src/bin/scripts/t/011_clusterdb_all.pl
2. src/bin/scripts/t/050_dropdb.pl
3. src/bin/scripts/t/091_reindexdb_all.pl
4. src/bin/scripts/t/101_vacuumdb_all.pl

Commit a3de0a65b6ef4cf864eca150b7fa94c5ce98b71a moved some Perl modules that are
used in the tests.
Commit 034a9fcd2bb8e8ac49165e983a44e8805c8a7c63 added a new tests that was in the
conflict with done_tesing from 8e2409ff3c5ab05b25935b5b0ce7c9b39cef6e6c.