### PR TITLE
ADBDEV-7258: Fix aborted database deletion on the entire cluster

### DIFF
--- a/src/test/isolation2/expected/invalid_database.out
+++ b/src/test/isolation2/expected/invalid_database.out
@@ -1,24 +1,31 @@
--- test that interruption of DROP DATABASE is handled properly
+-- Test that interruption of DROP DATABASE is handled properly. To ensure the
+-- interruption happens at the appropriate moment, we lock pg_tablespace. DROP
+-- DATABASE scans pg_tablespace once it has reached the "irreversible" part of
+-- dropping the database, making it a suitable point to wait.
 
 !\retcode gpconfig -c autovacuum -v off;
 (exited with code 0)
 !\retcode gpstop -au;
 (exited with code 0)
 
--- create the database
+-- start_ignore
+DROP DATABASE IF EXISTS regression_invalid_interrupt;
+DROP DATABASE
+-- end_ignore
+-- Create the database
 CREATE DATABASE regression_invalid_interrupt;
 CREATE DATABASE
 
--- prevent drop database via lock on pg_tablespace on segment 0
+-- Prevent drop database via lock on pg_tablespace on segment 0
 0U: BEGIN;
 BEGIN
 0U: LOCK pg_tablespace;
 LOCK TABLE
 
--- try to drop, this will wait due to the still held lock on segment 0
+-- Try to drop, this will wait due to the still held lock on segment 0
 1&: DROP DATABASE regression_invalid_interrupt;  <waiting ...>
 
--- ensure the DROP DATABASE is waiting for the lock
+-- Ensure the DROP DATABASE is waiting for the lock
 SELECT EXISTS (SELECT FROM pg_locks WHERE NOT granted AND relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock');
  exists 
 --------
@@ -31,24 +38,22 @@ SELECT EXISTS (SELECT FROM pg_locks WHERE NOT granted AND relation = 'pg_tablesp
 -------------------
  t                 
 (1 row)
-0Uq: ... <quitting>
 
+-- Ensure cancellation be processed
 1<:  <... completed>
-ERROR:  canceling MPP operation  (seg0 172.18.0.7:7002 pid=41634)
-1q: ... <quitting>
+ERROR:  canceling MPP operation  (seg0 172.18.0.7:7002 pid=78200)
 
--- verify that connection to the database aren't allowed
+-- Verify that connections to the database aren't allowed. The backend checks
+-- this before relcache init, so the lock won't interfere.
 ! psql -d regression_invalid_interrupt -c "SELECT 1";
 psql: error: FATAL:  cannot connect to invalid database "regression_invalid_interrupt"
 HINT:  Use DROP DATABASE to drop invalid databases.
 
 
--- to properly drop the database, we need to reset inject fault
-SELECT gp_inject_fault('dropdb_before_remove_tablespace', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
+-- To properly drop the database, we need to release the lock previously
+-- preventing doing so.
+0U: END;
+COMMIT
 
 DROP DATABASE regression_invalid_interrupt;
 DROP DATABASE

--- a/src/test/isolation2/expected/invalid_database.out
+++ b/src/test/isolation2/expected/invalid_database.out
@@ -8,10 +8,6 @@
 !\retcode gpstop -au;
 (exited with code 0)
 
--- start_ignore
-DROP DATABASE IF EXISTS regression_invalid_interrupt;
-DROP DATABASE
--- end_ignore
 -- Create the database
 CREATE DATABASE regression_invalid_interrupt;
 CREATE DATABASE

--- a/src/test/isolation2/expected/invalid_database.out
+++ b/src/test/isolation2/expected/invalid_database.out
@@ -1,0 +1,59 @@
+-- test that interruption of DROP DATABASE is handled properly
+
+!\retcode gpconfig -c autovacuum -v off;
+(exited with code 0)
+!\retcode gpstop -au;
+(exited with code 0)
+
+-- create the database
+CREATE DATABASE regression_invalid_interrupt;
+CREATE DATABASE
+
+-- prevent drop database via lock on pg_tablespace on segment 0
+0U: BEGIN;
+BEGIN
+0U: LOCK pg_tablespace;
+LOCK TABLE
+
+-- try to drop, this will wait due to the still held lock on segment 0
+1&: DROP DATABASE regression_invalid_interrupt;  <waiting ...>
+
+-- ensure the DROP DATABASE is waiting for the lock
+SELECT EXISTS (SELECT FROM pg_locks WHERE NOT granted AND relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock');
+ exists 
+--------
+ t      
+(1 row)
+
+-- and finally interrupt the DROP DATABASE on segment 0
+0U: SELECT pg_cancel_backend(pid) FROM pg_locks WHERE NOT granted AND relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+0Uq: ... <quitting>
+
+1<:  <... completed>
+ERROR:  canceling MPP operation  (seg0 172.18.0.7:7002 pid=41634)
+1q: ... <quitting>
+
+-- verify that connection to the database aren't allowed
+! psql -d regression_invalid_interrupt -c "SELECT 1";
+psql: error: FATAL:  cannot connect to invalid database "regression_invalid_interrupt"
+HINT:  Use DROP DATABASE to drop invalid databases.
+
+
+-- to properly drop the database, we need to reset inject fault
+SELECT gp_inject_fault('dropdb_before_remove_tablespace', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+DROP DATABASE regression_invalid_interrupt;
+DROP DATABASE
+
+!\retcode gpconfig -r autovacuum;
+(exited with code 0)
+!\retcode gpstop -au;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -319,6 +319,7 @@ test: reindex/vacuum_while_reindex_ao_bitmap reindex/vacuum_while_reindex_heap_b
 # Cancel test
 test: cancel_plpython
 test: cancel_query
+test: invalid_database
 
 # Tests for getting numsegments in utility mode
 test: upgrade_numsegments

--- a/src/test/isolation2/sql/invalid_database.sql
+++ b/src/test/isolation2/sql/invalid_database.sql
@@ -1,4 +1,7 @@
--- test that interruption of DROP DATABASE is handled properly
+-- Test that interruption of DROP DATABASE is handled properly. To ensure the
+-- interruption happens at the appropriate moment, we lock pg_tablespace. DROP
+-- DATABASE scans pg_tablespace once it has reached the "irreversible" part of
+-- dropping the database, making it a suitable point to wait.
 
 !\retcode gpconfig -c autovacuum -v off;
 !\retcode gpstop -au;
@@ -6,34 +9,34 @@
 -- start_ignore
 DROP DATABASE IF EXISTS regression_invalid_interrupt;
 -- end_ignore
--- create the database
+-- Create the database
 CREATE DATABASE regression_invalid_interrupt;
 
--- prevent drop database via lock on pg_tablespace on segment 0
+-- Prevent drop database via lock on pg_tablespace on segment 0
 0U: BEGIN;
 0U: LOCK pg_tablespace;
 
--- try to drop, this will wait due to the still held lock on segment 0
+-- Try to drop, this will wait due to the still held lock on segment 0
 1&: DROP DATABASE regression_invalid_interrupt;
 
--- ensure the DROP DATABASE is waiting for the lock
+-- Ensure the DROP DATABASE is waiting for the lock
 SELECT EXISTS (SELECT FROM pg_locks WHERE NOT granted AND
     relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock');
 
 -- and finally interrupt the DROP DATABASE on segment 0
 0U: SELECT pg_cancel_backend(pid) FROM pg_locks WHERE NOT granted AND
     relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock';
-0Uq:
 
+-- Ensure cancellation be processed
 1<:
-1q:
 
--- verify that connection to the database aren't allowed
+-- Verify that connections to the database aren't allowed. The backend checks
+-- this before relcache init, so the lock won't interfere.
 ! psql -d regression_invalid_interrupt -c "SELECT 1";
 
--- to properly drop the database, we need to reset inject fault
-SELECT gp_inject_fault('dropdb_before_remove_tablespace', 'reset', dbid)
-FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+-- To properly drop the database, we need to release the lock previously
+-- preventing doing so.
+0U: END;
 
 DROP DATABASE regression_invalid_interrupt;
 

--- a/src/test/isolation2/sql/invalid_database.sql
+++ b/src/test/isolation2/sql/invalid_database.sql
@@ -1,0 +1,41 @@
+-- test that interruption of DROP DATABASE is handled properly
+
+!\retcode gpconfig -c autovacuum -v off;
+!\retcode gpstop -au;
+
+-- start_ignore
+DROP DATABASE IF EXISTS regression_invalid_interrupt;
+-- end_ignore
+-- create the database
+CREATE DATABASE regression_invalid_interrupt;
+
+-- prevent drop database via lock on pg_tablespace on segment 0
+0U: BEGIN;
+0U: LOCK pg_tablespace;
+
+-- try to drop, this will wait due to the still held lock on segment 0
+1&: DROP DATABASE regression_invalid_interrupt;
+
+-- ensure the DROP DATABASE is waiting for the lock
+SELECT EXISTS (SELECT FROM pg_locks WHERE NOT granted AND
+    relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock');
+
+-- and finally interrupt the DROP DATABASE on segment 0
+0U: SELECT pg_cancel_backend(pid) FROM pg_locks WHERE NOT granted AND
+    relation = 'pg_tablespace'::regclass AND mode = 'AccessShareLock';
+0Uq:
+
+1<:
+1q:
+
+-- verify that connection to the database aren't allowed
+! psql -d regression_invalid_interrupt -c "SELECT 1";
+
+-- to properly drop the database, we need to reset inject fault
+SELECT gp_inject_fault('dropdb_before_remove_tablespace', 'reset', dbid)
+FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+DROP DATABASE regression_invalid_interrupt;
+
+!\retcode gpconfig -r autovacuum;
+!\retcode gpstop -au;


### PR DESCRIPTION
Fix aborted database deletion on the entire cluster

Commit 034a9fc fixes aborted database deletion on a single instance, and this
patch fixes the same behavior on the entire GPDB cluster. The specified commit
first marked the deleted database as invalid using the heap_inplace_update
function, and only then did the actual database deletion using the irreversible
CatalogTupleDelete function, the call to which was moved further. This is not
enough to do for the entire cluster, because the GPDB first deletes the
database on the segments before deleting it on the coordinator. When resolving
conflicts with commit 45dce8b6, this logic was incorrectly left in place, which
led to an error on the entire cluster. This patch moves this logic immediately
before the call to the irreversible CatalogTupleDelete function.

Ticket: ADBDEV-7258