### PR TITLE
Resolve conflicts in access/transam/twophase.c

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -502,12 +502,8 @@ MarkAsPreparingGuts(GlobalTransaction gxact, TransactionId xid, const char *gid,
 	proc->roleId = owner;
 	proc->tempNamespaceId = InvalidOid;
 	proc->isBackgroundWorker = false;
-<<<<<<< HEAD
 	proc->mppSessionId = gp_session_id;
-	proc->lwWaiting = false;
-=======
 	proc->lwWaiting = LW_WS_NOT_WAITING;
->>>>>>> REL_12_22
 	proc->lwWaitMode = 0;
 	proc->waitLock = NULL;
 	proc->waitProcLock = NULL;


### PR DESCRIPTION
Resolve conflicts in access/transam/twophase.c

The commit https://github.com/arenadata/gpdb/commit/81038228582aa92718be2afcb7ddb67a5a19fa43 introduced new
LWLock waiting states, which are used for more optimal proc tracking
in proclists waiting a lock.
The conflicts in twophase.c results from presence of proc->mppSessionId
field initialization in modified line.

