### PR TITLE
Fix test src/test/regress/expected/indexing.out

### DIFF
--- a/src/test/regress/expected/indexing.out
+++ b/src/test/regress/expected/indexing.out
@@ -1306,40 +1306,48 @@ drop table idxpart;
 create table idxpart (a int, b text, c int[]) partition by range (a);
 create table idxpart1 partition of idxpart for values from (0) to (100000);
 set enable_seqscan to off;
+set optimizer to off;
 create index idxpart_brin on idxpart using brin(b);
 explain (costs off) select * from idxpart where b = 'abcd';
-                QUERY PLAN                 
--------------------------------------------
- Bitmap Heap Scan on idxpart1
-   Recheck Cond: (b = 'abcd'::text)
-   ->  Bitmap Index Scan on idxpart1_b_idx
-         Index Cond: (b = 'abcd'::text)
-(4 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on idxpart1
+         Recheck Cond: (b = 'abcd'::text)
+         ->  Bitmap Index Scan on idxpart1_b_idx
+               Index Cond: (b = 'abcd'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 drop index idxpart_brin;
 create index idxpart_spgist on idxpart using spgist(b);
 explain (costs off) select * from idxpart where b = 'abcd';
-                QUERY PLAN                 
--------------------------------------------
- Bitmap Heap Scan on idxpart1
-   Recheck Cond: (b = 'abcd'::text)
-   ->  Bitmap Index Scan on idxpart1_b_idx
-         Index Cond: (b = 'abcd'::text)
-(4 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on idxpart1
+         Recheck Cond: (b = 'abcd'::text)
+         ->  Bitmap Index Scan on idxpart1_b_idx
+               Index Cond: (b = 'abcd'::text)
+ Optimizer: Postgres-based planner
+(6 rows)
 
 drop index idxpart_spgist;
 create index idxpart_gin on idxpart using gin(c);
 explain (costs off) select * from idxpart where c @> array[42];
-                  QUERY PLAN                  
-----------------------------------------------
- Bitmap Heap Scan on idxpart1
-   Recheck Cond: (c @> '{42}'::integer[])
-   ->  Bitmap Index Scan on idxpart1_c_idx
-         Index Cond: (c @> '{42}'::integer[])
-(4 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Bitmap Heap Scan on idxpart1
+         Recheck Cond: (c @> '{42}'::integer[])
+         ->  Bitmap Index Scan on idxpart1_c_idx
+               Index Cond: (c @> '{42}'::integer[])
+ Optimizer: Postgres-based planner
+(6 rows)
 
 drop index idxpart_gin;
 reset enable_seqscan;
+reset optimizer;
 drop table idxpart;
 -- intentionally leave some objects around
 create table idxpart (a int) partition by range (a);

--- a/src/test/regress/sql/indexing.sql
+++ b/src/test/regress/sql/indexing.sql
@@ -691,6 +691,7 @@ drop table idxpart;
 create table idxpart (a int, b text, c int[]) partition by range (a);
 create table idxpart1 partition of idxpart for values from (0) to (100000);
 set enable_seqscan to off;
+set optimizer to off;
 
 create index idxpart_brin on idxpart using brin(b);
 explain (costs off) select * from idxpart where b = 'abcd';
@@ -705,6 +706,7 @@ explain (costs off) select * from idxpart where c @> array[42];
 drop index idxpart_gin;
 
 reset enable_seqscan;
+reset optimizer;
 drop table idxpart;
 
 -- intentionally leave some objects around


### PR DESCRIPTION
Fix test src/test/regress/expected/indexing.out

Commit 1771ec9 added new tests to src/test/regress/sql/indexing.sql, the output
of which should be adapted for GPDB. The mentioned commit does not affect the
ORCA planner, so it was disabled for new tests.