### PR TITLE
Resolve conflicts in src/backend/catalog/dependency.c

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -76,11 +76,8 @@
 #include "commands/sequence.h"
 #include "commands/trigger.h"
 #include "commands/typecmds.h"
-<<<<<<< HEAD
 #include "foreign/foreign.h"
-=======
 #include "miscadmin.h"
->>>>>>> REL_12_22
 #include "nodes/nodeFuncs.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteRemove.h"


### PR DESCRIPTION
Resolve conflicts in src/backend/catalog/dependency.c

Commit 98bfb75 added a new include, while earlier commit cae565e had already
added another new include in the same place.