### PR TITLE
ADBDEV-7238: Fix TAP tests related to pg_database modification

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1807,7 +1807,14 @@ exec_simple_query(const char *query_string)
 		if (Gp_role == GP_ROLE_UTILITY && IsA(parsetree->stmt, TransactionStmt) &&
 			((TransactionStmt *) parsetree->stmt)->kind == TRANS_STMT_PREPARE)
 		{
-			ereport(ERROR,
+			int		elevel = ERROR;
+
+#ifdef FAULT_INJECTOR
+			if (SIMPLE_FAULT_INJECTOR("enable_prepare_transaction") == FaultInjectorTypeSkip)
+				elevel = WARNING;
+#endif
+
+			ereport(elevel,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("PREPARE TRANSACTION is not supported in utility mode")));
 		}

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -1550,7 +1550,9 @@ my %tests = (
 		create_order => 1,
 		create_sql => q(
 		    CREATE DATABASE regression_invalid;
-			UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid'),
+			SET allow_system_table_mods = on;
+			UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+			RESET allow_system_table_mods;),
 		regexp => qr/^CREATE DATABASE regression_invalid/m,
 
 		# invalid databases should never be dumped

--- a/src/bin/scripts/t/011_clusterdb_all.pl
+++ b/src/bin/scripts/t/011_clusterdb_all.pl
@@ -21,7 +21,9 @@ $node->issues_sql_like(
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
+	SET allow_system_table_mods = on;
 	UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+	RESET allow_system_table_mods;
 ));
 $node->command_ok([ 'clusterdb', '-a' ],
   'invalid database not targeted by clusterdb -a');

--- a/src/bin/scripts/t/050_dropdb.pl
+++ b/src/bin/scripts/t/050_dropdb.pl
@@ -26,7 +26,9 @@ $node->command_fails([ 'dropdb', 'nonexistent' ],
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
+	SET allow_system_table_mods = on;
 	UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+	RESET allow_system_table_mods;
 ));
 $node->command_ok([ 'dropdb', 'regression_invalid' ],
   'invalid database can be dropped');

--- a/src/bin/scripts/t/091_reindexdb_all.pl
+++ b/src/bin/scripts/t/091_reindexdb_all.pl
@@ -18,7 +18,9 @@ $node->issues_sql_like(
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
+	SET allow_system_table_mods = on;
 	UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+	RESET allow_system_table_mods;
 ));
 $node->command_ok([ 'reindexdb', '-a' ],
   'invalid database not targeted by reindexdb -a');

--- a/src/bin/scripts/t/101_vacuumdb_all.pl
+++ b/src/bin/scripts/t/101_vacuumdb_all.pl
@@ -16,7 +16,9 @@ $node->issues_sql_like(
 $node->safe_psql(
 	'postgres', q(
 	CREATE DATABASE regression_invalid;
+	SET allow_system_table_mods = on;
 	UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+	RESET allow_system_table_mods;
 ));
 $node->command_ok([ 'vacuumdb', '-a' ],
   'invalid database not targeted by vacuumdb -a');

--- a/src/test/recovery/t/037_invalid_database.pl
+++ b/src/test/recovery/t/037_invalid_database.pl
@@ -29,7 +29,9 @@ $node->start;
 $node->safe_psql(
 	"postgres", qq(
 CREATE DATABASE regression_invalid;
+SET allow_system_table_mods = on;
 UPDATE pg_database SET datconnlimit = -2 WHERE datname = 'regression_invalid';
+RESET allow_system_table_mods;
 ));
 
 my $psql_stdout = '';
@@ -58,7 +60,9 @@ $psql_stderr = '';
 $node->psql(
 	'postgres',
 	qq(
+SET allow_system_table_mods = on;
 UPDATE pg_database SET datfrozenxid = '123456' WHERE datname = 'regression_invalid';
+RESET allow_system_table_mods;
 DROP TABLE IF EXISTS foo_tbl; CREATE TABLE foo_tbl();
 VACUUM FREEZE;),
 	stderr => \$psql_stderr);
@@ -89,8 +93,9 @@ my $bgpsql_in    = '';
 my $bgpsql_out   = '';
 my $bgpsql_err   = '';
 my $bgpsql_timer = IPC::Run::timer($PostgreSQL::Test::Utils::timeout_default);
-my $bgpsql = $node->background_psql('postgres', \$bgpsql_in, \$bgpsql_out,
-	$bgpsql_timer, on_error_stop => 0);
+my $bgpsql = IPC::Run::start(
+	['psql', '-XAtq', '-d', $node->connstr('postgres'), '-f', '-'],
+	'<', \$bgpsql_in, '>', \$bgpsql_out, '2>', \$bgpsql_err, $bgpsql_timer);
 $bgpsql_out = '';
 $bgpsql_in .= "SELECT pg_backend_pid();\n";
 
@@ -101,10 +106,13 @@ $bgpsql_out = '';
 
 # create the database, prevent drop database via lock held by a 2PC transaction
 $bgpsql_in .= qq(
+  CREATE EXTENSION gp_inject_fault;
   CREATE DATABASE regression_invalid_interrupt;
   BEGIN;
   LOCK pg_tablespace;
+  SELECT gp_inject_fault('enable_prepare_transaction', 'skip', 1);
   PREPARE TRANSACTION 'lock_tblspc';
+  SELECT gp_inject_fault('enable_prepare_transaction', 'reset', 1);
   \\echo done
 );
 


### PR DESCRIPTION
Fix TAP tests related to pg_database modification

Commit 034a9fc added modification of the pg_database system catalog to the TAP
tests src/bin/pg_dump/t/002_pg_dump.pl, src/bin/scripts/t/011_clusterdb_all.pl,
src/bin/scripts/t/050_dropdb.pl, src/bin/scripts/t/091_reindexdb_all.pl,
src/bin/scripts/t/101_vacuumdb_all.pl and
src/test/recovery/t/037_invalid_database.pl, while the earlier commit 6b0e52b
forbade such action at the parser level. So this patch manually allows
modification of system tables in the above tests. In the last test, the
deprecated use of the background_psql function was replaced by analogy with the
src/test/recovery/t/013_crash_restart.pl test, so as not to change the test
itself. GPDB does not support prepared transactions in utility mode, so a
fault injector was added specifically for the last test.

Ticket: ADBDEV-7238