### PR TITLE
Resolve conflicts in src/include/pg_config.h.in

### DIFF
--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -118,15 +118,9 @@
 /* Define to 1 if you have the <atomic.h> header file. */
 #undef HAVE_ATOMIC_H
 
-<<<<<<< HEAD
 /* Define to 1 if you have the `backtrace_symbols' function. */
 #undef HAVE_BACKTRACE_SYMBOLS
 
-/* Define to 1 if you have the `BIO_get_data' function. */
-#undef HAVE_BIO_GET_DATA
-
-=======
->>>>>>> REL_12_22
 /* Define to 1 if you have the `BIO_meth_new' function. */
 #undef HAVE_BIO_METH_NEW
 


### PR DESCRIPTION
Resolve conflicts in src/include/pg_config.h.in

Commit 0bd6822 removed the HAVE_BIO_GET_DATA undef from
src/include/pg_config.h.in, while an earlier commit 8fee61d added the
HAVE_BACKTRACE_SYMBOLS undef before that location.