### PR TITLE
ADBDEV-7238: Fix src/backend/storage/smgr/md.c

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -221,7 +221,12 @@ mdcreate(SMgrRelation reln, ForkNumber forkNum, bool isRedo)
 	mdfd->mdfd_segno = 0;
 
 	if (!SmgrIsTemp(reln))
-		register_dirty_segment(reln, forkNum, mdfd);
+	{
+		if (reln->smgr_which == SMGR_MD)
+			register_dirty_segment(reln, forkNum, mdfd);
+		else
+			register_dirty_segment_ao(reln->smgr_rnode.node, 0, fd);
+	}
 }
 
 /*
@@ -262,6 +267,9 @@ mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
 	}
 
 	pfree(path);
+
+	if (!RelFileNodeBackendIsTemp(rnode))
+		register_dirty_segment_ao(rnode.node, segmentFileNum, fd);
 }
 
 /*

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -220,13 +220,8 @@ mdcreate(SMgrRelation reln, ForkNumber forkNum, bool isRedo)
 	mdfd->mdfd_vfd = fd;
 	mdfd->mdfd_segno = 0;
 
-	if (!SmgrIsTemp(reln))
-	{
-		if (reln->smgr_which == SMGR_MD)
-			register_dirty_segment(reln, forkNum, mdfd);
-		else
-			register_dirty_segment_ao(reln->smgr_rnode.node, 0, fd);
-	}
+	if (!SmgrIsTemp(reln) && reln->smgr_which == SMGR_MD)
+		register_dirty_segment(reln, forkNum, mdfd);
 }
 
 /*
@@ -267,9 +262,6 @@ mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
 	}
 
 	pfree(path);
-
-	if (!RelFileNodeBackendIsTemp(rnode))
-		register_dirty_segment_ao(rnode.node, segmentFileNum, fd);
 }
 
 /*

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1012,6 +1012,7 @@ register_dirty_segment(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 {
 	FileTag		tag;
 
+	Assert(reln->smgr_which == SMGR_MD);
 	INIT_MD_FILETAG(tag, reln->smgr_rnode.node, forknum, seg->mdfd_segno);
 
 	/* Temp relations should never be fsync'd */


### PR DESCRIPTION
Fix src/backend/storage/smgr/md.c

Commit 1b4f1c6 added a register_dirty_segment call to mdcreate for heap tables,
but it does not take into account GPDB-specific logic. mdcreate is called not
only for heap tables but also for AO tables, while register_dirty_segment
should only be called for heap tables. So the patch adds an extra condition to
mdcreate to call register_dirty_segment, and also adds an assertion to
register_dirty_segment to ensure that it is only called for heap tables.

We don't need fsync when creating the AO table because until we insert any data
we won't have any segments.

Also, this patch fixes the crash of the test
src/test/isolation2/expected/ao_same_trans_truncate_crash.out.

Ticket: ADBDEV-7238