### PR TITLE
ADBDEV-7238: Fix missing argument when calling log_smgrcreate

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -3153,7 +3153,7 @@ index_build(Relation heapRelation,
 		!smgrexists(RelationGetSmgr(indexRelation), INIT_FORKNUM))
 	{
 		smgrcreate(RelationGetSmgr(indexRelation), INIT_FORKNUM, false);
-		log_smgrcreate(&indexRelation->rd_node, INIT_FORKNUM);
+		log_smgrcreate(&indexRelation->rd_node, INIT_FORKNUM, SMGR_MD);
 		indexRelation->rd_indam->ambuildempty(indexRelation);
 	}
 


### PR DESCRIPTION
Fix missing argument when calling log_smgrcreate

Commit 80abec3 added a two-argument log_smgrcreate call to index_build, while
the earlier commit fb20cfd had already added a third argument to that function.
This patch fixes that by adding a third argument, SMGR_MD, to the
log_smgrcreate call in index_build, because the index uses a heap storage
manager.

Ticket: ADBDEV-7238