### PR TITLE
ADBDEV-7354: Fix segfault in utility mode due to uninitialized curSlice

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4445,7 +4445,7 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			RelOptInfo *sub_final_rel;
 			GangType	saved_gangType = GANGTYPE_UNALLOCATED;
 			/*
-			 * Since topSlice is only initialized in the dispatcher role,
+			 * Since topSlice is only initialized on the QD,
 			 * root->curSlice may be NULL in other roles. Check before accessing it.
 			 */
 			if (root->curSlice)

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4448,8 +4448,6 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			{
 				saved_gangType = root->curSlice->gangType;
 			}
-			/* temp */
-			Assert(Gp_role == GP_ROLE_DISPATCH); 
 
 			sub_final_rel = fetch_upper_rel(best_path->parent->subroot, UPPERREL_FINAL, NULL);
 			subplan = create_plan(best_path->parent->subroot, sub_final_rel->cheapest_total_path, root->curSlice);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4448,11 +4448,9 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * Since topSlice is only initialized on the QD,
 			 * root->curSlice may be NULL in other roles. Check it first.
 			 */
-			Assert(Gp_role != GP_ROLE_DISPATCH || root->curSlice != NULL);
-			if (root->curSlice)
-			{
+			AssertImply(Gp_role == GP_ROLE_DISPATCH, root->curSlice != NULL);
+			if (Gp_role == GP_ROLE_DISPATCH && root->curSlice != NULL)
 				saved_gangType = root->curSlice->gangType;
-			}
 
 			sub_final_rel = fetch_upper_rel(best_path->parent->subroot, UPPERREL_FINAL, NULL);
 			subplan = create_plan(best_path->parent->subroot, sub_final_rel->cheapest_total_path, root->curSlice);
@@ -4469,7 +4467,7 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * applies on QD, where slice and gangType are assigned.
 			 */
 			if (Gp_role == GP_ROLE_DISPATCH &&
-				root->curSlice &&
+				root->curSlice != NULL &&
 				root->curSlice->gangType != saved_gangType &&
 				root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
 				cteplaninfo->rootSliceIsWriter = true;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4444,7 +4444,11 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 		{
 			RelOptInfo *sub_final_rel;
 			GangType	saved_gangType = GANGTYPE_UNALLOCATED;
-			if (Gp_role == GP_ROLE_DISPATCH)
+			/*
+			 * Since topSlice is only initialized in the dispatcher role,
+			 * root->curSlice may be NULL in other roles. Check before accessing it.
+			 */
+			if (root->curSlice)
 			{
 				saved_gangType = root->curSlice->gangType;
 			}
@@ -4462,7 +4466,7 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * gets to the reader gang (it depends of tree traverse order
 			 * inside the apply_shareinput_dag_to_tree function)
 			 */
-			if (Gp_role == GP_ROLE_DISPATCH &&
+			if (root->curSlice &&
 				root->curSlice->gangType != saved_gangType &&
 				root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
 				cteplaninfo->rootSliceIsWriter = true;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4446,8 +4446,9 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			GangType	saved_gangType = GANGTYPE_UNALLOCATED;
 			/*
 			 * Since topSlice is only initialized on the QD,
-			 * root->curSlice may be NULL in other roles. Check before accessing it.
+			 * root->curSlice may be NULL in other roles. Check it first.
 			 */
+			Assert(Gp_role != GP_ROLE_DISPATCH || root->curSlice != NULL);
 			if (root->curSlice)
 			{
 				saved_gangType = root->curSlice->gangType;
@@ -4464,9 +4465,11 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * ShareInputScan as writing slice creator, in order to prevent
 			 * the situation, when consumer gets to the writer gang and producer
 			 * gets to the reader gang (it depends of tree traverse order
-			 * inside the apply_shareinput_dag_to_tree function)
+			 * inside the apply_shareinput_dag_to_tree function). This only
+			 * applies on QD, where slice and gangType are assigned.
 			 */
-			if (root->curSlice &&
+			if (Gp_role == GP_ROLE_DISPATCH &&
+				root->curSlice &&
 				root->curSlice->gangType != saved_gangType &&
 				root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
 				cteplaninfo->rootSliceIsWriter = true;

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4448,6 +4448,8 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			{
 				saved_gangType = root->curSlice->gangType;
 			}
+			/* temp */
+			Assert(Gp_role == GP_ROLE_DISPATCH); 
 
 			sub_final_rel = fetch_upper_rel(best_path->parent->subroot, UPPERREL_FINAL, NULL);
 			subplan = create_plan(best_path->parent->subroot, sub_final_rel->cheapest_total_path, root->curSlice);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4443,7 +4443,11 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 		if (!cteplaninfo->shared_plan)
 		{
 			RelOptInfo *sub_final_rel;
-			GangType	saved_gangType = root->curSlice->gangType;
+			GangType	saved_gangType;
+			if (Gp_role == GP_ROLE_DISPATCH)
+			{
+				saved_gangType = root->curSlice->gangType;
+			}
 
 			sub_final_rel = fetch_upper_rel(best_path->parent->subroot, UPPERREL_FINAL, NULL);
 			subplan = create_plan(best_path->parent->subroot, sub_final_rel->cheapest_total_path, root->curSlice);
@@ -4458,9 +4462,12 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * gets to the reader gang (it depends of tree traverse order
 			 * inside the apply_shareinput_dag_to_tree function)
 			 */
-			if (root->curSlice->gangType != saved_gangType &&
-				root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
-				cteplaninfo->rootSliceIsWriter = true;
+			if (Gp_role == GP_ROLE_DISPATCH)
+			{
+				if (root->curSlice->gangType != saved_gangType &&
+					root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
+					cteplaninfo->rootSliceIsWriter = true;
+			}
 		}
 		/* Wrap the common Plan tree in a ShareInputScan node */
 		subplan = share_prepared_plan(cteroot, cteplaninfo->shared_plan);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -4443,7 +4443,7 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 		if (!cteplaninfo->shared_plan)
 		{
 			RelOptInfo *sub_final_rel;
-			GangType	saved_gangType;
+			GangType	saved_gangType = GANGTYPE_UNALLOCATED;
 			if (Gp_role == GP_ROLE_DISPATCH)
 			{
 				saved_gangType = root->curSlice->gangType;
@@ -4462,12 +4462,10 @@ create_ctescan_plan(PlannerInfo *root, Path *best_path,
 			 * gets to the reader gang (it depends of tree traverse order
 			 * inside the apply_shareinput_dag_to_tree function)
 			 */
-			if (Gp_role == GP_ROLE_DISPATCH)
-			{
-				if (root->curSlice->gangType != saved_gangType &&
-					root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
-					cteplaninfo->rootSliceIsWriter = true;
-			}
+			if (Gp_role == GP_ROLE_DISPATCH &&
+				root->curSlice->gangType != saved_gangType &&
+				root->curSlice->gangType == GANGTYPE_PRIMARY_WRITER)
+				cteplaninfo->rootSliceIsWriter = true;
 		}
 		/* Wrap the common Plan tree in a ShareInputScan node */
 		subplan = share_prepared_plan(cteroot, cteplaninfo->shared_plan);

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -446,11 +446,8 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 
 	best_path = cdbllize_adjust_init_plan_path(root, best_path);
 
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		subroot->curSlice = palloc0(sizeof(PlanSlice));
-		subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
-	}
+	subroot->curSlice = palloc0(sizeof(PlanSlice));
+	subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
 
 	if (splan_is_initplan(plan_params, subLinkType))
 		unset_allow_append_initplan_for_function_scan();
@@ -510,11 +507,8 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 				SubPlan    *hashplan;
 				AlternativeSubPlan *asplan;
 
-				if (Gp_role == GP_ROLE_DISPATCH)
-				{
-					subroot->curSlice = palloc0(sizeof(PlanSlice));
-					subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
-				}
+				subroot->curSlice = palloc0(sizeof(PlanSlice));
+				subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
 
 				/* OK, finish planning the ANY subquery */
 				plan = create_plan(subroot, best_path, subroot->curSlice);

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -446,8 +446,11 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 
 	best_path = cdbllize_adjust_init_plan_path(root, best_path);
 
-	subroot->curSlice = palloc0(sizeof(PlanSlice));
-	subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		subroot->curSlice = palloc0(sizeof(PlanSlice));
+		subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
+	}
 
 	if (splan_is_initplan(plan_params, subLinkType))
 		unset_allow_append_initplan_for_function_scan();
@@ -507,8 +510,11 @@ make_subplan(PlannerInfo *root, Query *orig_subquery,
 				SubPlan    *hashplan;
 				AlternativeSubPlan *asplan;
 
-				subroot->curSlice = palloc0(sizeof(PlanSlice));
-				subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
+				if (Gp_role == GP_ROLE_DISPATCH)
+				{
+					subroot->curSlice = palloc0(sizeof(PlanSlice));
+					subroot->curSlice->gangType = GANGTYPE_UNALLOCATED;
+				}
 
 				/* OK, finish planning the ANY subquery */
 				plan = create_plan(subroot, best_path, subroot->curSlice);

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2539,6 +2539,51 @@ JOIN cte b USING (i);
 (1 row)
 
 DROP TABLE with_test;
+-- Test shared modifying CTE behavior in utility mode
+CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
+-- check when slice is not allocated (topslice is allocated only on QD)
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Hash Join
+   Hash Cond: (share0_ref2.i = b.i)
+   ->  Shared Scan (share slice:id -1:0)
+   ->  Hash
+         ->  Subquery Scan on b
+               ->  Shared Scan (share slice:id -1:0)
+                     ->  Insert on with_test
+                           ->  Result
+ Optimizer: Postgres-based planner
+(9 rows)
+
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+ i 
+---
+ 1
+(1 row)
+
+-- check when slice is allocated inside InitPlan
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+                   QUERY PLAN                    
+-------------------------------------------------
+ Result
+   One-Time Filter: (4 = $1)
+   InitPlan 1 (returns $1)
+     ->  Subquery Scan on cte
+           ->  Shared Scan (share slice:id -1:0)
+                 ->  Insert on with_test
+                       ->  Result
+   ->  Shared Scan (share slice:id -1:0)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+ i 
+---
+ 3
+(1 row)
+
+DROP TABLE with_test;
 -- Test cross slice Shared Scan with consumer in slice 0.
 CREATE TABLE d (c1 int, c2 int) DISTRIBUTED BY (c1);
 INSERT INTO d (VALUES ( 2, 0 ),( 2 , 0 ));

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2542,7 +2542,7 @@ DROP TABLE with_test;
 -- Test shared modifying CTE behavior in utility mode
 CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
 -- check when slice is not allocated (topslice is allocated only on QD)
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
                      QUERY PLAN                      
 -----------------------------------------------------
  Hash Join
@@ -2556,14 +2556,14 @@ CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
  Optimizer: Postgres-based planner
 (9 rows)
 
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
  i 
 ---
  1
 (1 row)
 
 -- check when slice is allocated inside InitPlan
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
                    QUERY PLAN                    
 -------------------------------------------------
  Result
@@ -2577,7 +2577,7 @@ CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
  Optimizer: Postgres-based planner
 (9 rows)
 
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
  i 
 ---
  3

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -2558,7 +2558,7 @@ DROP TABLE with_test;
 -- Test shared modifying CTE behavior in utility mode
 CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
 -- check when slice is not allocated (topslice is allocated only on QD)
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
                      QUERY PLAN                      
 -----------------------------------------------------
  Hash Join
@@ -2572,14 +2572,14 @@ CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
  Optimizer: Postgres-based planner
 (9 rows)
 
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
  i 
 ---
  1
 (1 row)
 
 -- check when slice is allocated inside InitPlan
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
                    QUERY PLAN                    
 -------------------------------------------------
  Result
@@ -2593,7 +2593,7 @@ CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
  Optimizer: Postgres-based planner
 (9 rows)
 
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
  i 
 ---
  3

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -2555,6 +2555,51 @@ JOIN cte b USING (i);
 (1 row)
 
 DROP TABLE with_test;
+-- Test shared modifying CTE behavior in utility mode
+CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
+-- check when slice is not allocated (topslice is allocated only on QD)
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Hash Join
+   Hash Cond: (share0_ref2.i = b.i)
+   ->  Shared Scan (share slice:id -1:0)
+   ->  Hash
+         ->  Subquery Scan on b
+               ->  Shared Scan (share slice:id -1:0)
+                     ->  Insert on with_test
+                           ->  Result
+ Optimizer: Postgres-based planner
+(9 rows)
+
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+ i 
+---
+ 1
+(1 row)
+
+-- check when slice is allocated inside InitPlan
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+                   QUERY PLAN                    
+-------------------------------------------------
+ Result
+   One-Time Filter: (4 = $1)
+   InitPlan 1 (returns $1)
+     ->  Subquery Scan on cte
+           ->  Shared Scan (share slice:id -1:0)
+                 ->  Insert on with_test
+                       ->  Result
+   ->  Shared Scan (share slice:id -1:0)
+ Optimizer: Postgres-based planner
+(9 rows)
+
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+ i 
+---
+ 3
+(1 row)
+
+DROP TABLE with_test;
 -- Test cross slice Shared Scan with consumer in slice 0.
 --start_ignore
 SET enable_nestloop = ON;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1228,6 +1228,18 @@ JOIN cte b USING (i);
 
 DROP TABLE with_test;
 
+-- Test shared modifying CTE behavior in utility mode
+CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
+
+-- check when slice is not allocated (topslice is allocated only on QD)
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+
+-- check when slice is allocated inside InitPlan
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+DROP TABLE with_test;
+
 -- Test cross slice Shared Scan with consumer in slice 0.
 --start_ignore
 SET enable_nestloop = ON;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1232,12 +1232,12 @@ DROP TABLE with_test;
 CREATE TABLE with_test (i int, j int) DISTRIBUTED RANDOMLY;
 
 -- check when slice is not allocated (topslice is allocated only on QD)
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (1, 2) RETURNING *) SELECT i FROM cte a JOIN cte b USING (i);'
 
 -- check when slice is allocated inside InitPlan
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
-\! PGOPTIONS='-c gp_session_role=utility' psql -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'EXPLAIN (SLICETABLE, COSTS OFF) WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
+\! PGOPTIONS='-c gp_session_role=utility' psql -p 7002 -d regression -c 'WITH cte AS (INSERT INTO with_test VALUES (3, 4) RETURNING *) SELECT i FROM cte WHERE 4 = (SELECT j FROM cte);'
 DROP TABLE with_test;
 
 -- Test cross slice Shared Scan with consumer in slice 0.


### PR DESCRIPTION
Fix segfault in utility mode due to uninitialized curSlice

27cd38f introduced logic using root->curSlice without checking its presence. 
However, curSlice, which can refer to topSlice, is only initialized on the QD
(GP_ROLE_DISPATCH) in standard_planner(). This caused a segfault in utility
mode during DML CTE execution.

Add a curSlice != NULL check and ensure rootSliceIsWriter is accessed only on
the QD, consistent with the logic around apply_shareinput_xslice().
