### PR TITLE
Fix test src/pl/plpython/expected/python3/plpython_trigger.out

### DIFF
--- a/src/pl/plpython/expected/plpython_trigger.out
+++ b/src/pl/plpython/expected/plpython_trigger.out
@@ -590,7 +590,7 @@ SELECT * FROM trigger_test_generated;
 (0 rows)
 
 -- recursive call of a trigger mustn't corrupt TD (bug #18456)
-CREATE TABLE recursive_trigger_test (a int, b int);
+CREATE TABLE recursive_trigger_test (a int, b int) DISTRIBUTED BY (b);
 CREATE FUNCTION recursive_trigger_func() RETURNS trigger
 LANGUAGE plpythonu
 AS $$
@@ -604,12 +604,14 @@ $$;
 CREATE TRIGGER recursive_trigger_trig
   AFTER INSERT OR UPDATE ON recursive_trigger_test
   FOR EACH ROW EXECUTE PROCEDURE recursive_trigger_func();
-INSERT INTO recursive_trigger_test VALUES (0, 0);
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "INSERT INTO recursive_trigger_test VALUES (0, 0);"
 NOTICE:  TD[event] => INSERT, expecting INSERT
-UPDATE recursive_trigger_test SET a = 11 WHERE b = 0;
+INSERT 0 1
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "UPDATE recursive_trigger_test SET a = 11 WHERE b = 0;"
 NOTICE:  TD[event] => INSERT, expecting INSERT
 NOTICE:  TD[event] => UPDATE, expecting UPDATE
-SELECT * FROM recursive_trigger_test;
+UPDATE 1
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "SELECT * FROM recursive_trigger_test;"
  a  | b 
 ----+---
  11 | 0

--- a/src/pl/plpython/sql/plpython_trigger.sql
+++ b/src/pl/plpython/sql/plpython_trigger.sql
@@ -480,7 +480,7 @@ SELECT * FROM trigger_test_generated;
 
 -- recursive call of a trigger mustn't corrupt TD (bug #18456)
 
-CREATE TABLE recursive_trigger_test (a int, b int);
+CREATE TABLE recursive_trigger_test (a int, b int) DISTRIBUTED BY (b);
 
 CREATE FUNCTION recursive_trigger_func() RETURNS trigger
 LANGUAGE plpythonu
@@ -497,6 +497,6 @@ CREATE TRIGGER recursive_trigger_trig
   AFTER INSERT OR UPDATE ON recursive_trigger_test
   FOR EACH ROW EXECUTE PROCEDURE recursive_trigger_func();
 
-INSERT INTO recursive_trigger_test VALUES (0, 0);
-UPDATE recursive_trigger_test SET a = 11 WHERE b = 0;
-SELECT * FROM recursive_trigger_test;
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "INSERT INTO recursive_trigger_test VALUES (0, 0);"
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "UPDATE recursive_trigger_test SET a = 11 WHERE b = 0;"
+\! PGOPTIONS='-c gp_role=utility' psql -X pl_regression -c "SELECT * FROM recursive_trigger_test;"


### PR DESCRIPTION
Fix test src/pl/plpython/expected/python3/plpython_trigger.out

Commit 4488142 added a new test to src/pl/plpython/sql/plpython_trigger.sql,
but GPDB does not allow updating the distribution column in a trigger, so the
new table recursive_trigger_test was forced to be distributed on a different
column. Also, GPDB does not allow modifying operations to be performed on the
executor slice, so the operations were moved to utility mode.