### PR TITLE
Fix test src/test/regress/sql/join_hash.sql

### DIFF
--- a/src/test/regress/expected/join_hash.out
+++ b/src/test/regress/expected/join_hash.out
@@ -1133,12 +1133,12 @@ ROLLBACK;
 begin;
 set local enable_hashjoin = on;
 -- GPDB: Join with the replicated table to avoid passing the parameter through motion.
-create table int4_tbl_repl (like int4_tbl) distributed replicated;
-insert into int4_tbl_repl select * from int4_tbl;
+create table tenk1_repl (like tenk1) distributed replicated;
+insert into tenk1_repl select * from tenk1;
 explain (costs off)
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
                               QUERY PLAN                               
 -----------------------------------------------------------------------
@@ -1150,16 +1150,16 @@ lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
                ->  Sort
                      Sort Key: t1.fivethous, i4.f1
                      ->  Hash Join
-                           Hash Cond: ((i4.f1 + i8.q2) = t1.fivethous)
-                           ->  Seq Scan on int4_tbl_repl i4
+                           Hash Cond: (t1.fivethous = (i4.f1 + i8.q2))
+                           ->  Seq Scan on tenk1_repl t1
                            ->  Hash
-                                 ->  Seq Scan on tenk1 t1
+                                 ->  Seq Scan on int4_tbl i4
  Optimizer: Postgres-based planner
 (13 rows)
 
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
  q2  | fivethous | f1 
 -----+-----------+----

--- a/src/test/regress/expected/join_hash.out
+++ b/src/test/regress/expected/join_hash.out
@@ -1132,27 +1132,34 @@ ROLLBACK;
 -- re-use of the inner hash table across rescans.
 begin;
 set local enable_hashjoin = on;
+-- GPDB: Join with the replicated table to avoid passing the parameter through motion.
+create table int4_tbl_repl (like int4_tbl) distributed replicated;
+insert into int4_tbl_repl select * from int4_tbl;
 explain (costs off)
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl i4
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
-                        QUERY PLAN                         
------------------------------------------------------------
- Nested Loop
-   ->  Seq Scan on int8_tbl i8
-   ->  Sort
-         Sort Key: t1.fivethous, i4.f1
-         ->  Hash Join
-               Hash Cond: (t1.fivethous = (i4.f1 + i8.q2))
-               ->  Seq Scan on tenk1 t1
-               ->  Hash
-                     ->  Seq Scan on int4_tbl i4
-(9 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Seq Scan on int8_tbl i8
+         ->  Materialize
+               ->  Sort
+                     Sort Key: t1.fivethous, i4.f1
+                     ->  Hash Join
+                           Hash Cond: ((i4.f1 + i8.q2) = t1.fivethous)
+                           ->  Seq Scan on int4_tbl_repl i4
+                           ->  Hash
+                                 ->  Seq Scan on tenk1 t1
+ Optimizer: Postgres-based planner
+(13 rows)
 
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl i4
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
  q2  | fivethous | f1 
 -----+-----------+----

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -1255,12 +1255,12 @@ ROLLBACK;
 begin;
 set local enable_hashjoin = on;
 -- GPDB: Join with the replicated table to avoid passing the parameter through motion.
-create table int4_tbl_repl (like int4_tbl) distributed replicated;
-insert into int4_tbl_repl select * from int4_tbl;
+create table tenk1_repl (like tenk1) distributed replicated;
+insert into tenk1_repl select * from tenk1;
 explain (costs off)
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
                               QUERY PLAN                               
 -----------------------------------------------------------------------
@@ -1272,16 +1272,16 @@ lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
                ->  Sort
                      Sort Key: t1.fivethous, i4.f1
                      ->  Hash Join
-                           Hash Cond: ((i4.f1 + i8.q2) = t1.fivethous)
-                           ->  Seq Scan on int4_tbl_repl i4
+                           Hash Cond: (t1.fivethous = (i4.f1 + i8.q2))
+                           ->  Seq Scan on tenk1_repl t1
                            ->  Hash
-                                 ->  Seq Scan on tenk1 t1
+                                 ->  Seq Scan on int4_tbl i4
  Optimizer: Postgres-based planner
 (13 rows)
 
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
  q2  | fivethous | f1 
 -----+-----------+----

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -1249,3 +1249,46 @@ WHERE
 (1 row)
 
 ROLLBACK;
+-- Verify that we behave sanely when the inner hash keys contain parameters
+-- (that is, outer or lateral references).  This situation has to defeat
+-- re-use of the inner hash table across rescans.
+begin;
+set local enable_hashjoin = on;
+-- GPDB: Join with the replicated table to avoid passing the parameter through motion.
+create table int4_tbl_repl (like int4_tbl) distributed replicated;
+insert into int4_tbl_repl select * from int4_tbl;
+explain (costs off)
+select i8.q2, ss.* from
+int8_tbl i8,
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+         on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Seq Scan on int8_tbl i8
+         ->  Materialize
+               ->  Sort
+                     Sort Key: t1.fivethous, i4.f1
+                     ->  Hash Join
+                           Hash Cond: ((i4.f1 + i8.q2) = t1.fivethous)
+                           ->  Seq Scan on int4_tbl_repl i4
+                           ->  Hash
+                                 ->  Seq Scan on tenk1 t1
+ Optimizer: Postgres-based planner
+(13 rows)
+
+select i8.q2, ss.* from
+int8_tbl i8,
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+         on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
+ q2  | fivethous | f1 
+-----+-----------+----
+ 456 |       456 |  0
+ 456 |       456 |  0
+ 123 |       123 |  0
+ 123 |       123 |  0
+(4 rows)
+
+rollback;

--- a/src/test/regress/sql/join_hash.sql
+++ b/src/test/regress/sql/join_hash.sql
@@ -593,16 +593,19 @@ ROLLBACK;
 -- re-use of the inner hash table across rescans.
 begin;
 set local enable_hashjoin = on;
+-- GPDB: Join with the replicated table to avoid passing the parameter through motion.
+create table int4_tbl_repl (like int4_tbl) distributed replicated;
+insert into int4_tbl_repl select * from int4_tbl;
 
 explain (costs off)
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl i4
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
 
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl i4
+lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
 
 rollback;

--- a/src/test/regress/sql/join_hash.sql
+++ b/src/test/regress/sql/join_hash.sql
@@ -594,18 +594,18 @@ ROLLBACK;
 begin;
 set local enable_hashjoin = on;
 -- GPDB: Join with the replicated table to avoid passing the parameter through motion.
-create table int4_tbl_repl (like int4_tbl) distributed replicated;
-insert into int4_tbl_repl select * from int4_tbl;
+create table tenk1_repl (like tenk1) distributed replicated;
+insert into tenk1_repl select * from tenk1;
 
 explain (costs off)
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
 
 select i8.q2, ss.* from
 int8_tbl i8,
-lateral (select t1.fivethous, i4.f1 from tenk1 t1 join int4_tbl_repl i4
+lateral (select t1.fivethous, i4.f1 from tenk1_repl t1 join int4_tbl i4
          on t1.fivethous = i4.f1+i8.q2 order by 1,2) ss;
 
 rollback;


### PR DESCRIPTION
Commit 9529b1eb1b833686b09aff8f325626872be34297 add a new test that produces a
different plan in GPDB. This patch fixes its output. Also use the replicated
table in join to avoid passing the parameter through motion.