### PR TITLE
Resolve conflicts in src/backend/storage/lmgr/predicate.c

### DIFF
--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -931,7 +931,7 @@ SerialAdd(TransactionId xid, SerCommitSeqNo minConflictCommitSeqNo)
 	tailXid = serialControl->tailXid;
 	if (!TransactionIdIsValid(tailXid) || TransactionIdPrecedes(xid, tailXid))
 	{
-		LWLockRelease(serialControl);
+		LWLockRelease(SerialSLRULock);
 		return;
 	}
 

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -928,17 +928,12 @@ SerialAdd(TransactionId xid, SerCommitSeqNo minConflictCommitSeqNo)
 	 * back the global xmin just finished, making 'xid' uninteresting, but
 	 * ClearOldPredicateLocks() has not yet run.
 	 */
-<<<<<<< HEAD
 	tailXid = serialControl->tailXid;
-	Assert(TransactionIdIsValid(tailXid));
-=======
-	tailXid = oldSerXidControl->tailXid;
 	if (!TransactionIdIsValid(tailXid) || TransactionIdPrecedes(xid, tailXid))
 	{
 		LWLockRelease(OldSerXidLock);
 		return;
 	}
->>>>>>> REL_12_22
 
 	/*
 	 * If the SLRU is currently unused, zero out the whole active region from

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -931,7 +931,7 @@ SerialAdd(TransactionId xid, SerCommitSeqNo minConflictCommitSeqNo)
 	tailXid = serialControl->tailXid;
 	if (!TransactionIdIsValid(tailXid) || TransactionIdPrecedes(xid, tailXid))
 	{
-		LWLockRelease(OldSerXidLock);
+		LWLockRelease(serialControl);
 		return;
 	}
 


### PR DESCRIPTION
Resolve conflicts in src/backend/storage/lmgr/predicate.c

Commit e2ec3af changed the assert in the OldSerXidAdd function to a conditional
return, while an earlier commit by dab892d renamed the global variable
oldSerXidControl to serialControl before that.