### PR TITLE
ADBDEV-7238: Fix test src/test/regress/expected/expressions_optimizer.out

### DIFF
--- a/src/test/regress/expected/expressions_optimizer.out
+++ b/src/test/regress/expected/expressions_optimizer.out
@@ -45,7 +45,7 @@ SELECT now()::timestamp::text = localtimestamp::text;
  t
 (1 row)
 
--- current_role/user/user is tested in rolnames.sql
+-- current_role/user/user is tested in rolenames.sql
 -- current database / catalog
 SELECT current_catalog = current_database();
  ?column? 


### PR DESCRIPTION
Fix test src/test/regress/expected/expressions_optimizer.out

Commit dfaa705 fixed a comment in src/test/regress/sql/expressions.sql, so we
need to fix it in the output for the ORCA planner.

Ticket: ADBDEV-7238