### PR TITLE
Resolve conflicts in src/backend/commands/matview.c

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -867,18 +867,11 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	 */
 	SetUserIdAndSecContext(relowner,
 						   save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
-<<<<<<< HEAD
 
 	/* Get distribute key of matview */
 	distributed = TextDatumGetCString(DirectFunctionCall1(pg_get_table_distributedby,
 														   ObjectIdGetDatum(tempOid)));
 
-	/* Start building the query for creating the diff table. */
-	resetStringInfo(&querybuf);
-	appendStringInfo(&querybuf,
-					 "CREATE TEMP TABLE %s AS "
-					 "SELECT mv.ctid AS tid, mv.gp_segment_id as sid, newdata.* "
-=======
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
 					 "CREATE TEMP TABLE %s (tid pg_catalog.tid)",
@@ -898,8 +891,7 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
 					 "INSERT INTO %s "
-					 "SELECT mv.ctid AS tid, newdata.*::%s AS newdata "
->>>>>>> REL_12_22
+					 "SELECT mv.ctid AS tid, mv.gp_segment_id as sid, newdata.* "
 					 "FROM %s mv FULL JOIN %s newdata ON (",
 					 diffname, matviewname, tempname);
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -861,9 +861,9 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 	 * Create the temporary "diff" table.
 	 *
 	 * Temporarily switch out of the SECURITY_RESTRICTED_OPERATION context,
-	 * because you cannot create temp tables in SRO context.  For extra
-	 * paranoia, add the composite type column only after switching back to
-	 * SRO context.
+	 * because you cannot create temp tables in SRO context.  In GPDB use
+	 * "SELECT alias.*" rather than "alias.*::compositetype" in upstream to
+	 * support DISTRIBUTED BY clause.
 	 */
 	SetUserIdAndSecContext(relowner,
 						   save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
@@ -874,24 +874,30 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
-					 "CREATE TEMP TABLE %s (tid pg_catalog.tid)",
+					 "CREATE TEMP TABLE %s (LIKE %s)",
+					 diffname, tempname);
+	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
+		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
+	resetStringInfo(&querybuf);
+	appendStringInfo(&querybuf,
+					 "ALTER TABLE %s ADD COLUMN tid pg_catalog.tid",
+					 diffname);
+	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
+		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
+	resetStringInfo(&querybuf);
+	appendStringInfo(&querybuf,
+					 "ALTER TABLE %s ADD COLUMN sid pg_catalog.int",
 					 diffname);
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 	SetUserIdAndSecContext(relowner,
 						   save_sec_context | SECURITY_RESTRICTED_OPERATION);
-	resetStringInfo(&querybuf);
-	appendStringInfo(&querybuf,
-					 "ALTER TABLE %s ADD COLUMN newdata %s",
-					 diffname, tempname);
-	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
-		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 
 	/* Start building the query for populating the diff table. */
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
 					 "INSERT INTO %s "
-					 "SELECT mv.ctid AS tid, mv.gp_segment_id as sid, newdata.* "
+					 "SELECT newdata.*, mv.ctid AS tid, mv.gp_segment_id as sid "
 					 "FROM %s mv FULL JOIN %s newdata ON (",
 					 diffname, matviewname, tempname);
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -878,6 +878,8 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 					 diffname, tempname);
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
+	SetUserIdAndSecContext(relowner,
+						   save_sec_context | SECURITY_RESTRICTED_OPERATION);
 	resetStringInfo(&querybuf);
 	appendStringInfo(&querybuf,
 					 "ALTER TABLE %s ADD COLUMN tid pg_catalog.tid",
@@ -890,8 +892,6 @@ refresh_by_match_merge(Oid matviewOid, Oid tempOid, Oid relowner,
 					 diffname);
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_UTILITY)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
-	SetUserIdAndSecContext(relowner,
-						   save_sec_context | SECURITY_RESTRICTED_OPERATION);
 
 	/* Start building the query for populating the diff table. */
 	resetStringInfo(&querybuf);


### PR DESCRIPTION
Resolve conflicts in src/backend/commands/matview.c

Commit 2699fc0 added temporary diff table creation to refresh_by_match_merge
function, while earlier commits 0f5f663, 81a20f6 and c654c50 already added
GPDB-specific logic before that place. Unlike upstream, GPDB does not use a
composite type column when updating a materialized view, so the patch first
creates a temporary table with all the columns as in the original materialized
view, and then adds a tid column and a GPDB-specific sid column to it.