### PR TITLE
ADBDEV-7238: Fix conflicts in timetz test

### DIFF
--- a/src/test/regress/expected/timetz.out
+++ b/src/test/regress/expected/timetz.out
@@ -144,7 +144,6 @@ ERROR:  operator does not exist: time with time zone + time with time zone
 LINE 1: SELECT f1 + time with time zone '00:01' AS "Illegal" FROM TI...
                   ^
 HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
-<<<<<<< HEAD
 -- basic sanity of sample timezones
 set timezone = 'America/New_York';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as NYC;
@@ -189,7 +188,6 @@ SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Ca
  Sat Aug 09 01:52:00 2014 +01
 (1 row)
 
-=======
 --
 -- Test timetz_zone, timetz_izone
 --
@@ -250,4 +248,3 @@ SELECT f1 AS dat,
 (12 rows)
 
 ROLLBACK;
->>>>>>> REL_12_17

--- a/src/test/regress/sql/timetz.sql
+++ b/src/test/regress/sql/timetz.sql
@@ -56,7 +56,6 @@ SELECT '25:00:00 PDT'::timetz;  -- not allowed
 
 SELECT f1 + time with time zone '00:01' AS "Illegal" FROM TIMETZ_TBL;
 
-<<<<<<< HEAD
 -- basic sanity of sample timezones
 set timezone = 'America/New_York';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as NYC;
@@ -71,7 +70,7 @@ SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Sh
 -- Casablanca time has changed in new timezone db lets verify it
 set timezone = 'Africa/Casablanca';
 SELECT TIMESTAMP WITH TIME ZONE 'epoch' + 1407545520 * INTERVAL '1 second' as Casablanca;
-=======
+
 --
 -- Test timetz_zone, timetz_izone
 --
@@ -91,4 +90,3 @@ SELECT f1 AS dat,
   FROM TIMETZ_TBL
   ORDER BY f1;
 ROLLBACK;
->>>>>>> REL_12_17


### PR DESCRIPTION
Fix conflicts in timetz test

Commit b18781c added new tests in src/test/regress/sql/timetz.sql and
src/test/regress/expected/timetz.out, while earlier commit 6b0e52b already
added other new tests in the same places. We need all the tests.

Ticket: ADBDEV-7238