### PR TITLE
ADBDEV-7233: Fix join regress test

### DIFF
--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3476,9 +3476,8 @@ where b;
 
 -- Test PHV in a semijoin qual, which confused useless-RTE removal (bug #17700)
 explain (verbose, costs off)
-with ctetable as not materialized ( select 1 as f1 )
-select * from ctetable c1
-where f1 in ( select c3.f1 from ctetable c2 full join ctetable c3 on true );
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
          QUERY PLAN         
 ----------------------------
  Result
@@ -3486,9 +3485,8 @@ where f1 in ( select c3.f1 from ctetable c2 full join ctetable c3 on true );
    One-Time Filter: (1 = 1)
 (3 rows)
 
-with ctetable as not materialized ( select 1 as f1 )
-select * from ctetable c1
-where f1 in ( select c3.f1 from ctetable c2 full join ctetable c3 on true );
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
  f1 
 ----
   1
@@ -6630,23 +6628,33 @@ left join j2 on j1.id1 = j2.id1 where j1.id2 = 1;
  Settings: enable_nestloop=on, optimizer=off
 (17 rows)
 
-create unique index j1_id2_idx on j1(id2) where id2 is not null;
+-- GPDB: distributed by (id2) is needed to create a unique index later
+create table j1d (id1 int, id2 int, primary key(id1,id2)) distributed by (id2);
+create unique index j1_id2_idx on j1d(id2) where id2 is not null;
 -- ensure we don't use a partial unique index as unique proofs
 explain (verbose, costs off)
-select * from j1
-inner join j2 on j1.id2 = j2.id2;
-                QUERY PLAN                
-------------------------------------------
- Nested Loop
-   Output: j1.id1, j1.id2, j2.id1, j2.id2
-   Join Filter: (j1.id2 = j2.id2)
-   ->  Seq Scan on public.j2
-         Output: j2.id1, j2.id2
-   ->  Seq Scan on public.j1
-         Output: j1.id1, j1.id2
-(7 rows)
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+   ->  Nested Loop
+         Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: j2.id1, j2.id2
+               Hash Key: j2.id2
+               ->  Seq Scan on public.j2
+                     Output: j2.id1, j2.id2
+         ->  Index Scan using j1_id2_idx on public.j1d
+               Output: j1d.id1, j1d.id2
+               Index Cond: (j1d.id2 = j2.id2)
+ Optimizer: Postgres-based planner
+ Settings: enable_nestloop = 'on', optimizer = 'off'
+(14 rows)
 
 drop index j1_id2_idx;
+drop table j1d;
 -- validate logic in merge joins which skips mark and restore.
 -- it should only do this if all quals which were used to detect the unique
 -- are present as join quals, and not plain quals.

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6653,6 +6653,31 @@ inner join j1d on j1d.id2 = j2.id2;
  Settings: enable_nestloop = 'on', optimizer = 'off'
 (14 rows)
 
+create unique index j1_id2_idx_full on j1d(id2);
+-- ensure we detect a unique join with a full unique index (on Postgres optimizer)
+explain (verbose, costs off)
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+   ->  Nested Loop
+         Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+         Inner Unique: true
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: j2.id1, j2.id2
+               Hash Key: j2.id2
+               ->  Seq Scan on public.j2
+                     Output: j2.id1, j2.id2
+         ->  Index Scan using j1_id2_idx_full on public.j1d
+               Output: j1d.id1, j1d.id2
+               Index Cond: (j1d.id2 = j2.id2)
+ Optimizer: Postgres-based planner
+ Settings: enable_nestloop = 'on', optimizer = 'off'
+(15 rows)
+
+drop index j1_id2_idx_full;
 drop index j1_id2_idx;
 drop table j1d;
 -- validate logic in merge joins which skips mark and restore.

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3573,6 +3573,24 @@ where b;
  0 | t | t
 (2 rows)
 
+-- Test PHV in a semijoin qual, which confused useless-RTE removal (bug #17700)
+explain (verbose, costs off)
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
+         QUERY PLAN         
+----------------------------
+ Result
+   Output: 1
+   One-Time Filter: (1 = 1)
+(3 rows)
+
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
+ f1 
+----
+  1
+(1 row)
+
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)
@@ -6746,6 +6764,34 @@ left join j2 on j1.id1 = j2.id1 where j1.id2 = 1;
  Settings: enable_nestloop=on
 (16 rows)
 
+-- GPDB: distributed by (id2) is needed to create a unique index later
+create table j1d (id1 int, id2 int, primary key(id1,id2)) distributed by (id2);
+create unique index j1_id2_idx on j1d(id2) where id2 is not null;
+-- ensure we don't use a partial unique index as unique proofs
+explain (verbose, costs off)
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+   ->  Nested Loop
+         Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+         Join Filter: true
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: j2.id1, j2.id2
+               Hash Key: j2.id2
+               ->  Seq Scan on public.j2
+                     Output: j2.id1, j2.id2
+         ->  Index Scan using j1d_pkey on public.j1d
+               Output: j1d.id1, j1d.id2
+               Index Cond: (j1d.id2 = j2.id2)
+ Optimizer: GPORCA
+ Settings: enable_nestloop = 'on'
+(15 rows)
+
+drop index j1_id2_idx;
+drop table j1d;
 -- validate logic in merge joins which skips mark and restore.
 -- it should only do this if all quals which were used to detect the unique
 -- are present as join quals, and not plain quals.

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6790,6 +6790,31 @@ inner join j1d on j1d.id2 = j2.id2;
  Settings: enable_nestloop = 'on'
 (15 rows)
 
+create unique index j1_id2_idx_full on j1d(id2);
+-- ensure we detect a unique join with a full unique index (on Postgres optimizer)
+explain (verbose, costs off)
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+   ->  Nested Loop
+         Output: j2.id1, j2.id2, j1d.id1, j1d.id2
+         Join Filter: true
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: j2.id1, j2.id2
+               Hash Key: j2.id2
+               ->  Seq Scan on public.j2
+                     Output: j2.id1, j2.id2
+         ->  Index Scan using j1_id2_idx_full on public.j1d
+               Output: j1d.id1, j1d.id2
+               Index Cond: (j1d.id2 = j2.id2)
+ Optimizer: GPORCA
+ Settings: enable_nestloop = 'on'
+(15 rows)
+
+drop index j1_id2_idx_full;
 drop index j1_id2_idx;
 drop table j1d;
 -- validate logic in merge joins which skips mark and restore.

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1115,13 +1115,11 @@ where b;
 
 -- Test PHV in a semijoin qual, which confused useless-RTE removal (bug #17700)
 explain (verbose, costs off)
-with ctetable as not materialized ( select 1 as f1 )
-select * from ctetable c1
-where f1 in ( select c3.f1 from ctetable c2 full join ctetable c3 on true );
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
 
-with ctetable as not materialized ( select 1 as f1 )
-select * from ctetable c1
-where f1 in ( select c3.f1 from ctetable c2 full join ctetable c3 on true );
+select * from ( select 1 as f1 ) c1
+where f1 in ( select c3.f1 from ( select 1 as f1 ) c2 full join ( select 1 as f1 ) c3 on true );
 
 --
 -- test extraction of restriction OR clauses from join OR clause
@@ -2208,14 +2206,18 @@ explain (verbose, costs off)
 select * from j1
 left join j2 on j1.id1 = j2.id1 where j1.id2 = 1;
 
-create unique index j1_id2_idx on j1(id2) where id2 is not null;
+-- GPDB: distributed by (id2) is needed to create a unique index later
+create table j1d (id1 int, id2 int, primary key(id1,id2)) distributed by (id2);
+
+create unique index j1_id2_idx on j1d(id2) where id2 is not null;
 
 -- ensure we don't use a partial unique index as unique proofs
 explain (verbose, costs off)
-select * from j1
-inner join j2 on j1.id2 = j2.id2;
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
 
 drop index j1_id2_idx;
+drop table j1d;
 
 -- validate logic in merge joins which skips mark and restore.
 -- it should only do this if all quals which were used to detect the unique

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -2216,6 +2216,14 @@ explain (verbose, costs off)
 select * from j2
 inner join j1d on j1d.id2 = j2.id2;
 
+create unique index j1_id2_idx_full on j1d(id2);
+
+-- ensure we detect a unique join with a full unique index (on Postgres optimizer)
+explain (verbose, costs off)
+select * from j2
+inner join j1d on j1d.id2 = j2.id2;
+
+drop index j1_id2_idx_full;
 drop index j1_id2_idx;
 drop table j1d;
 


### PR DESCRIPTION
Fix join regress test

First output mismatch: Happened in test added by commit
bb8d48cb9df1cb9266a73b24d7b6987019a90578. The commit was fixing an assert
failure in remove_useless_results_recurse() function, but it seems like in
GPDB CTEs are not inlined early enough, and so this plan optimization isn't
applied the same way it is in Postgres. However, the original issue has
nothing to do with CTEs and is reproducible with raw subqueries too, so this
patch changes the test to use subqueries instead, which has identical behavior
in GPDB and Postgres.

Second output mismatch: Happened in test added by commit
dcef5b052e09917c42c5100843152950616ff1f9. The commit was fixing partial unique
indexes being used as uniqueness proofs. However, GPDB also requires unique
indexes to use all distribution key columns, so both id1 and id2 in case of
table j1. This patch adds a table j1d distributed by just id2 so that the
correct unique index can be added. It also swapped j1 and j2 to preserve j1
being the inner child. This way if uniqueness proof was detected, the plan
would contain "Unique Inner: true". To demonstrate it, another subtest was added
with a full unique index.
