### PR TITLE
ADBDEV-7158: Do not use CdbDispatchCommand() in pg_lock_status()

### DIFF
--- a/.abi-check/6.27.1_arenadata61/postgres.symbols.ignore
+++ b/.abi-check/6.27.1_arenadata61/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -87,7 +87,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select (pg_catalog.pg_lock_status()).*"
+	"select * from pg_catalog.pg_lock_status()"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -173,6 +173,21 @@ pg_lock_status(PG_FUNCTION_ARGS)
 	LockData   *lockData;
 	PredicateLockData *predLockData;
 
+	if (SRF_IS_SQUELCH_CALL())
+	{
+		funcctx = SRF_PERCALL_SETUP();
+		mystatus = funcctx->user_fctx;
+
+		if (mystatus->segQueryDesc != NULL)
+		{
+			ExecutorFinish(mystatus->segQueryDesc);
+			ExecutorEnd(mystatus->segQueryDesc);
+			FreeQueryDesc(mystatus->segQueryDesc);
+		}
+
+		SRF_RETURN_DONE(funcctx);
+	}
+
 	if (SRF_IS_FIRSTCALL())
 	{
 		MemoryContext oldcontext;
@@ -203,12 +218,8 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		 *
 		 * We collect the lock information from all the segments via gather
 		 * motion. There might be multiple instances of the same lock coming
-		 * from different segments.
-		 *
-		 * Routines from executor are used to fetch rows one-by-one. The
-		 * results are still materialized, unfortunately. This is a limitation
-		 * of set-returning functions, since they cannot surely know whether
-		 * the upper node was limited, and are called until they are
+		 * from different segments. Routines from executor are used to fetch
+		 * rows one-by-one.
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
@@ -238,6 +249,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 
 	funcctx = SRF_PERCALL_SETUP();
 	mystatus = (PG_Lock_Status *) funcctx->user_fctx;
+
 	lockData = mystatus->lockData;
 
 	/*
@@ -474,6 +486,8 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		ExecutorFinish(queryDesc);
 		ExecutorEnd(queryDesc);
 		FreeQueryDesc(queryDesc);
+
+		mystatus->segQueryDesc = NULL;
 	}
 
 	/*

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -180,6 +180,9 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
 
+		/*
+		 * switch to memory context appropriate for multiple function calls
+		 */
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		/*
@@ -187,6 +190,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		 * out as a result set.
 		 */
 		mystatus = (PG_Lock_Status *) palloc0(sizeof(PG_Lock_Status));
+		funcctx->user_fctx = (void *) mystatus;
 
 		mystatus->lockData = GetLockStatusData();
 		mystatus->predLockData = GetPredicateLockStatusData();
@@ -228,8 +232,6 @@ pg_lock_status(PG_FUNCTION_ARGS)
 			 */
 			funcctx->tuple_desc = BlessTupleDesc(build_pg_locks_tupdesc());
 		}
-
-		funcctx->user_fctx = (void *) mystatus;
 
 		MemoryContextSwitchTo(oldcontext);
 	}
@@ -455,18 +457,13 @@ pg_lock_status(PG_FUNCTION_ARGS)
 	/* Collect locks sent out by the segments on coordinator. */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		QueryDesc  *queryDesc = mystatus->segQueryDesc;
+		HeapTuple ht;
+		QueryDesc *queryDesc = mystatus->segQueryDesc;
 
-		for (;;)
+		TupleTableSlot *tts = ExecProcNode(queryDesc->planstate);
+
+		if (!TupIsNull(tts))
 		{
-			HeapTuple	ht;
-			TupleTableSlot *tts = ExecProcNode(queryDesc->planstate);
-
-			if (TupIsNull(tts))
-			{
-				break;
-			}
-
 			Assert(tts->tts_tupleDescriptor->natts == NUM_LOCK_STATUS_COLUMNS);
 
 			ht = ExecFetchSlotHeapTuple(tts);

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -22,6 +22,8 @@
 #include "utils/builtins.h"
 #include "utils/faultinjector.h"
 
+#include "cdb/cdbsetop.h"
+#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "utils/snapmgr.h"
 
@@ -85,7 +87,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select * from gp_dist_random('pg_catalog.pg_locks')"
+	"select (pg_catalog.pg_lock_status()).*"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.
@@ -118,6 +120,14 @@ build_pg_locks_querydesc(void)
 	/* There is only one statement in list due to simple select. */
 	Assert(list_length(plantree_list) == 1);
 	plan_stmt = (PlannedStmt *) linitial(plantree_list);
+
+	/* Add a gather motion atop the plan. */
+	plan_stmt->planTree->flow = NULL;
+	mark_plan_strewn(plan_stmt->planTree, getgpsegmentCount());
+	plan_stmt->planTree =
+		(Plan *) make_motion_gather_to_QD(NULL, plan_stmt->planTree, NULL);
+	((Motion *) plan_stmt->planTree)->motionID = 1;
+	plan_stmt->nMotionNodes = 1;
 
 	queryDesc =
 		CreateQueryDesc(plan_stmt, PG_LOCKS_INTERNAL_QUERY, GetActiveSnapshot(),

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -85,7 +85,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select * from gp_dist_random('pg_catalog.pg_locks')"
+	"SELECT * FROM gp_dist_random('pg_catalog.pg_locks')"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -262,7 +262,6 @@ pg_lock_status(PG_FUNCTION_ARGS)
 
 	funcctx = SRF_PERCALL_SETUP();
 	mystatus = (PG_Lock_Status *) funcctx->user_fctx;
-
 	lockData = mystatus->lockData;
 
 	/*

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -87,7 +87,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select * from pg_catalog.pg_lock_status()"
+	"select (pg_catalog.pg_lock_status()).*"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -92,12 +92,12 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 static QueryDesc *
 build_pg_locks_querydesc(void)
 {
-	List *raw_parsetree_list;
-	Node *parsetree;
-	List *querytree_list;
-	List *plantree_list;
+	List	  *raw_parsetree_list;
+	Node	  *parsetree;
+	List	  *querytree_list;
+	List	  *plantree_list;
 	PlannedStmt *plan_stmt;
-	QueryDesc *queryDesc = NULL;
+	QueryDesc  *queryDesc = NULL;
 
 	/* Parse the SQL string into a list of raw parse trees. */
 	raw_parsetree_list = pg_parse_query(PG_LOCKS_INTERNAL_QUERY);
@@ -131,7 +131,7 @@ build_pg_locks_querydesc(void)
 static TupleDesc
 build_pg_locks_tupdesc(void)
 {
-	TupleDesc tupdesc = CreateTemplateTupleDesc(NUM_LOCK_STATUS_COLUMNS, false);
+	TupleDesc	tupdesc = CreateTemplateTupleDesc(NUM_LOCK_STATUS_COLUMNS, false);
 
 	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "locktype", TEXTOID, -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "database", OIDOID, -1, 0);
@@ -192,24 +192,23 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		mystatus->predLockData = GetPredicateLockStatusData();
 
 		/*
-		 * Seeing the locks just from the masterDB isn't enough to know what is
-		 * locked, or if there is a deadlock, because segments also take locks.
-		 * Some show up only on the master, some only on the segDBs, and some on
-		 * both.
+		 * Seeing the locks just from the masterDB isn't enough to know what
+		 * is locked, or if there is a deadlock, because segments also take
+		 * locks. Some show up only on the master, some only on the segDBs,
+		 * and some on both.
 		 *
 		 * We collect the lock information from all the segments via gather
 		 * motion. There might be multiple instances of the same lock coming
 		 * from different segments.
 		 *
-		 * Routines from executor are used to fetch rows one-by-one. The results
-		 * are still materialized, unfortunately. This is a limitation of
-		 * set-returning functions, since they cannot surely know whether the
-		 * upper node was limited, and are called until they are
-		 * SRF_RETURN_DONE().
+		 * Routines from executor are used to fetch rows one-by-one. The
+		 * results are still materialized, unfortunately. This is a limitation
+		 * of set-returning functions, since they cannot surely know whether
+		 * the upper node was limited, and are called until they are
 		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			QueryDesc *queryDesc = build_pg_locks_querydesc();
+			QueryDesc  *queryDesc = build_pg_locks_querydesc();
 
 			ExecutorStart(queryDesc, 0);
 
@@ -456,11 +455,11 @@ pg_lock_status(PG_FUNCTION_ARGS)
 	/* Collect locks sent out by the segments on coordinator. */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		QueryDesc *queryDesc = mystatus->segQueryDesc;
+		QueryDesc  *queryDesc = mystatus->segQueryDesc;
 
 		for (;;)
 		{
-			HeapTuple ht;
+			HeapTuple	ht;
 			TupleTableSlot *tts = ExecProcNode(queryDesc->planstate);
 
 			if (TupIsNull(tts))

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -84,7 +84,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select * from gp_dist_random('pg_catalog.pg_locks')"
+	"select l.* from gp_dist_random('pg_catalog.pg_locks') l, generate_series(1, 10000)"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -87,7 +87,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 	"select l.* from gp_dist_random('pg_catalog.pg_locks') l, generate_series(1, 10000)"
 
 /*
- * Build a querydesc for SELECT on pg_locks relation to be into executor.
+ * Build a querydesc for SELECT on pg_locks relation to be passed to executor.
  */
 static QueryDesc *
 build_pg_locks_querydesc(void)

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -14,15 +14,15 @@
 
 #include "access/htup_details.h"
 #include "catalog/pg_type.h"
+#include "executor/tuptable.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "storage/predicate_internals.h"
+#include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 
-#include "libpq-fe.h"
-#include "cdb/cdbdisp_query.h"
-#include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbvars.h"
+#include "utils/snapmgr.h"
 
 /* This must match enum LockTagType! */
 static const char *const LockTagTypeNames[] = {
@@ -54,12 +54,7 @@ typedef struct
 	int			currIdx;		/* current PROCLOCK index */
 	PredicateLockData *predLockData;	/* state data for pred locks */
 	int			predLockIdx;	/* current index for pred lock */
-
-	int			numSegLocks;	/* Total number of locks being reported back to client */
-	int			numsegresults;	/* If we dispatch to segDBs, the number of segresults */
-	int			nextResultset;	/* which result set is being processed */
-	int			nextRow;		/* which row in current result set will be processed next */
-	struct pg_result **segresults;	/* pg_result for each segDB */
+	QueryDesc  *segQueryDesc;
 } PG_Lock_Status;
 
 /* Number of columns in pg_locks output */
@@ -84,6 +79,87 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 	return CStringGetTextDatum(vxidstr);
 }
 
+/*
+ * This query relies on the existance of pg_locks view to use a force random
+ * distribution on it.
+ */
+#define PG_LOCKS_INTERNAL_QUERY \
+	"select * from gp_dist_random('pg_catalog.pg_locks')"
+
+/*
+ * Build a querydesc for pg_locks relation to be executed on segments, set
+ * "dest" to portal->holdStore.
+ */
+static QueryDesc *build_pg_locks_querydesc(void)
+{
+	List *raw_parsetree_list;
+	Node *parsetree;
+	List *querytree_list;
+	List *plantree_list;
+	PlannedStmt *plan_stmt;
+	QueryDesc *queryDesc = NULL;
+
+	/* Parse the SQL string into a list of raw parse trees. */
+	raw_parsetree_list = pg_parse_query(PG_LOCKS_INTERNAL_QUERY);
+	/* There is only one element in list due to simple select. */
+	Assert(list_length(raw_parsetree_list) == 1);
+
+	/*
+	 * Do parse analysis, rule rewrite, planning, and execution for each raw
+	 * parsetree.
+	 */
+	parsetree = (Node *) linitial(raw_parsetree_list);
+
+	querytree_list =
+		pg_analyze_and_rewrite(parsetree, PG_LOCKS_INTERNAL_QUERY, NULL, 0);
+	plantree_list = pg_plan_queries(querytree_list, 0, NULL);
+
+	/* There is only one statement in list due to simple select. */
+	Assert(list_length(plantree_list) == 1);
+	plan_stmt = (PlannedStmt *) linitial(plantree_list);
+
+	queryDesc =
+		CreateQueryDesc(plan_stmt, PG_LOCKS_INTERNAL_QUERY, GetActiveSnapshot(),
+						InvalidSnapshot, NULL, NULL, INSTRUMENT_NONE);
+
+	list_free_deep(querytree_list);
+	list_free_deep(raw_parsetree_list);
+
+	return queryDesc;
+}
+
+static TupleDesc build_pg_locks_tupdesc(void)
+{
+	TupleDesc tupdesc = CreateTemplateTupleDesc(NUM_LOCK_STATUS_COLUMNS, false);
+
+	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "locktype", TEXTOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "database", OIDOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 3, "relation", OIDOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 4, "page", INT4OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 5, "tuple", INT2OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 6, "virtualxid", TEXTOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 7, "transactionid", XIDOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 8, "classid", OIDOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 9, "objid", OIDOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 10, "objsubid", INT2OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 11, "virtualtransaction", TEXTOID,
+					   -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 12, "pid", INT4OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 13, "mode", TEXTOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 14, "granted", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 15, "fastpath", BOOLOID, -1, 0);
+
+	/*
+	 * These next columns are specific to GPDB
+	 */
+	TupleDescInitEntry(tupdesc, (AttrNumber) 16, "mppSessionId", INT4OID, -1,
+					   0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 17, "mppIsWriter", BOOLOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 18, "gp_segment_id", INT4OID, -1,
+					   0);
+
+	return tupdesc;
+}
 
 /*
  * pg_lock_status - produce a view with one row per held or awaited lock mode
@@ -98,178 +174,47 @@ pg_lock_status(PG_FUNCTION_ARGS)
 
 	if (SRF_IS_FIRSTCALL())
 	{
-		TupleDesc	tupdesc;
 		MemoryContext oldcontext;
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
 
-		/*
-		 * switch to memory context appropriate for multiple function calls
-		 */
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-
-		/* build tupdesc for result tuples */
-		/* this had better match pg_locks view in system_views.sql */
-		tupdesc = CreateTemplateTupleDesc(NUM_LOCK_STATUS_COLUMNS, false);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "locktype",
-						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "database",
-						   OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "relation",
-						   OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "page",
-						   INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "tuple",
-						   INT2OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "virtualxid",
-						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "transactionid",
-						   XIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "classid",
-						   OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "objid",
-						   OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "objsubid",
-						   INT2OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 11, "virtualtransaction",
-						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 12, "pid",
-						   INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 13, "mode",
-						   TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 14, "granted",
-						   BOOLOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 15, "fastpath",
-						   BOOLOID, -1, 0);
-		/*
-		 * These next columns are specific to GPDB
-		 */
-		TupleDescInitEntry(tupdesc, (AttrNumber) 16, "mppSessionId",
-						   INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 17, "mppIsWriter",
-						   BOOLOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 18, "gp_segment_id",
-						   INT4OID, -1, 0);
-
-		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 
 		/*
 		 * Collect all the locking information that we will format and send
 		 * out as a result set.
 		 */
-		mystatus = (PG_Lock_Status *) palloc(sizeof(PG_Lock_Status));
-		funcctx->user_fctx = (void *) mystatus;
+		mystatus = (PG_Lock_Status *) palloc0(sizeof(PG_Lock_Status));
 
 		mystatus->lockData = GetLockStatusData();
-		mystatus->currIdx = 0;
 		mystatus->predLockData = GetPredicateLockStatusData();
-		mystatus->predLockIdx = 0;
 
-		mystatus->numSegLocks = 0;
-		mystatus->numsegresults = 0;
-		mystatus->nextResultset = 0;
-		mystatus->nextRow = 0;
-		mystatus->segresults = NULL;
-
-		/*
-		 * Seeing the locks just from the masterDB isn't enough to know what is locked,
-		 * or if there is a deadlock.  That's because the segDBs also take locks.
-		 * Some locks show up only on the master, some only on the segDBs, and some on both.
-		 *
-		 * So, let's collect the lock information from all the segDBs.  Sure, this means
-		 * there are a lot more rows coming back from pg_locks than before, since most locks
-		 * on the segDBs happen across all the segDBs at the same time.  But not always,
-		 * so let's play it safe and get them all.
-		 */
-
+		/* Sent out a plan to the segments. To receive the results later. */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			CdbPgResults cdb_pgresults = {NULL, 0};
-			StringInfoData buffer;
-			int i;
-			initStringInfo(&buffer);
+			QueryDesc *queryDesc = build_pg_locks_querydesc();
+
+			ExecutorStart(queryDesc, 0);
+
+			mystatus->segQueryDesc = queryDesc;
 
 			/*
-			 * Why dispatch something here, rather than do a UNION ALL in pg_locks view, and
-			 * a join to gp_dist_random('gp_id')?  There are several important reasons.
-			 *
-			 * The union all method is much slower, and requires taking locks on gp_id.
-			 * More importantly, applications such as pgAdmin do queries of this view that
-			 * involve a correlated subqueries joining to other catalog tables,
-			 * which works if we do it this way, but fails
-			 * if the view includes the union all.  That completely breaks the server status
-			 * display in pgAdmin.
-			 *
-			 * Why dispatch this way, rather than via SPI?  There are several advantages.
-			 * First, it's easy to get "writer gang is busy" errors if we use SPI.
-			 *
-			 * Second, this should be much faster, as it doesn't require setting up
-			 * the interconnect, and doesn't need to touch any actual data tables to be
-			 * able to get the gp_segment_id.
-			 *
-			 * The downside is we get n result sets, where n == number of segDBs.
-			 *
-			 * It would be better yet if we sent a plan tree rather than a text string,
-			 * so the segDBs don't need to parse it.  That would also avoid taking any relation locks
-			 * on the segDB to get this info (normally need to get an accessShareLock on pg_locks on the segDB
-			 * to make sure it doesn't go away during parsing).  But the only safe way I know to do this
-			 * is to hand-build the plan tree, and I'm to lazy to do it right now. It's just a matter of
-			 * building a function scan node, and filling it in with our result set info (from the tupledesc).
-			 *
-			 * One thing to note:  it's OK to join pg_locks with any catalog table or master-only table,
-			 * but joining to a distributed table will result in "writer gang busy: possible attempt to
-			 * execute volatile function in unsupported context" errors, because
-			 * the scan of the distributed table might already be running on the writer gang
-			 * when we want to dispatch this.
-			 *
-			 * This could be fixed by allocating a reader gang and dispatching to that, but the cost
-			 * of setting up a new gang is high, and I've never seen anyone need to join this to a
-			 * distributed table.
-			 *
-			 * GPDB_84_MERGE_FIXME: Should we rewrite this in a different way now that we have
-			 * ON SEGMENT/ ON MASTER attributes on functions?
+			 * On coordinator, we receive proper tupDesc from the parsed
+			 * query.
 			 */
-			CdbDispatchCommand("SELECT * FROM pg_catalog.pg_lock_status()", DF_WITH_SNAPSHOT, &cdb_pgresults);
-
-			if (cdb_pgresults.numResults == 0)
-				elog(ERROR, "pg_locks didn't get back any data from the segDBs");
-
-			for (i = 0; i < cdb_pgresults.numResults; i++)
-			{
-				/*
-				 * Any error here should have propagated into errbuf, so we shouldn't
-				 * ever see anything other that tuples_ok here.  But, check to be
-				 * sure.
-				 */
-				if (PQresultStatus(cdb_pgresults.pg_results[i]) != PGRES_TUPLES_OK)
-				{
-					cdbdisp_clearCdbPgResults(&cdb_pgresults);
-					elog(ERROR,"pg_locks: resultStatus not tuples_Ok");
-				}
-
-				/*
-				 * numSegLocks needs to be the total size we are returning to
-				 * the application. At the start of this loop, it has the count
-				 * for the masterDB locks.  Add each of the segDB lock counts.
-				 */
-				mystatus->numSegLocks += PQntuples(cdb_pgresults.pg_results[i]);
-
-				/*
-				 * This query better match the tupledesc we just made above.
-				 */
-				if (PQnfields(cdb_pgresults.pg_results[i]) != tupdesc->natts)
-					elog(ERROR, "unexpected number of columns returned from pg_lock_status() on segment (%d, expected %d)",
-						 PQnfields(cdb_pgresults.pg_results[i]), tupdesc->natts);
-			}
-
-			mystatus->numsegresults = cdb_pgresults.numResults;
-			/*
-			 * cdbdisp_dispatchRMCommand copies the result sets into our memory, which
-			 * will still exist on the subsequent calls.
-			 */
-			mystatus->segresults = cdb_pgresults.pg_results;
+			funcctx->tuple_desc = BlessTupleDesc(queryDesc->tupDesc);
 		}
+		else
+		{
+			/*
+			 * On segments, build tupdesc for result tuples manually. It
+			 * should match pg_locks view in system_views.sql file.
+			 */
+			funcctx->tuple_desc = BlessTupleDesc(build_pg_locks_tupdesc());
+		}
+
+		funcctx->user_fctx = (void *) mystatus;
 
 		MemoryContextSwitchTo(oldcontext);
 	}
@@ -492,98 +437,41 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		SRF_RETURN_NEXT(funcctx, result);
 	}
 
+
 	/*
-	 * This loop only executes on the masterDB and only in dispatch mode,
-	 * because that is the only time we dispatched to the segDBs.
+	 * Seeing the locks just from the masterDB isn't enough to know what is locked,
+	 * or if there is a deadlock.  That's because the segDBs also take locks.
+	 * Some locks show up only on the master, some only on the segDBs, and some on both.
+	 *
+	 * So, let's collect the lock information from all the segDBs.  Sure, this means
+	 * there are a lot more rows coming back from pg_locks than before, since most locks
+	 * on the segDBs happen across all the segDBs at the same time.  But not always,
+	 * so let's play it safe and get them all.
 	 */
-	while (mystatus->currIdx >= lockData->nelements && mystatus->currIdx < lockData->nelements + mystatus->numSegLocks)
+	if (Gp_role == GP_ROLE_DISPATCH)
 	{
-		HeapTuple	tuple;
-		Datum		result;
-		Datum		values[NUM_LOCK_STATUS_COLUMNS];
-		bool		nulls[NUM_LOCK_STATUS_COLUMNS];
-		int			i;
-		int			whichresultset;
-		int			whichrow;
+		QueryDesc *queryDesc = mystatus->segQueryDesc;
 
-		Assert(Gp_role == GP_ROLE_DISPATCH);
-
-		/*
-		 * Because we have one result set per segDB (rather than one big result
-		 * set with everything), we use mystatus->nextResultset and
-		 * mystatus->nextRow to track which result set we are on, and which row
-		 * within that result set we are returning, respectively.
-		 */
-		whichresultset = mystatus->nextResultset;
-		whichrow = mystatus->nextRow;
-		Assert(whichresultset < mystatus->numsegresults);
-		Assert(whichrow < PQntuples(mystatus->segresults[whichresultset]));
-
-		/*
-		 * Advance to next row. If we're out of rows in this result set,
-		 * advance to next one.
-		 */
-		if (mystatus->nextRow + 1 < PQntuples(mystatus->segresults[mystatus->nextResultset]))
+		for (;;)
 		{
-			mystatus->nextRow++;
-		}
-		else
-		{
-			mystatus->nextResultset++;
-			mystatus->nextRow = 0;
-		}
-		mystatus->currIdx++;
+			HeapTuple ht;
+			TupleTableSlot *tts = ExecProcNode(queryDesc->planstate);
 
-		/*
-		 * Form tuple with appropriate data we got from the segDBs
-		 */
-		MemSet(values, 0, sizeof(values));
-		MemSet(nulls, false, sizeof(nulls));
+			if (TupIsNull(tts))
+			{
+				break;
+			}
 
-		/*
-		 * For each column, extract out the value (which comes out in text).
-		 * Convert it to the appropriate datatype to match our tupledesc,
-		 * and put that in values.
-		 * The columns look like this (from select statement earlier):
-		 *
-		 * "   (locktype text, database oid, relation oid, page int4, tuple int2,"
-		 *	"   transactionid xid, classid oid, objid oid, objsubid int2,"
-		 *	"    transaction xid, pid int4, mode text, granted boolean, "
-		 *	"    mppSessionId int4, mppIsWriter boolean, gp_segment_id int4) ,"
-		 */
+			Assert(tts->tts_tupleDescriptor->natts == NUM_LOCK_STATUS_COLUMNS);
 
-		values[0] = CStringGetTextDatum(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 0));
-		values[1] = ObjectIdGetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 1)));
-		values[2] = ObjectIdGetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 2)));
-		values[3] = UInt32GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 3)));
-		values[4] = UInt16GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 4)));
+			ht = ExecFetchSlotHeapTuple(tts);
 
-		values[5] = CStringGetTextDatum(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 5));
-		values[6] = TransactionIdGetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 6)));
-		values[7] = ObjectIdGetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 7)));
-		values[8] = ObjectIdGetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 8)));
-		values[9] = UInt16GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 9)));
-
-		values[10] = CStringGetTextDatum(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 10));
-		values[11] = UInt32GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 11)));
-		values[12] = CStringGetTextDatum(PQgetvalue(mystatus->segresults[whichresultset], whichrow, 12));
-		values[13] = BoolGetDatum(strncmp(PQgetvalue(mystatus->segresults[whichresultset], whichrow,13),"t",1)==0);
-		values[14] = BoolGetDatum(strncmp(PQgetvalue(mystatus->segresults[whichresultset], whichrow,14),"t",1)==0);
-		values[15] = Int32GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow,15)));
-		values[16] = BoolGetDatum(strncmp(PQgetvalue(mystatus->segresults[whichresultset], whichrow,16),"t",1)==0);
-		values[17] = Int32GetDatum(atoi(PQgetvalue(mystatus->segresults[whichresultset], whichrow,17)));
-
-		/*
-		 * Copy the null info over.  It should all match properly.
-		 */
-		for (i = 0; i < NUM_LOCK_STATUS_COLUMNS; i++)
-		{
-			nulls[i] = PQgetisnull(mystatus->segresults[whichresultset], whichrow, i);
+			SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(ht));
 		}
 
-		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
-		result = HeapTupleGetDatum(tuple);
-		SRF_RETURN_NEXT(funcctx, result);
+		ExecutorFinish(queryDesc);
+		ExecutorEnd(queryDesc);
+		FreeQueryDesc(queryDesc);
 	}
 
 	/*
@@ -663,20 +551,6 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 		result = HeapTupleGetDatum(tuple);
 		SRF_RETURN_NEXT(funcctx, result);
-	}
-
-	/*
-	 * if we dispatched to the segDBs, free up the memory holding the result sets.
-	 * Otherwise we might leak this memory each time we got called (does it automatically
-	 * get freed by the pool being deleted?  Probably, but this is safer).
-	 */
-	if (mystatus->segresults != NULL)
-	{
-		int i;
-		for (i = 0; i < mystatus->numsegresults; i++)
-			PQclear(mystatus->segresults[i]);
-
-		pfree(mystatus->segresults);
 	}
 
 	SRF_RETURN_DONE(funcctx);

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -84,7 +84,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select l.* from gp_dist_random('pg_catalog.pg_locks') l, generate_series(1, 10000)"
+	"select * from gp_dist_random('pg_catalog.pg_locks')"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -22,8 +22,6 @@
 #include "utils/builtins.h"
 #include "utils/faultinjector.h"
 
-#include "cdb/cdbsetop.h"
-#include "cdb/cdbutil.h"
 #include "cdb/cdbvars.h"
 #include "utils/snapmgr.h"
 
@@ -87,7 +85,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select (pg_catalog.pg_lock_status()).*"
+	"select * from gp_dist_random('pg_catalog.pg_locks')"
 
 /*
  * Build a querydesc for SELECT on pg_locks relation to be passed to executor.
@@ -120,14 +118,6 @@ build_pg_locks_querydesc(void)
 	/* There is only one statement in list due to simple select. */
 	Assert(list_length(plantree_list) == 1);
 	plan_stmt = (PlannedStmt *) linitial(plantree_list);
-
-	/* Add a gather motion atop the plan. */
-	plan_stmt->planTree->flow = NULL;
-	mark_plan_strewn(plan_stmt->planTree, getgpsegmentCount());
-	plan_stmt->planTree =
-		(Plan *) make_motion_gather_to_QD(NULL, plan_stmt->planTree, NULL);
-	((Motion *) plan_stmt->planTree)->motionID = 1;
-	plan_stmt->nMotionNodes = 1;
 
 	queryDesc =
 		CreateQueryDesc(plan_stmt, PG_LOCKS_INTERNAL_QUERY, GetActiveSnapshot(),

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -20,6 +20,7 @@
 #include "storage/predicate_internals.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 
 #include "cdb/cdbvars.h"
 #include "utils/snapmgr.h"
@@ -184,6 +185,8 @@ pg_lock_status(PG_FUNCTION_ARGS)
 			ExecutorEnd(mystatus->segQueryDesc);
 			FreeQueryDesc(mystatus->segQueryDesc);
 		}
+
+		SIMPLE_FAULT_INJECTOR("pg_lock_status_squelched");
 
 		SRF_RETURN_DONE(funcctx);
 	}
@@ -465,6 +468,8 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		result = HeapTupleGetDatum(tuple);
 		SRF_RETURN_NEXT(funcctx, result);
 	}
+
+	SIMPLE_FAULT_INJECTOR("pg_lock_status_local_locks_collected");
 
 	/* Collect locks sent out by the segments on coordinator. */
 	if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -84,13 +84,13 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * distribution on it.
  */
 #define PG_LOCKS_INTERNAL_QUERY \
-	"select * from gp_dist_random('pg_catalog.pg_locks')"
+	"select l.* from gp_dist_random('pg_catalog.pg_locks') l, generate_series(1, 10000)"
 
 /*
- * Build a querydesc for pg_locks relation to be executed on segments, set
- * "dest" to portal->holdStore.
+ * Build a querydesc for SELECT on pg_locks relation to be into executor.
  */
-static QueryDesc *build_pg_locks_querydesc(void)
+static QueryDesc *
+build_pg_locks_querydesc(void)
 {
 	List *raw_parsetree_list;
 	Node *parsetree;
@@ -128,7 +128,8 @@ static QueryDesc *build_pg_locks_querydesc(void)
 	return queryDesc;
 }
 
-static TupleDesc build_pg_locks_tupdesc(void)
+static TupleDesc
+build_pg_locks_tupdesc(void)
 {
 	TupleDesc tupdesc = CreateTemplateTupleDesc(NUM_LOCK_STATUS_COLUMNS, false);
 
@@ -150,7 +151,7 @@ static TupleDesc build_pg_locks_tupdesc(void)
 	TupleDescInitEntry(tupdesc, (AttrNumber) 15, "fastpath", BOOLOID, -1, 0);
 
 	/*
-	 * These next columns are specific to GPDB
+	 * These next columns are specific to GPDB.
 	 */
 	TupleDescInitEntry(tupdesc, (AttrNumber) 16, "mppSessionId", INT4OID, -1,
 					   0);
@@ -190,7 +191,22 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		mystatus->lockData = GetLockStatusData();
 		mystatus->predLockData = GetPredicateLockStatusData();
 
-		/* Sent out a plan to the segments. To receive the results later. */
+		/*
+		 * Seeing the locks just from the masterDB isn't enough to know what is
+		 * locked, or if there is a deadlock, because segments also take locks.
+		 * Some show up only on the master, some only on the segDBs, and some on
+		 * both.
+		 *
+		 * We collect the lock information from all the segments via gather
+		 * motion. There might be multiple instances of the same lock coming
+		 * from different segments.
+		 *
+		 * Routines from executor are used to fetch rows one-by-one. The results
+		 * are still materialized, unfortunately. This is a limitation of
+		 * set-returning functions, since they cannot surely know whether the
+		 * upper node was limited, and are called until they are
+		 * SRF_RETURN_DONE().
+		 */
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
 			QueryDesc *queryDesc = build_pg_locks_querydesc();
@@ -437,17 +453,7 @@ pg_lock_status(PG_FUNCTION_ARGS)
 		SRF_RETURN_NEXT(funcctx, result);
 	}
 
-
-	/*
-	 * Seeing the locks just from the masterDB isn't enough to know what is locked,
-	 * or if there is a deadlock.  That's because the segDBs also take locks.
-	 * Some locks show up only on the master, some only on the segDBs, and some on both.
-	 *
-	 * So, let's collect the lock information from all the segDBs.  Sure, this means
-	 * there are a lot more rows coming back from pg_locks than before, since most locks
-	 * on the segDBs happen across all the segDBs at the same time.  But not always,
-	 * so let's play it safe and get them all.
-	 */
+	/* Collect locks sent out by the segments on coordinator. */
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		QueryDesc *queryDesc = mystatus->segQueryDesc;

--- a/src/test/isolation2/expected/lock_status.out
+++ b/src/test/isolation2/expected/lock_status.out
@@ -1,0 +1,150 @@
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+CREATE
+-- end_ignore
+
+CREATE TABLE t_part(i int) PARTITION BY RANGE (i) (START (0) END (20) EVERY (1));
+CREATE
+
+-- Create a lot of locks.
+2: BEGIN;
+BEGIN
+2: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+LOCK
+
+--
+-- Test pg_locks view behavior.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Materializes everything regardless of LIMIT clause, as of now.
+SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
+ f 
+---
+ f 
+(1 row)
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- only from coordinator.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Doesn't materialize anything.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
+ f 
+---
+ f 
+(1 row)
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- both from coordinator and from segments.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Retrieves only 40 rows, should pull in ~20 locks from coordinator and from a
+-- segment.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
+ f 
+---
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+ f 
+(40 rows)
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid), gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault | gp_wait_until_triggered_fault 
+-------------------------------+-------------------------------
+ Success:                      | Success:                      
+(1 row)
+
+1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2: ROLLBACK;
+ROLLBACK
+
+-- start_ignore
+DROP TABLE t_part;
+DROP
+-- end_ignore

--- a/src/test/isolation2/expected/lock_status.out
+++ b/src/test/isolation2/expected/lock_status.out
@@ -3,7 +3,7 @@ CREATE EXTENSION gp_inject_fault;
 CREATE
 -- end_ignore
 
-CREATE TABLE t_part(i int) PARTITION BY RANGE (i) (START (0) END (20) EVERY (1));
+CREATE TABLE t_part(i int) PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
 CREATE
 
 -- Create a lot of locks.
@@ -52,7 +52,8 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
  Success:        | Success:        
 (1 row)
 
--- Doesn't materialize anything.
+-- Doesn't materialize anything, gets squelched after the first row from
+-- coordinator.
 SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
  f 
 ---
@@ -82,9 +83,9 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
  Success:        | Success:        
 (1 row)
 
--- Retrieves only 40 rows, should pull in ~20 locks from coordinator and from a
--- segment.
-SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
+-- Retrieves some rows from coordinator and from a segment, then gets
+-- squelched.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 10;
  f 
 ---
  f 
@@ -97,37 +98,7 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
  f 
  f 
  f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
- f 
-(40 rows)
+(10 rows)
 
 1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid), gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
  gp_wait_until_triggered_fault | gp_wait_until_triggered_fault 
@@ -144,7 +115,5 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
 2: ROLLBACK;
 ROLLBACK
 
--- start_ignore
 DROP TABLE t_part;
 DROP
--- end_ignore

--- a/src/test/isolation2/expected/lock_status.out
+++ b/src/test/isolation2/expected/lock_status.out
@@ -7,16 +7,16 @@ CREATE TABLE t_part(i int) PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
 CREATE
 
 -- Create a lot of locks.
-2: BEGIN;
+1: BEGIN;
 BEGIN
-2: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+1: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
 LOCK
 
 --
 -- Test pg_locks view behavior.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault | gp_inject_fault 
 -----------------+-----------------
  Success:        | Success:        
@@ -29,13 +29,13 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
  f 
 (1 row)
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 
-1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -46,7 +46,7 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
 -- only from coordinator.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault | gp_inject_fault 
 -----------------+-----------------
  Success:        | Success:        
@@ -60,13 +60,13 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
  f 
 (1 row)
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 
-1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault 
 -----------------
  Success:        
@@ -77,7 +77,7 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
 -- both from coordinator and from segments.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault | gp_inject_fault 
 -----------------+-----------------
  Success:        | Success:        
@@ -100,19 +100,19 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 10;
  f 
 (10 rows)
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid), gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid), gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
  gp_wait_until_triggered_fault | gp_wait_until_triggered_fault 
 -------------------------------+-------------------------------
  Success:                      | Success:                      
 (1 row)
 
-1: SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
 
-2: ROLLBACK;
+1: ROLLBACK;
 ROLLBACK
 
 DROP TABLE t_part;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -355,3 +355,6 @@ test: free_remapper_fatal
 test: spilling_hashagg
 
 test: copy_interrupt
+
+# test pg_locks view and pg_lock_status() function
+test: lock_status

--- a/src/test/isolation2/sql/lock_status.sql
+++ b/src/test/isolation2/sql/lock_status.sql
@@ -6,24 +6,24 @@ CREATE TABLE t_part(i int)
 PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
 
 -- Create a lot of locks.
-2: BEGIN;
-2: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+1: BEGIN;
+1: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
 
 --
 -- Test pg_locks view behavior.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
           gp_inject_fault('pg_lock_status_squelched', 'error', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 -- Materializes everything regardless of LIMIT clause, as of now.
 SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
+SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
    FROM gp_segment_configuration WHERE role = 'p' and content = -1;
 
-1: SELECT gp_inject_fault('all', 'reset', dbid)
+SELECT gp_inject_fault('all', 'reset', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 --
@@ -31,7 +31,7 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
 -- only from coordinator.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid),
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid),
           gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
@@ -39,10 +39,10 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
 -- coordinator.
 SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid)
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid)
    FROM gp_segment_configuration WHERE role = 'p' and content = -1;
 
-1: SELECT gp_inject_fault('all', 'reset', dbid)
+SELECT gp_inject_fault('all', 'reset', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 --
@@ -50,7 +50,7 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
 -- both from coordinator and from segments.
 --
 
-1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
           gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
@@ -58,13 +58,13 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
 -- squelched.
 SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 10;
 
-1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid),
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid),
           gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
    FROM gp_segment_configuration WHERE role = 'p' and content = -1;
 
-1: SELECT gp_inject_fault('all', 'reset', dbid)
+SELECT gp_inject_fault('all', 'reset', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
-2: ROLLBACK;
+1: ROLLBACK;
 
 DROP TABLE t_part;

--- a/src/test/isolation2/sql/lock_status.sql
+++ b/src/test/isolation2/sql/lock_status.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION gp_inject_fault;
 -- end_ignore
 
 CREATE TABLE t_part(i int)
-PARTITION BY RANGE (i) (START (0) END (20) EVERY (1));
+PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
 
 -- Create a lot of locks.
 2: BEGIN;
@@ -35,7 +35,8 @@ SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
           gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
--- Doesn't materialize anything.
+-- Doesn't materialize anything, gets squelched after the first row from
+-- coordinator.
 SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
 
 1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid)
@@ -53,9 +54,9 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
           gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
--- Retrieves only 40 rows, should pull in ~20 locks from coordinator and from a
--- segment.
-SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
+-- Retrieves some rows from coordinator and from a segment, then gets
+-- squelched.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 10;
 
 1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid),
           gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
@@ -66,6 +67,4 @@ SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
 
 2: ROLLBACK;
 
--- start_ignore
 DROP TABLE t_part;
--- end_ignore

--- a/src/test/isolation2/sql/lock_status.sql
+++ b/src/test/isolation2/sql/lock_status.sql
@@ -1,0 +1,71 @@
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+-- end_ignore
+
+CREATE TABLE t_part(i int)
+PARTITION BY RANGE (i) (START (0) END (20) EVERY (1));
+
+-- Create a lot of locks.
+2: BEGIN;
+2: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+
+--
+-- Test pg_locks view behavior.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+          gp_inject_fault('pg_lock_status_squelched', 'error', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Materializes everything regardless of LIMIT clause, as of now.
+SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
+   FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+1: SELECT gp_inject_fault('all', 'reset', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- only from coordinator.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid),
+          gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Doesn't materialize anything.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid)
+   FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+1: SELECT gp_inject_fault('all', 'reset', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- both from coordinator and from segments.
+--
+
+1: SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+          gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Retrieves only 40 rows, should pull in ~20 locks from coordinator and from a
+-- segment.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 40;
+
+1: SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid),
+          gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
+   FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+1: SELECT gp_inject_fault('all', 'reset', dbid)
+   FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+2: ROLLBACK;
+
+-- start_ignore
+DROP TABLE t_part;
+-- end_ignore


### PR DESCRIPTION
Do not use CdbDispatchCommand() in pg_lock_status()

Previosly, `pg_lock_status()` implementation used `CdbDispatchCommand()` which
relied on libpq's `pqRowProcessor()` that internally performed humongous amount
of `malloc()`/`realloc()` allocations for large queries. This caused progressive
memory leaks that could exhaust system memory if querying `pg_locks` frequently
or with many concurrent locks.

This patch completely replaces `CdbDispatchCommand()` in `pg_lock_status()` with
executor-based routines that stream row-by-row directly through the executor
infrastructure, while also improving its performance.

Benchmarks show the changes reduce peak memory usage by 63% (down to 350MB) and
improve execution time by 20% (from 7.6s to 6.1s) for the same 1.5 million lock
test case.

The results are still materialized, unfortunately. This occurs because
`pg_locks` view selects everything from `pg_lock_status()`, regardless of what
LIMIT clause has. The way to bypass it is to select `pg_lock_status()` directly:

    SELECT pg_lock_status() LIMIT 10;

---
Commit 7f6d6c6 increased the size of the `ConfigureNamesBool_gp` structure and added it to the ignore list for the `6.27.1_arenadata60` tag, but now the current tag is `6.27.1_arenadata61`, and that commit is not in it yet, so I had to add this structure to the ignore list for the current tag as well.

---
### Profiling

Preparation, in a separate session:
```sql
CREATE TABLE t_part_small(i int, j int) PARTITION BY RANGE (j) (START (0) END (50) EVERY (1)); 
BEGIN;
LOCK TABLE t_part_small IN ACCESS EXCLUSIVE MODE;
```

#### Without the patch
`CdbDispatchCommand(...)`'s query is replaced with: 
```sql
select l.* from pg_catalog.pg_locks l, generate_series(1, 10000)
```

```
postgres=# select count(*) from pg_locks;
  count  
---------
 1590055
(1 row)
postgres=# 

Time: 7601.848 ms
postgres=# select pg_backend_pid();
 pg_backend_pid 
----------------
          10323
(1 row)

postgres=# \!grep VmPeak /proc/10323/status
VmPeak:	 975360 kB -- (~950 MB)
```

#### With patch
`PG_LOCKS_INTERNAL_QUERY` macro is replaced with: 
```sql
select l.* from gp_dist_random('pg_catalog.pg_locks') l, generate_series(1, 10000)
```

```
postgres=# select count(*) from pg_locks;
  count  
---------
 1590055
(1 row)

Time: 6137.254 ms
postgres=# select pg_backend_pid();
 pg_backend_pid 
----------------
          20436
(1 row)

postgres=# \!grep VmPeak /proc/20436/status
VmPeak:	 357580 kB -- (~350 MB)
```
