### PR TITLE
Resolve conflicts in partitioning/partdesc.c

### DIFF
--- a/src/backend/partitioning/partdesc.c
+++ b/src/backend/partitioning/partdesc.c
@@ -236,14 +236,6 @@ RelationBuildPartitionDesc_guts(Relation rel, bool validate)
 			scan = systable_beginscan(pg_class, ClassOidIndexId, true,
 									  NULL, 1, key);
 			tuple = systable_getnext(scan);
-<<<<<<< HEAD
-			if (!tuple)
-				elog(ERROR, "could not find pg_class entry for oid %u", inhrelid);
-			datum = heap_getattr(tuple, Anum_pg_class_relpartbound,
-								 RelationGetDescr(pg_class), &isnull);
-			if (!isnull)
-				boundspec = stringToNode(TextDatumGetCString(datum));
-=======
 			if (HeapTupleIsValid(tuple))
 			{
 				Datum		datum;
@@ -254,7 +246,6 @@ RelationBuildPartitionDesc_guts(Relation rel, bool validate)
 				if (!isnull)
 					boundspec = stringToNode(TextDatumGetCString(datum));
 			}
->>>>>>> REL_12_22
 			systable_endscan(scan);
 			table_close(pg_class, AccessShareLock);
 		}

--- a/src/backend/partitioning/partdesc.c
+++ b/src/backend/partitioning/partdesc.c
@@ -246,6 +246,8 @@ RelationBuildPartitionDesc_guts(Relation rel, bool validate)
 				if (!isnull)
 					boundspec = stringToNode(TextDatumGetCString(datum));
 			}
+			else
+				elog(ERROR, "could not find pg_class entry for oid %u", inhrelid);
 			systable_endscan(scan);
 			table_close(pg_class, AccessShareLock);
 		}


### PR DESCRIPTION
Resolve conflicts in partitioning/partdesc.c
The conflict is issued by different approach for validating catalog
scan results (https://github.com/arenadata/gpdb/commit/559ae1336e030c427e6a7df3ad59e657fd77734c). The resolutoin
is in accepting incoming changes.
The error throwing code is left as it is. It was originally
designed for crash robustness (https://github.com/arenadata/gpdb/commit/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4).

