### PR TITLE
Resolve conflicts in src/backend/utils/cache/catcache.c

### DIFF
--- a/src/backend/utils/cache/catcache.c
+++ b/src/backend/utils/cache/catcache.c
@@ -1409,27 +1409,6 @@ SearchCatCacheMiss(CatCache *cache,
 	do
 	{
 		/*
-<<<<<<< HEAD
-		 * Good place to sanity check the tuple, before adding it to cache.
-		 * So if its fetched using index, lets cross verify tuple intended is the tuple
-		 * fetched. If not fail and contain the damage which maybe caused due to
-		 * index corruption for some reason.
-		 */
-		if (scandesc->irel)
-		{
-			CrossCheckTuple(cache->id, v1, v2, v3, v4, ntp);
-		}
-
-		ct = CatalogCacheCreateEntry(cache, ntp, arguments,
-									 hashValue, hashIndex,
-									 false);
-		/* immediately set the refcount to 1 */
-		ResourceOwnerEnlargeCatCacheRefs(CurrentResourceOwner);
-		ct->refcount++;
-		ResourceOwnerRememberCatCacheRef(CurrentResourceOwner, &ct->tuple);
-		break;					/* assume only one match */
-	}
-=======
 		 * Ok, need to make a lookup in the relation, copy the scankey and
 		 * fill out any per-call fields.  (We must re-do this when retrying,
 		 * because systable_beginscan scribbles on the scankey.)
@@ -1439,7 +1418,6 @@ SearchCatCacheMiss(CatCache *cache,
 		cur_skey[1].sk_argument = v2;
 		cur_skey[2].sk_argument = v3;
 		cur_skey[3].sk_argument = v4;
->>>>>>> REL_12_22
 
 		scandesc = systable_beginscan(relation,
 									  cache->cc_indexoid,
@@ -1453,6 +1431,18 @@ SearchCatCacheMiss(CatCache *cache,
 
 		while (HeapTupleIsValid(ntp = systable_getnext(scandesc)))
 		{
+
+			/*
+			 * Good place to sanity check the tuple, before adding it to cache.
+			 * So if its fetched using index, lets cross verify tuple intended is the tuple
+			 * fetched. If not fail and contain the damage which maybe caused due to
+			 * index corruption for some reason.
+			 */
+			if (scandesc->irel)
+			{
+				CrossCheckTuple(cache->id, v1, v2, v3, v4, ntp);
+			}
+
 			ct = CatalogCacheCreateEntry(cache, ntp, scandesc, NULL,
 										 hashValue, hashIndex);
 			/* upon failure, we must start the scan over */


### PR DESCRIPTION
Resolve conflicts in src/backend/utils/cache/catcache.c

Commit 3b4d85c moved the initialization of the local variable cur_skey in the
SearchCatCacheMiss function, while the earlier commit 0ff952e added a
conditional call to the new function CrossCheckTuple to the same place.