### PR TITLE
ADBDEV-7323: Emit an error if GUC synchronization fails

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -288,6 +288,8 @@ cdbdisp_dispatchSetCommandInternal(const char *strCommand, bool cancelOnError, b
 	elogif(Debug_print_full_dtm, LOG,
 		   "CdbDispatchSetCommand for command = '%s'", strCommand);
 
+	SIMPLE_FAULT_INJECTOR("dispatch_set_command");
+
 	/*
 	 * Dispatch a command with DF_SYNC_SET flag if we are performing a config
 	 * reload. This will allow us to distinguish between user-invoked SET and QD

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1572,7 +1572,6 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 
 	foreach(lc, guc_list)
 	{
-		bool is_success = true;
 		struct config_generic* gconfig = (struct config_generic *)lfirst(lc);
 
 		/*
@@ -1591,30 +1590,41 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 		}
 		PG_CATCH();
 		{
+			/*
+			 * report error as warning 
+			*/
 			if (!elog_dismiss(WARNING))
+			{
 				PG_RE_THROW();
+			}
 
-			is_success = false;
-
-			MemoryContextSwitchTo(oldcontext);
-		}
-		PG_END_TRY();
-
-		/*
-		 * Can't continue the transaction or keep the gang alive if GUCs are out
-		 * of sync. Explode!
-		 */
-		if (!is_success)
-		{
+			/* if some guc can not restore successful
+			 * we can not keep alive gang anymore.
+			 */
 			DisconnectAndDestroyAllGangs(true);
+
+			/*
+			 * when qe elog an error, qd will use ReThrowError to
+			 * re throw the error, the errordata_stack_depth will ++,
+			 * when we catch the error we should reset errordata_stack_depth
+			 * by FlushErrorState.
+			 */
+			FlushErrorState();
 
 			ereport(
 				ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("failed to synchronize GUC settings across segments"),
-				 errdetail("Query aborted due to GUC synchronization failure"),
-				 errhint("Check segment logs for more details")));
+					errmsg("failed to synchronize GUC settings across segments"),
+					errdetail("Query aborted due to GUC synchronization failure"),
+					errhint("Check segment logs for more details")));
+
+			/*
+			 * this is a top-level catch block and we are responsible for
+			 * restoring the right memory context.
+			*/	 					
+			MemoryContextSwitchTo(oldcontext);
 		}
+		PG_END_TRY();
 	}
 
 	finish_xact_command();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1592,9 +1592,7 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 		PG_CATCH();
 		{
 			if (!elog_dismiss(WARNING))
-				EmitErrorReport();
-
-			FlushErrorState();
+				PG_RE_THROW();
 
 			is_success = false;
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/socket.h>
+#include "utils/elog.h"
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
@@ -1590,10 +1591,13 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 		}
 		PG_CATCH();
 		{
-			EmitErrorReport();
+			if (!elog_dismiss(WARNING))
+				EmitErrorReport();
+
 			FlushErrorState();
 
 			is_success = false;
+
 			MemoryContextSwitchTo(oldcontext);
 		}
 		PG_END_TRY();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1564,6 +1564,7 @@ static void
 send_guc_to_QE(List *guc_list, bool is_restore)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH && guc_list);
+
 	ListCell *lc;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
@@ -1571,6 +1572,7 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 
 	foreach(lc, guc_list)
 	{
+		bool is_success = true;
 		struct config_generic* gconfig = (struct config_generic *)lfirst(lc);
 
 		/*
@@ -1589,25 +1591,29 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 		}
 		PG_CATCH();
 		{
-			/* if some guc can not restore successful
-			 * we can not keep alive gang anymore.
-			 */
-			DisconnectAndDestroyAllGangs(true);
-			CheckForResetSession();
-			/*
-			 * when qe elog an error, qd will use ReThrowError to
-			 * re throw the error, the errordata_stack_depth will ++,
-			 * when we catch the error we should reset errordata_stack_depth
-			 * by FlushErrorState.
-			 */
+			EmitErrorReport();
 			FlushErrorState();
-			/*
-			 * this is a top-level catch block and we are responsible for
-			 * restoring the right memory context.
-			 */
+
+			is_success = false;
 			MemoryContextSwitchTo(oldcontext);
 		}
 		PG_END_TRY();
+
+		/*
+		 * Can't continue the transaction or keep the gang alive if GUCs are out
+		 * of sync. Explode!
+		 */
+		if (!is_success)
+		{
+			DisconnectAndDestroyAllGangs(true);
+
+			ereport(
+				ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("failed to synchronize GUC settings across segments"),
+				 errdetail("Query aborted due to GUC synchronization failure"),
+				 errhint("Check segment logs for more details")));
+		}
 	}
 
 	finish_xact_command();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1621,7 +1621,7 @@ send_guc_to_QE(List *guc_list, bool is_restore)
 			/*
 			 * this is a top-level catch block and we are responsible for
 			 * restoring the right memory context.
-			*/	 					
+			 */
 			MemoryContextSwitchTo(oldcontext);
 		}
 		PG_END_TRY();

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1564,7 +1564,6 @@ static void
 send_guc_to_QE(List *guc_list, bool is_restore)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH && guc_list);
-
 	ListCell *lc;
 	MemoryContext oldcontext = CurrentMemoryContext;
 

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -173,9 +173,9 @@ ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (
 
 -- Query to execute GUC sync (GUC sync fails)
 1: select 1;
-+ERROR:  failed to synchronize GUC settings across segments (postgres.c:1614)
-+DETAIL:  Query aborted due to GUC synchronization failure
-+HINT:  Check segment logs for more details
+ERROR:  failed to synchronize GUC settings across segments (postgres.c:1614)
+DETAIL:  Query aborted due to GUC synchronization failure
+HINT:  Check segment logs for more details
 -- Should fail with "relation does not exist"
 1: select * from sync_temp_table;
 ERROR:  relation "sync_temp_table" does not exist

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -171,12 +171,11 @@ ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (
 !\retcode gpstop -u;
 (exited with code 0)
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
+-- Query to execute GUC sync (GUC sync fails)
 1: select 1;
- ?column? 
-----------
- 1        
-(1 row)
++ERROR:  failed to synchronize GUC settings across segments (postgres.c:1614)
++DETAIL:  Query aborted due to GUC synchronization failure
++HINT:  Check segment logs for more details
 -- Should fail with "relation does not exist"
 1: select * from sync_temp_table;
 ERROR:  relation "sync_temp_table" does not exist

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -152,3 +152,39 @@ RESET
  Success:        
 (4 rows)
 4q: ... <quitting>
+
+-- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
+1: create temp table sync_temp_table(a int) distributed by (a);
+CREATE
+-- Cause panic on segment from another session
+2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2: create function my_function() returns void as $$ begin end; $$ language plpgsql;
+ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (seg0 192.168.0.101:6002 pid=347506)
+2q: ... <quitting>
+-- Attempting to change GUC
+!\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+-- Query to execute GUC sync (GUC sync fails, query succeeds)
+1: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+-- Should fail with "relation does not exist"
+1: select * from sync_temp_table;
+ERROR:  relation "sync_temp_table" does not exist
+LINE 1: select * from sync_temp_table;
+                      ^
+
+!\retcode gpconfig -r log_min_messages;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+1q: ... <quitting>

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -152,36 +152,3 @@ RESET
  Success:        
 (4 rows)
 4q: ... <quitting>
-
--- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
-1: create temp table sync_temp_table(a int) distributed by (a);
-CREATE
--- Cause panic on segment from another session
-2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-2: create function my_function() returns void as $$ begin end; $$ language plpgsql;
-ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (seg0 192.168.0.101:6002 pid=347506)
-2q: ... <quitting>
--- Attempting to change GUC
-!\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
-(exited with code 0)
-!\retcode gpstop -u;
-(exited with code 0)
-
--- Sync fails, query fails too. The table is gone.
-1: select * from sync_temp_table;
-ERROR:  Error on receive from seg0 127.0.0.1:6102 pid=26265: server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-ERROR:  failed to synchronize GUC settings across segments (postgres.c:1616)
-DETAIL:  Query aborted due to GUC synchronization failure
-HINT:  Check segment logs for more details
-
-!\retcode gpconfig -r log_min_messages;
-(exited with code 0)
-!\retcode gpstop -u;
-(exited with code 0)
-1q: ... <quitting>

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -171,17 +171,14 @@ ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (
 !\retcode gpstop -u;
 (exited with code 0)
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
-1: select 1;
- ?column? 
-----------
- 1        
-(1 row)
--- Should fail with "relation does not exist"
+-- Sync fails, query fails too. The table is gone.
 1: select * from sync_temp_table;
-ERROR:  relation "sync_temp_table" does not exist
-LINE 1: select * from sync_temp_table;
-                      ^
+ERROR:  Error on receive from seg0 127.0.0.1:6102 pid=26265: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+ERROR:  failed to synchronize GUC settings across segments (postgres.c:1616)
+DETAIL:  Query aborted due to GUC synchronization failure
+HINT:  Check segment logs for more details
 
 !\retcode gpconfig -r log_min_messages;
 (exited with code 0)

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -80,7 +80,7 @@
 !\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
 !\retcode gpstop -u;
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
+-- Query to execute GUC sync (GUC sync fails)
 1: select 1;
 -- Should fail with "relation does not exist"
 1: select * from sync_temp_table;

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -80,9 +80,7 @@
 !\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
 !\retcode gpstop -u;
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
-1: select 1;
--- Should fail with "relation does not exist"
+-- Sync fails, query fails too. The table is gone.
 1: select * from sync_temp_table;
 
 !\retcode gpconfig -r log_min_messages;

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -69,20 +69,3 @@
 4: select gp_inject_fault('reset_variable_fault', 'reset', dbid)
      from gp_segment_configuration where role='p';
 4q:
-
--- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
-1: create temp table sync_temp_table(a int) distributed by (a);
--- Cause panic on segment from another session
-2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
-2: create function my_function() returns void as $$ begin end; $$ language plpgsql;
-2q:
--- Attempting to change GUC
-!\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
-!\retcode gpstop -u;
-
--- Sync fails, query fails too. The table is gone.
-1: select * from sync_temp_table;
-
-!\retcode gpconfig -r log_min_messages;
-!\retcode gpstop -u;
-1q:

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -69,3 +69,22 @@
 4: select gp_inject_fault('reset_variable_fault', 'reset', dbid)
      from gp_segment_configuration where role='p';
 4q:
+
+-- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
+1: create temp table sync_temp_table(a int) distributed by (a);
+-- Cause panic on segment from another session
+2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+2: create function my_function() returns void as $$ begin end; $$ language plpgsql;
+2q:
+-- Attempting to change GUC
+!\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
+!\retcode gpstop -u;
+
+-- Query to execute GUC sync (GUC sync fails, query succeeds)
+1: select 1;
+-- Should fail with "relation does not exist"
+1: select * from sync_temp_table;
+
+!\retcode gpconfig -r log_min_messages;
+!\retcode gpstop -u;
+1q:

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -736,6 +736,7 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
 --start_ignore
 \!gpconfig -r log_min_messages
+\!gpstop -u
 --end_ignore
 
 RESET SESSION AUTHORIZATION;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -710,7 +710,20 @@ SELECT * from show_on_segments('backslash_quote');
 
 SELECT FROM gang_is_the_same;
 
+-- But don't fail silently if we encountered an error.
+SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--start_ignore
+\!gpstop -u
+--end_ignore
+
+-- Table is gone after an error.
 DROP TABLE gang_is_the_same;
+
+SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
 RESET SESSION AUTHORIZATION;
 
 DROP FUNCTION show_on_segments(show_name text);

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -10,7 +10,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
--- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected \(session id = \d*\)/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
 -- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
@@ -715,7 +715,12 @@ SELECT * from show_on_segments('backslash_quote');
 
 SELECT FROM gang_is_the_same;
 
--- But don't fail silently if we encountered an error.
+-- Make sure that at least one parameter from synced list has been changed
+--start_ignore
+\!gpconfig -c log_min_messages -v 'info'
+--end_ignore
+
+-- Don't fail silently if we encountered an error.
 SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 
@@ -728,6 +733,10 @@ DROP TABLE gang_is_the_same;
 
 SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--start_ignore
+\!gpconfig -r log_min_messages
+--end_ignore
 
 RESET SESSION AUTHORIZATION;
 

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -634,6 +634,11 @@ drop table t_create_gang_time;
 -- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
 --
 
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
+
 -- start_ignore
 DROP ROLE IF EXISTS dispatch_test_user2;
 -- end_ignore

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1220,9 +1220,9 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 --end_ignore
 -- Table is gone after an error.
 DROP TABLE gang_is_the_same;
-WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 214)
-ERROR:  failed to synchronize GUC settings across segments (postgres.c:1611)
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 36)
+ERROR:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
+ERROR:  failed to synchronize GUC settings across segments (postgres.c:1615)
 DETAIL:  Query aborted due to GUC synchronization failure
 HINT:  Check segment logs for more details
 SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1220,9 +1220,6 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  Success:
 (1 row)
 
---start_ignore
-\!gpstop -u
---end_ignore
 -- Table is gone after an error.
 DROP TABLE gang_is_the_same;
 WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1207,7 +1207,31 @@ SELECT FROM gang_is_the_same;
 --
 (0 rows)
 
+-- But don't fail silently if we encountered an error.
+SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+--start_ignore
+\!gpstop -u
+--end_ignore
+-- Table is gone after an error.
 DROP TABLE gang_is_the_same;
+WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 214)
+ERROR:  failed to synchronize GUC settings across segments (postgres.c:1611)
+DETAIL:  Query aborted due to GUC synchronization failure
+HINT:  Check segment logs for more details
+SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -8,7 +8,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
--- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected \(session id = \d*\)/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
 -- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
@@ -1211,7 +1211,8 @@ SELECT FROM gang_is_the_same;
 --
 (0 rows)
 
--- But don't fail silently if we encountered an error.
+-- Make sure that at least one parameter from synced list has been changed
+-- Don't fail silently if we encountered an error.
 SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
  gp_inject_fault 

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1080,6 +1080,10 @@ drop table t_create_gang_time;
 -- GUCs that were changed in the configuration file of the QD should be re-sent
 -- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
 --
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
 -- Use a separate user without any priveleges to catch possible context issues.
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
@@ -1222,7 +1226,7 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 DROP TABLE gang_is_the_same;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 36)
 ERROR:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
-ERROR:  failed to synchronize GUC settings across segments (postgres.c:1615)
+ERROR:  failed to synchronize GUC settings across segments
 DETAIL:  Query aborted due to GUC synchronization failure
 HINT:  Check segment logs for more details
 SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1224,8 +1224,8 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 --end_ignore
 -- Table is gone after an error.
 DROP TABLE gang_is_the_same;
-WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 36)
 WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 36)
 ERROR:  failed to synchronize GUC settings across segments
 DETAIL:  Query aborted due to GUC synchronization failure
 HINT:  Check segment logs for more details

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1225,7 +1225,7 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 -- Table is gone after an error.
 DROP TABLE gang_is_the_same;
 WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = 36)
-ERROR:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
+WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
 ERROR:  failed to synchronize GUC settings across segments
 DETAIL:  Query aborted due to GUC synchronization failure
 HINT:  Check segment logs for more details


### PR DESCRIPTION
Emit an error if GUC synchronization fails

GPDB requires certain GUCs to remain synchronized  across all segments.
While most of the GUCs are automatically dispatched when modified,  there are
some which require config file edits and a `SIGHUP` signal. For these cases, the
coordinator dispatches standard `SELECT pg_set_config(...)` queries to synchronize
GUC values across segments on the next query after such signal.

Previously, if any `pg_set_config()` query failed on a segment, the coordinator
would silently eat the error and simply abolish the gang. This behavior led to a
critical bug where transaction data could be lost -- since no error propagated
to the top level, the gang would be recreated and the transaction would continue
from its mid-point without access to previous data as if nothing has happened,
saving changes only on the coordinator.

This patch modifies the behavior to explicitly propagate any dispatcher errors.
Now, if any `pg_set_config()` query fails, the coordinator will output an error,
which in turn terminates the current query and fails the ongoing transaction.

