### PR TITLE
ADBDEV-7238: Fix conflict in src/test/regress/expected/alter_table.out

### DIFF
--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -2631,23 +2631,15 @@ View definition:
    FROM at_view_1 v1;
 
 explain (verbose, costs off) select * from at_view_2;
-<<<<<<< HEAD
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: bt.id, bt.stuff, (to_json(ROW(bt.id, bt.stuff, NULL)))
+   Output: bt.id, bt.stuff, (to_json(ROW(bt.id, bt.stuff, 4)))
    ->  Seq Scan on public.at_base_table bt
-         Output: bt.id, bt.stuff, to_json(ROW(bt.id, bt.stuff, NULL))
+         Output: bt.id, bt.stuff, to_json(ROW(bt.id, bt.stuff, 4))
  Optimizer: Postgres query optimizer
  Settings: constraint_exclusion=partition
 (6 rows)
-=======
-                         QUERY PLAN                          
--------------------------------------------------------------
- Seq Scan on public.at_base_table bt
-   Output: bt.id, bt.stuff, to_json(ROW(bt.id, bt.stuff, 4))
-(2 rows)
->>>>>>> REL_12_17
 
 select * from at_view_2;
  id | stuff  |                  j                  


### PR DESCRIPTION
Fix conflict in src/test/regress/expected/alter_table.out

Commit 5a19da5 changed the output in the test, while the earlier commit f2e0802
had already changed the same output in the same test to GPDB-specific, which
caused the conflict.

Ticket: ADBDEV-7238