### PR TITLE
Fix is_superuser GUC

### DIFF
--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -239,7 +239,7 @@ typedef enum
 #define GUC_UNIT_TIME		   0xF0000	/* mask for time-related units */
 
 #define GUC_EXPLAIN			  0x100000	/* include in explain */
-#define GUC_ALLOW_IN_PARALLEL 0x200000	/* allow setting in parallel mode */
+#define GUC_ALLOW_IN_PARALLEL 0x1000000	/* allow setting in parallel mode */
 
 #define GUC_UNIT				(GUC_UNIT_MEMORY | GUC_UNIT_TIME)
 


### PR DESCRIPTION
Fix is_superuser GUC

Commit adc28d0 added a new flag GUC_ALLOW_IN_PARALLEL with value 0x200000 to
is_superuser GUC, while earlier commit 8ae22d1 already added another new flag
GUC_DISALLOW_USER_SET with the same value, which resulted in is_superuser GUC
being disallowed for normal users. This patch increases the bitness in the new
GUC_ALLOW_IN_PARALLEL GUC to avoid ABI incompatibility.