### PR TITLE
ADBDEV-7238: Fix test src/pl/plpython/expected/python3/plpython_error.out

### DIFF
--- a/src/pl/plpython/expected/plpython_subtransaction.out
+++ b/src/pl/plpython/expected/plpython_subtransaction.out
@@ -482,7 +482,7 @@ select gp_inject_fault_infinite('begin_internal_sub_transaction', 'error', 1);
 (1 row)
 
 SELECT test_func();
-ERROR:  function "test_func" error fetching next item from iterator
+ERROR:  error fetching next item from iterator
 DETAIL:  spiexceptions.FaultInject: fault triggered, fault name:'begin_internal_sub_transaction' fault type:'error'
 CONTEXT:  Traceback (most recent call last):
 PL/Python function "test_func"

--- a/src/pl/plpython/plpy_exec.c
+++ b/src/pl/plpython/plpy_exec.c
@@ -169,7 +169,7 @@ PLy_exec_function(FunctionCallInfo fcinfo, PLyProcedure *proc)
 				srfstate->iter = NULL;
 
 				if (has_error)
-					PLy_elog(ERROR, "function \"%s\" error fetching next item from iterator", proc->proname);
+					PLy_elog(ERROR, "error fetching next item from iterator");
 
 				/* Pass a null through the data-returning steps below */
 				Py_INCREF(Py_None);


### PR DESCRIPTION
Fix test src/pl/plpython/expected/python3/plpython_error.out

Commit 99d27e5 added a new test to src/pl/plpython/sql/plpython_error.sql,
while earlier commit 598f4b0 added the name of the function that caused the
error to the function PLy_exec_function. But the name of this function is
already in the context of the error, so this patch brings the error output in
line with vanilla Postgres, including in the test that commit a381d2d added.

Ticket: ADBDEV-7238