### PR TITLE
ADBDEV-7318: Fix permission error for synchronization SET

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7289,33 +7289,15 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 
 			SIMPLE_FAULT_INJECTOR("set_variable_fault");
 
-			/*
-			 * If this is a synchronization SET, previous values from the
-			 * startup packet should be overwritten. We can only get here if we
-			 * are a QE.
-			 */
-			if (isMppTxOptions_SynchronizationSet(QEDtxContextInfo.distributedTxnOptions))
-			{
-				(void) set_config_option(stmt->name,
-										 ExtractSetVariableArgs(stmt),
-										 PGC_SIGHUP,
-										 PGC_S_CLIENT,
-										 GUC_ACTION_SET,
-										 true,
-										 0);
-			}
-			else
-			{
-				(void) set_config_option(stmt->name,
-										 ExtractSetVariableArgs(stmt),
-										 (superuser() ? PGC_SUSET : PGC_USERSET),
-										 PGC_S_SESSION,
-										 action,
-										 true,
-										 0);
+			(void) set_config_option(stmt->name,
+									 ExtractSetVariableArgs(stmt),
+									 (superuser() ? PGC_SUSET : PGC_USERSET),
+									 PGC_S_SESSION,
+									 action,
+									 true,
+									 0);
 
-				DispatchSetPGVariable(stmt->name, stmt->args, stmt->is_local);
-			}
+			DispatchSetPGVariable(stmt->name, stmt->args, stmt->is_local);
 			break;
 		case VAR_SET_MULTI:
 
@@ -7594,6 +7576,16 @@ set_config_by_name(PG_FUNCTION_ARGS)
 	char	   *value;
 	char	   *new_value;
 	bool		is_local;
+	bool		is_sync;
+	GucContext	context;
+
+	is_sync = isMppTxOptions_SynchronizationSet(
+		QEDtxContextInfo.distributedTxnOptions);
+
+	if (is_sync)
+		context = PGC_SIGHUP;
+	else
+		context = (superuser() ? PGC_SUSET : PGC_USERSET);
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
@@ -7621,8 +7613,8 @@ set_config_by_name(PG_FUNCTION_ARGS)
 	/* Note SET DEFAULT (argstring == NULL) is equivalent to RESET */
 	(void) set_config_option(name,
 							 value,
-							 (superuser() ? PGC_SUSET : PGC_USERSET),
-							 PGC_S_SESSION,
+							 context,
+							 (is_sync) ? PGC_S_CLIENT : PGC_S_SESSION,
 							 is_local ? GUC_ACTION_LOCAL : GUC_ACTION_SET,
 							 true,
 							 0);
@@ -7648,7 +7640,10 @@ set_config_by_name(PG_FUNCTION_ARGS)
 			pfree(quoted_value);
 		pfree(quoted_name);
 
-		CdbDispatchSetCommand(buffer.data, false /* cancelOnError */ );
+		if (is_sync)
+			CdbDispatchSetCommandForSync(buffer.data);
+		else
+			CdbDispatchSetCommand(buffer.data, false /* cancelOnError */ );
 	}
 
 	/* get the new current value */

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7576,16 +7576,28 @@ set_config_by_name(PG_FUNCTION_ARGS)
 	char	   *value;
 	char	   *new_value;
 	bool		is_local;
+
 	bool		is_sync;
 	GucContext	context;
+	GucSource 	source;
 
 	is_sync = isMppTxOptions_SynchronizationSet(
 		QEDtxContextInfo.distributedTxnOptions);
 
+	/*
+	 * If this is a synchronization SET, previous values from the startup packet
+	 * should be overwritten. The source and context are adjusted accordingly.
+	 */
 	if (is_sync)
+	{
+		source = PGC_S_CLIENT;
 		context = PGC_SIGHUP;
+	}
 	else
+	{
+		source = PGC_S_SESSION;
 		context = (superuser() ? PGC_SUSET : PGC_USERSET);
+	}
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
@@ -7614,7 +7626,7 @@ set_config_by_name(PG_FUNCTION_ARGS)
 	(void) set_config_option(name,
 							 value,
 							 context,
-							 (is_sync) ? PGC_S_CLIENT : PGC_S_SESSION,
+							 source,
 							 is_local ? GUC_ACTION_LOCAL : GUC_ACTION_SET,
 							 true,
 							 0);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -642,6 +642,9 @@ DROP ROLE IF EXISTS dispatch_test_user2;
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
 
+-- Make sure the gang wasn't dropped by a silent error.
+CREATE TEMP TABLE gang_is_the_same();
+
 CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
 RETURNS table (guc_name text, guc_setting text)
 EXECUTE ON ALL SEGMENTS AS $$
@@ -705,6 +708,9 @@ SELECT * from show_on_segments('log_min_messages');
 SHOW backslash_quote;
 SELECT * from show_on_segments('backslash_quote');
 
+SELECT FROM gang_is_the_same;
+
+DROP TABLE gang_is_the_same;
 RESET SESSION AUTHORIZATION;
 
 DROP FUNCTION show_on_segments(show_name text);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1083,6 +1083,8 @@ drop table t_create_gang_time;
 -- Use a separate user without any priveleges to catch possible context issues.
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
+-- Make sure the gang wasn't dropped by a silent error.
+CREATE TEMP TABLE gang_is_the_same();
 CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
 RETURNS table (guc_name text, guc_setting text)
 EXECUTE ON ALL SEGMENTS AS $$
@@ -1201,6 +1203,11 @@ SELECT * from show_on_segments('backslash_quote');
  backslash_quote | safe_encoding
 (3 rows)
 
+SELECT FROM gang_is_the_same;
+--
+(0 rows)
+
+DROP TABLE gang_is_the_same;
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;


### PR DESCRIPTION
Fix permission error for synchronization SET

993b6c4 changed how `SIGHUP` synchronization works by replacing `SET` commands
with a call to `pg_catalog.set_config()`. It was left unnoticed that the latter
method does not bypass permissions, as it should, based on the distributed
transaction flags, to allow changing all GUCs with context equal to or lower
than `PGC_SIGHUP`. The bypass was left implemented only for `SET` and there was no
tests to cover such behavior.

Since `SET` isn't used for sync anymore, the same check is moved to
`pg_catalog.set_config()`. A test is added to make sure the gang and a temporary
table remains intact after sending the signal multiple times, indicating that no
error has occurred.