### PR TITLE
ADBDEV-7238: Fix conflict in src/test/regress/expected/namespace.out

### DIFF
--- a/src/test/regress/expected/namespace.out
+++ b/src/test/regress/expected/namespace.out
@@ -16,11 +16,44 @@ CREATE SCHEMA test_ns_schema_1
        CREATE TABLE abc (
               a serial,
               b int UNIQUE
-<<<<<<< HEAD
        ) DISTRIBUTED BY (b);
-=======
-       );
->>>>>>> REL_12_17
+-- verify that the correct search_path restored on abort
+SET search_path to public;
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT c FROM abc;
+ERROR:  column "c" does not exist
+LINE 2:        CREATE VIEW abc_view AS SELECT c FROM abc;
+                                              ^
+COMMIT;
+SHOW search_path;
+ search_path 
+-------------
+ public
+(1 row)
+
+-- verify that the correct search_path preserved
+-- after creating the schema and on commit
+BEGIN;
+SET search_path to public, test_ns_schema_1;
+CREATE SCHEMA test_ns_schema_2
+       CREATE VIEW abc_view AS SELECT a FROM abc;
+SHOW search_path;
+       search_path        
+--------------------------
+ public, test_ns_schema_1
+(1 row)
+
+COMMIT;
+SHOW search_path;
+       search_path        
+--------------------------
+ public, test_ns_schema_1
+(1 row)
+
+DROP SCHEMA test_ns_schema_2 CASCADE;
+NOTICE:  drop cascades to view test_ns_schema_2.abc_view
 -- verify that the correct search_path restored on abort
 SET search_path to public;
 BEGIN;

--- a/src/test/regress/expected/namespace.out
+++ b/src/test/regress/expected/namespace.out
@@ -54,43 +54,6 @@ SHOW search_path;
 
 DROP SCHEMA test_ns_schema_2 CASCADE;
 NOTICE:  drop cascades to view test_ns_schema_2.abc_view
--- verify that the correct search_path restored on abort
-SET search_path to public;
-BEGIN;
-SET search_path to public, test_ns_schema_1;
-CREATE SCHEMA test_ns_schema_2
-       CREATE VIEW abc_view AS SELECT c FROM abc;
-ERROR:  column "c" does not exist
-LINE 2:        CREATE VIEW abc_view AS SELECT c FROM abc;
-                                              ^
-COMMIT;
-SHOW search_path;
- search_path 
--------------
- public
-(1 row)
-
--- verify that the correct search_path preserved
--- after creating the schema and on commit
-BEGIN;
-SET search_path to public, test_ns_schema_1;
-CREATE SCHEMA test_ns_schema_2
-       CREATE VIEW abc_view AS SELECT a FROM abc;
-SHOW search_path;
-       search_path        
---------------------------
- public, test_ns_schema_1
-(1 row)
-
-COMMIT;
-SHOW search_path;
-       search_path        
---------------------------
- public, test_ns_schema_1
-(1 row)
-
-DROP SCHEMA test_ns_schema_2 CASCADE;
-NOTICE:  drop cascades to view test_ns_schema_2.abc_view
 -- verify that the objects were created
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
     (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');

--- a/src/test/regress/sql/namespace.sql
+++ b/src/test/regress/sql/namespace.sql
@@ -37,26 +37,6 @@ COMMIT;
 SHOW search_path;
 DROP SCHEMA test_ns_schema_2 CASCADE;
 
--- verify that the correct search_path restored on abort
-SET search_path to public;
-BEGIN;
-SET search_path to public, test_ns_schema_1;
-CREATE SCHEMA test_ns_schema_2
-       CREATE VIEW abc_view AS SELECT c FROM abc;
-COMMIT;
-SHOW search_path;
-
--- verify that the correct search_path preserved
--- after creating the schema and on commit
-BEGIN;
-SET search_path to public, test_ns_schema_1;
-CREATE SCHEMA test_ns_schema_2
-       CREATE VIEW abc_view AS SELECT a FROM abc;
-SHOW search_path;
-COMMIT;
-SHOW search_path;
-DROP SCHEMA test_ns_schema_2 CASCADE;
-
 -- verify that the objects were created
 SELECT COUNT(*) FROM pg_class WHERE relnamespace =
     (SELECT oid FROM pg_namespace WHERE nspname = 'test_ns_schema_1');


### PR DESCRIPTION
Fix conflict in src/test/regress/expected/namespace.out

The conflict was caused by a GPDB-specific explicit distribution specification.
Also removed duplicate code that resulted from incorrect merge of commits
dd692ab and 78119a0.

Ticket: ADBDEV-7238