### PR TITLE
Resolve conflicts in src/bin/pg_rewind/t/003_extrafiles.pl

### DIFF
--- a/src/bin/pg_rewind/t/003_extrafiles.pl
+++ b/src/bin/pg_rewind/t/003_extrafiles.pl
@@ -109,9 +109,7 @@ sub run_test
 		},
 		$test_primary_datadir);
 	@paths = sort @paths;
-<<<<<<< HEAD
 	@list_of_expected_files = sort @list_of_expected_files;
-=======
 
 	# File::Find converts backslashes to slashes in the newer Perl
 	# versions. To support all Perl versions, do the same conversion
@@ -122,10 +120,9 @@ sub run_test
 		{
 			$filename =~ s{\\}{/}g;
 		}
-		$test_master_datadir =~ s{\\}{/}g;
+		$test_primary_datadir =~ s{\\}{/}g;
 	}
 
->>>>>>> REL_12_22
 	is_deeply(
 		\@paths,
 		\@list_of_expected_files,


### PR DESCRIPTION
The commit e894d1d829196a482511577de743088e4e0aed76 conflicts 
with GPDB specific e358573762ee35a40f95ba96630f176b0cd795cc 
The patch allows both changes and replaces the test_master_datadir
with test_primary_datadir.