### PR TITLE
ADBDEV-7238: Fix src/test/recovery/t/039_end_of_wal.pl test

### DIFF
--- a/src/test/perl/PostgreSQL/Test/Utils.pm
+++ b/src/test/perl/PostgreSQL/Test/Utils.pm
@@ -68,6 +68,7 @@ our @EXPORT = qw(
   check_mode_recursive
   chmod_recursive
   check_pg_config
+  scan_server_header
   system_or_bail
   system_log
   run_log
@@ -551,6 +552,39 @@ sub chmod_recursive
 		},
 		$dir);
 	return;
+}
+
+# Returns an array that stores all the matches of the given regular expression
+# within the PostgreSQL installation's C<header_path>.  This can be used to
+# retrieve specific value patterns from the installation's header files.
+sub scan_server_header
+{
+	my ($header_path, $regexp) = @_;
+
+	my ($stdout, $stderr);
+	my $result = IPC::Run::run [ 'pg_config', '--includedir-server' ], '>',
+	  \$stdout, '2>', \$stderr
+	  or die "could not execute pg_config";
+	chomp($stdout);
+	$stdout =~ s/\r$//;
+
+	open my $header_h, '<', "$stdout/$header_path" or die "$!";
+
+	my @match = undef;
+	while (<$header_h>)
+	{
+		my $line = $_;
+
+		if (@match = $line =~ /^$regexp/)
+		{
+			last;
+		}
+	}
+
+	close $header_h;
+	die "could not find match in header $header_path\n"
+	  unless @match;
+	return @match;
 }
 
 # Check presence of a given regexp within pg_config.h for the installation

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -212,8 +212,7 @@ sub advance_to_record_splitting_zone
 
 	# Calibrate our message size so that we can get closer 8 bytes at
 	# a time.
-	# (wal_block_size is 4 times larger in GPDB than in Postgres)
-	my $message_size = $WAL_BLOCK_SIZE - 80 * 4;
+	my $message_size = $WAL_BLOCK_SIZE - 80;
 	while ($page_offset <= $WAL_BLOCK_SIZE - $RECORD_HEADER_SIZE)
 	{
 		emit_message($node, $message_size);
@@ -449,7 +448,7 @@ write_wal($node, $TLI, $end_lsn,
 	build_record_header(2 * 1024 * 1024 * 1024, 0, 0xdeadbeef));
 $log_size = -s $node->logfile;
 $node->start;
-ok($node->log_contains("invalid magic number 0000 ", $log_size),
+ok($node->log_contains("invalid magic number BEEF ", $log_size),
 	"xlp_magic zero (split record header)");
 
 # And we'll also check xlp_pageaddr before any header checks.

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -212,7 +212,7 @@ sub advance_to_record_splitting_zone
 
 	# Calibrate our message size so that we can get closer 8 bytes at
 	# a time.
-	my $message_size = $WAL_BLOCK_SIZE - 80;
+	my $message_size = $WAL_BLOCK_SIZE - 80 * 4;
 	while ($page_offset <= $WAL_BLOCK_SIZE - $RECORD_HEADER_SIZE)
 	{
 		emit_message($node, $message_size);

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -448,6 +448,9 @@ write_wal($node, $TLI, $end_lsn,
 	build_record_header(2 * 1024 * 1024 * 1024, 0, 0xdeadbeef));
 $log_size = -s $node->logfile;
 $node->start;
+# in GPDB, 8 bytes remain at the end of the page instead of 16 as in Postgres,
+# so at the beginning of the next page there is a part of the xl_prev field
+# instead of zeros
 ok($node->log_contains("invalid magic number BEEF ", $log_size),
 	"xlp_magic zero (split record header)");
 

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -212,6 +212,7 @@ sub advance_to_record_splitting_zone
 
 	# Calibrate our message size so that we can get closer 8 bytes at
 	# a time.
+	# (wal_block_size is 4 times larger in GPDB than in Postgres)
 	my $message_size = $WAL_BLOCK_SIZE - 80 * 4;
 	while ($page_offset <= $WAL_BLOCK_SIZE - $RECORD_HEADER_SIZE)
 	{

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -452,7 +452,7 @@ $node->start;
 # so at the beginning of the next page there is a part of the xl_prev field
 # instead of zeros
 ok($node->log_contains("invalid magic number BEEF ", $log_size),
-	"xlp_magic zero (split record header)");
+	"xlp_magic bad (split record header)");
 
 # And we'll also check xlp_pageaddr before any header checks.
 emit_message($node, 0);


### PR DESCRIPTION
Fix src/test/recovery/t/039_end_of_wal.pl test

Commit e8f3c06 added a new function scan_server_header to
src/test/perl/TestLib.pm and its usage in the new test
src/test/recovery/t/039_end_of_wal.pl, but an earlier commit a3de0a6 renamed
src/test/perl/TestLib.pm to src/test/perl/PostgreSQL/Test/Utils.pm. So this new
function scan_server_header was lost during the merge, and this patch restores
it. Also, this patch adapts the test to the size of the checkpoint record,
which is 8 bytes larger in GPDB than in Postgres.

Ticket: ADBDEV-7238