### PR TITLE
Resolve conflicts in src/backend/commands/tsearchcmds.c

### DIFF
--- a/src/backend/commands/tsearchcmds.c
+++ b/src/backend/commands/tsearchcmds.c
@@ -48,17 +48,15 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
-<<<<<<< HEAD
 #include "cdb/cdbvars.h"
 #include "cdb/cdbdisp_query.h"
-=======
+
 /* Single entry of List returned by getTokenTypes() */
 typedef struct
 {
 	int			num;			/* token type number */
 	char	   *name;			/* token type name */
 } TSTokenTypeItem;
->>>>>>> REL_12_22
 
 static void MakeConfigurationMapping(AlterTSConfigurationStmt *stmt,
 									 HeapTuple tup, Relation relMap);


### PR DESCRIPTION
Resolve conflicts in src/backend/commands/tsearchcmds.c

Commit 0561097 added a new TSTokenTypeItem structure, while earlier commit
604bb13 had already added new includes in the same place.