### PR TITLE
ADBDEV-7238: Fix conflict in src/test/modules/brin/expected/summarization-and-inprogress-insertion.out

### DIFF
--- a/src/test/modules/brin/expected/summarization-and-inprogress-insertion.out
+++ b/src/test/modules/brin/expected/summarization-and-inprogress-insertion.out
@@ -2,15 +2,9 @@ Parsed test spec with 2 sessions
 
 starting permutation: s2check s1b s2b s1i s2summ s1c s2c s2check
 step s2check: SELECT * FROM brin_page_items(get_raw_page('brinidx', 2), 'brinidx'::regclass);
-<<<<<<< HEAD
 itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|empty|value   
 ----------+------+------+--------+--------+-----------+-----+--------
          1|     0|     1|f       |t       |f          |f    |{1 .. 1}
-=======
-itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|value   
-----------+------+------+--------+--------+-----------+--------
-         1|     0|     1|f       |t       |f          |{1 .. 1}
->>>>>>> REL_12_17
 (1 row)
 
 step s1b: BEGIN ISOLATION LEVEL REPEATABLE READ;
@@ -30,31 +24,18 @@ brin_summarize_new_values
 step s1c: COMMIT;
 step s2c: COMMIT;
 step s2check: SELECT * FROM brin_page_items(get_raw_page('brinidx', 2), 'brinidx'::regclass);
-<<<<<<< HEAD
 itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|empty|value      
 ----------+------+------+--------+--------+-----------+-----+-----------
          1|     0|     1|f       |t       |f          |f    |{1 .. 1}   
          2|     1|     1|f       |f       |f          |f    |{1 .. 1000}
-=======
-itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|value      
-----------+------+------+--------+--------+-----------+-----------
-         1|     0|     1|f       |t       |f          |{1 .. 1}   
-         2|     1|     1|f       |f       |f          |{1 .. 1000}
->>>>>>> REL_12_17
 (2 rows)
 
 
 starting permutation: s2check s1b s1i s2vacuum s1c s2check
 step s2check: SELECT * FROM brin_page_items(get_raw_page('brinidx', 2), 'brinidx'::regclass);
-<<<<<<< HEAD
 itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|empty|value   
 ----------+------+------+--------+--------+-----------+-----+--------
          1|     0|     1|f       |t       |f          |f    |{1 .. 1}
-=======
-itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|value   
-----------+------+------+--------+--------+-----------+--------
-         1|     0|     1|f       |t       |f          |{1 .. 1}
->>>>>>> REL_12_17
 (1 row)
 
 step s1b: BEGIN ISOLATION LEVEL REPEATABLE READ;
@@ -62,16 +43,9 @@ step s1i: INSERT INTO brin_iso VALUES (1000);
 step s2vacuum: VACUUM brin_iso;
 step s1c: COMMIT;
 step s2check: SELECT * FROM brin_page_items(get_raw_page('brinidx', 2), 'brinidx'::regclass);
-<<<<<<< HEAD
 itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|empty|value      
 ----------+------+------+--------+--------+-----------+-----+-----------
          1|     0|     1|f       |t       |f          |f    |{1 .. 1}   
          2|     1|     1|f       |f       |f          |f    |{1 .. 1000}
-=======
-itemoffset|blknum|attnum|allnulls|hasnulls|placeholder|value      
-----------+------+------+--------+--------+-----------+-----------
-         1|     0|     1|f       |t       |f          |{1 .. 1}   
-         2|     1|     1|f       |f       |f          |{1 .. 1000}
->>>>>>> REL_12_17
 (2 rows)
 


### PR DESCRIPTION
Fix conflict in src/test/modules/brin/expected/summarization-and-inprogress-insertion.out

Commit d78a66d added a NULL insert to the brin_iso table in the test, while an
earlier commit by 2d6c3db added an "empty" output column to the brin_page_items
function, causing a conflict.

Ticket: ADBDEV-7238