### PR TITLE
ADBDEV-7238: Resolve conflicts in subselect

### DIFF
--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -94,16 +94,12 @@ static bool subplan_is_hashable(PlannerInfo *root, Plan *plan);
 static bool subpath_is_hashable(PlannerInfo *root, Path *path);
 static bool test_opexpr_is_hashable(OpExpr *testexpr, List *param_ids);
 static bool hash_ok_operator(OpExpr *expr);
-<<<<<<< HEAD
-static bool SS_make_multiexprs_unique_walker(Node *node, void *context);
 #if 0
 /*
  * The following several functions are used by SS_process_ctes.
  * But SS_process_ctes is commentted of because gpdb does not
  * use it.
  */
-=======
->>>>>>> REL_12_17
 static bool contain_dml(Node *node);
 static bool contain_dml_walker(Node *node, void *context);
 static bool contain_outer_selfref(Node *node);

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -18,12 +18,8 @@
 #include "nodes/pathnodes.h"
 #include "nodes/plannodes.h"
 
-<<<<<<< HEAD
-extern void SS_make_multiexprs_unique(PlannerInfo *root, PlannerInfo *subroot);
 #if 0
 /* Not used in GPDB */
-=======
->>>>>>> REL_12_17
 extern void SS_process_ctes(PlannerInfo *root);
 #endif
 extern Node *convert_testexpr(PlannerInfo *root,


### PR DESCRIPTION
Resolve conflicts in subselect

The conflict in src/include/optimizer/subselect.h was caused by commit 904b171
removing the prototype of the SS_make_multiexprs_unique function, while the
earlier commit dd9ee7fb had already disabled the SS_process_ctes function
nearby.

The conflict in src/backend/optimizer/plan/subselect.c was caused by commit
904b171 removing the prototype of the SS_make_multiexprs_unique_walker
function, while the earlier commit 19cd1cf had already disabled several
functions nearby.

Ticket: ADBDEV-7238