### PR TITLE
ADBDEV-7233: Fix src/test/regress/partition_pruning.out

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -4342,29 +4342,36 @@ SELECT * FROM pt_bool_tab_df WHERE col2 IS unknown;
 (1 row)
 
 EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT true;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000969.00 rows=46750 width=5)
-   ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
-         Filter: (col2 IS NOT TRUE)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT TRUE)
+ Optimizer: Postgres-based planner
+(7 rows)
 
 SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT true;
  col1 | col2 
 ------+------
     2 | f
     1 | f
-(2 rows)
+    1 | 
+(3 rows)
 
 EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT false;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000969.00 rows=46750 width=5)
-   ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
-         Filter: (col2 IS NOT FALSE)
- Optimizer: Postgres query optimizer
-(4 rows)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_df_1_prt_def  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT FALSE)
+ Optimizer: Postgres-based planner
+(7 rows)
 
 SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT false;
  col1 | col2 
@@ -4372,7 +4379,8 @@ SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT false;
     2 | t
     3 | t
     1 | t
-(3 rows)
+    1 | 
+(4 rows)
 
 EXPLAIN SELECT * FROM pt_bool_tab_df WHERE col2 IS NOT unknown;
                                                   QUERY PLAN                                                  


### PR DESCRIPTION
Fix src/test/regress/partition_pruning.out

Our partition_pruning test was incorrect: since NULL IS NOT TRUE and NULL IS
NOT FALSE, default partition also should be scanned. However, it wasn't,
leading to incorrect results. After Postgres's partition pruning changes this
behavior is now correct. Note that corresponding
partition_pruning_optimizer.out already has correct pruning with NULLs
included.