### PR TITLE
ADBDEV-7237: Fix cluster expansion on builds without IC proxy

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2050,28 +2050,24 @@ class gpexpand:
         And prompt user to set a proper value via gpconfig before expansion.
         """
 
-        conn = dbconn.connect(_gp_expand.dburl, encoding='UTF8')
-        # get GUC value: gp_interconnect_proxy_addresses
-        try:
-            sql = "show gp_interconnect_proxy_addresses;"
-            cursor = dbconn.execSQL(conn, sql)
-            icproxy_addresses_string = cursor.fetchone()[0].strip()
-            cursor.close()
-        except Exception as e:
-            if 'unrecognized configuration parameter' in str(e):
-                self.logger.info("gp_interconnect_proxy_addresses GUC does not exist, skipping IC Proxy validation.")
-                conn.close()
-                return
-            else:
-                conn.close()
+        with closing (dbconn.connect(_gp_expand.dburl, encoding='UTF8')) as conn:
+            # get GUC value: gp_interconnect_proxy_addresses
+            try:
+                sql = "show gp_interconnect_proxy_addresses;"
+                cursor = dbconn.execSQL(conn, sql)
+                icproxy_addresses_string = cursor.fetchone()[0].strip()
+                cursor.close()
+            except DatabaseError as ex:
+                if re.search("unrecognized configuration parameter", ex.__str__()):
+                    self.logger.info("gp_interconnect_proxy_addresses GUC does not exist, skipping IC Proxy validation.")
+                    return
                 raise
 
-        # get GUC value: gp_interconnect_type
-        sql = "show gp_interconnect_type;"
-        cursor = dbconn.execSQL(conn, sql)
-        ic_type = cursor.fetchone()[0].strip()
-        cursor.close()
-        conn.close()
+            # get GUC value: gp_interconnect_type
+            sql = "show gp_interconnect_type;"
+            cursor = dbconn.execSQL(conn, sql)
+            ic_type = cursor.fetchone()[0].strip()
+            cursor.close()
 
         # check if newly added dbid exists in gp_interconnect_proxy_addresses
         need_prompt = False

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2053,10 +2053,7 @@ class gpexpand:
         with closing (dbconn.connect(_gp_expand.dburl, encoding='UTF8')) as conn:
             # get GUC value: gp_interconnect_proxy_addresses
             try:
-                sql = "show gp_interconnect_proxy_addresses;"
-                cursor = dbconn.execSQL(conn, sql)
-                icproxy_addresses_string = cursor.fetchone()[0].strip()
-                cursor.close()
+                icproxy_addresses_string = catalog.getSessionGUC(conn, 'gp_interconnect_proxy_addresses').strip()
             except DatabaseError as ex:
                 # If the error indicates that the GUC "gp_interconnect_proxy_addresses" is not recognized,
                 # it means the cluster was built without this option, for example,
@@ -2067,10 +2064,7 @@ class gpexpand:
                 raise
 
             # get GUC value: gp_interconnect_type
-            sql = "show gp_interconnect_type;"
-            cursor = dbconn.execSQL(conn, sql)
-            ic_type = cursor.fetchone()[0].strip()
-            cursor.close()
+            ic_type = catalog.getSessionGUC(conn, 'gp_interconnect_type').strip()
 
         # check if newly added dbid exists in gp_interconnect_proxy_addresses
         need_prompt = False

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2052,10 +2052,20 @@ class gpexpand:
 
         conn = dbconn.connect(_gp_expand.dburl, encoding='UTF8')
         # get GUC value: gp_interconnect_proxy_addresses
-        sql = "show gp_interconnect_proxy_addresses;"
-        cursor = dbconn.execSQL(conn, sql)
-        icproxy_addresses_string = cursor.fetchone()[0].strip()
-        cursor.close()
+        try:
+            sql = "show gp_interconnect_proxy_addresses;"
+            cursor = dbconn.execSQL(conn, sql)
+            icproxy_addresses_string = cursor.fetchone()[0].strip()
+            cursor.close()
+        except Exception as e:
+            if 'unrecognized configuration parameter' in str(e):
+                self.logger.info("gp_interconnect_proxy_addresses GUC does not exist, skipping IC Proxy validation.")
+                conn.close()
+                return
+            else:
+                conn.close()
+                raise
+
         # get GUC value: gp_interconnect_type
         sql = "show gp_interconnect_type;"
         cursor = dbconn.execSQL(conn, sql)

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2058,6 +2058,9 @@ class gpexpand:
                 icproxy_addresses_string = cursor.fetchone()[0].strip()
                 cursor.close()
             except DatabaseError as ex:
+                # If the error indicates that the GUC "gp_interconnect_proxy_addresses" is not recognized,
+                # it means the cluster is not using IC Proxy mode (or the feature is not enabled).
+                # In this case, we simply return without raising an error.
                 if re.search("unrecognized configuration parameter", ex.__str__()):
                     return
                 raise

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2059,7 +2059,6 @@ class gpexpand:
                 cursor.close()
             except DatabaseError as ex:
                 if re.search("unrecognized configuration parameter", ex.__str__()):
-                    self.logger.info("gp_interconnect_proxy_addresses GUC does not exist, skipping IC Proxy validation.")
                     return
                 raise
 

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2051,19 +2051,17 @@ class gpexpand:
         """
 
         with closing (dbconn.connect(_gp_expand.dburl, encoding='UTF8')) as conn:
-            # get GUC value: gp_interconnect_proxy_addresses
             try:
                 icproxy_addresses_string = catalog.getSessionGUC(conn, 'gp_interconnect_proxy_addresses').strip()
             except DatabaseError as ex:
-                # If the error indicates that the GUC "gp_interconnect_proxy_addresses" is not recognized,
-                # it means the cluster was built without this option, for example,
-                # the --enable-ic-proxy flag was not enabled during compilation.
+                # If the error indicates that gp_interconnect_proxy_addresses is not recognized,
+                # it means the cluster was built without this GUC, for example,
+                # the --enable-ic-proxy flag was not set during compilation.
                 # In this case, we simply return without raising an error.
                 if re.search("unrecognized configuration parameter", ex.__str__()):
                     return
                 raise
 
-            # get GUC value: gp_interconnect_type
             ic_type = catalog.getSessionGUC(conn, 'gp_interconnect_type').strip()
 
         # check if newly added dbid exists in gp_interconnect_proxy_addresses

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2059,7 +2059,8 @@ class gpexpand:
                 cursor.close()
             except DatabaseError as ex:
                 # If the error indicates that the GUC "gp_interconnect_proxy_addresses" is not recognized,
-                # it means the cluster is not using IC Proxy mode (or the feature is not enabled).
+                # it means the cluster was built without this option, for example,
+                # the --enable-ic-proxy flag was not enabled during compilation.
                 # In this case, we simply return without raising an error.
                 if re.search("unrecognized configuration parameter", ex.__str__()):
                     return


### PR DESCRIPTION
When running gpexpand on a GPDB cluster with udpifc as the interconnect type,
but using GPDB binaries built without the --enable-ic-proxy flag, the operation
failed because the gp_interconnect_proxy_addresses GUC is absent.

Сatch the "unrecognized configuration parameter" error because
gp_interconnect_proxy_addresses is not stored in pg_settings, so its presence
cannot be validated directly.

Tests are not added because it would require rebuilding the project without the
--enable-ic-proxy flag.
