### PR TITLE
Resolve conflicts in async.c and sinval.c

### DIFF
--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -2103,10 +2103,7 @@ asyncQueueAdvanceTail(void)
 static void
 ProcessIncomingNotify(void)
 {
-<<<<<<< HEAD
-=======
 	MemoryContext oldcontext;
->>>>>>> REL_12_22
 
 	/* We *must* reset the flag */
 	notifyInterruptPending = false;

--- a/src/backend/storage/ipc/sinval.c
+++ b/src/backend/storage/ipc/sinval.c
@@ -230,14 +230,12 @@ ProcessCatchupInterrupt(void)
 
 			StartTransactionCommand();
 			CommitTransactionCommand();
-<<<<<<< HEAD
 
 			setDistributedTransactionContext(saveDistributedTransactionContext);
-=======
+
 			/* Caller's context had better not have been transaction-local */
 			Assert(MemoryContextIsValid(oldcontext));
 			MemoryContextSwitchTo(oldcontext);
->>>>>>> REL_12_22
 		}
 
 		in_process_catchup_event = 0;


### PR DESCRIPTION
Resolve conflicts in async.c and sinval.c

1) Commit 8565fb6 added a new local variable oldcontext to the
ProcessIncomingNotify function, while the earlier commit cdc0104 had already
removed the local variable client_wait_timeout_enabled in the same place.

2) Commit 8565fb6 added an assert and context switch to the
ProcessCatchupInterrupt function, while earlier commit 2fafef9 refactored the
previously added GPDB-specific logic before that.
