### PR TITLE
Resolve conflicts in src/backend/executor/nodeIndexonlyscan.c

### DIFF
--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -538,7 +538,6 @@ IndexOnlyScanState *
 ExecInitIndexOnlyScan(IndexOnlyScan *node, EState *estate, int eflags)
 {
 	Relation	currentRelation;
-<<<<<<< HEAD
 
 	/*
 	 * open the scan relation
@@ -554,9 +553,7 @@ ExecInitIndexOnlyScanForPartition(IndexOnlyScan *node, EState *estate, int eflag
 								  Relation currentRelation, Oid indexid)
 {
 	IndexOnlyScanState *indexstate;
-=======
 	Relation	indexRelation;
->>>>>>> REL_12_22
 	LOCKMODE	lockmode;
 	TupleDesc	tupDesc;
 	int			indnkeyatts;
@@ -628,12 +625,8 @@ ExecInitIndexOnlyScanForPartition(IndexOnlyScan *node, EState *estate, int eflag
 
 	/* Open the index relation. */
 	lockmode = exec_rt_fetch(node->scan.scanrelid, estate)->rellockmode;
-<<<<<<< HEAD
-	indexstate->ioss_RelationDesc = index_open(indexid, lockmode);
-=======
-	indexRelation = index_open(node->indexid, lockmode);
+	indexRelation = index_open(indexid, lockmode);
 	indexstate->ioss_RelationDesc = indexRelation;
->>>>>>> REL_12_22
 
 	/*
 	 * Initialize index-specific scan state


### PR DESCRIPTION
Resolve conflicts in src/backend/executor/nodeIndexonlyscan.c

Commit e3f9dca added a new local variable indexRelation to the
ExecInitIndexOnlyScan function, while earlier commit 08189b6 renamed this
function to ExecInitIndexOnlyScanForPartition.