### PR TITLE
ADBDEV-7238: Fix missing argument when calling smgropen

### DIFF
--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -579,7 +579,8 @@ static inline SMgrRelation
 RelationGetSmgr(Relation rel)
 {
 	if (unlikely(rel->rd_smgr == NULL))
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
+		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend,
+					 RelationStorageIsAO(rel) ? SMGR_AO : SMGR_MD));
 	return rel->rd_smgr;
 }
 #endif							/* !FRONTEND */


### PR DESCRIPTION
Fix missing argument when calling smgropen

Commit e21856f added a new function RelationGetSmgr to src/include/utils/rel.h,
which called smgropen with two arguments, while the earlier commit 19cd1cf had
already added a third argument to this function. This patch fixes this
inconsistency by adding a third argument when calling smgropen in
RelationGetSmgr, as is done in the similar deprecated macro RelationOpenSmgr.

Ticket: ADBDEV-7238