### PR TITLE
ADBDEV-7327: Sync only changed GUCs across gang when reload config

### DIFF
--- a/src/backend/utils/misc/guc-file.l
+++ b/src/backend/utils/misc/guc-file.l
@@ -389,8 +389,11 @@ ProcessConfigFileInternal(GucContext context, bool return_changed)
 		if (item->ignore)
 			continue;
 
-		/* In SIGHUP cases in the postmaster, we want to report changes */
-		if (context == PGC_SIGHUP && !IsUnderPostmaster)
+		/*
+		 * In SIGHUP cases in the postmaster, we want to report changes.
+		 * GPDB: if return_changed we need save pre_value too.
+		 */
+		if ((context == PGC_SIGHUP && !IsUnderPostmaster) || return_changed)
 		{
 			const char *preval = GetConfigOption(item->name, true, false);
 
@@ -414,16 +417,20 @@ ProcessConfigFileInternal(GucContext context, bool return_changed)
 				if (!post_value)
 					post_value = "";
 				if (strcmp(pre_value, post_value) != 0)
-					ereport(elevel,
-							(errmsg("parameter \"%s\" changed to \"%s\"",
-									item->name, item->value)));
-			}
+				{
 
-			if (return_changed)
-			{
-				struct config_generic *gconf = find_option(item->name, false, elevel);
-				if (gconf != NULL)
-					changed_gucs = lappend(changed_gucs, gconf);
+					if (context == PGC_SIGHUP && !IsUnderPostmaster)
+						ereport(elevel,
+								(errmsg("parameter \"%s\" changed to \"%s\"",
+										item->name, item->value)));
+
+					if (return_changed)
+					{
+						struct config_generic *gconf = find_option(item->name, false, elevel);
+						if (gconf != NULL)
+							changed_gucs = lappend(changed_gucs, gconf);
+					}
+				}
 			}
 		}
 		else if (scres == 0)

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -752,10 +752,10 @@ DROP ROLE dispatch_test_user2;
 \! gpstop -u
 --end_ignore
 
--- this command should send on segments only changed GUCs
+-- this command should send only changed GUCs to segments
 SELECT 1;
 
--- check sended GUCs on segment 0
+-- check sent GUCs on segment 0
 SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
 WHERE logdatabase = current_database()
 AND logseverity = 'LOG'

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -744,14 +744,18 @@ RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;
 
+-- connect to postgres database to reproduce unchanged GUCs sending
 \c postgres
+-- set log_duration to view `SELECT pg_catalog.set_config` in log on segment
 --start_ignore
 \! gpconfig -c log_duration -v on
 \! gpstop -u
 --end_ignore
 
+-- this command should send on segments only changed GUCs
 SELECT 1;
 
+-- check sended GUCs on segment 0
 SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
 WHERE logdatabase = current_database()
 AND logseverity = 'LOG'
@@ -759,8 +763,10 @@ AND logsegment = 'seg0'
 AND logsession = 'con' || current_setting('gp_session_id')
 AND logdebug LIKE 'SELECT pg_catalog.set_config(%';
 
+-- restore log_duration
 --start_ignore
 \! gpconfig -r log_duration
 \! gpstop -u
 --end_ignore
+-- restore connection to regression database for future tests below
 \c regression

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -743,3 +743,24 @@ RESET SESSION AUTHORIZATION;
 
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;
+
+\c postgres
+--start_ignore
+\! gpconfig -c log_duration -v on
+\! gpstop -u
+--end_ignore
+
+SELECT 1;
+
+SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
+WHERE logdatabase = current_database()
+AND logseverity = 'LOG'
+AND logsegment = 'seg0'
+AND logsession = 'con' || current_setting('gp_session_id')
+AND logdebug LIKE 'SELECT pg_catalog.set_config(%';
+
+--start_ignore
+\! gpconfig -r log_duration
+\! gpstop -u
+--end_ignore
+\c regression

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1240,14 +1240,14 @@ DROP ROLE dispatch_test_user2;
 -- connect to postgres database to reproduce unchanged GUCs sending
 \c postgres
 -- set log_duration to view `SELECT pg_catalog.set_config` in log on segment
--- this command should send on segments only changed GUCs
+-- this command should send only changed GUCs to segments
 SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
--- check sended GUCs on segment 0
+-- check sent GUCs on segment 0
 SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
 WHERE logdatabase = current_database()
 AND logseverity = 'LOG'

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1237,3 +1237,22 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;
+\c postgres
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
+WHERE logdatabase = current_database()
+AND logseverity = 'LOG'
+AND logsegment = 'seg0'
+AND logsession = 'con' || current_setting('gp_session_id')
+AND logdebug LIKE 'SELECT pg_catalog.set_config(%';
+                          logdebug                           
+-------------------------------------------------------------
+ SELECT pg_catalog.set_config('log_duration', 'true', false)
+(1 row)
+
+\c regression

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1237,13 +1237,17 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;
+-- connect to postgres database to reproduce unchanged GUCs sending
 \c postgres
+-- set log_duration to view `SELECT pg_catalog.set_config` in log on segment
+-- this command should send on segments only changed GUCs
 SELECT 1;
  ?column? 
 ----------
         1
 (1 row)
 
+-- check sended GUCs on segment 0
 SELECT logdebug FROM gp_toolkit.__gp_log_segment_ext
 WHERE logdatabase = current_database()
 AND logseverity = 'LOG'
@@ -1255,4 +1259,6 @@ AND logdebug LIKE 'SELECT pg_catalog.set_config(%';
  SELECT pg_catalog.set_config('log_duration', 'true', false)
 (1 row)
 
+-- restore log_duration
+-- restore connection to regression database for future tests below
 \c regression


### PR DESCRIPTION
Sync only changed GUCs across gang when reload config

The ProcessConfigFileInternal function returned all GUCs for synchronization on
segments, even if in fact they did not change. Add a check so that the function
returns only changed GUCs.

Ticket: ADBDEV-7327