### PR TITLE
Fix gpcontrib/orafce/expected/dbms_random.out test

### DIFF
--- a/gpcontrib/orafce/expected/dbms_random_3.out
+++ b/gpcontrib/orafce/expected/dbms_random_3.out
@@ -1,0 +1,129 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal   
+------------
+ 0.47333584
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -0.29616583
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+   random   
+------------
+ 1951052976
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ LWLPN
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ \a
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ HJPS
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ Hg
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ fwz
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value()::numeric(10, 8);
+   value    
+------------
+ 0.08003045
+(1 row)
+
+SELECT dbms_random.value(10,15)::numeric(10, 8);
+    value    
+-------------
+ 12.24227702
+(1 row)
+
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+
+SELECT dbms_random.string('u', 10);
+   string   
+------------
+ AHZFKGJHKG
+(1 row)
+
+SELECT dbms_random.string('l', 10);
+   string   
+------------
+ hllhbvzkjz
+(1 row)
+
+SELECT dbms_random.string('a', 10);
+   string   
+------------
+ yHayLiCaFc
+(1 row)
+
+SELECT dbms_random.string('x', 10);
+   string   
+------------
+ WMBVUQ470J
+(1 row)
+
+SELECT dbms_random.string('p', 10);
+   string   
+------------
+ /h`N+8A(/-
+(1 row)
+
+SELECT dbms_random.string('uu', 10); -- error
+ERROR:  this first parameter value is more than 1 characters long
+SELECT dbms_random.string('w', 10);
+   string   
+------------
+ NYTOLMSZNI
+(1 row)
+

--- a/gpcontrib/orafce/expected/dbms_random_4.out
+++ b/gpcontrib/orafce/expected/dbms_random_4.out
@@ -1,0 +1,129 @@
+-- Tests for package DBMS_RANDOM
+SELECT dbms_random.initialize(8);
+ initialize 
+------------
+ 
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal   
+------------
+ 0.12583199
+(1 row)
+
+SELECT dbms_random.normal()::numeric(10, 8);
+   normal    
+-------------
+ -0.61543969
+(1 row)
+
+SELECT dbms_random.seed(8);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.random();
+   random   
+------------
+ 1951052976
+(1 row)
+
+SELECT dbms_random.seed('test');
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.string('U',5);
+ string 
+--------
+ LWLPN
+(1 row)
+
+SELECT dbms_random.string('P',2);
+ string 
+--------
+ \a
+(1 row)
+
+SELECT dbms_random.string('x',4);
+ string 
+--------
+ HJPS
+(1 row)
+
+SELECT dbms_random.string('a',2);
+ string 
+--------
+ Hg
+(1 row)
+
+SELECT dbms_random.string('l',3);
+ string 
+--------
+ fwz
+(1 row)
+
+SELECT dbms_random.seed(5);
+ seed 
+------
+ 
+(1 row)
+
+SELECT dbms_random.value()::numeric(10, 8);
+   value    
+------------
+ 0.08003045
+(1 row)
+
+SELECT dbms_random.value(10,15)::numeric(10, 8);
+    value    
+-------------
+ 12.24227702
+(1 row)
+
+SELECT dbms_random.terminate();
+ terminate 
+-----------
+ 
+(1 row)
+
+SELECT dbms_random.string('u', 10);
+   string   
+------------
+ AHZFKGJHKG
+(1 row)
+
+SELECT dbms_random.string('l', 10);
+   string   
+------------
+ hllhbvzkjz
+(1 row)
+
+SELECT dbms_random.string('a', 10);
+   string   
+------------
+ yHayLiCaFc
+(1 row)
+
+SELECT dbms_random.string('x', 10);
+   string   
+------------
+ WMBVUQ470J
+(1 row)
+
+SELECT dbms_random.string('p', 10);
+   string   
+------------
+ /h`N+8A(/-
+(1 row)
+
+SELECT dbms_random.string('uu', 10); -- error
+ERROR:  this first parameter value is more than 1 characters long
+SELECT dbms_random.string('w', 10);
+   string   
+------------
+ NYTOLMSZNI
+(1 row)
+

--- a/gpcontrib/orafce/expected/dbms_random_5.out
+++ b/gpcontrib/orafce/expected/dbms_random_5.out
@@ -6,15 +6,15 @@ SELECT dbms_random.initialize(8);
 (1 row)
 
 SELECT dbms_random.normal()::numeric(10, 8);
-   normal    
--------------
- -0.49725878
+   normal   
+------------
+ 0.12583199
 (1 row)
 
 SELECT dbms_random.normal()::numeric(10, 8);
    normal    
 -------------
- -0.01196404
+ -0.61543969
 (1 row)
 
 SELECT dbms_random.seed(8);

--- a/gpcontrib/orafce/expected/dbms_random_6.out
+++ b/gpcontrib/orafce/expected/dbms_random_6.out
@@ -6,15 +6,15 @@ SELECT dbms_random.initialize(8);
 (1 row)
 
 SELECT dbms_random.normal()::numeric(10, 8);
-   normal    
--------------
- -0.49725878
+   normal   
+------------
+ 0.23585085
 (1 row)
 
 SELECT dbms_random.normal()::numeric(10, 8);
    normal    
 -------------
- -0.01196404
+ -1.20083609
 (1 row)
 
 SELECT dbms_random.seed(8);


### PR DESCRIPTION
Fix gpcontrib/orafce/expected/dbms_random.out test

Commit 3b4d85c introduced random fails in CatalogCacheCreateEntry function on
builds with asserts, which affected tests in
gpcontrib/orafce/expected/dbms_random.out. In upstream these tests are fixed by
adding new outputs, see commits orafce/orafce@ab8732b and
orafce/orafce@0ad6b3c. The patch adds a couple more outputs.