### PR TITLE
Fix src/test/regress/sql/partition_join.sql test

### DIFF
--- a/src/test/regress/expected/partition_join.out
+++ b/src/test/regress/expected/partition_join.out
@@ -507,24 +507,26 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM prt1 t1 JOIN LATERAL
 			  (SELECT * FROM prt1 t2 TABLESAMPLE SYSTEM (t1.a) REPEATABLE(t1.b)) s
 			  ON t1.a = s.a;
-                       QUERY PLAN                        
----------------------------------------------------------
- Nested Loop
-   ->  Append
-         ->  Seq Scan on prt1_p1 t1
-         ->  Seq Scan on prt1_p2 t1_1
-         ->  Seq Scan on prt1_p3 t1_2
-   ->  Append
-         ->  Sample Scan on prt1_p1 t2
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: (t1.a = a)
-         ->  Sample Scan on prt1_p2 t2_1
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: (t1.a = a)
-         ->  Sample Scan on prt1_p3 t2_2
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: (t1.a = a)
-(15 rows)
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         ->  Append
+               ->  Seq Scan on prt1_p1 t1
+               ->  Seq Scan on prt1_p2 t1_1
+               ->  Seq Scan on prt1_p3 t1_2
+         ->  Append
+               ->  Sample Scan on prt1_p1 t2
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: (t1.a = a)
+               ->  Sample Scan on prt1_p2 t2_1
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: (t1.a = a)
+               ->  Sample Scan on prt1_p3 t2_2
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: (t1.a = a)
+ Optimizer: Postgres-based planner
+(17 rows)
 
 -- If there are lateral references to the other relation in scan's restriction
 -- clauses, we cannot generate a partitionwise join.
@@ -532,25 +534,29 @@ EXPLAIN (COSTS OFF)
 SELECT count(*) FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t1.b AS t1b, t2.* FROM prt2 t2) s
 			  ON t1.a = s.b WHERE s.t1b = s.a;
-                          QUERY PLAN                           
----------------------------------------------------------------
- Aggregate
-   ->  Nested Loop
-         ->  Append
-               ->  Seq Scan on prt1_p1 t1
-               ->  Seq Scan on prt1_p2 t1_1
-               ->  Seq Scan on prt1_p3 t1_2
-         ->  Append
-               ->  Index Scan using iprt2_p1_b on prt2_p1 t2
-                     Index Cond: (b = t1.a)
-                     Filter: (t1.b = a)
-               ->  Index Scan using iprt2_p2_b on prt2_p2 t2_1
-                     Index Cond: (b = t1.a)
-                     Filter: (t1.b = a)
-               ->  Index Scan using iprt2_p3_b on prt2_p3 t2_2
-                     Index Cond: (b = t1.a)
-                     Filter: (t1.b = a)
-(16 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Nested Loop
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Append
+                                 ->  Seq Scan on prt1_p1 t1
+                                 ->  Seq Scan on prt1_p2 t1_1
+                                 ->  Seq Scan on prt1_p3 t1_2
+                     ->  Append
+                           ->  Index Scan using iprt2_p1_b on prt2_p1 t2
+                                 Index Cond: (b = t1.a)
+                                 Filter: (t1.b = a)
+                           ->  Index Scan using iprt2_p2_b on prt2_p2 t2_1
+                                 Index Cond: (b = t1.a)
+                                 Filter: (t1.b = a)
+                           ->  Index Scan using iprt2_p3_b on prt2_p3 t2_2
+                                 Index Cond: (b = t1.a)
+                                 Filter: (t1.b = a)
+ Optimizer: Postgres-based planner
+(20 rows)
 
 SELECT count(*) FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t1.b AS t1b, t2.* FROM prt2 t2) s
@@ -564,25 +570,29 @@ EXPLAIN (COSTS OFF)
 SELECT count(*) FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t1.b AS t1b, t2.* FROM prt2 t2) s
 			  ON t1.a = s.b WHERE s.t1b = s.b;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Aggregate
-   ->  Nested Loop
-         ->  Append
-               ->  Seq Scan on prt1_p1 t1
-               ->  Seq Scan on prt1_p2 t1_1
-               ->  Seq Scan on prt1_p3 t1_2
-         ->  Append
-               ->  Index Only Scan using iprt2_p1_b on prt2_p1 t2
-                     Index Cond: (b = t1.a)
-                     Filter: (b = t1.b)
-               ->  Index Only Scan using iprt2_p2_b on prt2_p2 t2_1
-                     Index Cond: (b = t1.a)
-                     Filter: (b = t1.b)
-               ->  Index Only Scan using iprt2_p3_b on prt2_p3 t2_2
-                     Index Cond: (b = t1.a)
-                     Filter: (b = t1.b)
-(16 rows)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Partial Aggregate
+               ->  Nested Loop
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Append
+                                 ->  Seq Scan on prt1_p1 t1
+                                 ->  Seq Scan on prt1_p2 t1_1
+                                 ->  Seq Scan on prt1_p3 t1_2
+                     ->  Append
+                           ->  Index Only Scan using iprt2_p1_b on prt2_p1 t2
+                                 Index Cond: (b = t1.a)
+                                 Filter: (b = t1.b)
+                           ->  Index Only Scan using iprt2_p2_b on prt2_p2 t2_1
+                                 Index Cond: (b = t1.a)
+                                 Filter: (b = t1.b)
+                           ->  Index Only Scan using iprt2_p3_b on prt2_p3 t2_2
+                                 Index Cond: (b = t1.a)
+                                 Filter: (b = t1.b)
+ Optimizer: Postgres-based planner
+(20 rows)
 
 SELECT count(*) FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t1.b AS t1b, t2.* FROM prt2 t2) s
@@ -2133,25 +2143,7 @@ ERROR:  could not devise a query plan for the given query
 SELECT * FROM prt1_l t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t2.c AS t2c, t2.b AS t2b, t3.b AS t3b, least(t1.a,t2.a,t3.b) FROM prt1_l t2 JOIN prt2_l t3 ON (t2.a = t3.b AND t2.c = t3.c)) ss
 			  ON t1.a = ss.t2a AND t1.c = ss.t2c WHERE t1.b = 0 ORDER BY t1.a;
-<<<<<<< HEAD
 ERROR:  could not devise a query plan for the given query
-=======
-  a  | b |  c   | t2a | t2c  | t2b | t3b | least 
------+---+------+-----+------+-----+-----+-------
-   0 | 0 | 0000 |   0 | 0000 |   0 |   0 |     0
-  50 | 0 | 0002 |     |      |     |     |      
- 100 | 0 | 0000 |     |      |     |     |      
- 150 | 0 | 0002 | 150 | 0002 |   0 | 150 |   150
- 200 | 0 | 0000 |     |      |     |     |      
- 250 | 0 | 0002 |     |      |     |     |      
- 300 | 0 | 0000 | 300 | 0000 |   0 | 300 |   300
- 350 | 0 | 0002 |     |      |     |     |      
- 400 | 0 | 0000 |     |      |     |     |      
- 450 | 0 | 0002 | 450 | 0002 |   0 | 450 |   450
- 500 | 0 | 0000 |     |      |     |     |      
- 550 | 0 | 0002 |     |      |     |     |      
-(12 rows)
-
 SET max_parallel_workers_per_gather = 0;
 -- If there are lateral references to the other relation in sample scan,
 -- we cannot generate a partitionwise join.
@@ -2159,43 +2151,9 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM prt1_l t1 JOIN LATERAL
 			  (SELECT * FROM prt1_l t2 TABLESAMPLE SYSTEM (t1.a) REPEATABLE(t1.b)) s
 			  ON t1.a = s.a AND t1.b = s.b AND t1.c = s.c;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Nested Loop
-   ->  Append
-         ->  Seq Scan on prt1_l_p1 t1
-         ->  Seq Scan on prt1_l_p2_p1 t1_1
-         ->  Seq Scan on prt1_l_p2_p2 t1_2
-         ->  Seq Scan on prt1_l_p3_p1 t1_3
-         ->  Seq Scan on prt1_l_p3_p2 t1_4
-   ->  Append
-         ->  Sample Scan on prt1_l_p1 t2
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
-         ->  Sample Scan on prt1_l_p2_p1 t2_1
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
-         ->  Sample Scan on prt1_l_p2_p2 t2_2
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
-         ->  Sample Scan on prt1_l_p3_p1 t2_3
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
-         ->  Sample Scan on prt1_l_p3_p2 t2_4
-               Sampling: system (t1.a) REPEATABLE (t1.b)
-               Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
-(23 rows)
-
--- If there are lateral references to the other relation in scan's restriction
--- clauses, we cannot generate a partitionwise join.
-EXPLAIN (COSTS OFF)
-SELECT COUNT(*) FROM prt1_l t1 LEFT JOIN LATERAL
-			  (SELECT t1.b AS t1b, t2.* FROM prt2_l t2) s
-			  ON t1.a = s.b AND t1.b = s.a AND t1.c = s.c
-			  WHERE s.t1b = s.a;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Aggregate
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          ->  Append
                ->  Seq Scan on prt1_l_p1 t1
@@ -2204,29 +2162,39 @@ SELECT COUNT(*) FROM prt1_l t1 LEFT JOIN LATERAL
                ->  Seq Scan on prt1_l_p3_p1 t1_3
                ->  Seq Scan on prt1_l_p3_p2 t1_4
          ->  Append
-               ->  Seq Scan on prt2_l_p1 t2
-                     Filter: ((a = t1.b) AND (t1.a = b) AND (t1.b = a) AND ((t1.c)::text = (c)::text))
-               ->  Seq Scan on prt2_l_p2_p1 t2_1
-                     Filter: ((a = t1.b) AND (t1.a = b) AND (t1.b = a) AND ((t1.c)::text = (c)::text))
-               ->  Seq Scan on prt2_l_p2_p2 t2_2
-                     Filter: ((a = t1.b) AND (t1.a = b) AND (t1.b = a) AND ((t1.c)::text = (c)::text))
-               ->  Seq Scan on prt2_l_p3_p1 t2_3
-                     Filter: ((a = t1.b) AND (t1.a = b) AND (t1.b = a) AND ((t1.c)::text = (c)::text))
-               ->  Seq Scan on prt2_l_p3_p2 t2_4
-                     Filter: ((a = t1.b) AND (t1.a = b) AND (t1.b = a) AND ((t1.c)::text = (c)::text))
-(19 rows)
+               ->  Sample Scan on prt1_l_p1 t2
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
+               ->  Sample Scan on prt1_l_p2_p1 t2_1
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
+               ->  Sample Scan on prt1_l_p2_p2 t2_2
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
+               ->  Sample Scan on prt1_l_p3_p1 t2_3
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
+               ->  Sample Scan on prt1_l_p3_p2 t2_4
+                     Sampling: system (t1.a) REPEATABLE (t1.b)
+                     Filter: ((t1.a = a) AND (t1.b = b) AND ((t1.c)::text = (c)::text))
+ Optimizer: Postgres-based planner
+(25 rows)
 
+-- GPDB: FIXME For now GPDB do not support such queries.
+-- If there are lateral references to the other relation in scan's restriction
+-- clauses, we cannot generate a partitionwise join.
+EXPLAIN (COSTS OFF)
 SELECT COUNT(*) FROM prt1_l t1 LEFT JOIN LATERAL
 			  (SELECT t1.b AS t1b, t2.* FROM prt2_l t2) s
 			  ON t1.a = s.b AND t1.b = s.a AND t1.c = s.c
 			  WHERE s.t1b = s.a;
- count 
--------
-   100
-(1 row)
-
+ERROR:  could not pull up equivalence class using projected target list
+SELECT COUNT(*) FROM prt1_l t1 LEFT JOIN LATERAL
+			  (SELECT t1.b AS t1b, t2.* FROM prt2_l t2) s
+			  ON t1.a = s.b AND t1.b = s.a AND t1.c = s.c
+			  WHERE s.t1b = s.a;
+ERROR:  could not pull up equivalence class using projected target list
 RESET max_parallel_workers_per_gather;
->>>>>>> REL_12_22
 -- join with one side empty
 EXPLAIN (COSTS OFF)
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE a = 1 AND a = 2) t1 RIGHT JOIN prt2_l t2 ON t1.a = t2.b AND t1.b = t2.a AND t1.c = t2.c;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -166,6 +166,9 @@ s/nodename nor servname provided, or not known/Name or service not known/
 m/ERROR:  could not devise a query plan for the given query \(.*\)/
 s/ERROR:  could not devise a query plan for the given query \(.*\)/ERROR:  could not devise a query plan for the given query/
 
+m/ERROR:  could not pull up equivalence class using projected target list \(.*\)/
+s/ERROR:  could not pull up equivalence class using projected target list \(.*\)/ERROR:  could not pull up equivalence class using projected target list/
+
 m/^DETAIL:.*gid=.*/
 s/gid=\d+/gid DUMMY/
 

--- a/src/test/regress/sql/partition_join.sql
+++ b/src/test/regress/sql/partition_join.sql
@@ -413,6 +413,7 @@ SELECT * FROM prt1_l t1 JOIN LATERAL
 			  (SELECT * FROM prt1_l t2 TABLESAMPLE SYSTEM (t1.a) REPEATABLE(t1.b)) s
 			  ON t1.a = s.a AND t1.b = s.b AND t1.c = s.c;
 
+-- GPDB: FIXME For now GPDB do not support such queries.
 -- If there are lateral references to the other relation in scan's restriction
 -- clauses, we cannot generate a partitionwise join.
 EXPLAIN (COSTS OFF)


### PR DESCRIPTION
Commit 2e822a1d62d0f78b7d471076ea982cd0734cc875 added a new tests to
partition_join.sql but commit 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 replaced
the output of one of the queries with an error, which led to a conflict.
Update the output of new tests for GPDB.
One query from new tests is not supported in GPDB.
