### PR TITLE
Fix test src/test/regress/expected/partition_pruning.out

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -4690,29 +4690,36 @@ SELECT * FROM pt_bool_tab_null WHERE col2 IS unknown;
 (1 row)
 
 EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT true;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000969.00 rows=46750 width=5)
-   ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
-         Filter: (col2 IS NOT TRUE)
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part2  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT TRUE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT TRUE)
  Optimizer: Postgres query optimizer
-(4 rows)
+(7 rows)
 
 SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT true;
  col1 | col2 
 ------+------
-    1 | f
     2 | f
-(2 rows)
+    1 | f
+    1 | 
+(3 rows)
 
 EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT false;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000000969.00 rows=46750 width=5)
-   ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
-         Filter: (col2 IS NOT FALSE)
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..20000002093.83 rows=93500 width=5)
+   ->  Append  (cost=10000000000.00..20000000847.17 rows=31167 width=5)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part1  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT FALSE)
+         ->  Seq Scan on pt_bool_tab_null_1_prt_part3  (cost=10000000000.00..10000000345.67 rows=15583 width=5)
+               Filter: (col2 IS NOT FALSE)
  Optimizer: Postgres query optimizer
-(4 rows)
+(7 rows)
 
 SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT false;
  col1 | col2 
@@ -4720,7 +4727,8 @@ SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT false;
     2 | t
     3 | t
     1 | t
-(3 rows)
+    1 | 
+(4 rows)
 
 EXPLAIN SELECT * FROM pt_bool_tab_null WHERE col2 IS NOT unknown;
                                                    QUERY PLAN                                                   


### PR DESCRIPTION
Fix test src/test/regress/expected/partition_pruning.out

Commit 3ffcd24 fixes incorrect pruning of NULL partition for boolean IS NOT
clauses for the Postgres planner, so we need to fix the output of GPDB-specific
tests. ORCA already does this correctly.