### PR TITLE
ADBDEV-7238: Fix test src/test/regress/expected/generated_optimizer.out

### DIFF
--- a/src/test/regress/expected/generated_optimizer.out
+++ b/src/test/regress/expected/generated_optimizer.out
@@ -811,6 +811,9 @@ DROP TABLE gtest_parent;
 -- partitioned table
 CREATE TABLE gtest_parent (f1 date NOT NULL, f2 bigint, f3 bigint GENERATED ALWAYS AS (f2 * 2) STORED) PARTITION BY RANGE (f1);
 CREATE TABLE gtest_child PARTITION OF gtest_parent FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE gtest_child3 PARTITION OF gtest_parent FOR VALUES FROM ('2016-09-01') TO ('2016-10-01');
+NOTICE:  table has parent, setting distribution columns to match parent table
 INSERT INTO gtest_parent (f1, f2) VALUES ('2016-07-15', 1);
 SELECT * FROM gtest_parent;
      f1     | f2 | f3 
@@ -822,6 +825,19 @@ SELECT * FROM gtest_child;
      f1     | f2 | f3 
 ------------+----+----
  07-15-2016 |  1 |  2
+(1 row)
+
+UPDATE gtest_parent SET f1 = f1 + 60, f2 = f2 + 1;
+SELECT * FROM gtest_parent;
+     f1     | f2 | f3 
+------------+----+----
+ 09-13-2016 |  2 |  4
+(1 row)
+
+SELECT * FROM gtest_child3;
+     f1     | f2 | f3 
+------------+----+----
+ 09-13-2016 |  2 |  4
 (1 row)
 
 DROP TABLE gtest_parent;


### PR DESCRIPTION
Fix test src/test/regress/expected/generated_optimizer.out

Commit 23b75dd added new tests to src/test/regress/sql/generated.sql, so we
need to add them in the output for the ORCA planner.

Ticket: ADBDEV-7238