### PR TITLE
[ADBDEV-7276] Fix partition pruning for IS NULL clause

### DIFF
--- a/src/backend/optimizer/util/predtest.c
+++ b/src/backend/optimizer/util/predtest.c
@@ -84,13 +84,13 @@ typedef struct PredIterInfoData
 
 
 static bool predicate_implied_by_internal(List *predicate_list, List *clause_list,
-							 bool clause_is_check);
+							 bool weak);
 static bool predicate_implied_by_recurse(Node *clause, Node *predicate,
-							 bool clause_is_check);
+							 bool weak);
 static bool predicate_refuted_by_internal(List *predicate_list, List *clause_list,
-							 bool clause_is_check);
+							 bool weak);
 static bool predicate_refuted_by_recurse(Node *clause, Node *predicate,
-							 bool clause_is_check);
+							 bool weak);
 static PredClass predicate_classify(Node *clause, PredIterInfo info);
 static void list_startup_fn(Node *clause, PredIterInfo info);
 static Node *list_next_fn(PredIterInfo info);
@@ -103,14 +103,14 @@ static void arrayexpr_startup_fn(Node *clause, PredIterInfo info);
 static Node *arrayexpr_next_fn(PredIterInfo info);
 static void arrayexpr_cleanup_fn(PredIterInfo info);
 static bool predicate_implied_by_simple_clause(Expr *predicate, Node *clause,
-								   bool clause_is_check);
+								   bool weak);
 static bool predicate_refuted_by_simple_clause(Expr *predicate, Node *clause,
-								   bool clause_is_check);
+								   bool weak);
 static Node *extract_not_arg(Node *clause);
 static Node *extract_strong_not_arg(Node *clause);
-static bool list_member_strip(List *list, Expr *datum);
 static bool btree_predicate_proof(Expr *predicate, Node *clause,
-					  bool refute_it);
+					  bool refute_it, bool weak);
+static bool clause_is_strict_for(Node *clause, Node *subexpr);
 static Oid	get_btree_test_op(Oid pred_op, Oid clause_op, bool refute_it);
 static void InvalidateOprProofCacheCallBack(Datum arg, int cacheid, uint32 hashvalue);
 
@@ -120,10 +120,23 @@ static bool simple_equality_predicate_refuted(Node *clause, Node *predicate);
 /*
  * predicate_implied_by_internal
  *	  Recursively checks whether the clauses in clause_list imply that the
- *	  given predicate is true.  If clause_is_check is true, assume that the
- *	  clauses in clause_list are CHECK constraints (where null is
- *	  effectively true) rather than WHERE clauses (where null is effectively
- *	  false).
+ *	  given predicate is true.
+ *
+ * We support two definitions of implication:
+ *
+ * "Strong" implication: A implies B means that truth of A implies truth of B.
+ * We use this to prove that a row satisfying one WHERE clause or index
+ * predicate must satisfy another one.
+ *
+ * "Weak" implication: A implies B means that non-falsity of A implies
+ * non-falsity of B ("non-false" means "either true or NULL").  We use this to
+ * prove that a row satisfying one CHECK constraint must satisfy another one.
+ *
+ * Strong implication can also be used to prove that a WHERE clause implies a
+ * CHECK constraint, although it will fail to prove a few cases where we could
+ * safely conclude that the implication holds.  There's no support for proving
+ * the converse case, since only a few kinds of CHECK constraint would allow
+ * deducing anything.
  *
  * The top-level List structure of each list corresponds to an AND list.
  * We assume that eval_const_expressions() has been applied and so there
@@ -133,18 +146,19 @@ static bool simple_equality_predicate_refuted(Node *clause, Node *predicate);
  * valid, but no worse consequences will ensue.
  *
  * We assume the predicate has already been checked to contain only
- * immutable functions and operators.  (In most current uses this is true
- * because the predicate is part of an index predicate that has passed
- * CheckPredicate().)  We dare not make deductions based on non-immutable
- * functions, because they might change answers between the time we make
- * the plan and the time we execute the plan.
+ * immutable functions and operators.  (In many current uses this is known
+ * true because the predicate is part of an index predicate that has passed
+ * CheckPredicate(); otherwise, the caller must check it.)  We dare not make
+ * deductions based on non-immutable functions, because they might change
+ * answers between the time we make the plan and the time we execute the plan.
+ * Immutability of functions in the clause_list is checked here, if necessary.
  */
 static bool
 predicate_implied_by_internal(List *predicate_list, List *clause_list,
-					 bool clause_is_check)
+					 bool weak)
 {
 	Node	   *p,
-			   *r;
+			   *c;
 
 	if (predicate_list == NIL)
 		return true;			/* no predicate: implication is vacuous */
@@ -162,12 +176,12 @@ predicate_implied_by_internal(List *predicate_list, List *clause_list,
 	else
 		p = (Node *) predicate_list;
 	if (list_length(clause_list) == 1)
-		r = (Node *) linitial(clause_list);
+		c = (Node *) linitial(clause_list);
 	else
-		r = (Node *) clause_list;
+		c = (Node *) clause_list;
 
 	/* And away we go ... */
-	return predicate_implied_by_recurse(r, p, clause_is_check);
+	return predicate_implied_by_recurse(c, p, weak);
 }
 
 bool
@@ -185,21 +199,28 @@ predicate_implied_by_weak(List *predicate_list, List *clause_list)
 /*
  * predicate_refuted_by_internal
  *	  Recursively checks whether the clauses in clause_list refute the given
- *	  predicate (that is, prove it false).  If clause_is_check is true, assume
- *	  that the clauses in clause_list are CHECK constraints (where null is
- *	  effectively true) rather than WHERE clauses (where null is effectively
- *	  false).
+ *	  predicate (that is, prove it false).
  *
- * This is NOT the same as !(predicate_implied_by), though it is similar
+ * This is NOT the same as !(predicate_implied_by_internal), though it is similar
  * in the technique and structure of the code.
  *
- * An important fine point is that truth of the clauses must imply that
- * the predicate returns FALSE, not that it does not return TRUE.  This
- * is normally used to try to refute CHECK constraints, and the only
- * thing we can assume about a CHECK constraint is that it didn't return
- * FALSE --- a NULL result isn't a violation per the SQL spec.  (Someday
- * perhaps this code should be extended to support both "strong" and
- * "weak" refutation, but for now we only need "strong".)
+ * We support two definitions of refutation:
+ *
+ * "Strong" refutation: A refutes B means truth of A implies falsity of B.
+ * We use this to disprove a CHECK constraint given a WHERE clause, i.e.,
+ * prove that any row satisfying the WHERE clause would violate the CHECK
+ * constraint.  (Observe we must prove B yields false, not just not-true.)
+ *
+ * "Weak" refutation: A refutes B means truth of A implies non-truth of B
+ * (i.e., B must yield false or NULL).  We use this to detect mutually
+ * contradictory WHERE clauses.
+ *
+ * Weak refutation can be proven in some cases where strong refutation doesn't
+ * hold, so it's useful to use it when possible.  We don't currently have
+ * support for disproving one CHECK constraint based on another one, nor for
+ * disproving WHERE based on CHECK.  (As with implication, the last case
+ * doesn't seem very practical.  CHECK-vs-CHECK might be useful, but isn't
+ * currently needed anywhere.)
  *
  * The top-level List structure of each list corresponds to an AND list.
  * We assume that eval_const_expressions() has been applied and so there
@@ -212,13 +233,14 @@ predicate_implied_by_weak(List *predicate_list, List *clause_list)
  * immutable functions and operators.  We dare not make deductions based on
  * non-immutable functions, because they might change answers between the
  * time we make the plan and the time we execute the plan.
+ * Immutability of functions in the clause_list is checked here, if necessary.
  */
 static bool
 predicate_refuted_by_internal(List *predicate_list, List *clause_list,
-					 bool clause_is_check)
+					 bool weak)
 {
 	Node	   *p,
-			   *r;
+			   *c;
 
 	if (predicate_list == NIL)
 		return false;			/* no predicate: no refutation is possible */
@@ -236,12 +258,12 @@ predicate_refuted_by_internal(List *predicate_list, List *clause_list,
 	else
 		p = (Node *) predicate_list;
 	if (list_length(clause_list) == 1)
-		r = (Node *) linitial(clause_list);
+		c = (Node *) linitial(clause_list);
 	else
-		r = (Node *) clause_list;
+		c = (Node *) clause_list;
 
 	/* And away we go ... */
-	if ( predicate_refuted_by_recurse(r, p, clause_is_check))
+	if (predicate_refuted_by_recurse(c, p, weak))
         return true;
 
     if ( ! kUseFnEvaluationForPredicates )
@@ -280,7 +302,9 @@ predicate_refuted_by_weak(List *predicate_list, List *clause_list)
  *
  * An "atom" is anything other than an AND or OR node.  Notice that we don't
  * have any special logic to handle NOT nodes; these should have been pushed
- * down or eliminated where feasible by prepqual.c.
+ * down or eliminated where feasible during eval_const_expressions().
+ *
+ * All of these rules apply equally to strong or weak implication.
  *
  * We can't recursively expand either side first, but have to interleave
  * the expansions per the above rules, to be sure we handle all of these
@@ -298,7 +322,7 @@ predicate_refuted_by_weak(List *predicate_list, List *clause_list)
  */
 static bool
 predicate_implied_by_recurse(Node *clause, Node *predicate,
-							 bool clause_is_check)
+							 bool weak)
 {
 	PredIterInfoData clause_info;
 	PredIterInfoData pred_info;
@@ -326,7 +350,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (!predicate_implied_by_recurse(clause, pitem,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -346,7 +370,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (predicate_implied_by_recurse(clause, pitem,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -364,7 +388,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (predicate_implied_by_recurse(citem, predicate,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -382,7 +406,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (predicate_implied_by_recurse(citem, predicate,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -410,7 +434,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 						iterate_begin(pitem, predicate, pred_info)
 						{
 							if (predicate_implied_by_recurse(citem, pitem,
-															 clause_is_check))
+															 weak))
 							{
 								presult = true;
 								break;
@@ -438,7 +462,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (!predicate_implied_by_recurse(citem, predicate,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -461,7 +485,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (!predicate_implied_by_recurse(clause, pitem,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -479,7 +503,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (predicate_implied_by_recurse(clause, pitem,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -496,7 +520,7 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
 					return
 						predicate_implied_by_simple_clause((Expr *) predicate,
 														   clause,
-														   clause_is_check);
+														   weak);
 			}
 			break;
 	}
@@ -523,22 +547,23 @@ predicate_implied_by_recurse(Node *clause, Node *predicate,
  *	OR-expr A R=> AND-expr B iff:	each of A's components R=> any of B's
  *	OR-expr A R=> OR-expr B iff:	A R=> each of B's components
  *
+ * All of the above rules apply equally to strong or weak refutation.
+ *
  * In addition, if the predicate is a NOT-clause then we can use
  *	A R=> NOT B if:					A => B
  * This works for several different SQL constructs that assert the non-truth
- * of their argument, ie NOT, IS FALSE, IS NOT TRUE, IS UNKNOWN.
- * Unfortunately we *cannot* use
+ * of their argument, ie NOT, IS FALSE, IS NOT TRUE, IS UNKNOWN, although some
+ * of them require that we prove strong implication.  Likewise, we can use
  *	NOT A R=> B if:					B => A
- * because this type of reasoning fails to prove that B doesn't yield NULL.
- * We can however make the more limited deduction that
- *	NOT A R=> A
+ * but here we must be careful about strong vs. weak refutation and make
+ * the appropriate type of implication proof (weak or strong respectively).
  *
  * Other comments are as for predicate_implied_by_recurse().
  *----------
  */
 static bool
 predicate_refuted_by_recurse(Node *clause, Node *predicate,
-							 bool clause_is_check)
+							 bool weak)
 {
 	PredIterInfoData clause_info;
 	PredIterInfoData pred_info;
@@ -571,7 +596,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (predicate_refuted_by_recurse(clause, pitem,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -589,7 +614,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (predicate_refuted_by_recurse(citem, predicate,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -607,7 +632,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (!predicate_refuted_by_recurse(clause, pitem,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -619,12 +644,19 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 				case CLASS_ATOM:
 
 					/*
-					 * If B is a NOT-clause, A R=> B if A => B's arg
+					 * If B is a NOT-type clause, A R=> B if A => B's arg
+					 *
+					 * Since, for either type of refutation, we are starting
+					 * with the premise that A is true, we can use a strong
+					 * implication test in all cases.  That proves B's arg is
+					 * true, which is more than we need for weak refutation if
+					 * B is a simple NOT, but it allows not worrying about
+					 * exactly which kind of negation clause we have.
 					 */
 					not_arg = extract_not_arg(predicate);
 					if (not_arg &&
 						predicate_implied_by_recurse(clause, not_arg,
-													 clause_is_check))
+													 false))
 						return true;
 
 					/*
@@ -634,7 +666,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (predicate_refuted_by_recurse(citem, predicate,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -657,7 +689,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (!predicate_refuted_by_recurse(clause, pitem,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -680,7 +712,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 						iterate_begin(pitem, predicate, pred_info)
 						{
 							if (predicate_refuted_by_recurse(citem, pitem,
-															 clause_is_check))
+															 weak))
 							{
 								presult = true;
 								break;
@@ -699,12 +731,14 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 				case CLASS_ATOM:
 
 					/*
-					 * If B is a NOT-clause, A R=> B if A => B's arg
+					 * If B is a NOT-type clause, A R=> B if A => B's arg
+					 *
+					 * Same logic as for the AND-clause case above.
 					 */
 					not_arg = extract_not_arg(predicate);
 					if (not_arg &&
 						predicate_implied_by_recurse(clause, not_arg,
-													 clause_is_check))
+													 false))
 						return true;
 
 					/*
@@ -714,7 +748,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(citem, clause, clause_info)
 					{
 						if (!predicate_refuted_by_recurse(citem, predicate,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -728,16 +762,18 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 		case CLASS_ATOM:
 
 			/*
-			 * If A is a strong NOT-clause, A R=> B if B equals A's arg
+			 * If A is a strong NOT-clause, A R=> B if B => A's arg
 			 *
-			 * We cannot make the stronger conclusion that B is refuted if B
-			 * implies A's arg; that would only prove that B is not-TRUE, not
-			 * that it's not NULL either.  Hence use equal() rather than
-			 * predicate_implied_by_recurse().  We could do the latter if we
-			 * ever had a need for the weak form of refutation.
+			 * Since A is strong, we may assume A's arg is false (not just
+			 * not-true).  If B weakly implies A's arg, then B can be neither
+			 * true nor null, so that strong refutation is proven.  If B
+			 * strongly implies A's arg, then B cannot be true, so that weak
+			 * refutation is proven.
 			 */
 			not_arg = extract_strong_not_arg(clause);
-			if (not_arg && equal(predicate, not_arg))
+			if (not_arg &&
+				predicate_implied_by_recurse(predicate, not_arg,
+											 !weak))
 				return true;
 
 			switch (pclass)
@@ -751,7 +787,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (predicate_refuted_by_recurse(clause, pitem,
-														 clause_is_check))
+														 weak))
 						{
 							result = true;
 							break;
@@ -769,7 +805,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					iterate_begin(pitem, predicate, pred_info)
 					{
 						if (!predicate_refuted_by_recurse(clause, pitem,
-														  clause_is_check))
+														  weak))
 						{
 							result = false;
 							break;
@@ -781,12 +817,14 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 				case CLASS_ATOM:
 
 					/*
-					 * If B is a NOT-clause, A R=> B if A => B's arg
+					 * If B is a NOT-type clause, A R=> B if A => B's arg
+					 *
+					 * Same logic as for the AND-clause case above.
 					 */
 					not_arg = extract_not_arg(predicate);
 					if (not_arg &&
 						predicate_implied_by_recurse(clause, not_arg,
-													 clause_is_check))
+													 false))
 						return true;
 
 					/*
@@ -795,7 +833,7 @@ predicate_refuted_by_recurse(Node *clause, Node *predicate,
 					return
 						predicate_refuted_by_simple_clause((Expr *) predicate,
 														   clause,
-														   clause_is_check);
+														   weak);
 			}
 			break;
 	}
@@ -1093,19 +1131,16 @@ arrayexpr_cleanup_fn(PredIterInfo info)
  * implies another:
  *
  * A simple and general way is to see if they are equal(); this works for any
- * kind of expression.  (Actually, there is an implied assumption that the
- * functions in the expression are immutable, ie dependent only on their input
- * arguments --- but this was checked for the predicate by the caller.)
+ * kind of expression, and for either implication definition.  (Actually,
+ * there is an implied assumption that the functions in the expression are
+ * immutable --- but this was checked for the predicate by the caller.)
  *
- * When clause_is_check is false, we know we are within an AND/OR
- * subtree of a WHERE clause.  So, if the predicate is of the form "foo IS
- * NOT NULL", we can conclude that the predicate is implied if the clause is
- * a strict operator or function that has "foo" as an input.  In this case
- * the clause must yield NULL when "foo" is NULL, which we can take as
- * equivalent to FALSE given the context. (Again, "foo" is already known
- * immutable, so the clause will certainly always fail.) Also, if the clause
- * is just "foo" (meaning it's a boolean variable), the predicate is implied
- * since the clause can't be true if "foo" is NULL.
+ * If the predicate is of the form "foo IS NOT NULL", and we are considering
+ * strong implication, we can conclude that the predicate is implied if the
+ * clause is strict for "foo", i.e., it must yield NULL when "foo" is NULL.
+ * In that case truth of the clause requires that "foo" isn't NULL.
+ * (Again, this is a safe conclusion because "foo" must be immutable.)
+ * This doesn't work for weak implication, though.
  *
  * Finally, we may be able to deduce something using knowledge about btree
  * operator families; this is encapsulated in btree_predicate_proof().
@@ -1113,7 +1148,7 @@ arrayexpr_cleanup_fn(PredIterInfo info)
  */
 static bool
 predicate_implied_by_simple_clause(Expr *predicate, Node *clause,
-								   bool clause_is_check)
+								   bool weak)
 {
 	/* Allow interrupting long proof attempts */
 	CHECK_FOR_INTERRUPTS();
@@ -1123,28 +1158,24 @@ predicate_implied_by_simple_clause(Expr *predicate, Node *clause,
 		return true;
 
 	/* Next try the IS NOT NULL case */
-	if (predicate && IsA(predicate, NullTest) &&
-		((NullTest *) predicate)->nulltesttype == IS_NOT_NULL)
+	if (!weak &&
+		predicate && IsA(predicate, NullTest))
 	{
-		Expr	   *nonnullarg = ((NullTest *) predicate)->arg;
+		NullTest   *ntest = (NullTest *) predicate;
 
 		/* row IS NOT NULL does not act in the simple way we have in mind */
-		if (!((NullTest *) predicate)->argisrow && !clause_is_check)
+		if (ntest->nulltesttype == IS_NOT_NULL &&
+			!ntest->argisrow)
 		{
-			if (is_opclause(clause) &&
-				list_member_strip(((OpExpr *) clause)->args, nonnullarg) &&
-				op_strict(((OpExpr *) clause)->opno))
-				return true;
-			if (is_funcclause(clause) &&
-				list_member_strip(((FuncExpr *) clause)->args, nonnullarg) &&
-				func_strict(((FuncExpr *) clause)->funcid))
+			/* strictness of clause for foo implies foo IS NOT NULL */
+			if (clause_is_strict_for(clause, (Node *) ntest->arg))
 				return true;
 		}
 		return false;			/* we can't succeed below... */
 	}
 
 	/* Else try btree operator knowledge */
-	return btree_predicate_proof(predicate, clause, false);
+	return btree_predicate_proof(predicate, clause, false, weak);
 }
 
 /*----------
@@ -1154,17 +1185,23 @@ predicate_implied_by_simple_clause(Expr *predicate, Node *clause,
  *
  * We return TRUE if able to prove the refutation, FALSE if not.
  *
- * Unlike the implication case, checking for equal() clauses isn't
- * helpful.
+ * Unlike the implication case, checking for equal() clauses isn't helpful.
+ * But relation_excluded_by_constraints() checks for self-contradictions in a
+ * list of clauses, so that we may get here with predicate and clause being
+ * actually pointer-equal, and that is worth eliminating quickly.
  *
  * When the predicate is of the form "foo IS NULL", we can conclude that
- * the predicate is refuted if the clause is a strict operator or function
- * that has "foo" as an input (see notes for implication case), or if the
- * clause is "foo IS NOT NULL".  A clause "foo IS NULL" refutes a predicate
- * "foo IS NOT NULL", but unfortunately does not refute strict predicates,
- * because we are looking for strong refutation.  (The motivation for covering
- * these cases is to support using IS NULL/IS NOT NULL as partition-defining
- * constraints.)
+ * the predicate is refuted if the clause is strict for "foo" (see notes for
+ * implication case), or is "foo IS NOT NULL".  That works for either strong
+ * or weak refutation.
+ *
+ * A clause "foo IS NULL" refutes a predicate "foo IS NOT NULL" in all cases.
+ * If we are considering weak refutation, it also refutes a predicate that
+ * is strict for "foo", since then the predicate must yield NULL (and since
+ * "foo" appears in the predicate, it's known immutable).
+ *
+ * (The main motivation for covering these IS [NOT] NULL cases is to support
+ * using IS NULL/IS NOT NULL as partition-defining constraints.)
  *
  * Finally, we may be able to deduce something using knowledge about btree
  * operator families; this is encapsulated in btree_predicate_proof().
@@ -1172,7 +1209,7 @@ predicate_implied_by_simple_clause(Expr *predicate, Node *clause,
  */
 static bool
 predicate_refuted_by_simple_clause(Expr *predicate, Node *clause,
-								   bool clause_is_check)
+								   bool weak)
 {
 	/* Allow interrupting long proof attempts */
 	CHECK_FOR_INTERRUPTS();
@@ -1188,21 +1225,12 @@ predicate_refuted_by_simple_clause(Expr *predicate, Node *clause,
 	{
 		Expr	   *isnullarg = ((NullTest *) predicate)->arg;
 
-		if (clause_is_check)
-			return false;
-
 		/* row IS NULL does not act in the simple way we have in mind */
 		if (((NullTest *) predicate)->argisrow)
 			return false;
 
-		/* Any strict op/func on foo refutes foo IS NULL */
-		if (is_opclause(clause) &&
-			list_member_strip(((OpExpr *) clause)->args, isnullarg) &&
-			op_strict(((OpExpr *) clause)->opno))
-			return true;
-		if (is_funcclause(clause) &&
-			list_member_strip(((FuncExpr *) clause)->args, isnullarg) &&
-			func_strict(((FuncExpr *) clause)->funcid))
+		/* strictness of clause for foo refutes foo IS NULL */
+		if (clause_is_strict_for(clause, (Node *) isnullarg))
 			return true;
 
 		/* foo IS NOT NULL refutes foo IS NULL */
@@ -1232,11 +1260,16 @@ predicate_refuted_by_simple_clause(Expr *predicate, Node *clause,
 			equal(((NullTest *) predicate)->arg, isnullarg))
 			return true;
 
+		/* foo IS NULL weakly refutes any predicate that is strict for foo */
+		if (weak &&
+			clause_is_strict_for((Node *) predicate, (Node *) isnullarg))
+			return true;
+
 		return false;			/* we can't succeed below... */
 	}
 
 	/* Else try btree operator knowledge */
-	return btree_predicate_proof(predicate, clause, true);
+	return btree_predicate_proof(predicate, clause, true, weak);
 }
 
 /**
@@ -1460,29 +1493,63 @@ extract_strong_not_arg(Node *clause)
 
 
 /*
- * Check whether an Expr is equal() to any member of a list, ignoring
- * any top-level RelabelType nodes.  This is legitimate for the purposes
- * we use it for (matching IS [NOT] NULL arguments to arguments of strict
- * functions) because RelabelType doesn't change null-ness.  It's helpful
- * for cases such as a varchar argument of a strict function on text.
+ * Can we prove that "clause" returns NULL if "subexpr" does?
+ *
+ * The base case is that clause and subexpr are equal().  (We assume that
+ * the caller knows at least one of the input expressions is immutable,
+ * as this wouldn't hold for volatile expressions.)
+ *
+ * We can also report success if the subexpr appears as a subexpression
+ * of "clause" in a place where it'd force nullness of the overall result.
  */
 static bool
-list_member_strip(List *list, Expr *datum)
+clause_is_strict_for(Node *clause, Node *subexpr)
 {
-	ListCell   *cell;
+	ListCell   *lc;
 
-	if (datum && IsA(datum, RelabelType))
-		datum = ((RelabelType *) datum)->arg;
+	/* safety checks */
+	if (clause == NULL || subexpr == NULL)
+		return false;
 
-	foreach(cell, list)
+	/*
+	 * Look through any RelabelType nodes, so that we can match, say,
+	 * varcharcol with lower(varcharcol::text).  (In general we could recurse
+	 * through any nullness-preserving, immutable operation.)  We should not
+	 * see stacked RelabelTypes here.
+	 */
+	if (IsA(clause, RelabelType))
+		clause = (Node *) ((RelabelType *) clause)->arg;
+	if (IsA(subexpr, RelabelType))
+		subexpr = (Node *) ((RelabelType *) subexpr)->arg;
+
+	/* Base case */
+	if (equal(clause, subexpr))
+		return true;
+
+	/*
+	 * If we have a strict operator or function, a NULL result is guaranteed
+	 * if any input is forced NULL by subexpr.  This is OK even if the op or
+	 * func isn't immutable, since it won't even be called on NULL input.
+	 */
+	if (is_opclause(clause) &&
+		op_strict(((OpExpr *) clause)->opno))
 	{
-		Expr	   *elem = (Expr *) lfirst(cell);
-
-		if (elem && IsA(elem, RelabelType))
-			elem = ((RelabelType *) elem)->arg;
-
-		if (equal(elem, datum))
-			return true;
+		foreach(lc, ((OpExpr *) clause)->args)
+		{
+			if (clause_is_strict_for((Node *) lfirst(lc), subexpr))
+				return true;
+		}
+		return false;
+	}
+	if (is_funcclause(clause) &&
+		func_strict(((FuncExpr *) clause)->funcid))
+	{
+		foreach(lc, ((FuncExpr *) clause)->args)
+		{
+			if (clause_is_strict_for((Node *) lfirst(lc), subexpr))
+				return true;
+		}
+		return false;
 	}
 
 	return false;
@@ -1578,18 +1645,26 @@ static const StrategyNumber BT_refute_table[6][6] = {
  * in one routine.)  We return TRUE if able to make the proof, FALSE
  * if not able to prove it.
  *
- * What we look for here is binary boolean opclauses of the form
- * "foo op constant", where "foo" is the same in both clauses.  The operators
- * and constants can be different but the operators must be in the same btree
- * operator family.  We use the above operator implication tables to
- * derive implications between nonidentical clauses.  (Note: "foo" is known
- * immutable, and constants are surely immutable, but we have to check that
- * the operators are too.  As of 8.0 it's possible for opfamilies to contain
- * operators that are merely stable, and we dare not make deductions with
- * these.)
+ * We mostly need not distinguish strong vs. weak implication/refutation here.
+ * This depends on the assumption that a pair of related operators (i.e.,
+ * commutators, negators, or btree opfamily siblings) will not return one NULL
+ * and one non-NULL result for the same inputs.  Then, for the proof types
+ * where we start with an assumption of truth of the clause, the predicate
+ * operator could not return NULL either, so it doesn't matter whether we are
+ * trying to make a strong or weak proof.  For weak implication, it could be
+ * that the clause operator returned NULL, but then the predicate operator
+ * would as well, so that the weak implication still holds.  This argument
+ * doesn't apply in the case where we are considering two different constant
+ * values, since then the operators aren't being given identical inputs.  But
+ * we only support that for btree operators, for which we can assume that all
+ * non-null inputs result in non-null outputs, so that it doesn't matter which
+ * two non-null constants we consider.  Currently the code below just reports
+ * "proof failed" if either constant is NULL, but in some cases we could be
+ * smarter (and that likely would require checking strong vs. weak proofs).
+ *
  */
 static bool
-btree_predicate_proof(Expr *predicate, Node *clause, bool refute_it)
+btree_predicate_proof(Expr *predicate, Node *clause, bool refute_it, bool weak)
 {
 	Node	   *leftop,
 			   *rightop;
@@ -1640,8 +1715,6 @@ btree_predicate_proof(Expr *predicate, Node *clause, bool refute_it)
 	}
 	else
 		return false;			/* no Const to be found */
-	if (pred_const->constisnull)
-		return false;
 
 	if (!is_opclause(clause))
 		return false;
@@ -1663,8 +1736,6 @@ btree_predicate_proof(Expr *predicate, Node *clause, bool refute_it)
 	}
 	else
 		return false;			/* no Const to be found */
-	if (clause_const->constisnull)
-		return false;
 
 	/*
 	 * Check for matching subexpressions on the non-Const sides.  We used to
@@ -1702,6 +1773,47 @@ btree_predicate_proof(Expr *predicate, Node *clause, bool refute_it)
 		clause_op = get_commutator(clause_op);
 		if (!OidIsValid(clause_op))
 			return false;
+	}
+
+	if (!equal(pred_const, clause_const) &&
+		clause_const->constisnull)
+	{
+		/* If clause_op isn't strict, we can't prove anything */
+		if (!op_strict(clause_op))
+			return false;
+
+		/*
+		 * At this point we know that the clause returns NULL.  For proof
+		 * types that assume truth of the clause, this means the proof is
+		 * vacuously true (a/k/a "false implies anything").  That's all proof
+		 * types except weak implication.
+		 */
+		if (!(weak && !refute_it))
+			return true;
+
+		/*
+		 * For weak implication, it's still possible for the proof to succeed,
+		 * if the predicate can also be proven NULL.  In that case we've got
+		 * NULL => NULL which is valid for this proof type.
+		 */
+		if (pred_const->constisnull && op_strict(pred_op))
+			return true;
+		/* Else the proof fails */
+		return false;
+	}
+
+	if (!equal(pred_const, clause_const) &&
+		pred_const->constisnull)
+	{
+		/*
+		 * If the pred_op is strict, we know the predicate yields NULL, which
+		 * means the proof succeeds for either weak implication or weak
+		 * refutation.
+		 */
+		if (weak && op_strict(pred_op))
+			return true;
+		/* Else the proof fails */
+		return false;
 	}
 
 	/*

--- a/src/include/optimizer/predtest.h
+++ b/src/include/optimizer/predtest.h
@@ -25,6 +25,8 @@ extern bool predicate_implied_by(List *predicate_list,
 					 List *restrictinfo_list);
 extern bool predicate_refuted_by(List *predicate_list,
 					 List *restrictinfo_list);
+extern bool predicate_implied_by_weak(List *predicate_list, List *clause_list);
+extern bool predicate_refuted_by_weak(List *predicate_list, List *clause_list);
 
 /***************************************************************************************
  * BEGIN functions and structures for determining a set of possible values from a clause

--- a/src/test/modules/test_predtest/.gitignore
+++ b/src/test/modules/test_predtest/.gitignore
@@ -1,0 +1,4 @@
+# Generated subdirectories
+/log/
+/results/
+/tmp_check/

--- a/src/test/modules/test_predtest/Makefile
+++ b/src/test/modules/test_predtest/Makefile
@@ -1,0 +1,21 @@
+# src/test/modules/test_predtest/Makefile
+
+MODULE_big = test_predtest
+OBJS = test_predtest.o $(WIN32RES)
+PGFILEDESC = "test_predtest - test code for optimizer/util/predtest.c"
+
+EXTENSION = test_predtest
+DATA = test_predtest--1.0.sql
+
+REGRESS = test_predtest
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/modules/test_predtest
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/src/test/modules/test_predtest/README
+++ b/src/test/modules/test_predtest/README
@@ -1,0 +1,28 @@
+test_predtest is a module for checking the correctness of the optimizer's
+predicate-proof logic, in src/backend/optimizer/util/predtest.c.
+
+The module provides a function that allows direct application of
+predtest.c's exposed functions, predicate_implied_by() and
+predicate_refuted_by(), to arbitrary boolean expressions, with direct
+inspection of the results.  This could be done indirectly by checking
+planner results, but it can be difficult to construct end-to-end test
+cases that prove that the expected results were obtained.
+
+In general, the use of this function is like
+	select * from test_predtest('query string')
+where the query string must be a SELECT returning two boolean
+columns, for example
+
+	select * from test_predtest($$
+	select x, not x
+	from (values (false), (true), (null)) as v(x)
+	$$);
+
+The function parses and plans the given query, and then applies the
+predtest.c code to the two boolean expressions in the SELECT list, to see
+if the first expression can be proven or refuted by the second.  It also
+executes the query, and checks the resulting rows to see whether any
+claimed implication or refutation relationship actually holds.  If the
+query is designed to exercise the expressions on a full set of possible
+input values, as in the example above, then this provides a mechanical
+cross-check as to whether the proof code has given a correct answer.

--- a/src/test/modules/test_predtest/expected/test_predtest.out
+++ b/src/test/modules/test_predtest/expected/test_predtest.out
@@ -1,0 +1,769 @@
+CREATE EXTENSION test_predtest;
+-- Make output more legible
+\pset expanded on
+-- Test data
+-- all combinations of four boolean values
+create table booleans as
+select
+  case i%3 when 0 then true when 1 then false else null end as x,
+  case (i/3)%3 when 0 then true when 1 then false else null end as y,
+  case (i/9)%3 when 0 then true when 1 then false else null end as z,
+  case (i/27)%3 when 0 then true when 1 then false else null end as w
+from generate_series(0, 3*3*3*3-1) i;
+-- all combinations of two integers 0..9, plus null
+create table integers as
+select
+  case i%11 when 10 then null else i%11 end as x,
+  case (i/11)%11 when 10 then null else (i/11)%11 end as y
+from generate_series(0, 11*11-1) i;
+-- Basic proof rules for single boolean variables
+select * from test_predtest($$
+select x, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x, not x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select not x, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select not x, not x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is not null, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is not null, x is null
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x is null, x is not null
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x is not true, x
+from booleans
+$$);
+WARNING:  weak_refuted_by result is incorrect
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | f
+
+select * from test_predtest($$
+select x, x is not true
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | t
+
+select * from test_predtest($$
+select x is false, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x, x is false
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x is unknown, x
+from booleans
+$$);
+WARNING:  weak_refuted_by result is incorrect
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | f
+
+select * from test_predtest($$
+select x, x is unknown
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | t
+
+-- XXX seems like we should be able to refute x is null here
+select * from test_predtest($$
+select x is null, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | f
+
+select * from test_predtest($$
+select x, x is null
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | t
+
+-- Tests involving AND/OR constructs
+select * from test_predtest($$
+select x, x and y
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select not x, x and y
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x, not x and y
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x or y, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x and y, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x and y, not x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x and y, y and x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select not y, y and x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x or y, y or x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x or y or z, x or z
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select z or w, x or y
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select z and w, x or y
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x, (x and y) or (x and z)
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select (x and y) or z, y and x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select (not x or not y) and z, y and x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select y or x, (x or y) and z
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select not x and not y, (x or y) and z
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+-- Tests using btree operator knowledge
+select * from test_predtest($$
+select x <= y, x < y
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= y, x > y
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x <= y, y >= x
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= y, y > x and y < x+2
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= 5, x <= 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= 5, x > 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x <= 5, 7 > x
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select 5 >= x, 7 > x
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select 5 >= x, x > 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select 5 = x, x = 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select x is not null, x > 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is not null, int4lt(x,8)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is null, x > 7
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is null, int4lt(x,8)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | f
+
+select * from test_predtest($$
+select x is not null, x < 'foo'
+from (values
+  ('aaa'::varchar), ('zzz'::varchar), (null)) as v(x)
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+-- Cases using ScalarArrayOpExpr
+select * from test_predtest($$
+select x <= 5, x in (1,3,5)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= 5, x in (1,3,5,7)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+-- XXX ideally, we could prove this case too
+select * from test_predtest($$
+select x <= 5, x in (1,3,5,null)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x in (null,1,3,5,7), x in (1,3,5)
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= 5, x < all(array[1,3,5])
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x <= y, x = any(array[1,3,y])
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | f
+w_r_holds         | f
+

--- a/src/test/modules/test_predtest/expected/test_predtest.out
+++ b/src/test/modules/test_predtest/expected/test_predtest.out
@@ -16,6 +16,9 @@ select
   case i%11 when 10 then null else i%11 end as x,
   case (i/11)%11 when 10 then null else (i/11)%11 end as y
 from generate_series(0, 11*11-1) i;
+-- and a simple strict function that's opaque to the optimizer
+create function strictf(bool, bool) returns bool
+language plpgsql as $$begin return $1 and not $2; end$$ strict;
 -- Basic proof rules for single boolean variables
 select * from test_predtest($$
 select x, x
@@ -109,7 +112,7 @@ $$);
 strong_implied_by | f
 weak_implied_by   | f
 strong_refuted_by | t
-weak_refuted_by   | f
+weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
@@ -119,7 +122,6 @@ select * from test_predtest($$
 select x is not true, x
 from booleans
 $$);
-WARNING:  weak_refuted_by result is incorrect
 -[ RECORD 1 ]-----+--
 strong_implied_by | f
 weak_implied_by   | f
@@ -128,7 +130,7 @@ weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
-w_r_holds         | f
+w_r_holds         | t
 
 select * from test_predtest($$
 select x, x is not true
@@ -176,7 +178,6 @@ select * from test_predtest($$
 select x is unknown, x
 from booleans
 $$);
-WARNING:  weak_refuted_by result is incorrect
 -[ RECORD 1 ]-----+--
 strong_implied_by | f
 weak_implied_by   | f
@@ -185,7 +186,7 @@ weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
-w_r_holds         | f
+w_r_holds         | t
 
 select * from test_predtest($$
 select x, x is unknown
@@ -201,7 +202,7 @@ w_i_holds         | t
 s_r_holds         | f
 w_r_holds         | t
 
--- XXX seems like we should be able to refute x is null here
+-- Assorted not-so-trivial refutation rules
 select * from test_predtest($$
 select x is null, x
 from booleans
@@ -209,12 +210,12 @@ $$);
 -[ RECORD 1 ]-----+--
 strong_implied_by | f
 weak_implied_by   | f
-strong_refuted_by | f
-weak_refuted_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
-w_r_holds         | f
+w_r_holds         | t
 
 select * from test_predtest($$
 select x, x is null
@@ -224,10 +225,66 @@ $$);
 strong_implied_by | f
 weak_implied_by   | f
 strong_refuted_by | f
-weak_refuted_by   | f
+weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | t
 s_r_holds         | f
+w_r_holds         | t
+
+select * from test_predtest($$
+select strictf(x,y), x is null
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | t
+
+select * from test_predtest($$
+select (x is not null) is not true, x
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
+w_r_holds         | t
+
+select * from test_predtest($$
+select strictf(x,y), (x is not null) is false
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | f
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | t
+
+select * from test_predtest($$
+select x > y, (y < x) is false
+from integers
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | f
+weak_implied_by   | f
+strong_refuted_by | t
+weak_refuted_by   | t
+s_i_holds         | f
+w_i_holds         | f
+s_r_holds         | t
 w_r_holds         | t
 
 -- Tests involving AND/OR constructs
@@ -359,6 +416,20 @@ w_r_holds         | f
 
 select * from test_predtest($$
 select x or y or z, x or z
+from booleans
+$$);
+-[ RECORD 1 ]-----+--
+strong_implied_by | t
+weak_implied_by   | t
+strong_refuted_by | f
+weak_refuted_by   | f
+s_i_holds         | t
+w_i_holds         | t
+s_r_holds         | f
+w_r_holds         | f
+
+select * from test_predtest($$
+select x and z, x and y and z
 from booleans
 $$);
 -[ RECORD 1 ]-----+--
@@ -646,11 +717,11 @@ $$);
 strong_implied_by | f
 weak_implied_by   | f
 strong_refuted_by | t
-weak_refuted_by   | f
+weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
-w_r_holds         | f
+w_r_holds         | t
 
 select * from test_predtest($$
 select x is null, int4lt(x,8)
@@ -660,11 +731,11 @@ $$);
 strong_implied_by | f
 weak_implied_by   | f
 strong_refuted_by | t
-weak_refuted_by   | f
+weak_refuted_by   | t
 s_i_holds         | f
 w_i_holds         | f
 s_r_holds         | t
-w_r_holds         | f
+w_r_holds         | t
 
 select * from test_predtest($$
 select x is not null, x < 'foo'
@@ -710,7 +781,7 @@ w_i_holds         | f
 s_r_holds         | f
 w_r_holds         | f
 
--- XXX ideally, we could prove this case too
+-- XXX ideally, we could prove this case too, for strong implication
 select * from test_predtest($$
 select x <= 5, x in (1,3,5,null)
 from integers

--- a/src/test/modules/test_predtest/sql/test_predtest.sql
+++ b/src/test/modules/test_predtest/sql/test_predtest.sql
@@ -1,0 +1,298 @@
+CREATE EXTENSION test_predtest;
+
+-- Make output more legible
+\pset expanded on
+
+-- Test data
+
+-- all combinations of four boolean values
+create table booleans as
+select
+  case i%3 when 0 then true when 1 then false else null end as x,
+  case (i/3)%3 when 0 then true when 1 then false else null end as y,
+  case (i/9)%3 when 0 then true when 1 then false else null end as z,
+  case (i/27)%3 when 0 then true when 1 then false else null end as w
+from generate_series(0, 3*3*3*3-1) i;
+
+-- all combinations of two integers 0..9, plus null
+create table integers as
+select
+  case i%11 when 10 then null else i%11 end as x,
+  case (i/11)%11 when 10 then null else (i/11)%11 end as y
+from generate_series(0, 11*11-1) i;
+
+-- Basic proof rules for single boolean variables
+
+select * from test_predtest($$
+select x, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, not x
+from booleans
+$$);
+
+select * from test_predtest($$
+select not x, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select not x, not x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x is not null, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x is not null, x is null
+from integers
+$$);
+
+select * from test_predtest($$
+select x is null, x is not null
+from integers
+$$);
+
+select * from test_predtest($$
+select x is not true, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, x is not true
+from booleans
+$$);
+
+select * from test_predtest($$
+select x is false, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, x is false
+from booleans
+$$);
+
+select * from test_predtest($$
+select x is unknown, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, x is unknown
+from booleans
+$$);
+
+-- XXX seems like we should be able to refute x is null here
+select * from test_predtest($$
+select x is null, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, x is null
+from booleans
+$$);
+
+-- Tests involving AND/OR constructs
+
+select * from test_predtest($$
+select x, x and y
+from booleans
+$$);
+
+select * from test_predtest($$
+select not x, x and y
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, not x and y
+from booleans
+$$);
+
+select * from test_predtest($$
+select x or y, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x and y, x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x and y, not x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x and y, y and x
+from booleans
+$$);
+
+select * from test_predtest($$
+select not y, y and x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x or y, y or x
+from booleans
+$$);
+
+select * from test_predtest($$
+select x or y or z, x or z
+from booleans
+$$);
+
+select * from test_predtest($$
+select z or w, x or y
+from booleans
+$$);
+
+select * from test_predtest($$
+select z and w, x or y
+from booleans
+$$);
+
+select * from test_predtest($$
+select x, (x and y) or (x and z)
+from booleans
+$$);
+
+select * from test_predtest($$
+select (x and y) or z, y and x
+from booleans
+$$);
+
+select * from test_predtest($$
+select (not x or not y) and z, y and x
+from booleans
+$$);
+
+select * from test_predtest($$
+select y or x, (x or y) and z
+from booleans
+$$);
+
+select * from test_predtest($$
+select not x and not y, (x or y) and z
+from booleans
+$$);
+
+-- Tests using btree operator knowledge
+
+select * from test_predtest($$
+select x <= y, x < y
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= y, x > y
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= y, y >= x
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= y, y > x and y < x+2
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= 5, x <= 7
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= 5, x > 7
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= 5, 7 > x
+from integers
+$$);
+
+select * from test_predtest($$
+select 5 >= x, 7 > x
+from integers
+$$);
+
+select * from test_predtest($$
+select 5 >= x, x > 7
+from integers
+$$);
+
+select * from test_predtest($$
+select 5 = x, x = 7
+from integers
+$$);
+
+select * from test_predtest($$
+select x is not null, x > 7
+from integers
+$$);
+
+select * from test_predtest($$
+select x is not null, int4lt(x,8)
+from integers
+$$);
+
+select * from test_predtest($$
+select x is null, x > 7
+from integers
+$$);
+
+select * from test_predtest($$
+select x is null, int4lt(x,8)
+from integers
+$$);
+
+select * from test_predtest($$
+select x is not null, x < 'foo'
+from (values
+  ('aaa'::varchar), ('zzz'::varchar), (null)) as v(x)
+$$);
+
+-- Cases using ScalarArrayOpExpr
+
+select * from test_predtest($$
+select x <= 5, x in (1,3,5)
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= 5, x in (1,3,5,7)
+from integers
+$$);
+
+-- XXX ideally, we could prove this case too
+select * from test_predtest($$
+select x <= 5, x in (1,3,5,null)
+from integers
+$$);
+
+select * from test_predtest($$
+select x in (null,1,3,5,7), x in (1,3,5)
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= 5, x < all(array[1,3,5])
+from integers
+$$);
+
+select * from test_predtest($$
+select x <= y, x = any(array[1,3,y])
+from integers
+$$);

--- a/src/test/modules/test_predtest/test_predtest--1.0.sql
+++ b/src/test/modules/test_predtest/test_predtest--1.0.sql
@@ -1,0 +1,16 @@
+/* src/test/modules/test_predtest/test_predtest--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_predtest" to load this file. \quit
+
+CREATE FUNCTION test_predtest(query text,
+  OUT strong_implied_by bool,
+  OUT weak_implied_by bool,
+  OUT strong_refuted_by bool,
+  OUT weak_refuted_by bool,
+  OUT s_i_holds bool,
+  OUT w_i_holds bool,
+  OUT s_r_holds bool,
+  OUT w_r_holds bool)
+STRICT
+AS 'MODULE_PATHNAME' LANGUAGE C;

--- a/src/test/modules/test_predtest/test_predtest.c
+++ b/src/test/modules/test_predtest/test_predtest.c
@@ -104,14 +104,18 @@ test_predtest(PG_FUNCTION_ARGS)
 			c2 = 'f';
 
 		/* Check for violations of various proof conditions */
+
+		/* strong implication: truth of c2 implies truth of c1 */
 		if (c2 == 't' && c1 != 't')
 			s_i_holds = false;
+		/* weak implication: non-falsity of c2 implies non-falsity of c1 */
 		if (c2 != 'f' && c1 == 'f')
 			w_i_holds = false;
+		/* strong refutation: truth of c2 implies falsity of c1 */
 		if (c2 == 't' && c1 != 'f')
 			s_r_holds = false;
-		/* XXX is this the correct definition for weak refutation? */
-		if (c2 != 'f' && c1 == 't')
+		/* weak refutation: truth of c2 implies non-truth of c1 */
+		if (c2 == 't' && c1 == 't')
 			w_r_holds = false;
 	}
 

--- a/src/test/modules/test_predtest/test_predtest.c
+++ b/src/test/modules/test_predtest/test_predtest.c
@@ -1,0 +1,211 @@
+/*--------------------------------------------------------------------------
+ *
+ * test_predtest.c
+ *		Test correctness of optimizer's predicate proof logic.
+ *
+ * Copyright (c) 2018, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *		src/test/modules/test_predtest/test_predtest.c
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_type.h"
+#include "executor/spi.h"
+#include "funcapi.h"
+#include "optimizer/clauses.h"
+#include "optimizer/predtest.h"
+#include "optimizer/prep.h"
+#include "utils/builtins.h"
+
+PG_MODULE_MAGIC;
+
+/*
+ * test_predtest(query text) returns record
+ */
+PG_FUNCTION_INFO_V1(test_predtest);
+
+Datum
+test_predtest(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *query_string = text_to_cstring(txt);
+	SPIPlanPtr	spiplan;
+	int			spirc;
+	TupleDesc	tupdesc;
+	bool		s_i_holds,
+				w_i_holds,
+				s_r_holds,
+				w_r_holds;
+	CachedPlan *cplan;
+	PlannedStmt *stmt;
+	Plan	   *plan;
+	Expr	   *clause1;
+	Expr	   *clause2;
+	bool		strong_implied_by,
+				weak_implied_by,
+				strong_refuted_by,
+				weak_refuted_by;
+	Datum		values[8];
+	bool		nulls[8];
+	int			i;
+
+	/* We use SPI to parse, plan, and execute the test query */
+	if (SPI_connect() != SPI_OK_CONNECT)
+		elog(ERROR, "SPI_connect failed");
+
+	/*
+	 * First, plan and execute the query, and inspect the results.  To the
+	 * extent that the query fully exercises the two expressions, this
+	 * provides an experimental indication of whether implication or
+	 * refutation holds.
+	 */
+	spiplan = SPI_prepare(query_string, 0, NULL);
+	if (spiplan == NULL)
+		elog(ERROR, "SPI_prepare failed for \"%s\"", query_string);
+
+	spirc = SPI_execute_plan(spiplan, NULL, NULL, true, 0);
+	if (spirc != SPI_OK_SELECT)
+		elog(ERROR, "failed to execute \"%s\"", query_string);
+	tupdesc = SPI_tuptable->tupdesc;
+	if (tupdesc->natts != 2 ||
+		TupleDescAttr(tupdesc, 0)->atttypid != BOOLOID ||
+		TupleDescAttr(tupdesc, 1)->atttypid != BOOLOID)
+		elog(ERROR, "query must yield two boolean columns");
+
+	s_i_holds = w_i_holds = s_r_holds = w_r_holds = true;
+	for (i = 0; i < SPI_processed; i++)
+	{
+		HeapTuple	tup = SPI_tuptable->vals[i];
+		Datum		dat;
+		bool		isnull;
+		char		c1,
+					c2;
+
+		/* Extract column values in a 3-way representation */
+		dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
+		if (isnull)
+			c1 = 'n';
+		else if (DatumGetBool(dat))
+			c1 = 't';
+		else
+			c1 = 'f';
+
+		dat = SPI_getbinval(tup, tupdesc, 2, &isnull);
+		if (isnull)
+			c2 = 'n';
+		else if (DatumGetBool(dat))
+			c2 = 't';
+		else
+			c2 = 'f';
+
+		/* Check for violations of various proof conditions */
+		if (c2 == 't' && c1 != 't')
+			s_i_holds = false;
+		if (c2 != 'f' && c1 == 'f')
+			w_i_holds = false;
+		if (c2 == 't' && c1 != 'f')
+			s_r_holds = false;
+		/* XXX is this the correct definition for weak refutation? */
+		if (c2 != 'f' && c1 == 't')
+			w_r_holds = false;
+	}
+
+	/*
+	 * Now, dig the clause querytrees out of the plan, and see what predtest.c
+	 * does with them.
+	 */
+	cplan = SPI_plan_get_cached_plan(spiplan);
+
+	if (list_length(cplan->stmt_list) != 1)
+		elog(ERROR, "failed to decipher query plan");
+	stmt = linitial_node(PlannedStmt, cplan->stmt_list);
+	if (stmt->commandType != CMD_SELECT)
+		elog(ERROR, "failed to decipher query plan");
+	plan = stmt->planTree;
+	Assert(list_length(plan->targetlist) >= 2);
+	clause1 = castNode(TargetEntry, linitial(plan->targetlist))->expr;
+	clause2 = castNode(TargetEntry, lsecond(plan->targetlist))->expr;
+
+	/*
+	 * Because the clauses are in the SELECT list, preprocess_expression did
+	 * not pass them through canonicalize_qual nor make_ands_implicit.  We can
+	 * do that here, though, and should do so to match the planner's normal
+	 * usage of the predicate proof functions.
+	 *
+	 * This still does not exactly duplicate the normal usage of the proof
+	 * functions, in that they are often given qual clauses containing
+	 * RestrictInfo nodes.  But since predtest.c just looks through those
+	 * anyway, it seems OK to not worry about that point.
+	 */
+	clause1 = canonicalize_qual(clause1);
+	clause2 = canonicalize_qual(clause2);
+
+	clause1 = (Expr *) make_ands_implicit(clause1);
+	clause2 = (Expr *) make_ands_implicit(clause2);
+
+	strong_implied_by = predicate_implied_by((List *) clause1,
+											 (List *) clause2);
+
+	weak_implied_by = predicate_implied_by_weak((List *) clause1,
+										   (List *) clause2);
+
+	strong_refuted_by = predicate_refuted_by((List *) clause1,
+											 (List *) clause2);
+
+	weak_refuted_by = predicate_refuted_by((List *) clause1,
+										   (List *) clause2);
+
+	/*
+	 * Issue warning if any proof is demonstrably incorrect.
+	 */
+	if (strong_implied_by && !s_i_holds)
+		elog(WARNING, "strong_implied_by result is incorrect");
+	if (weak_implied_by && !w_i_holds)
+		elog(WARNING, "weak_implied_by result is incorrect");
+	if (strong_refuted_by && !s_r_holds)
+		elog(WARNING, "strong_refuted_by result is incorrect");
+	if (weak_refuted_by && !w_r_holds)
+		elog(WARNING, "weak_refuted_by result is incorrect");
+
+	/*
+	 * Clean up and return a record of the results.
+	 */
+	if (SPI_finish() != SPI_OK_FINISH)
+		elog(ERROR, "SPI_finish failed");
+
+	tupdesc = CreateTemplateTupleDesc(8, false);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 1,
+					   "strong_implied_by", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 2,
+					   "weak_implied_by", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 3,
+					   "strong_refuted_by", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 4,
+					   "weak_refuted_by", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 5,
+					   "s_i_holds", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 6,
+					   "w_i_holds", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 7,
+					   "s_r_holds", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 8,
+					   "w_r_holds", BOOLOID, -1, 0);
+	tupdesc = BlessTupleDesc(tupdesc);
+
+	MemSet(nulls, 0, sizeof(nulls));
+	values[0] = BoolGetDatum(strong_implied_by);
+	values[1] = BoolGetDatum(weak_implied_by);
+	values[2] = BoolGetDatum(strong_refuted_by);
+	values[3] = BoolGetDatum(weak_refuted_by);
+	values[4] = BoolGetDatum(s_i_holds);
+	values[5] = BoolGetDatum(w_i_holds);
+	values[6] = BoolGetDatum(s_r_holds);
+	values[7] = BoolGetDatum(w_r_holds);
+
+	PG_RETURN_DATUM(HeapTupleGetDatum(heap_form_tuple(tupdesc, values, nulls)));
+}

--- a/src/test/modules/test_predtest/test_predtest.control
+++ b/src/test/modules/test_predtest/test_predtest.control
@@ -1,0 +1,4 @@
+comment = 'Test code for optimizer/util/predtest.c'
+default_version = '1.0'
+module_pathname = '$libdir/test_predtest'
+relocatable = true

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11412,13 +11412,12 @@ SELECT a FROM ggg WHERE a IN (NULL, 'x');
 (3 rows)
 
 EXPLAIN SELECT a FROM ggg WHERE a NOT IN (NULL, '');
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=2)
-   ->  Seq Scan on ggg  (cost=0.00..1.01 rows=1 width=2)
-         Filter: a <> ALL ('{NULL,""}'::bpchar[])
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.00 rows=0 width=0)
+   One-Time Filter: false
  Optimizer: Postgres query optimizer
-(4 rows)
+(3 rows)
 
 EXPLAIN SELECT a FROM ggg WHERE a IN (NULL, 'x');
                                  QUERY PLAN                                 

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -4150,4 +4150,27 @@ select tableoid::regclass, ctid, i, j, k from test;
 (2 rows)
 
 drop table test, test_extra_exchanged, test_in_predicate;
+-- Check isnull clause prunes the not null partitions.
+create table test(i int, j int, k int) distributed by (i)
+partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (1, null, 1), (2, 1, 2);
+explain (costs off) select * from test where j isnull;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on test_1_prt_extra
+               Filter: (j IS NULL)
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+select * from test where j isnull;
+ i | j | k 
+---+---+---
+ 1 |   | 1
+(1 row)
+
+drop table test;
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3744,4 +3744,29 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 (2 rows)
 
 drop table test, test_extra_exchanged, test_in_predicate;
+-- Check isnull clause prunes the not null partitions.
+create table test(i int, j int, k int) distributed by (i)
+partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (1, null, 1), (2, 1, 2);
+explain (costs off) select * from test where j isnull;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for test (dynamic scan id: 1)
+               Partitions selected: 1 (out of 2)
+         ->  Dynamic Seq Scan on test (dynamic scan id: 1)
+               Filter: (j IS NULL)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+select * from test where j isnull;
+ i | j | k 
+---+---+---
+ 1 |   | 1
+(1 row)
+
+drop table test;
 RESET ALL;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -1310,4 +1310,15 @@ select tableoid::regclass, ctid, i, j, k from test;
 
 drop table test, test_extra_exchanged, test_in_predicate;
 
+-- Check isnull clause prunes the not null partitions.
+create table test(i int, j int, k int) distributed by (i)
+partition by range(j) (start (1) end(3) every(2), default partition extra);
+insert into test values (1, null, 1), (2, 1, 2);
+
+explain (costs off) select * from test where j isnull;
+
+select * from test where j isnull;
+
+drop table test;
+
 RESET ALL;


### PR DESCRIPTION
Enhance predtest.c with weak refutation support for improved partition pruning.

This PR backports essential improvements to predtest.c from 7X to enable better partition pruning in 6.x, particularly focusing on NULL handling and CHECK constraints. The changes maintain backwards compatibility while introducing new functionality through wrapper functions.

The changes are based on 4 upstream commits:
- b08df9c: Initial implementation of CHECK clause awareness. This partial backport contains some enhancements of functions from predtest.c, which perform some checks for logical implication or perfutaion. The predicate_refuted_by and predicate_implied_by are now wrappers over predicate_refuted_by_internal and predicate_implied_by_internal functions containing original logic and changes from cherry-picked commit. The logic of the rest of the code remains unchanged, all predicate implication/perfutation function calls are made with false is_clause_check argument.
- https://github.com/arenadata/gpdb/commit/44468f49bbe7e47e5a27a1ccbf13549ff85149f2: Test scaffolding additions for predicate-proof logic. This backport imports the predicate logic tests for code from predtest.c. The tests are not launched from main installcheck-world since they do not pass (either in 6X or 7X). However, the fact, that the tests do not pass, indicates only about future improvements of current behaviour. The main point is that the result of implication/refutation (strong_implied_by, weak_implied_by, strong_refuted_by, weak_refuted_by) in failed tests becomes 'f' while expected to be 't' and not vice versa. It is safe when predtest.c functions return false, this do not issue any bad consequences.
- 5748f3a: Enhanced functionality and documentation improvements. The purpose of this backport is to achieve proper partition pruning for the 6X planner. It uses the weak refutation logic in order to use IS [NOT] NULL clause for pruning. This is achieved due to original changes, enhancing the predtest.c refutation/implication logics. We are allowed to use weak constraint refutation because the inserted values must correspond to partition rules, whose expressions does not accept NULL values if not configured explicitly. (The insertion is performed by explicit comparison, nulls are handled poorely). The tests from modules/test_predtests are not changed since they do not pass either in 6X or 7X (both versions require additional improvements), and the tests also do not run in main installcheck-world rule. Comparing to original patch, which relies on operator_predicate_proof(), for proving implication/refutation for general logical expressions, 6X uses lighter version of this function called btree_predicate_proof(), which is able to work with simple "expr op Const" expressions. This function was also enhanced in this backport, handling the case when one Const has NULL value.
- https://github.com/arenadata/gpdb/commit/a63c3274a68832182f84ca5d2b8cc5a7462bdacb :Fix weak profutation semantics in /tests/modules/test_predtest.c
