### PR TITLE
Fix compilation of backend/jit/llvm/llvmjit_expr.c

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -2038,9 +2038,9 @@ llvm_compile_expr(ExprState *state)
 
 					/* Fetch and increment rowcounter */
 					v_rowcounter_p = l_ptr_const(rowcounter_p,
-												 l_ptr(LLVMInt64Type()));
-					v_rowcounter = l_load(b, LLVMInt64Type(), v_rowcounter_p, "v_rowcounter");
-					v_rowcounter_new = LLVMBuildAdd(b, v_rowcounter, l_int64_const(1), "v_rowcounter_new");
+												 l_ptr(LLVMInt64TypeInContext(lc)));
+					v_rowcounter = l_load(b, LLVMInt64TypeInContext(lc), v_rowcounter_p, "v_rowcounter");
+					v_rowcounter_new = LLVMBuildAdd(b, v_rowcounter, l_int64_const(lc, 1), "v_rowcounter_new");
 
 					/* Store the new value back */
 					LLVMBuildStore(b, v_rowcounter_new, v_rowcounter_p);
@@ -2397,7 +2397,7 @@ llvm_compile_expr(ExprState *state)
 						FIELDNO_AGGSTATE_ALL_PERGROUPS,
 						"aggstate.all_pergroups");
 
-					v_setoff = l_int32_const(
+					v_setoff = l_int32_const(lc,
 						op->d.agg_plain_pergroup_nullcheck.setoff);
 
 					v_pergroup_allaggs = l_load_gep1(b, l_ptr(StructAggStatePerGroupData),


### PR DESCRIPTION
The commit https://github.com/arenadata/gpdb/commit/3b991f81c45720515144b928bb8d1f03577628f1 introduced
several memory optimizations for using types. Merge of the changes
has sidestepped GPDB-specific code path coresponding to EEOP_ROWIDEXPR
from https://github.com/arenadata/gpdb/commit/19cd1cf4b68faff2e29bc2fa884c480e4644cdb4.
The code has been fixed in accordance with incoming patch.
