### PR TITLE
Fix tests in src/test/regress/expected/aggregates.out

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1235,18 +1235,21 @@ set local enable_sort = off;
 explain (costs off)
   select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
   from int4_tbl t0;
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Seq Scan on int4_tbl t0
-   SubPlan 2
-     ->  HashAggregate
-           Group Key: $1
-           InitPlan 1 (returns $1)
-             ->  Limit
-                   ->  Seq Scan on int4_tbl t1
-                         Filter: ((f1 IS NOT NULL) AND (f1 = t0.f1))
-           ->  Result
-(9 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on int4_tbl t0
+         SubPlan 1
+           ->  HashAggregate
+                 Group Key: min(t1.f1)
+                 ->  Aggregate
+                       ->  Result
+                             Filter: (t1.f1 = t0.f1)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on int4_tbl t1
+ Optimizer: Postgres-based planner
+(12 rows)
 
 select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
 from int4_tbl t0;

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1234,14 +1234,13 @@ drop cascades to table minmaxtest3
 -- in the postgres planner
 begin;
 set local enable_sort = off;
-create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-  from int4_tbl_repl t0;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Seq Scan on int4_tbl_repl t0
+  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+  from int4_tbl t0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on int4_tbl t0
          SubPlan 1
            ->  HashAggregate
                  Group Key: min(t1.f1)
@@ -1249,12 +1248,13 @@ explain (costs off)
                        ->  Result
                              Filter: (t1.f1 = t0.f1)
                              ->  Materialize
-                                   ->  Seq Scan on int4_tbl_repl t1
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on int4_tbl t1
  Optimizer: Postgres-based planner
-(11 rows)
+(12 rows)
 
-select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-from int4_tbl_repl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+from int4_tbl t0;
      f1      |     min     
 -------------+-------------
            0 |           0

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1232,13 +1232,14 @@ drop cascades to table minmaxtest3
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
 begin;
 set local enable_sort = off;
+create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-  from int4_tbl t0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on int4_tbl t0
+  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+  from int4_tbl_repl t0;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on int4_tbl_repl t0
          SubPlan 1
            ->  HashAggregate
                  Group Key: min(t1.f1)
@@ -1246,13 +1247,12 @@ explain (costs off)
                        ->  Result
                              Filter: (t1.f1 = t0.f1)
                              ->  Materialize
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         ->  Seq Scan on int4_tbl t1
+                                   ->  Seq Scan on int4_tbl_repl t1
  Optimizer: Postgres-based planner
-(12 rows)
+(11 rows)
 
-select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-from int4_tbl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+from int4_tbl_repl t0;
      f1      |     min     
 -------------+-------------
            0 |           0

--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1230,6 +1230,8 @@ DETAIL:  drop cascades to table minmaxtest1
 drop cascades to table minmaxtest2
 drop cascades to table minmaxtest3
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
+-- Note: GPDB does not support the min/max optimization for correlated subplans
+-- in the postgres planner
 begin;
 set local enable_sort = off;
 create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1251,6 +1251,8 @@ DETAIL:  drop cascades to table minmaxtest1
 drop cascades to table minmaxtest2
 drop cascades to table minmaxtest3
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
+-- Note: GPDB does not support the min/max optimization for correlated subplans
+-- in the postgres planner
 begin;
 set local enable_sort = off;
 create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1255,25 +1255,27 @@ drop cascades to table minmaxtest3
 -- in the postgres planner
 begin;
 set local enable_sort = off;
-create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-  from int4_tbl_repl t0;
-                       QUERY PLAN                       
---------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
-   ->  Seq Scan on int4_tbl_repl t0
+  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+  from int4_tbl t0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on int4_tbl t0
          SubPlan 1
            ->  GroupAggregate
                  Group Key: min(t1.f1)
                  ->  Aggregate
-                       ->  Seq Scan on int4_tbl_repl t1
-                             Filter: (f1 = t0.f1)
+                       ->  Result
+                             Filter: (t1.f1 = t0.f1)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on int4_tbl t1
  Optimizer: GPORCA
-(9 rows)
+(12 rows)
 
-select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-from int4_tbl_repl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+from int4_tbl t0;
      f1      |     min     
 -------------+-------------
       123456 |      123456

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1253,27 +1253,25 @@ drop cascades to table minmaxtest3
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
 begin;
 set local enable_sort = off;
+create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-  from int4_tbl t0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on int4_tbl t0
+  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+  from int4_tbl_repl t0;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on int4_tbl_repl t0
          SubPlan 1
            ->  GroupAggregate
                  Group Key: min(t1.f1)
                  ->  Aggregate
-                       ->  Result
-                             Filter: (t1.f1 = t0.f1)
-                             ->  Materialize
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         ->  Seq Scan on int4_tbl t1
+                       ->  Seq Scan on int4_tbl_repl t1
+                             Filter: (f1 = t0.f1)
  Optimizer: GPORCA
-(12 rows)
+(9 rows)
 
-select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-from int4_tbl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+from int4_tbl_repl t0;
      f1      |     min     
 -------------+-------------
       123456 |      123456

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1250,6 +1250,40 @@ NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table minmaxtest1
 drop cascades to table minmaxtest2
 drop cascades to table minmaxtest3
+-- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
+begin;
+set local enable_sort = off;
+explain (costs off)
+  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+  from int4_tbl t0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on int4_tbl t0
+         SubPlan 1
+           ->  GroupAggregate
+                 Group Key: min(t1.f1)
+                 ->  Aggregate
+                       ->  Result
+                             Filter: (t1.f1 = t0.f1)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                         ->  Seq Scan on int4_tbl t1
+ Optimizer: GPORCA
+(12 rows)
+
+select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+from int4_tbl t0;
+     f1      |     min     
+-------------+-------------
+      123456 |      123456
+     -123456 |     -123456
+           0 |           0
+  2147483647 |  2147483647
+ -2147483647 | -2147483647
+(5 rows)
+
+rollback;
 -- check for correct detection of nested-aggregate errors
 select max(min(unique1)) from tenk1;
 ERROR:  aggregate function calls cannot be nested

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -418,12 +418,11 @@ drop table minmaxtest cascade;
 -- in the postgres planner
 begin;
 set local enable_sort = off;
-create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-  from int4_tbl_repl t0;
-select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
-from int4_tbl_repl t0;
+  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+  from int4_tbl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
+from int4_tbl t0;
 rollback;
 
 -- check for correct detection of nested-aggregate errors

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -414,6 +414,8 @@ select distinct min(f1), max(f1) from minmaxtest;
 drop table minmaxtest cascade;
 
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
+-- Note: GPDB does not support the min/max optimization for correlated subplans
+-- in the postgres planner
 begin;
 set local enable_sort = off;
 create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -416,11 +416,12 @@ drop table minmaxtest cascade;
 -- DISTINCT can also trigger wrong answers with hash aggregation (bug #18465)
 begin;
 set local enable_sort = off;
+create temp table int4_tbl_repl as select * from int4_tbl distributed replicated;
 explain (costs off)
-  select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-  from int4_tbl t0;
-select f1, (select distinct min(t1.f1) from int4_tbl t1 where t1.f1 = t0.f1)
-from int4_tbl t0;
+  select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+  from int4_tbl_repl t0;
+select f1, (select distinct min(t1.f1) from int4_tbl_repl t1 where t1.f1 = t0.f1)
+from int4_tbl_repl t0;
 rollback;
 
 -- check for correct detection of nested-aggregate errors


### PR DESCRIPTION
Fix tests in src/test/regress/expected/aggregates.out

Commit 686c995 added new tests to src/test/regress/sql/aggregates.sql whose
output should be adapted for GPDB, including a separate output for ORCA.