### PR TITLE
Resolve conflicts in src/tests/modules/test_pg_dump/001_base.pl

### DIFF
--- a/src/test/modules/test_pg_dump/t/001_base.pl
+++ b/src/test/modules/test_pg_dump/t/001_base.pl
@@ -674,13 +674,8 @@ my %tests = (
 #########################################
 # Create a PG instance to test actually dumping from
 
-<<<<<<< HEAD
 my $node = PostgreSQL::Test::Cluster->new('main');
-$node->init;
-=======
-my $node = get_new_node('main');
 $node->init('auth_extra' => [ '--create-role', 'regress_dump_login_role' ]);
->>>>>>> REL_12_22
 $node->start;
 
 my $port = $node->port;


### PR DESCRIPTION
Resolve conflicts in src/tests/modules/test_pg_dump/001_base.pl
The commit https://github.com/arenadata/gpdb/commit/e43790342be29addaa843b80e8f58334fe7346d3 adjusted
the node->init() call in test_pg_dump TAP test.
The conflict resolution in accepting this change. The test is launched
normally, but fails. However, it fails at base GPDB version before sync.


