### PR TITLE
ADBDEV-7233: Fix test src/test/regress/expected/tsearch_optimizer.out

### DIFF
--- a/src/test/regress/expected/tsearch_optimizer.out
+++ b/src/test/regress/expected/tsearch_optimizer.out
@@ -1523,6 +1523,23 @@ to_tsquery('english','Lorem') && phraseto_tsquery('english','ullamcorper urna'),
  <b>Lorem</b> ipsum <b>urna</b>.  Nullam nullam <b>ullamcorper</b> <b>urna</b>
 (1 row)
 
+-- Edge cases with empty query
+SELECT ts_headline('english',
+'', to_tsquery('english', ''));
+NOTICE:  text-search query doesn't contain lexemes: ""
+ ts_headline 
+-------------
+ 
+(1 row)
+
+SELECT ts_headline('english',
+'foo bar', to_tsquery('english', ''));
+NOTICE:  text-search query doesn't contain lexemes: ""
+ ts_headline 
+-------------
+ foo bar
+(1 row)
+
 --Rewrite sub system
 CREATE TABLE test_tsquery (txtkeyword TEXT, txtsample TEXT);
 \set ECHO none


### PR DESCRIPTION
Fix test src/test/regress/expected/tsearch_optimizer.out

Commit a1fb4bd8562e0a7f162ff8a08c3c2ecdeb792f80 added another test to
tsearch.sql, so we need to fix ORCA output (same as Postgres output).