### PR TITLE
Fix conflicts in src/test/ldap/t/001_auth.pl

### DIFF
--- a/src/test/ldap/t/001_auth.pl
+++ b/src/test/ldap/t/001_auth.pl
@@ -370,5 +370,8 @@ $node->append_conf('pg_hba.conf',
 );
 $node->stop;
 is($node->start(fail_ok => 1), 0, "bad combination of LDAPS and StartTLS");
+ok($node->log_contains(
+	"cannot use 'ldaptls' with 'ldaps' scheme or 'ldapurl' start with 'ldaps://'"),
+	"bad combination of LDAPS and StartTLS");
 
 done_testing();

--- a/src/test/ldap/t/001_auth.pl
+++ b/src/test/ldap/t/001_auth.pl
@@ -368,9 +368,7 @@ unlink($node->data_dir . '/pg_hba.conf');
 $node->append_conf('pg_hba.conf',
 	qq{local all all ldap ldapurl="$ldaps_url/$ldap_basedn??sub?(uid=\$username)" ldaptls=1}
 );
-$node->restart;
-
-$ENV{"PGPASSWORD"} = 'secret1';
-test_access($node, 'test1', 2, 'bad combination of LDAPS and StartTLS');
+$node->stop;
+is($node->start(fail_ok => 1), 0, "bad combination of LDAPS and StartTLS");
 
 done_testing();

--- a/src/test/ldap/t/001_auth.pl
+++ b/src/test/ldap/t/001_auth.pl
@@ -4,14 +4,6 @@ use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::Cluster;
 use Test::More;
 
-<<<<<<< HEAD
-if ($ENV{with_ldap} ne 'yes')
-{
-	plan skip_all => 'LDAP not supported by this build';
-}
-
-=======
->>>>>>> REL_12_22
 my ($slapd, $ldap_bin_dir, $ldap_schema_dir);
 
 $ldap_bin_dir = undef;    # usually in PATH


### PR DESCRIPTION
Fix conflicts in src/test/ldap/t/001_auth.pl

1) Commit 1782571 changed the beginning of the file, while earlier commit
8e2409f had already done so.

2) Commit 8fbf03b added an error when using both ldaptls and ldaps options, but
that was already checked by the last lines in the test. This patch adapts them
to that commit.