### PR TITLE
ADBDEV-7233: Fix conflicts in src/test/regress/sql/with.sql

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1068,7 +1068,6 @@ WITH RECURSIVE x(n) AS (SELECT n FROM x UNION ALL SELECT 1)
 ERROR:  recursive reference to query "x" must not appear within its non-recursive term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT n FROM x UNION ALL SELECT 1)
                                               ^
-<<<<<<< HEAD
 -- recursive term with a self-reference within a subquery is not allowed
 WITH RECURSIVE cte(level, id) as (
 	SELECT 1, 2
@@ -1076,8 +1075,6 @@ WITH RECURSIVE cte(level, id) as (
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
 ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
-CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
-=======
 -- allow this, because we historically have
 WITH RECURSIVE x(n) AS (
   WITH x1 AS (SELECT 1 AS n)
@@ -1118,8 +1115,7 @@ WITH RECURSIVE x(n) AS (
 ERROR:  ORDER BY in a recursive query is not implemented
 LINE 3:   ORDER BY (SELECT n FROM x))
                    ^
-CREATE TEMPORARY TABLE y (a INTEGER);
->>>>>>> REL_12_22
+CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN
 WITH RECURSIVE x(n) AS (SELECT a FROM y WHERE a = 1

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -1082,6 +1082,46 @@ WITH RECURSIVE cte(level, id) as (
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
 ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+-- allow this, because we historically have
+WITH RECURSIVE x(n) AS (
+  WITH x1 AS (SELECT 1 AS n)
+    SELECT 0
+    UNION
+    SELECT * FROM x1)
+	SELECT * FROM x;
+ n 
+---
+ 0
+ 1
+(2 rows)
+
+-- but this should be rejected
+WITH RECURSIVE x(n) AS (
+  WITH x1 AS (SELECT 1 FROM x)
+    SELECT 0
+    UNION
+    SELECT * FROM x1)
+	SELECT * FROM x;
+ERROR:  recursive reference to query "x" must not appear within a subquery
+LINE 2:   WITH x1 AS (SELECT 1 FROM x)
+                                    ^
+-- and this too
+WITH RECURSIVE x(n) AS (
+  (WITH x1 AS (SELECT 1 FROM x) SELECT * FROM x1)
+  UNION
+  SELECT 0)
+	SELECT * FROM x;
+ERROR:  recursive reference to query "x" must not appear within its non-recursive term
+LINE 2:   (WITH x1 AS (SELECT 1 FROM x) SELECT * FROM x1)
+                                     ^
+-- and this
+WITH RECURSIVE x(n) AS (
+  SELECT 0 UNION SELECT 1
+  ORDER BY (SELECT n FROM x))
+	SELECT * FROM x;
+ERROR:  ORDER BY in a recursive query is not implemented
+LINE 3:   ORDER BY (SELECT n FROM x))
+                   ^
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -475,7 +475,6 @@ WITH RECURSIVE x(n) AS (SELECT n FROM x)
 WITH RECURSIVE x(n) AS (SELECT n FROM x UNION ALL SELECT 1)
 	SELECT * FROM x;
 
-<<<<<<< HEAD
 -- recursive term with a self-reference within a subquery is not allowed
 WITH RECURSIVE cte(level, id) as (
 	SELECT 1, 2
@@ -483,8 +482,6 @@ WITH RECURSIVE cte(level, id) as (
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
 
-CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
-=======
 -- allow this, because we historically have
 WITH RECURSIVE x(n) AS (
   WITH x1 AS (SELECT 1 AS n)
@@ -514,8 +511,7 @@ WITH RECURSIVE x(n) AS (
   ORDER BY (SELECT n FROM x))
 	SELECT * FROM x;
 
-CREATE TEMPORARY TABLE y (a INTEGER);
->>>>>>> REL_12_22
+CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 
 -- LEFT JOIN


### PR DESCRIPTION
Fix conflicts in src/test/regress/sql/with.sql

Conflicts caused by Postgres commit 236b225ed452ae54bf3bb778b926495c4f1aa388
and GPDB-specific commit 3f5cf5c730f2f32d524d03c193743c70e2fcf320 which placed
new tests nearby. Preserve both tests, also add new test to ORCA output.

