### PR TITLE
Fix test src/test/isolation/specs/intra-grant-inplace.spec

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3708,7 +3708,7 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 	 * TODO: if future ORCA can emit LockRows plannode,
 	 * we should remove such restriction here.
 	 */
-	if (optimizer)
+	if (Gp_role == GP_ROLE_DISPATCH && optimizer)
 		return false;
 
 	if (stmt->op != SETOP_NONE)

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3705,6 +3705,7 @@ checkCanOptSelectLockingClause(SelectStmt *stmt)
 		return false;
 
 	/*
+	 * GPDB can use ORCA only in dispatch mode.
 	 * TODO: if future ORCA can emit LockRows plannode,
 	 * we should remove such restriction here.
 	 */


### PR DESCRIPTION
Fix test src/test/isolation/specs/intra-grant-inplace.spec

Commit 796d191 added a new test
src/test/isolation/specs/intra-grant-inplace.spec, but these tests in GPDB are
run in utility mode, in which the ORCA planner does not work, while the
optimizer GUC remains enabled and the checkCanOptSelectLockingClause function
returns false after commit 0e11844, which causes the test to hang. We should
check the optimizer GUC only in dispatch mode.