### PR TITLE
ADBDEV-7238: Fix test src/test/regress/expected/privileges_optimizer.out

### DIFF
--- a/src/test/regress/expected/privileges_optimizer.out
+++ b/src/test/regress/expected/privileges_optimizer.out
@@ -1831,6 +1831,24 @@ SELECT * FROM pg_largeobject LIMIT 0;
 SET SESSION AUTHORIZATION regress_priv_user1;
 SELECT * FROM pg_largeobject LIMIT 0;			-- to be denied
 ERROR:  permission denied for table pg_largeobject
+-- pg_signal_backend can't signal superusers
+RESET SESSION AUTHORIZATION;
+BEGIN;
+CREATE OR REPLACE FUNCTION terminate_nothrow(pid int) RETURNS bool
+	LANGUAGE plpgsql SECURITY DEFINER SET client_min_messages = error AS $$
+BEGIN
+	RETURN pg_terminate_backend($1);
+EXCEPTION WHEN OTHERS THEN
+	RETURN false;
+END$$;
+ALTER FUNCTION terminate_nothrow OWNER TO pg_signal_backend;
+SELECT backend_type FROM pg_stat_activity
+WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END;
+ backend_type 
+--------------
+(0 rows)
+
+ROLLBACK;
 -- test default ACLs
 \c -
 CREATE SCHEMA testns;


### PR DESCRIPTION
Fix test src/test/regress/expected/privileges_optimizer.out

Commit 2893f2f added a new test to src/test/regress/sql/privileges.sql, so it
needs to be added to the output for the ORCA scheduler.

Ticket: ADBDEV-7238