### PR TITLE
Fix src/test/regress/input/constraints test

### DIFF
--- a/src/test/regress/input/constraints.source
+++ b/src/test/regress/input/constraints.source
@@ -473,7 +473,7 @@ DROP TABLE parted_fk_naming;
 -- indexes (without constraints) on the partitioned table.  Ideally these should
 -- fail, but we don't dare change released behavior, so instead cope with it at
 -- DETACH time.
-CREATE TEMP TABLE t (a integer, b integer) PARTITION BY HASH (a, b);
+CREATE TEMP TABLE t (a integer, b integer) DISTRIBUTED BY (b, a) PARTITION BY HASH (a, b);
 CREATE TEMP TABLE tp (a integer, b integer, PRIMARY KEY (a, b), UNIQUE (b, a));
 ALTER TABLE t ATTACH PARTITION tp FOR VALUES WITH (MODULUS 1, REMAINDER 0);
 CREATE UNIQUE INDEX t_a_idx ON t (a, b);

--- a/src/test/regress/output/constraints.source
+++ b/src/test/regress/output/constraints.source
@@ -646,7 +646,7 @@ DROP TABLE parted_fk_naming;
 -- indexes (without constraints) on the partitioned table.  Ideally these should
 -- fail, but we don't dare change released behavior, so instead cope with it at
 -- DETACH time.
-CREATE TEMP TABLE t (a integer, b integer) PARTITION BY HASH (a, b);
+CREATE TEMP TABLE t (a integer, b integer) DISTRIBUTED BY (b, a) PARTITION BY HASH (a, b);
 CREATE TEMP TABLE tp (a integer, b integer, PRIMARY KEY (a, b), UNIQUE (b, a));
 ALTER TABLE t ATTACH PARTITION tp FOR VALUES WITH (MODULUS 1, REMAINDER 0);
 CREATE UNIQUE INDEX t_a_idx ON t (a, b);


### PR DESCRIPTION
Commit d0054432d480e958e4650c4b56de4a4a6e05da78 added a new test to the
constraints.source. GPDB requires that all partitions have the same distribution
keys.
Add the distribution keys to table t so that it converge with table tp.