### PR TITLE
Fix index_including.sql test

### DIFF
--- a/src/test/regress/expected/index_including.out
+++ b/src/test/regress/expected/index_including.out
@@ -419,6 +419,8 @@ CREATE INDEX nametbl_c1_c2_idx ON nametbl (c2, c1) INCLUDE (c3);
 INSERT INTO nametbl VALUES(1, 'two', 3.0);
 VACUUM nametbl;
 SET enable_seqscan = 0;
+-- ORCA may sometimes use a Index Scan instead of an Index Only Scan.
+SET optimizer_enable_indexscan = 0;
 -- Ensure we get an index only scan plan
 EXPLAIN (COSTS OFF) SELECT c2, c1, c3 FROM nametbl WHERE c2 = 'two' AND c1 = 1;
                         QUERY PLAN                        
@@ -436,5 +438,6 @@ SELECT c2, c1, c3 FROM nametbl WHERE c2 = 'two' AND c1 = 1;
  two |  1 |  3
 (1 row)
 
+RESET optimizer_enable_indexscan;
 RESET enable_seqscan;
 DROP TABLE nametbl;

--- a/src/test/regress/sql/index_including.sql
+++ b/src/test/regress/sql/index_including.sql
@@ -229,6 +229,8 @@ CREATE INDEX nametbl_c1_c2_idx ON nametbl (c2, c1) INCLUDE (c3);
 INSERT INTO nametbl VALUES(1, 'two', 3.0);
 VACUUM nametbl;
 SET enable_seqscan = 0;
+-- ORCA may sometimes use a Index Scan instead of an Index Only Scan.
+SET optimizer_enable_indexscan = 0;
 
 -- Ensure we get an index only scan plan
 EXPLAIN (COSTS OFF) SELECT c2, c1, c3 FROM nametbl WHERE c2 = 'two' AND c1 = 1;
@@ -236,6 +238,7 @@ EXPLAIN (COSTS OFF) SELECT c2, c1, c3 FROM nametbl WHERE c2 = 'two' AND c1 = 1;
 -- Validate the results look sane
 SELECT c2, c1, c3 FROM nametbl WHERE c2 = 'two' AND c1 = 1;
 
+RESET optimizer_enable_indexscan;
 RESET enable_seqscan;
 
 DROP TABLE nametbl;


### PR DESCRIPTION
ORCA can sometimes use Index Scan instead of Index Only Scan, which led to
instability of the test.
Fix it by forcing ORCA to use Index Only Scan.