### PR TITLE
Fix restrict_nonsystem_relation_kind GUC

### DIFF
--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -269,6 +269,7 @@
 		"integer_datetimes",
 		"is_superuser",
 		"jit_provider",
+		"restrict_nonsystem_relation_kind",
 		"join_collapse_limit",
 		"krb_caseins_users",
 		"krb_server_keyfile",


### PR DESCRIPTION
Fix restrict_nonsystem_relation_kind GUC

Commit 79c7a7e added a new restrict_nonsystem_relation_kind GUC, but the
gpdb_assign_sync_flag function requires that all GUCs be placed in
sync_guc_names_array or unsync_guc_names_array.