### PR TITLE
Resolve conflicts in src/bin/pg_dump/pg_dump.h

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -340,10 +340,7 @@ typedef struct _tableInfo
 	uint32		toast_frozenxid;	/* toast table's relfrozenxid, if any */
 	uint32		toast_minmxid;	/* toast table's relminmxid */
 	int			ncheck;			/* # of CHECK expressions */
-<<<<<<< HEAD
 	Oid			reltype;		/* OID of table's composite type, if any */
-=======
->>>>>>> REL_12_17
 	Oid			reloftype;		/* underlying type for typed table */
 	/* these two are set only if table is a sequence owned by a column: */
 	Oid			owning_tab;		/* OID of table owning sequence */


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_dump/pg_dump.h

Conflict due to 0f6692822b7fceb2a6bae0c74e5cddba5cd6a000 already cherry-picked
from PG15.