### PR TITLE
ADBDEV-7238: Avoid using RelationOpenSmgr macro

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1363,7 +1363,6 @@ aoco_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 	 * implementation
 	 */
 	dstrel = smgropen(*newrnode, rel->rd_backend, SMGR_AO);
-	RelationOpenSmgr(rel);
 
 	/*
 	 * Create and copy all forks of the relation, and schedule unlinking of
@@ -1383,7 +1382,7 @@ aoco_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 	 */
 	if (rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED)
 	{
-		Assert (smgrexists(rel->rd_smgr, INIT_FORKNUM));
+		Assert (smgrexists(RelationGetSmgr(rel), INIT_FORKNUM));
 
 		/*
 		 * INIT_FORK is empty, creating it is sufficient, no need to copy

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1127,7 +1127,6 @@ appendonly_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 	 * implementation
 	 */
 	dstrel = smgropen(*newrnode, rel->rd_backend, SMGR_AO);
-	RelationOpenSmgr(rel);
 
 	/*
 	 * Create and copy all forks of the relation, and schedule unlinking of
@@ -1147,7 +1146,7 @@ appendonly_relation_copy_data(Relation rel, const RelFileNode *newrnode)
 	 */
 	if (rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED)
 	{
-		Assert (smgrexists(rel->rd_smgr, INIT_FORKNUM));
+		Assert (smgrexists(RelationGetSmgr(rel), INIT_FORKNUM));
 
 		/*
 		 * INIT_FORK is empty, creating it is sufficient, no need to copy

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15919,8 +15919,6 @@ index_copy_data(Relation rel, RelFileNode newrnode)
 	SMgrImpl smgr_which = RelationIsAppendOptimized(rel) ? SMGR_AO : SMGR_MD;
 
 	dstrel = smgropen(newrnode, rel->rd_backend, smgr_which);
-					  
-	RelationOpenSmgr(rel);
 
 	/*
 	 * Since we copy the file directly without looking at the shared buffers,


### PR DESCRIPTION
Avoid using RelationOpenSmgr macro

Commit e21856f removed the call to RelationOpenSmgr from index_copy_data, but
an earlier commit 19cd1cf added extra whitespace to the same location, so the
call was not removed during the merge. The patch also removes the
RelationOpenSmgr function call from similar GPDB-specific functions
aoco_relation_copy_data and appendonly_relation_copy_data, and uses the new
RelationGetSmgr function in them.

Ticket: ADBDEV-7238