### PR TITLE
ADBDEV-7238: Fix test src/test/regress/expected/subscription.out

### DIFF
--- a/src/test/regress/expected/subscription.out
+++ b/src/test/regress/expected/subscription.out
@@ -73,11 +73,10 @@ DROP SUBSCRIPTION regress_testsub3;
 -- fail, connection string does not parse
 CREATE SUBSCRIPTION regress_testsub5 CONNECTION 'i_dont_exist=param' PUBLICATION testpub;
 ERROR:  invalid connection string syntax: invalid connection option "i_dont_exist"
-
 -- fail, connection string parses, but doesn't work (and does so without
 -- connecting, so this is reliable and safe)
 CREATE SUBSCRIPTION regress_testsub5 CONNECTION 'port=-1' PUBLICATION testpub;
-ERROR:  could not connect to the publisher: invalid port number: "-1"
+ERROR:  could not connect to the publisher: invalid port number: "-1" (subscriptioncmds.c:464)
 -- fail - invalid connection string during ALTER
 ALTER SUBSCRIPTION regress_testsub CONNECTION 'foobar';
 ERROR:  invalid connection string syntax: missing "=" after "foobar" in connection info string


### PR DESCRIPTION
Fix test src/test/regress/expected/subscription.out

Commit 92fc127 added new tests to src/test/regress/sql/subscription.sql, this
patch fixes the outputs for them.

Ticket: ADBDEV-7238