### PR TITLE
ADBDEV-7233: Fix clang -Wimplicit-fallthrough

### DIFF
--- a/src/backend/partitioning/partprune.c
+++ b/src/backend/partitioning/partprune.c
@@ -3633,13 +3633,13 @@ match_boolean_partition_clause(Oid partopfamily, Expr *clause, Expr *partkey,
 			{
 				case IS_NOT_TRUE:
 					*noteq = true;
-					/* fall through */
+					fallthru;
 				case IS_TRUE:
 					*outconst = (Expr *) makeBoolConst(true, false);
 					break;
 				case IS_NOT_FALSE:
 					*noteq = true;
-					/* fall through */
+					fallthru;
 				case IS_FALSE:
 					*outconst = (Expr *) makeBoolConst(false, false);
 					break;

--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -1863,7 +1863,7 @@ xml_errorHandler(void *data, PgXmlErrorPtr error)
 			if (error->code == XML_ERR_NOT_WELL_BALANCED &&
 				xmlerrcxt->err_occurred)
 				return;
-			/* fall through */
+			fallthru;
 
 		case XML_FROM_NONE:
 		case XML_FROM_MEMORY:


### PR DESCRIPTION
Fix clang -Wimplicit-fallthrough

New fallthroughs were introduced by commits
0b2e77ce288d4339836ef3c920c877352b218873 and
a134baea7ab0cc907b9d9d3d16f9ac97ec8200be. Make them explicit to fix clang
warnings by making then explicit.

---

You can see a successfully built Clang image on CI branch where I pushed this commit directly.