### PR TITLE
Fix compilation of src/bin/pg_dump/pg_dump.c

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7836,6 +7836,7 @@ getExtendedStatistics(Archive *fout)
 	i_stxname = PQfnumber(res, "stxname");
 	i_stxnamespace = PQfnumber(res, "stxnamespace");
 	i_stxowner = PQfnumber(res, "stxowner");
+	i_stxrelid = PQfnumber(res, "stxrelid");
 
 	statsextinfo = (StatsExtInfo *) pg_malloc(ntups * sizeof(StatsExtInfo));
 


### PR DESCRIPTION
Fix compilation of src/bin/pg_dump/pg_dump.c

Commit 92a7796 incorrectly resolved conflicts by removing the initialization of
the new local variable i_stxrelid in the getExtendedStatistics function.