### PR TITLE
ADBDEV-7233: Resolve conflicts in src/test/regress/sql/select_parallel.sql

### DIFF
--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -1252,7 +1252,6 @@ select set_and_report_role();
 select set_role_and_error(0);
 ERROR:  division by zero
 CONTEXT:  SQL function "set_role_and_error" statement 1
-parallel worker
 reset force_parallel_mode;
 drop function set_and_report_role();
 drop function set_role_and_error(int);

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -1227,3 +1227,59 @@ SELECT 1 FROM tenk1_vw_sec
 (12 rows)
 
 rollback;
+-- test that function option SET ROLE works in parallel workers.
+create role regress_parallel_worker;
+create function set_and_report_role() returns text as
+  $$ select current_setting('role') $$ language sql parallel safe
+  set role = regress_parallel_worker;
+create function set_role_and_error(int) returns int as
+  $$ select 1 / $1 $$ language sql parallel safe
+  set role = regress_parallel_worker;
+set force_parallel_mode = 0;
+select set_and_report_role();
+   set_and_report_role   
+-------------------------
+ regress_parallel_worker
+(1 row)
+
+select set_role_and_error(0);
+ERROR:  division by zero
+CONTEXT:  SQL function "set_role_and_error" statement 1
+set force_parallel_mode = 1;
+select set_and_report_role();
+   set_and_report_role   
+-------------------------
+ regress_parallel_worker
+(1 row)
+
+select set_role_and_error(0);
+ERROR:  division by zero
+CONTEXT:  SQL function "set_role_and_error" statement 1
+reset force_parallel_mode;
+drop function set_and_report_role();
+drop function set_role_and_error(int);
+drop role regress_parallel_worker;
+-- don't freeze in ParallelFinish while holding an LWLock
+BEGIN;
+CREATE FUNCTION my_cmp (int4, int4)
+RETURNS int LANGUAGE sql AS
+$$
+	SELECT
+		CASE WHEN $1 < $2 THEN -1
+				WHEN $1 > $2 THEN  1
+				ELSE 0
+		END;
+$$;
+CREATE TABLE parallel_hang (i int4);
+INSERT INTO parallel_hang
+	(SELECT * FROM generate_series(1, 400) gs);
+CREATE OPERATOR CLASS int4_custom_ops FOR TYPE int4 USING btree AS
+	OPERATOR 1 < (int4, int4), OPERATOR 2 <= (int4, int4),
+	OPERATOR 3 = (int4, int4), OPERATOR 4 >= (int4, int4),
+	OPERATOR 5 > (int4, int4), FUNCTION 1 my_cmp(int4, int4);
+CREATE UNIQUE INDEX parallel_hang_idx
+					ON parallel_hang
+					USING btree (i int4_custom_ops);
+SET force_parallel_mode = on;
+DELETE FROM parallel_hang WHERE 380 <= i AND i <= 420;
+ROLLBACK;

--- a/src/test/regress/sql/select_parallel.sql
+++ b/src/test/regress/sql/select_parallel.sql
@@ -461,8 +461,6 @@ SELECT 1 FROM tenk1_vw_sec
 
 rollback;
 
-<<<<<<< HEAD
-=======
 -- test that function option SET ROLE works in parallel workers.
 create role regress_parallel_worker;
 
@@ -516,4 +514,3 @@ SET force_parallel_mode = on;
 DELETE FROM parallel_hang WHERE 380 <= i AND i <= 420;
 
 ROLLBACK;
->>>>>>> REL_12_22


### PR DESCRIPTION
Resolve conflicts in src/test/regress/sql/select_parallel.sql

1. Resolve conflicts with commits adc28d01e98bdfaf9720d363447124d22565620a and
507b72bd9f7de95a224ae5af8797f42bfce1ed9c caused by an extra newline.
2. Remove "parallel worker" message from expected output since GPDB doesn't
support parallel workers (see comment at the top of the test file). This means
all of the plans in this test are not actually running on parallel workers.
3. Add new test outputs to the ORCA version.
