### PR TITLE
Resolve conflicts in src/backend/executor/functions.c

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -177,16 +177,13 @@ static Datum postquel_get_single_result(TupleTableSlot *slot,
 										MemoryContext resultcontext);
 static void sql_exec_error_callback(void *arg);
 static void ShutdownSQLFunction(Datum arg);
-<<<<<<< HEAD
 static bool querytree_safe_for_qe_walker(Node *expr, void *context);
-=======
 static bool check_sql_fn_retval_ext2(Oid func_id,
 									 FunctionCallInfo fcinfo,
 									 Oid rettype, char prokind,
 									 List *queryTreeList,
 									 bool *modifyTargetList,
 									 JunkFilter **junkFilter);
->>>>>>> REL_12_22
 static void sqlfunction_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
 static bool sqlfunction_receive(TupleTableSlot *slot, DestReceiver *self);
 static void sqlfunction_shutdown(DestReceiver *self);


### PR DESCRIPTION
Resolve conflicts in src/backend/executor/functions.c

Commit 4208f44 added a declaration of a new private function
check_sql_fn_retval_ext2, while the earlier commit 32f099f renamed the
previously added declaration of another private function
querytree_safe_for_segment_walker to querytree_safe_for_qe_walker in the same
place.