### PR TITLE
ADBDEV-7233: Resolve conflicts in src/bin/pg_dump/common.c

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -322,7 +322,6 @@ flagInhTables(Archive *fout, TableInfo *tblinfo, int numTables,
 			continue;
 
 		/*
-<<<<<<< HEAD
 		 * FIXME: In PostgreSQL, foreign tables can be inherited. But
 		 * pg_dump chokes on external tables, if an external table is
 		 * used as a partition, and a column has attislocal=false.
@@ -331,18 +330,11 @@ flagInhTables(Archive *fout, TableInfo *tblinfo, int numTables,
 			continue;
 
 		/*
-		 * Normally, we don't bother computing anything for non-target tables,
-		 * but if load-via-partition-root is specified, we gather information
-		 * on every partition in the system so that getRootTableInfo can trace
-		 * from any given to leaf partition all the way up to the root.  (We
-		 * don't need to mark them as interesting for getTableAttrs, though.)
-=======
 		 * Normally, we don't bother computing anything for non-target tables.
 		 * However, we must find the parents of non-root partitioned tables in
 		 * any case, so that we can trace from leaf partitions up to the root
 		 * (in case a leaf is to be dumped but its parents are not).  We need
 		 * not mark such parents interesting for getTableAttrs, though.
->>>>>>> REL_12_17
 		 */
 		if (!tblinfo[i].dobj.dump)
 		{


### PR DESCRIPTION
Resolve conflicts in src/bin/pg_dump/common.c

Conflict caused by GPDB's commit b62e06014d1237ab9b3657e30609d2630954134d
adding condition for handling external tables and Postgres's change to the
comment nearby in commit 8f83ce8c5244ce40514e8643a648704d8c85baa9.
