### PR TITLE
Reapply "Fix JIT support for GPDB"

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -171,7 +171,9 @@ llvm_compile_expr(ExprState *state)
 								v_state,
 								FIELDNO_EXPRSTATE_RESNULL,
 								"v.state.resnull");
-	v_parent = l_load_struct_gep(b, v_state,
+	v_parent = l_load_struct_gep(b,
+								 StructExprState,
+								 v_state,
 								 FIELDNO_EXPRSTATE_PARENT,
 								 "v.state.parent");
 
@@ -1977,7 +1979,7 @@ llvm_compile_expr(ExprState *state)
 					/* Copy aggstate->group_id to the result */
 					v_group_id_p = l_ptr_const(&aggstate->group_id,
 											  l_ptr(TypeSizeT));
-					v_group_id = LLVMBuildLoad(b, v_group_id_p, "v_group_id");
+					v_group_id = l_load(b, TypeSizeT, v_group_id_p, "v_group_id");
 
 					/* and store result */
 					LLVMBuildStore(b, v_group_id, v_resvaluep);
@@ -1996,7 +1998,7 @@ llvm_compile_expr(ExprState *state)
 					/* Copy aggstate->gset_id to the result */
 					v_gset_id_p = l_ptr_const(&aggstate->gset_id,
 											  l_ptr(TypeSizeT));
-					v_gset_id = LLVMBuildLoad(b, v_gset_id_p, "v_gset_id");
+					v_gset_id = l_load(b, TypeSizeT, v_gset_id_p, "v_gset_id");
 
 					/* and store result */
 					LLVMBuildStore(b, v_gset_id, v_resvaluep);
@@ -2015,7 +2017,7 @@ llvm_compile_expr(ExprState *state)
 					/* Copy tsstate->currentExprId to the result */
 					v_currentExprId_p = l_ptr_const(&tsstate->currentExprId,
 											  l_ptr(TypeSizeT));
-					v_currentExprId = LLVMBuildLoad(b, v_currentExprId_p, "v_currentExprId");
+					v_currentExprId = l_load(b, TypeSizeT, v_currentExprId_p, "v_currentExprId");
 
 					/* and store result */
 					LLVMBuildStore(b, v_currentExprId, v_resvaluep);
@@ -2035,7 +2037,7 @@ llvm_compile_expr(ExprState *state)
 					/* Fetch and increment rowcounter */
 					v_rowcounter_p = l_ptr_const(rowcounter_p,
 												 l_ptr(LLVMInt64Type()));
-					v_rowcounter = LLVMBuildLoad(b, v_rowcounter_p, "v_rowcounter");
+					v_rowcounter = l_load(b, LLVMInt64Type(), v_rowcounter_p, "v_rowcounter");
 					v_rowcounter_new = LLVMBuildAdd(b, v_rowcounter, l_int64_const(1), "v_rowcounter_new");
 
 					/* Store the new value back */
@@ -2389,15 +2391,15 @@ llvm_compile_expr(ExprState *state)
 						b, v_parent, l_ptr(StructAggState), "");
 
 					v_allpergroupsp = l_load_struct_gep(
-						b, v_aggstatep,
+						b, StructAggState, v_aggstatep,
 						FIELDNO_AGGSTATE_ALL_PERGROUPS,
 						"aggstate.all_pergroups");
 
 					v_setoff = l_int32_const(
 						op->d.agg_plain_pergroup_nullcheck.setoff);
 
-					v_pergroup_allaggs = l_load_gep1(
-						b, v_allpergroupsp, v_setoff, "");
+					v_pergroup_allaggs = l_load_gep1(b, l_ptr(StructAggStatePerGroupData),
+													 v_allpergroupsp, v_setoff, "");
 
 					LLVMBuildCondBr(
 						b,


### PR DESCRIPTION
This patch is required to support LLVM 16 in GPDB. Support for Postgresql was
added in 15ddc9725eb73d97a16652c7c90d993302773544.
This reverts commit 3b168f0f15751a146f3b12788ec2f1915f9c001b.