### PR TITLE
Fix ABI tests

### DIFF
--- a/.abi-check/7.2.0_arenadata7/postgres.types.ignore
+++ b/.abi-check/7.2.0_arenadata7/postgres.types.ignore
@@ -1,0 +1,1 @@
+struct RunningTransactionsData


### PR DESCRIPTION
Fix ABI tests

Commit 5dea662 replaced the subxid_overflow boolean field in the public
RunningTransactionsData structure with the subxid_status enumeration.