### PR TITLE
Fix tests in src/test/regress/expected/join.out

### DIFF
--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6087,14 +6087,21 @@ select * from (
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Nested Loop Left Join
-   Filter: ((COALESCE(tenk1.hundred, 0) * arrayd.ad) = (COALESCE(tenk1.hundred, 0) * (arrayd.ad + 1)))
-   ->  Function Scan on unnest arrayd
-   ->  Index Scan using tenk1_unique2 on tenk1
-         Index Cond: (unique2 = arrayd.ad)
-(5 rows)
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: (tenk1.unique2 = arrayd.ad)
+         Filter: ((COALESCE(tenk1.hundred, 0) * arrayd.ad) = (COALESCE(tenk1.hundred, 0) * (arrayd.ad + 1)))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tenk1.unique2
+               ->  Seq Scan on tenk1
+         ->  Hash
+               ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                     Hash Key: arrayd.ad
+                     ->  Function Scan on unnest arrayd
+ Optimizer: Postgres-based planner
+(12 rows)
 
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6078,36 +6078,33 @@ select * from
 (6 rows)
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+create table tenk1_repl as select * from tenk1 distributed replicated;
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Hash Right Join
-         Hash Cond: (tenk1.unique2 = arrayd.ad)
-         Filter: ((COALESCE(tenk1.hundred, 0) * arrayd.ad) = (COALESCE(tenk1.hundred, 0) * (arrayd.ad + 1)))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: tenk1.unique2
-               ->  Seq Scan on tenk1
+         Hash Cond: (tenk1_repl.unique2 = arrayd.ad)
+         Filter: ((COALESCE(tenk1_repl.hundred, 0) * arrayd.ad) = (COALESCE(tenk1_repl.hundred, 0) * (arrayd.ad + 1)))
+         ->  Seq Scan on tenk1_repl
          ->  Hash
-               ->  Redistribute Motion 1:3  (slice3; segments: 1)
-                     Hash Key: arrayd.ad
-                     ->  Function Scan on unnest arrayd
+               ->  Function Scan on unnest arrayd
  Optimizer: Postgres-based planner
-(12 rows)
+(8 rows)
 
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6078,7 +6078,10 @@ select * from
 (6 rows)
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set enable_nestloop=on;
 create table tenk1_repl as select * from tenk1 distributed replicated;
+create index tenk1_repl_unique2 on tenk1_repl using btree(unique2 int4_ops);
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
@@ -6091,14 +6094,15 @@ where c2.h * c2.ad = c2.h * (c2.ad + 1);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Hash Right Join
-         Hash Cond: (tenk1_repl.unique2 = arrayd.ad)
+   ->  Nested Loop Left Join
          Filter: ((COALESCE(tenk1_repl.hundred, 0) * arrayd.ad) = (COALESCE(tenk1_repl.hundred, 0) * (arrayd.ad + 1)))
-         ->  Seq Scan on tenk1_repl
-         ->  Hash
-               ->  Function Scan on unnest arrayd
+         ->  Function Scan on unnest arrayd
+         ->  Bitmap Heap Scan on tenk1_repl
+               Recheck Cond: (unique2 = arrayd.ad)
+               ->  Bitmap Index Scan on tenk1_repl_unique2
+                     Index Cond: (unique2 = arrayd.ad)
  Optimizer: Postgres-based planner
-(8 rows)
+(9 rows)
 
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
@@ -6112,6 +6116,8 @@ where c2.h * c2.ad = c2.h * (c2.ad + 1);
 ----+---
 (0 rows)
 
+reset enable_nestloop;
+drop table tenk1_repl;
 -- check the number of columns specified
 SELECT * FROM (int8_tbl i cross join int4_tbl j) ss(a,b,c,d);
 ERROR:  join expression "ss" has 3 columns available but 4 columns specified

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6206,36 +6206,33 @@ select * from
 (6 rows)
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+create table tenk1_repl as select * from tenk1 distributed replicated;
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Hash Right Join
-         Hash Cond: (tenk1.unique2 = arrayd.ad)
-         Filter: ((COALESCE(tenk1.hundred, 0) * arrayd.ad) = (COALESCE(tenk1.hundred, 0) * (arrayd.ad + 1)))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: tenk1.unique2
-               ->  Seq Scan on tenk1
+         Hash Cond: (tenk1_repl.unique2 = arrayd.ad)
+         Filter: ((COALESCE(tenk1_repl.hundred, 0) * arrayd.ad) = (COALESCE(tenk1_repl.hundred, 0) * (arrayd.ad + 1)))
+         ->  Seq Scan on tenk1_repl
          ->  Hash
-               ->  Redistribute Motion 1:3  (slice3; segments: 1)
-                     Hash Key: arrayd.ad
-                     ->  Function Scan on unnest arrayd
+               ->  Function Scan on unnest arrayd
  Optimizer: Postgres-based planner
-(12 rows)
+(8 rows)
 
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6032,6 +6032,33 @@ select * from
  Optimizer: Postgres query optimizer
 (37 rows)
 
+-- another case requiring nested PlaceHolderVars
+explain (verbose, costs off)
+select * from
+  (select 0 as val0) as ss0
+  left join (select 1 as val) as ss1 on true
+  left join lateral (select ss1.val as val_filtered where false) as ss2 on true;
+            QUERY PLAN             
+-----------------------------------
+ Nested Loop Left Join
+   Output: 0, (1), ((1))
+   ->  Result
+         Output: 1
+   ->  Result
+         Output: (1)
+         One-Time Filter: false
+ Optimizer: Postgres-based planner
+(8 rows)
+
+select * from
+  (select 0 as val0) as ss0
+  left join (select 1 as val) as ss1 on true
+  left join lateral (select ss1.val as val_filtered where false) as ss2 on true;
+ val0 | val | val_filtered 
+------+-----+--------------
+    0 |   1 |             
+(1 row)
+
 -- case that breaks the old ph_may_need optimization
 explain (verbose, costs off)
 select c.*,a.*,ss1.q1,ss2.q1,ss3.* from
@@ -6177,6 +6204,44 @@ select * from
  3 | 5
  3 | 3
 (6 rows)
+
+-- check for generation of join EC conditions at wrong level (bug #18429)
+explain (costs off)
+select * from (
+  select arrayd.ad, coalesce(c.hundred, 0) as h
+  from unnest(array[1]) as arrayd(ad)
+  left join lateral (
+    select hundred from tenk1 where unique2 = arrayd.ad
+  ) c on true
+) c2
+where c2.h * c2.ad = c2.h * (c2.ad + 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: (tenk1.unique2 = arrayd.ad)
+         Filter: ((COALESCE(tenk1.hundred, 0) * arrayd.ad) = (COALESCE(tenk1.hundred, 0) * (arrayd.ad + 1)))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: tenk1.unique2
+               ->  Seq Scan on tenk1
+         ->  Hash
+               ->  Redistribute Motion 1:3  (slice3; segments: 1)
+                     Hash Key: arrayd.ad
+                     ->  Function Scan on unnest arrayd
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select * from (
+  select arrayd.ad, coalesce(c.hundred, 0) as h
+  from unnest(array[1]) as arrayd(ad)
+  left join lateral (
+    select hundred from tenk1 where unique2 = arrayd.ad
+  ) c on true
+) c2
+where c2.h * c2.ad = c2.h * (c2.ad + 1);
+ ad | h 
+----+---
+(0 rows)
 
 -- check the number of columns specified
 SELECT * FROM (int8_tbl i cross join int4_tbl j) ss(a,b,c,d);

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6206,7 +6206,10 @@ select * from
 (6 rows)
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set enable_nestloop=on;
 create table tenk1_repl as select * from tenk1 distributed replicated;
+create index tenk1_repl_unique2 on tenk1_repl using btree(unique2 int4_ops);
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
@@ -6219,14 +6222,15 @@ where c2.h * c2.ad = c2.h * (c2.ad + 1);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Hash Right Join
-         Hash Cond: (tenk1_repl.unique2 = arrayd.ad)
+   ->  Nested Loop Left Join
          Filter: ((COALESCE(tenk1_repl.hundred, 0) * arrayd.ad) = (COALESCE(tenk1_repl.hundred, 0) * (arrayd.ad + 1)))
-         ->  Seq Scan on tenk1_repl
-         ->  Hash
-               ->  Function Scan on unnest arrayd
+         ->  Function Scan on unnest arrayd
+         ->  Bitmap Heap Scan on tenk1_repl
+               Recheck Cond: (unique2 = arrayd.ad)
+               ->  Bitmap Index Scan on tenk1_repl_unique2
+                     Index Cond: (unique2 = arrayd.ad)
  Optimizer: Postgres-based planner
-(8 rows)
+(9 rows)
 
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
@@ -6240,6 +6244,8 @@ where c2.h * c2.ad = c2.h * (c2.ad + 1);
 ----+---
 (0 rows)
 
+reset enable_nestloop;
+drop table tenk1_repl;
 -- check the number of columns specified
 SELECT * FROM (int8_tbl i cross join int4_tbl j) ss(a,b,c,d);
 ERROR:  join expression "ss" has 3 columns available but 4 columns specified

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1973,12 +1973,13 @@ select * from
   ) as q2;
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+create table tenk1_repl as select * from tenk1 distributed replicated;
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);
@@ -1986,7 +1987,7 @@ select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
   from unnest(array[1]) as arrayd(ad)
   left join lateral (
-    select hundred from tenk1 where unique2 = arrayd.ad
+    select hundred from tenk1_repl where unique2 = arrayd.ad
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1973,7 +1973,13 @@ select * from
   ) as q2;
 
 -- check for generation of join EC conditions at wrong level (bug #18429)
+-- GPDB: persuade the planner to choose same plan as in upstream.
+set enable_nestloop=on;
+-- start_ignore
+drop table if exists tenk1_repl;
+-- end_ignore
 create table tenk1_repl as select * from tenk1 distributed replicated;
+create index tenk1_repl_unique2 on tenk1_repl using btree(unique2 int4_ops);
 explain (costs off)
 select * from (
   select arrayd.ad, coalesce(c.hundred, 0) as h
@@ -1991,6 +1997,8 @@ select * from (
   ) c on true
 ) c2
 where c2.h * c2.ad = c2.h * (c2.ad + 1);
+reset enable_nestloop;
+drop table tenk1_repl;
 
 -- check the number of columns specified
 SELECT * FROM (int8_tbl i cross join int4_tbl j) ss(a,b,c,d);


### PR DESCRIPTION
Fix tests in src/test/regress/expected/join.out

Commits f502849 and 69c12c4 added new tests to src/test/regress/sql/join.sql,
the output of which should be adapted for GPDB, including a separate output for
ORCA. A replicated table and enable_nestloop are used to reproduce the problem
of the first commit in GPDB.