### PR TITLE
ADBDEV-7240: Resolve conflicts in tablecmds.c

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15916,15 +15916,11 @@ index_copy_data(Relation rel, RelFileNode newrnode)
 {
 	SMgrRelation dstrel;
 
-<<<<<<< HEAD
 	SMgrImpl smgr_which = RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD;
 
 	dstrel = smgropen(newrnode, rel->rd_backend, smgr_which);
 					  
 	RelationOpenSmgr(rel);
-=======
-	dstrel = smgropen(newrnode, rel->rd_backend);
->>>>>>> REL_12_17
 
 	/*
 	 * Since we copy the file directly without looking at the shared buffers,
@@ -15962,13 +15958,8 @@ index_copy_data(Relation rel, RelFileNode newrnode)
 			if (rel->rd_rel->relpersistence == RELPERSISTENCE_PERMANENT ||
 				(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED &&
 				 forkNum == INIT_FORKNUM))
-<<<<<<< HEAD
-				log_smgrcreate(&newrnode, forkNum, smgr_which);
-			RelationCopyStorage(rel->rd_smgr, dstrel, forkNum,
-=======
-				log_smgrcreate(&newrnode, forkNum);
+				log_smgrcreate(&newrnode, forkNum, smgr_which);				
 			RelationCopyStorage(RelationGetSmgr(rel), dstrel, forkNum,
->>>>>>> REL_12_17
 								rel->rd_rel->relpersistence);
 		}
 	}


### PR DESCRIPTION
Conflict 1: Commit d25f519107bf introduced function `index_copy_data` into PG
Commit 19cd1cf4b68f merged it to GPDB with GPDB-specific additions which are
still in the diff.

Conflict 2: Same commit d25f519107bf introduced function `index_copy_data` into
PG and commit 19cd1cf4b68f merged it to GPDB. Atfer that commit e21856fd652a
introduced RelationGetSmgr in PG. While in GP commit fb20cfd9eafc added argument
to function `log_smgrcreate`
