### PR TITLE
Changed plan generation for replicated tables and general functions with limits.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -5543,7 +5543,9 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 	 * If the limit path's locus is general or segmentgeneral
 	 * we have to make it singleQE.
 	 */
-	if (contain_volatile_functions(pathnode->limitOffset) || contain_volatile_functions(pathnode->limitCount))
+	if (CdbPathLocus_IsSegmentGeneral(pathnode->path.locus) || 
+			CdbPathLocus_IsGeneral(pathnode->path.locus) ||
+			contain_volatile_functions(pathnode->limitOffset) || contain_volatile_functions(pathnode->limitCount))
 		return turn_volatile_seggen_to_singleqe(root, (Path *) pathnode, NULL);
 	else
 		return (Path *)pathnode;

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -5543,6 +5543,9 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 	 * If the limit path's locus is general or segmentgeneral
 	 * we have to make it singleQE.
 	 */
+	if (contains_outer_params(limitCount, root) || contains_outer_params(limitOffset, root)) 
+		return (Path *)pathnode;
+
 	if (CdbPathLocus_IsSegmentGeneral(pathnode->path.locus) || 
 			CdbPathLocus_IsGeneral(pathnode->path.locus) ||
 			contain_volatile_functions(pathnode->limitOffset) || contain_volatile_functions(pathnode->limitCount))

--- a/src/test/regress/expected/qp_full_join.out
+++ b/src/test/regress/expected/qp_full_join.out
@@ -268,17 +268,20 @@ select count(*) from uni full join rep on uni.c1 = rep.c1;
 -- both sides are gathered onto the coordinator.
 explain (costs off, timing off, summary off) select * from tainted_rep full join tainted_rep2 on tainted_rep.c1 = tainted_rep2.c1;
                 QUERY PLAN                
-------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Hash Full Join
-         Hash Cond: (rep2.c1 = rep.c1)
-         ->  Limit
-               ->  Seq Scan on rep2
-         ->  Hash
+------------------------------------------------------------
+ Hash Full Join
+   Hash Cond: (rep2.c1 = rep.c1)
+   ->  Result
+         ->  Gather Motion 1:1  (slice1; segments: 1)
                ->  Limit
-                     ->  Seq Scan on rep
+                     ->  Seq Scan on rep2
+   ->  Hash
+         ->  Result
+               ->  Gather Motion 1:1  (slice2; segments: 1)
+                     ->  Limit
+                           ->  Seq Scan on rep
  Optimizer: Postgres-based planner
-(9 rows)
+(12 rows)
 
 -- tainted-replicated ⟗  distributed 
 -- The left relation is tainted-replicated. To avoid duplicates, the left side
@@ -293,10 +296,11 @@ explain (costs off, timing off, summary off) select * from tainted_rep full join
          ->  Hash
                ->  Redistribute Motion 1:3  (slice2; segments: 1)
                      Hash Key: rep.c1
-                     ->  Limit
-                           ->  Seq Scan on rep
+                     ->  Result
+                           ->  Limit
+                                 ->  Seq Scan on rep
  Optimizer: Postgres-based planner
-(10 rows)
+(11 rows)
 
 ------------------------------------------
 -- 3-table join: test derived distribution spec

--- a/src/test/regress/expected/qp_indexscan.out
+++ b/src/test/regress/expected/qp_indexscan.out
@@ -1795,12 +1795,12 @@ INSERT INTO test_replicated_table values (null, null, null, null, null);
 -- Validate if 'rep_index_eda' is used for order by matching to the index
 explain(costs off) select e,d,a from test_replicated_table order by e desc nulls last, d, a desc limit 3;
                                 QUERY PLAN
---------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   Merge Key: e, d, a
-   ->  Limit
-         ->  Index Only Scan using rep_index_eda on test_replicated_table
- Optimizer: Postgres query optimizer
+--------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Limit
+               ->  Index Only Scan using rep_index_eda on test_replicated_table
+ Optimizer: Postgres-based planner
 (5 rows)
 
 select e,d,a from test_replicated_table order by e desc nulls last, d, a desc limit 3;
@@ -1814,12 +1814,12 @@ select e,d,a from test_replicated_table order by e desc nulls last, d, a desc li
 -- Validate if 'rep_index_eda' is used for order by commutative to the index
 explain(costs off) select e,d,a from test_replicated_table order by e nulls first, d desc, a limit 3;
                                     QUERY PLAN
------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   Merge Key: e, d, a
-   ->  Limit
-         ->  Index Only Scan Backward using rep_index_eda on test_replicated_table
- Optimizer: Postgres query optimizer
+-----------------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Limit
+               ->  Index Only Scan Backward using rep_index_eda on test_replicated_table
+ Optimizer: Postgres-based planner
 (5 rows)
 
 select e,d,a from test_replicated_table order by e nulls first, d desc, a limit 3;
@@ -1833,14 +1833,14 @@ select e,d,a from test_replicated_table order by e nulls first, d desc, a limit 
 -- Negative tests: Validate if a SeqScan is chosen for order by cols not matching any indices. Expected to choose SeqScan with Sort
 explain(costs off) select d,a from test_replicated_table order by d,a desc limit 3;
                      QUERY PLAN
------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   Merge Key: d, a
-   ->  Limit
-         ->  Sort
-               Sort Key: d, a DESC
-               ->  Seq Scan on test_replicated_table
- Optimizer: Postgres query optimizer
+-----------------------------------------------------------
+ Result
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Limit
+               ->  Sort
+                     Sort Key: d, a DESC
+                     ->  Seq Scan on test_replicated_table
+ Optimizer: Postgres-based planner
 (7 rows)
 
 select d,a from test_replicated_table order by d,a desc limit 3;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1586,16 +1586,17 @@ end;
 $$;
 select * from explain_sq_limit();
                                explain_sq_limit                               
-------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
-   ->  Limit (actual rows=3 loops=1)
-         ->  Subquery Scan on x (actual rows=3 loops=1)
-               ->  Sort (actual rows=3 loops=1)
-                     Sort Key: sq_limit.c1, sq_limit.pk
-                     Sort Method:  top-N heapsort  Memory: xxx
-                     Executor Memory: xxx  Segments: x  Max: xxkB (segment x)
-                     ->  Seq Scan on sq_limit (actual rows=8 loops=1)
- Optimizer: Postgres query optimizer
+------------------------------------------------------------------------------------
+ Result (actual rows=3 loops=1)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=3 loops=1)
+         ->  Limit (actual rows=3 loops=1)
+               ->  Subquery Scan on x (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: sq_limit.c1, sq_limit.pk
+                           Sort Method:  top-N heapsort  Memory: xxx
+                           Executor Memory: xxx  Segments: x  Max: xxkB (segment x)
+                           ->  Seq Scan on sq_limit (actual rows=8 loops=1)
+ Optimizer: Postgres-based planner
 (10 rows)
 
 -- a subpath is sorted under a subqueryscan. however, the subqueryscan is not.


### PR DESCRIPTION
Changed plan generation for replicated tables and general functions with limits.

As LIMIT is non-deterministic, without a order by, the results may not be consistent over consecutive excutions of the same query.
In case replicated tables there are not guarantee the same tuples will be fetched from each of the segments. 
This may distort the results of queries where there is, for example joins (see example below).


This commit changes limit path node for replicated tables and general functions - turns locus path node to single QE.
After fix limit slice executes only in one node and then redistribute tuples to others.

example:
explain (costs off) select * from t_dist join (select * from t_repl limit 2) tr using(a);

current plan:

                 QUERY PLAN                 
--------------------------------------------
 Hash Join
   Hash Cond: (t_dist.a = tr.a)
   ->  Seq Scan on t_dist
   ->  Hash
         ->  Subquery Scan on tr
               ->  Limit
                     ->  Seq Scan on t_repl


fixed plan:

                            QUERY PLAN                            
------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Hash Join
         Hash Cond: (t_dist.a = tr.a)
         ->  Seq Scan on t_dist
         ->  Hash
               ->  Redistribute Motion 1:3  (slice2; segments: 1)
                     Hash Key: tr.a
                     ->  Subquery Scan on tr
                           ->  Result
                                 ->  Limit
                                       ->  Seq Scan on t_repl

Ticket: ADBDEV-6928