### PR TITLE
Resolve conflicts in miscadmin.h, miscinit.c and parallel.c

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -87,19 +87,12 @@ typedef struct FixedParallelState
 	Oid			temp_namespace_id;
 	Oid			temp_toast_namespace_id;
 	int			sec_context;
-<<<<<<< HEAD
-	bool		is_superuser;
-	PGPROC	   *parallel_leader_pgproc;
-	pid_t		parallel_leader_pid;
-	BackendId	parallel_leader_backend_id;
-=======
 	bool		authenticated_user_is_superuser;
 	bool		session_user_is_superuser;
 	bool		role_is_superuser;
-	PGPROC	   *parallel_master_pgproc;
-	pid_t		parallel_master_pid;
-	BackendId	parallel_master_backend_id;
->>>>>>> REL_12_22
+	PGPROC	   *parallel_leader_pgproc;
+	pid_t		parallel_leader_pid;
+	BackendId	parallel_leader_backend_id;
 	TimestampTz xact_ts;
 	TimestampTz stmt_ts;
 	SerializableXactHandle serializable_xact_handle;

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -458,13 +458,6 @@ SetSessionUserId(Oid userid, bool is_superuser)
 	SessionUserIsSuperuser = is_superuser;
 }
 
-bool
-IsAuthenticatedUserSuperUser()
-{
-	AssertState(OidIsValid(AuthenticatedUserId));
-	return AuthenticatedUserIsSuperuser;
-}
-
 /*
  * GetAuthenticatedUserId/SetAuthenticatedUserId - get/set the authenticated
  * user ID

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -458,6 +458,13 @@ SetSessionUserId(Oid userid, bool is_superuser)
 	SessionUserIsSuperuser = is_superuser;
 }
 
+bool
+IsAuthenticatedUserSuperUser()
+{
+	AssertState(OidIsValid(AuthenticatedUserId));
+	return AuthenticatedUserIsSuperuser;
+}
+
 /*
  * GetAuthenticatedUserId/SetAuthenticatedUserId - get/set the authenticated
  * user ID

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -441,10 +441,6 @@ GetSessionUserId(void)
 	return SessionUserId;
 }
 
-<<<<<<< HEAD
-/* extern so DispatchAgent can use this (postgres.c) */
-extern void
-=======
 bool
 GetSessionUserIsSuperuser(void)
 {
@@ -452,8 +448,8 @@ GetSessionUserIsSuperuser(void)
 	return SessionUserIsSuperuser;
 }
 
-static void
->>>>>>> REL_12_22
+/* extern so DispatchAgent can use this (postgres.c) */
+extern void
 SetSessionUserId(Oid userid, bool is_superuser)
 {
 	AssertState(SecurityRestrictionContext == 0);
@@ -761,13 +757,8 @@ InitializeSessionUserId(const char *rolename, Oid roleid)
 		 * many connections to each segment to execute a non-trivial plan and
 		 * the user connection limit does not map, semantically, to that idea.
 		 */
-<<<<<<< HEAD
 		if (Gp_role == GP_ROLE_DISPATCH && rform->rolconnlimit >= 0 &&
-			!AuthenticatedUserIsSuperuser &&
-=======
-		if (rform->rolconnlimit >= 0 &&
 			!is_superuser &&
->>>>>>> REL_12_22
 			CountUserBackends(roleid) > rform->rolconnlimit)
 			ereport(FATAL,
 					(errcode(ERRCODE_TOO_MANY_CONNECTIONS),
@@ -775,7 +766,6 @@ InitializeSessionUserId(const char *rolename, Oid roleid)
 							rname)));
 	}
 
-<<<<<<< HEAD
 	/*
 	 * If resource scheduling is enabled, then set cached value for the
 	 * queue. Do this even in standalone backend mode, just in case someone
@@ -786,15 +776,6 @@ InitializeSessionUserId(const char *rolename, Oid roleid)
 		SetResQueueId();
 	}
 
-	/* Record username and superuser status as GUC settings too */
-	SetConfigOption("session_authorization", rname,
-					PGC_BACKEND, PGC_S_OVERRIDE);
-	SetConfigOption("is_superuser",
-					AuthenticatedUserIsSuperuser ? "on" : "off",
-					PGC_INTERNAL, PGC_S_OVERRIDE);
-
-=======
->>>>>>> REL_12_22
 	ReleaseSysCache(roleTup);
 }
 
@@ -851,20 +832,14 @@ SetSessionAuthorization(Oid userid, bool is_superuser)
 {
 	SetSessionUserId(userid, is_superuser);
 
-<<<<<<< HEAD
 	/* If resource scheduling enabled, set the cached queue for the new role.*/
 	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && IsResQueueEnabled())
 	{
 		SetResQueueId();
 	}
 
-	SetConfigOption("is_superuser",
-					is_superuser ? "on" : "off",
-					PGC_INTERNAL, PGC_S_OVERRIDE);
-=======
 	if (!SetRoleIsActive)
 		SetOuterUserId(userid, is_superuser);
->>>>>>> REL_12_22
 }
 
 /*
@@ -918,21 +893,13 @@ SetCurrentRoleId(Oid roleid, bool is_superuser)
 	else
 		SetRoleIsActive = true;
 
-<<<<<<< HEAD
-	SetOuterUserId(roleid);
+	SetOuterUserId(roleid, is_superuser);
 
 	/* If resource scheduling enabled, set the cached queue for the new role.*/
 	if ((Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) && IsResQueueEnabled())
 	{
 		SetResQueueId();
 	}
-
-	SetConfigOption("is_superuser",
-					is_superuser ? "on" : "off",
-					PGC_INTERNAL, PGC_S_OVERRIDE);
-=======
-	SetOuterUserId(roleid, is_superuser);
->>>>>>> REL_12_22
 }
 
 

--- a/src/backend/utils/init/miscinit.c
+++ b/src/backend/utils/init/miscinit.c
@@ -461,8 +461,7 @@ SetSessionUserId(Oid userid, bool is_superuser)
 bool
 IsAuthenticatedUserSuperUser()
 {
-	AssertState(OidIsValid(AuthenticatedUserId));
-	return AuthenticatedUserIsSuperuser;
+	return GetAuthenticatedUserIsSuperuser();
 }
 
 /*

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -427,7 +427,7 @@ extern Oid	GetUserId(void);
 extern Oid	GetOuterUserId(void);
 extern Oid	GetSessionUserId(void);
 extern void	SetSessionUserId(Oid, bool);
-extern bool IsAuthenticatedUserSuperUser(void);
+#define IsAuthenticatedUserSuperUser() GetAuthenticatedUserIsSuperuser()
 extern bool GetSessionUserIsSuperuser(void);
 extern Oid	GetAuthenticatedUserId(void);
 extern bool GetAuthenticatedUserIsSuperuser(void);

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -426,16 +426,12 @@ extern char *GetUserNameFromId(Oid roleid, bool noerr);
 extern Oid	GetUserId(void);
 extern Oid	GetOuterUserId(void);
 extern Oid	GetSessionUserId(void);
-<<<<<<< HEAD
 extern void	SetSessionUserId(Oid, bool);
-extern Oid	GetAuthenticatedUserId(void);
 extern bool IsAuthenticatedUserSuperUser(void);
-=======
 extern bool GetSessionUserIsSuperuser(void);
 extern Oid	GetAuthenticatedUserId(void);
 extern bool GetAuthenticatedUserIsSuperuser(void);
 extern void SetAuthenticatedUserId(Oid userid, bool is_superuser);
->>>>>>> REL_12_22
 extern void GetUserIdAndSecContext(Oid *userid, int *sec_context);
 extern void SetUserIdAndSecContext(Oid userid, int sec_context);
 extern bool InLocalUserIdChange(void);

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -427,7 +427,7 @@ extern Oid	GetUserId(void);
 extern Oid	GetOuterUserId(void);
 extern Oid	GetSessionUserId(void);
 extern void	SetSessionUserId(Oid, bool);
-#define IsAuthenticatedUserSuperUser() GetAuthenticatedUserIsSuperuser()
+extern bool IsAuthenticatedUserSuperUser(void);
 extern bool GetSessionUserIsSuperuser(void);
 extern Oid	GetAuthenticatedUserId(void);
 extern bool GetAuthenticatedUserIsSuperuser(void);


### PR DESCRIPTION
Resolve conflicts in miscadmin.h, miscinit.c and parallel.c

1) Commit 4c9d96f added new declarations GetSessionUserIsSuperuser,
GetAuthenticatedUserIsSuperuser and SetAuthenticatedUserId to
src/include/miscadmin.h, while an earlier commit 8ae22d1 changed the
indentation of the SetSessionUserId declaration in the same place.

2) Commit 4c9d96f added a new function GetSessionUserIsSuperuser to
src/backend/utils/init/miscinit.c, while an earlier commit 6b0e52b made the
private function SetSessionUserId below public.

3) Commit 4c9d96f changed the AuthenticatedUserIsSuperuser condition in the
InitializeSessionUserId function to is_superuser, while the earlier commit
6b0e52b added a condition on the coordinator just above.

4) Commit 4c9d96f removed a couple of calls to the SetConfigOption function at
the end of the InitializeSessionUserId function, while the earlier commit
6b0e52b added additional conditions just above.

5) Commit 4c9d96f replaced the SetConfigOption function call in the
SetSessionAuthorization function with a conditional call to the SetOuterUserId
function, while the earlier commit 6b0e52b added additional conditions just
above.

6) commit 4c9d96f added a new argument to the SetCurrentRoleId function when
calling the SetOuterUserId function, and removed the subsequent call to the
SetConfigOption function, while an earlier commit 6b0e52b added additional
conditions just above.

7) commit 4c9d96f changed the is_superuser field in the FixedParallelState
structure in the src/backend/access/transam/parallel.c file to
role_is_superuser and added new fields session_user_id,
authenticated_user_is_superuser and session_user_is_superuser to the same
structure, while an earlier commit e965aee changed the word master to leader in
the field names of the same structure just below.