### PR TITLE
ADBDEV-7238: Fix include in src/backend/access/common/heaptuple.c

### DIFF
--- a/src/backend/access/common/heaptuple.c
+++ b/src/backend/access/common/heaptuple.c
@@ -62,10 +62,10 @@
 #include "access/sysattr.h"
 #include "access/tupdesc_details.h"
 #include "access/tuptoaster.h"
+#include "common/hashfn.h"
 #include "executor/tuptable.h"
 #include "utils/datum.h"
 #include "utils/expandeddatum.h"
-#include "utils/hashutils.h"
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
 


### PR DESCRIPTION
Fix include in src/backend/access/common/heaptuple.c

Commit 01993ac added include utils/hashutils.h to
src/backend/access/common/heaptuple.c, while earlier commit 5d3dc2e had already
renamed this include to common/hashfn.h

Ticket: ADBDEV-7238