### PR TITLE
Remove code duplication in the src/bin/pg_upgrade/check.c

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -1265,41 +1265,6 @@ check_for_removed_data_type_usage(ClusterInfo *cluster, const char *version,
 }
 
 /*
- * check_for_removed_data_type_usage
- *
- *	Check for in-core data types that have been removed.  Callers know
- *	the exact list.
- */
-static void
-check_for_removed_data_type_usage(ClusterInfo *cluster, const char *version,
-								  const char *datatype)
-{
-	char		output_path[MAXPGPATH];
-	char		typename[NAMEDATALEN];
-
-	prep_status("Checking for removed \"%s\" data type in user tables",
-				datatype);
-
-	snprintf(output_path, sizeof(output_path), "tables_using_%s.txt",
-			 datatype);
-	snprintf(typename, sizeof(typename), "pg_catalog.%s", datatype);
-
-	if (check_for_data_type_usage(cluster, typename, output_path))
-	{
-		pg_log(PG_REPORT, "fatal\n");
-		pg_fatal("Your installation contains the \"%s\" data type in user tables.\n"
-				 "The \"%s\" type has been removed in PostgreSQL version %s,\n"
-				 "so this cluster cannot currently be upgraded.  You can drop the\n"
-				 "problem columns, or change them to another data type, and restart\n"
-				 "the upgrade.  A list of the problem columns is in the file:\n"
-				 "    %s\n\n", datatype, datatype, version, output_path);
-	}
-	else
-		check_ok();
-}
-
-
-/*
  * check_for_jsonb_9_4_usage()
  *
  *	JSONB changed its storage format during 9.4 beta, so check for it.


### PR DESCRIPTION
Since the af9f6cd1ddfa2bbc62c853f365fcf12d93bcde92 commit is already in 7.2.0,
its application led to duplication of the check_for_removed_data_type_usage
function. This patch removes the function duplicate.