### PR TITLE
Fix src/test/regress/sql/database.sql test

### DIFF
--- a/src/test/regress/expected/database.out
+++ b/src/test/regress/expected/database.out
@@ -5,9 +5,11 @@ ALTER DATABASE regression_utf8 RESET TABLESPACE;
 ALTER DATABASE regression_utf8 CONNECTION_LIMIT 123;
 -- Test PgDatabaseToastTable.  Doing this with GRANT would be slow.
 BEGIN;
+SET allow_system_table_mods=ON;
 UPDATE pg_database
 SET datacl = array_fill(makeaclitem(10, 10, 'USAGE', false), ARRAY[5e5::int])
 WHERE datname = 'regression_utf8';
+RESET allow_system_table_mods;
 -- load catcache entry, if nothing else does
 ALTER DATABASE regression_utf8 RESET TABLESPACE;
 ROLLBACK;

--- a/src/test/regress/sql/database.sql
+++ b/src/test/regress/sql/database.sql
@@ -6,9 +6,11 @@ ALTER DATABASE regression_utf8 CONNECTION_LIMIT 123;
 
 -- Test PgDatabaseToastTable.  Doing this with GRANT would be slow.
 BEGIN;
+SET allow_system_table_mods=ON;
 UPDATE pg_database
 SET datacl = array_fill(makeaclitem(10, 10, 'USAGE', false), ARRAY[5e5::int])
 WHERE datname = 'regression_utf8';
+RESET allow_system_table_mods;
 -- load catcache entry, if nothing else does
 ALTER DATABASE regression_utf8 RESET TABLESPACE;
 ROLLBACK;


### PR DESCRIPTION
Commit 796d191028bb642bb04d9b3fd18d6f0aab7b1f1f added a new test, this test
modifies the pg_database system table, which is prohibited in GPDB.
Fix it by using GUC allow_system_table_mods.