### PR TITLE
Fix src/backend/access/heap/heapam.c

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -6143,8 +6143,8 @@ heap_inplace_lock(Relation relation,
 	 * - don't try to continue even if the updater aborts: likewise
 	 * - no crosscheck
 	 */
-	result = HeapTupleSatisfiesUpdate(&oldtup, GetCurrentCommandId(false),
-									  buffer);
+	result = HeapTupleSatisfiesUpdate(relation, &oldtup,
+									  GetCurrentCommandId(false), buffer);
 
 	if (result == TM_Invisible)
 	{


### PR DESCRIPTION
Commit 7354b680ab64fbde6072f248fe3b2ff909a99d12 uses the
HeapTupleSatisfiesUpdate function, but HeapTupleSatisfiesUpdate has
an additional argument in GPDB.
This commit corrects usage of HeapTupleSatisfiesUpdate.
