### PR TITLE
ADBDEV-7238: Fix test src/test/regress/expected/aggregates_optimizer.out

### DIFF
--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1259,6 +1259,12 @@ select (select max(min(unique1)) from int8_tbl) from tenk1;
 ERROR:  aggregate function calls cannot be nested
 LINE 1: select (select max(min(unique1)) from int8_tbl) from tenk1;
                            ^
+select avg((select avg(a1.col1 order by (select avg(a2.col2) from tenk1 a3))
+            from tenk1 a1(col1)))
+from tenk1 a2(col2);
+ERROR:  aggregate function calls cannot be nested
+LINE 1: select avg((select avg(a1.col1 order by (select avg(a2.col2)...
+                                                        ^
 --
 -- Test removal of redundant GROUP BY columns
 --


### PR DESCRIPTION
Fix test src/test/regress/expected/aggregates_optimizer.out

Commit 62a91a1 added a new test to src/test/regress/sql/aggregates.sql, so we
need to add it in the output for the ORCA planner.

Ticket: ADBDEV-7238