### PR TITLE
ADBDEV-7233: Fix conflicts in src/test/regress/expected/partition_prune.out

### DIFF
--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -1350,31 +1350,37 @@ delete from boolpart where a is null;
 create table boolpart_null partition of boolpart for values in (null);
 insert into boolpart values(null);
 explain (costs off) select * from boolpart where a is not true;
-           QUERY PLAN            
----------------------------------
- Append
-   ->  Seq Scan on boolpart_f
-         Filter: (a IS NOT TRUE)
-   ->  Seq Scan on boolpart_null
-         Filter: (a IS NOT TRUE)
-(5 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolpart_f
+               Filter: (a IS NOT TRUE)
+         ->  Seq Scan on boolpart_null
+               Filter: (a IS NOT TRUE)
+ Optimizer: Postgres-based planner
+(7 rows)
 
 explain (costs off) select * from boolpart where a is not true and a is not false;
-                    QUERY PLAN                    
---------------------------------------------------
- Seq Scan on boolpart_null
-   Filter: ((a IS NOT TRUE) AND (a IS NOT FALSE))
-(2 rows)
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on boolpart_null
+         Filter: ((a IS NOT TRUE) AND (a IS NOT FALSE))
+ Optimizer: Postgres-based planner
+(4 rows)
 
 explain (costs off) select * from boolpart where a is not false;
-            QUERY PLAN            
-----------------------------------
- Append
-   ->  Seq Scan on boolpart_t
-         Filter: (a IS NOT FALSE)
-   ->  Seq Scan on boolpart_null
-         Filter: (a IS NOT FALSE)
-(5 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolpart_t
+               Filter: (a IS NOT FALSE)
+         ->  Seq Scan on boolpart_null
+               Filter: (a IS NOT FALSE)
+ Optimizer: Postgres-based planner
+(7 rows)
 
 select * from boolpart where a is not true;
  a 
@@ -1593,29 +1599,33 @@ explain (costs off)  select * from boolrangep where not a and not b and c = 25;
 
 -- ensure we prune boolrangep_tf
 explain (costs off)  select * from boolrangep where a is not true and not b and c = 25;
-                         QUERY PLAN                         
-------------------------------------------------------------
- Append
-   ->  Seq Scan on boolrangep_ff1
-         Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
-   ->  Seq Scan on boolrangep_ff2
-         Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
-   ->  Seq Scan on boolrangep_ft
-         Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
-   ->  Seq Scan on boolrangep_null
-         Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
-(9 rows)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolrangep_ff1
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_ff2
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_ft
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_null
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres-based planner
+(11 rows)
 
 -- ensure we prune everything apart from boolrangep_tf and boolrangep_null
 explain (costs off)  select * from boolrangep where a is not false and not b and c = 25;
-                         QUERY PLAN                          
--------------------------------------------------------------
- Append
-   ->  Seq Scan on boolrangep_tf
-         Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
-   ->  Seq Scan on boolrangep_null
-         Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
-(5 rows)
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolrangep_tf
+               Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_null
+               Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres-based planner
+(7 rows)
 
 -- test scalar-to-array operators
 create table coercepart (a varchar) partition by list (a);
@@ -3115,29 +3125,11 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                  Index Cond: (a = 1)
    ->  Nested Loop (actual rows=1 loops=1)
-<<<<<<< HEAD
          ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=1 loops=1)
                Recheck Cond: (a = 1)
                Heap Blocks: exact=1
                ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
                      Index Cond: (a = 1)
-=======
-         ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
->>>>>>> REL_12_22
          ->  Materialize (actual rows=1 loops=1)
                ->  Append (actual rows=1 loops=1)
                      ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
@@ -3154,7 +3146,6 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                            ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
                                  Index Cond: (a = 1)
    ->  Nested Loop (actual rows=0 loops=1)
-<<<<<<< HEAD
          ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
                Recheck Cond: (a = 1)
                ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
@@ -3175,30 +3166,6 @@ update ab_a1 set b = 3 from ab where ab.a = 1 and ab.a = ab_a1.a;
                                  Index Cond: (a = 1)
  Optimizer: Postgres query optimizer
 (62 rows)
-=======
-         ->  Append (actual rows=1 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b1 ab_a1_b1_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b2 ab_a1_b2_1 (actual rows=1 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-               ->  Bitmap Heap Scan on ab_a1_b3 ab_a1_b3_1 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-         ->  Materialize (actual rows=0 loops=1)
-               ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
-                     Recheck Cond: (a = 1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=1 loops=1)
-                           Index Cond: (a = 1)
-(68 rows)
->>>>>>> REL_12_22
 
 table ab;
  a | b 

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -1296,6 +1296,60 @@ select * from boolpart where a is not unknown;
  t
 (2 rows)
 
+-- try some other permutations with a NULL partition instead of a DEFAULT
+delete from boolpart where a is null;
+create table boolpart_null partition of boolpart for values in (null);
+insert into boolpart values(null);
+explain (costs off) select * from boolpart where a is not true;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Seq Scan on boolpart
+         Number of partitions to scan: 2 (out of 4)
+         Filter: (a IS NOT TRUE)
+ Optimizer: GPORCA
+(5 rows)
+
+explain (costs off) select * from boolpart where a is not true and a is not false;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Dynamic Seq Scan on boolpart
+         Number of partitions to scan: 1 (out of 4)
+         Filter: ((a IS NOT TRUE) AND (a IS NOT FALSE))
+ Optimizer: GPORCA
+(5 rows)
+
+explain (costs off) select * from boolpart where a is not false;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Seq Scan on boolpart
+         Number of partitions to scan: 2 (out of 4)
+         Filter: (a IS NOT FALSE)
+ Optimizer: GPORCA
+(5 rows)
+
+select * from boolpart where a is not true;
+ a 
+---
+ 
+ f
+(2 rows)
+
+select * from boolpart where a is not true and a is not false;
+ a 
+---
+ 
+(1 row)
+
+select * from boolpart where a is not false;
+ a 
+---
+ t
+ 
+(2 rows)
+
 -- inverse boolean partitioning - a seemingly unlikely design, but we've got
 -- code for it, so we'd better test it.
 create table iboolpart (a bool) partition by list ((not a));
@@ -1458,6 +1512,31 @@ select * from iboolpart where a is not unknown;
  f
 (2 rows)
 
+-- Try some other permutations with a NULL partition instead of a DEFAULT
+delete from iboolpart where a is null;
+create table iboolpart_null partition of iboolpart for values in (null);
+insert into iboolpart values(null);
+-- Pruning shouldn't take place for these.  Just check the result is correct
+select * from iboolpart where a is not true;
+ a 
+---
+ 
+ f
+(2 rows)
+
+select * from iboolpart where a is not true and a is not false;
+ a 
+---
+ 
+(1 row)
+
+select * from iboolpart where a is not false;
+ a 
+---
+ t
+ 
+(2 rows)
+
 create table boolrangep (a bool, b bool, c int) partition by range (a,b,c);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1469,6 +1548,8 @@ create table boolrangep_ff1 partition of boolrangep for values from ('false', 'f
 NOTICE:  table has parent, setting distribution columns to match parent table
 create table boolrangep_ff2 partition of boolrangep for values from ('false', 'false', 50) to ('false', 'false', 100);
 NOTICE:  table has parent, setting distribution columns to match parent table
+create table boolrangep_null partition of boolrangep default;
+NOTICE:  table has parent, setting distribution columns to match parent table
 -- try a more complex case that's been known to trip up pruning in the past
 explain (costs off)  select * from boolrangep where not a and not b and c = 25;
                      QUERY PLAN                     
@@ -1478,6 +1559,36 @@ explain (costs off)  select * from boolrangep where not a and not b and c = 25;
          Filter: ((NOT a) AND (NOT b) AND (c = 25))
  Optimizer: Postgres query optimizer
 (4 rows)
+
+-- ensure we prune boolrangep_tf
+explain (costs off)  select * from boolrangep where a is not true and not b and c = 25;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolrangep_ff1
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_ff2
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_ft
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_null
+               Filter: ((a IS NOT TRUE) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres-based planner
+(11 rows)
+
+-- ensure we prune everything apart from boolrangep_tf and boolrangep_null
+explain (costs off)  select * from boolrangep where a is not false and not b and c = 25;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on boolrangep_tf
+               Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
+         ->  Seq Scan on boolrangep_null
+               Filter: ((a IS NOT FALSE) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres-based planner
+(7 rows)
 
 -- test scalar-to-array operators
 create table coercepart (a varchar) partition by list (a);


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected/partition_prune.out

Conflict caused by commit f3e4581acdc83258ff75a4c03950ff89762c98e6 adding Heap
Blocks: exact=1 to EXPLAIN output, while GPDB plan was different due to
different partition pruning implementation. Notably, similar lines were
already added by GPDB commit 61de7b3bb63c45a18ea3c90c2e14e8e4bc829120. Resolv
in favor of original GPDB output.

Also adapt plans of new tests from commit
0b2e77ce288d4339836ef3c920c877352b218873 to GPDB and add the tests to the ORCA
output.