### PR TITLE
ADBDEV-7233: Fix conflict in sr/bin/pg_dump/t/002_pg_dump.pl

### DIFF
--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -3144,14 +3144,11 @@ my %tests = (
 		    /xms,
 		like =>
 		  { %full_runs, %dump_test_schema_runs, section_post_data => 1, },
-<<<<<<< HEAD
 		unlike => {
 			exclude_dump_test_schema => 1,
+			exclude_test_table       => 1,
 			only_dump_measurement    => 1,
 		},
-=======
-		unlike => { exclude_dump_test_schema => 1, exclude_test_table => 1, },
->>>>>>> REL_12_22
 	},
 
 	'CREATE STATISTICS extended_stats_options' => {


### PR DESCRIPTION
Fix conflict in sr/bin/pg_dump/t/002_pg_dump.pl

Conflict caused by Postgres commit
69d7edb06fc69da114b075be58dd4318916500e5 adding exclude_test_table flag while
ee72d81bfafe2e70bbed06fa1264796fb78685b9 added only_dump_measurement flag,
changing the formatting.