### PR TITLE
ADBDEV-7233: Fix test src/test/regress/expected/rowtypes.out

### DIFF
--- a/src/test/regress/expected/rowtypes.out
+++ b/src/test/regress/expected/rowtypes.out
@@ -1289,6 +1289,8 @@ drop view composite_v;
 --
 -- Check cases where the composite comes from a proven-dummy rel (bug #18576)
 --
+-- GPDB: only check with Postgres optimizer to avoid creating different plans
+set optimizer=off;
 explain (verbose, costs off)
 select (ss.a).x, (ss.a).n from
   (select information_schema._pg_expandarray(array[1,2]) AS a) ss;
@@ -1312,6 +1314,7 @@ where false;
    One-Time Filter: false
 (3 rows)
 
+reset optimizer;
 explain (verbose, costs off)
 with cte(c) as materialized (select row(1, 2)),
      cte2(c) as (select * from cte)

--- a/src/test/regress/expected/rowtypes.out
+++ b/src/test/regress/expected/rowtypes.out
@@ -1318,11 +1318,11 @@ with cte(c) as materialized (select row(1, 2)),
 select (c).f1 from cte2 as t;
             QUERY PLAN             
 -----------------------------------
- CTE Scan on cte
-   Output: (cte.c).f1
-   CTE cte
-     ->  Result
-           Output: '(1,2)'::record
+ Subquery Scan on t
+   Output: (t.c).f1
+   ->  Result
+         Output: ROW(1, 2)
+ Optimizer: Postgres-based planner
 (5 rows)
 
 explain (verbose, costs off)
@@ -1333,12 +1333,10 @@ where false;
             QUERY PLAN             
 -----------------------------------
  Result
-   Output: (cte.c).f1
+   Output: (c).f1
    One-Time Filter: false
-   CTE cte
-     ->  Result
-           Output: '(1,2)'::record
-(6 rows)
+ Optimizer: Postgres-based planner
+(4 rows)
 
 --
 -- Tests for component access / FieldSelect

--- a/src/test/regress/sql/rowtypes.sql
+++ b/src/test/regress/sql/rowtypes.sql
@@ -526,6 +526,8 @@ drop view composite_v;
 --
 -- Check cases where the composite comes from a proven-dummy rel (bug #18576)
 --
+-- GPDB: only check with Postgres optimizer to avoid creating different plans
+set optimizer=off;
 explain (verbose, costs off)
 select (ss.a).x, (ss.a).n from
   (select information_schema._pg_expandarray(array[1,2]) AS a) ss;
@@ -533,6 +535,7 @@ explain (verbose, costs off)
 select (ss.a).x, (ss.a).n from
   (select information_schema._pg_expandarray(array[1,2]) AS a) ss
 where false;
+reset optimizer;
 
 explain (verbose, costs off)
 with cte(c) as materialized (select row(1, 2)),


### PR DESCRIPTION
Fix test src/test/regress/expected/rowtypes.out

Adapt tests added by commit 7408772de56302f72694943d44a660f35aaf410e for GPDB,
since CTEs are handled differently.