### PR TITLE
ADBDEV-7233: Fix compilation error in src/backed/utils/cache/typcache.c

### DIFF
--- a/src/backend/utils/cache/typcache.c
+++ b/src/backend/utils/cache/typcache.c
@@ -1753,13 +1753,11 @@ reset_record_cache(void)
 	if (RecordCacheArray != NULL)
 	{
 		Assert(RecordCacheArrayLen != 0);
-		Assert(RecordIdentifierArray != NULL);
+		Assert(RecordCacheArray != NULL);
 
 		pfree(RecordCacheArray);
-		pfree(RecordIdentifierArray);
 
 		RecordCacheArray = NULL;
-		RecordIdentifierArray = NULL;
 		RecordCacheArrayLen = 0;
 	}
 }
@@ -2277,7 +2275,7 @@ build_tuple_node_list(int start)
 
 	for (; i < NextRecordTypmod; i++)
 	{
-		TupleDesc tmp = RecordCacheArray[i];
+		TupleDesc tmp = RecordCacheArray[i].tupdesc;
 
 		TupleDescNode *node = palloc0(sizeof(TupleDescNode));
 		node->type = T_TupleDescNode;


### PR DESCRIPTION
Fix compilation error in src/backed/utils/cache/typcache.c

Previously commit 012b80ad20c2f8459d4cbe083e3f0323050d275b merged
RecordCacheArray and RecordIdentifierArray into a single array. Update
GPDB-specific code to use the new merged RecordCacheArray.