### PR TITLE
Fix tuple lock leak in ATExecSetRelOptions

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15430,6 +15430,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 			*/
 			if (*aoopt_changed && rel->rd_rel->relkind != RELKIND_PARTITIONED_TABLE)
 			{
+				UnlockTuple(pgclass, &tuple->t_self, InplaceUpdateTupleLock);
 				ReleaseSysCache(tuple);
 				table_close(pgclass, RowExclusiveLock);
 				return newOptions;


### PR DESCRIPTION
Commit cafcc3ad0ed324993211b0dce09362aad3165146 added a lock acquire for the
pg_class row in ATExecSetRelOptions, but this function in GPDB may exit before
the lock is released. Fix this by releasing the lock in the GPDB-specific
branch.