### PR TITLE
ADBDEV-7238: Fix ABI tests

### DIFF
--- a/.abi-check/7.2.0_arenadata7/postgres.symbols.ignore
+++ b/.abi-check/7.2.0_arenadata7/postgres.symbols.ignore
@@ -1,1 +1,2 @@
 ConfigureNamesInt_gp
+transformCreateSchemaStmtElements

--- a/.abi-check/7.2.0_arenadata7/postgres.symbols.ignore
+++ b/.abi-check/7.2.0_arenadata7/postgres.symbols.ignore
@@ -1,2 +1,2 @@
 ConfigureNamesInt_gp
-transformCreateSchemaStmtElements
+transformCreateSchemaStmt


### PR DESCRIPTION
Fix ABI tests

Commit 63f7e91 changed the signature and renamed the public function
transformCreateSchemaStmt to transformCreateSchemaStmtElements. It is unlikely
that any extensions use this internal parser function, even though it is
public.

Ticket: ADBDEV-7238