### PR TITLE
Implement storage pending deletes module

### DIFF
--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -34,7 +34,7 @@ typedef struct PendingDeletesList
 
 typedef struct BackendsPendingDeletesArray
 {
-	PendingDeletesList *list;
+	PendingDeletesList *array;
 	char		dsa_mem[FLEXIBLE_ARRAY_MEMBER];
 }	BackendsPendingDeletesArray;
 
@@ -90,15 +90,15 @@ PdlShmemInit(void)
 	if (found)
 		return;
 
-	BackendsPendingDeletes->list = (PendingDeletesList *)
+	BackendsPendingDeletes->array = (PendingDeletesList *)
 		ShmemAlloc(PdlListArraySize());
-	if (BackendsPendingDeletes->list == NULL)
+	if (BackendsPendingDeletes->array == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_OUT_OF_MEMORY),
 				 errmsg("Not enough memory to create pending deletes lists.")));
 	
 	for (int i = 0; i < MaxBackends; i++)
-		BackendsPendingDeletes->list[i] = (PendingDeletesList)
+		BackendsPendingDeletes->array[i] = (PendingDeletesList)
 		{
 			.head = InvalidDsaPointer,
 			.lock = LWLockAssign()
@@ -125,7 +125,7 @@ pdl_beshutdown_hook(int code, Datum arg)
 	if (MyBackendId == InvalidBackendId)
 		return;
 
-	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	PendingDeletesList *list = &BackendsPendingDeletes->array[MyBackendId];
 
 	if (!DsaPointerIsValid(list->head))
 		return;
@@ -198,7 +198,7 @@ PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 		.prev = InvalidDsaPointer
 	};
 
-	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	PendingDeletesList *list = &BackendsPendingDeletes->array[MyBackendId];
 
 	LWLockAcquire(list->lock, LW_EXCLUSIVE);
 	node->next = list->head;
@@ -228,7 +228,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
 	Assert(DsaPointerIsValid(node_ptr));
 
 	dsa_area   *dsa = PdlAttachDsa();
-	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	PendingDeletesList *list = &BackendsPendingDeletes->array[MyBackendId];
 	const PendingDeleteListNode *node = dsa_get_address(dsa, node_ptr);
 
 	LWLockAcquire(list->lock, LW_EXCLUSIVE);
@@ -265,44 +265,35 @@ PdlXLogShmemDump(void)
 	dsa_area   *dsa = PdlAttachDsa();
 	PendingRelXactDeleteArray *ret = NULL;
 	Size		size = offsetof(PendingRelXactDeleteArray, array);
+	Size		step = sizeof(*ret->array) * 32;
 
 	for (int i = 0; i < MaxBackends; i++)
 	{
-		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
+		PendingDeletesList *list = &BackendsPendingDeletes->array[i];
 
 		LWLockAcquire(list->lock, LW_SHARED);
 
-		Size list_len = 0;
 		for (dsa_pointer pdl_node_dsa = list->head;
 			 DsaPointerIsValid(pdl_node_dsa);)
 		{
 			const PendingDeleteListNode *pdl_node = dsa_get_address(dsa,
 															   pdl_node_dsa);
 
-			list_len++;
-			pdl_node_dsa = pdl_node->next;
-		}
-
-		if (list_len > 0)
-		{
-			size += sizeof(*ret->array) * list_len;
-			if (ret != NULL)
-				ret = repalloc(ret, size);
-			else
+			if (ret == NULL)
 			{
+				size += step;
 				ret = palloc(size);
 				ret->count = 0;
 			}
-
-			for (dsa_pointer pdl_node_dsa = list->head;
-				 DsaPointerIsValid(pdl_node_dsa);)
+			else if (PdlDumpSize(ret->count + 1) > size)
 			{
-				const PendingDeleteListNode *pdl_node = dsa_get_address(dsa,
-																  pdl_node_dsa);
-
-				ret->array[ret->count++] = pdl_node->xrelnode;
-				pdl_node_dsa = pdl_node->next;
+				step *= 2;
+				size += step;
+				ret = repalloc(ret, size);
 			}
+
+			ret->array[ret->count++] = pdl_node->xrelnode;
+			pdl_node_dsa = pdl_node->next;
 		}
 
 		LWLockRelease(list->lock);

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -54,12 +54,48 @@ static void PdlAttachDsa(void);
 PendingRelXactDeleteArray *
 PdlXLogShmemDump(Size *size)
 {
-	/*
-	 * For now it is only a stub. Should be implemented in scope of
-	 * ADBDEV-7303.
-	 */
-	*size = 0;
-	return NULL;
+	PdlAttachDsa();
+
+	PendingRelXactDeleteArray *ret = NULL;
+
+	*size = offsetof(PendingRelXactDeleteArray, array);
+	for (int i = 0; i < MaxBackends; i++)
+	{
+		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
+
+		LWLockAcquire(list->lock, LW_SHARED);
+
+		if (list->count > 0 && DsaPointerIsValid(list->head))
+		{
+			*size += sizeof(*ret->array) * list->count;
+			if (ret != NULL)
+				ret = repalloc(ret, *size);
+			else
+			{
+				ret = palloc(*size);
+				ret->count = 0;
+			}
+			
+
+			for (dsa_pointer pdl_node_dsa = list->head; DsaPointerIsValid(pdl_node_dsa);)
+			{
+				PendingDeleteListNode *pdl_node = dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
+
+				ret->array[ret->count++] = pdl_node->xrelnode;
+				pdl_node_dsa = pdl_node->next;
+			}
+		}
+
+		LWLockRelease(list->lock);
+	}
+
+	if (ret == NULL)
+	{
+		*size = 0;
+		return NULL;
+	}
+
+	return ret;
 }
 
 /*
@@ -105,7 +141,7 @@ PdlShmemInit(void)
 
 	dsa_area *dsa = dsa_create_in_place(
 		BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
-		LWLockNewTrancheId(), "storage_pending_dsa", NULL);
+		LWLockNewTrancheId(), "storage_pending_deletes", NULL);
 	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
 		(Datum) BackendsPendingDeletes->dsa_mem);
 	dsa_detach(dsa);

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -272,13 +272,20 @@ PdlXLogShmemDump(void)
 
 		LWLockAcquire(list->lock, LW_SHARED);
 
+		Size list_len = 0;
 		for (dsa_pointer pdl_node_dsa = list->head;
 			 DsaPointerIsValid(pdl_node_dsa);)
 		{
 			const PendingDeleteListNode *pdl_node = dsa_get_address(dsa,
 															   pdl_node_dsa);
 
-			size += sizeof(*ret->array);
+			list_len++;
+			pdl_node_dsa = pdl_node->next;
+		}
+
+		if (list_len > 0)
+		{
+			size += sizeof(*ret->array) * list_len;
 			if (ret != NULL)
 				ret = repalloc(ret, size);
 			else
@@ -287,8 +294,15 @@ PdlXLogShmemDump(void)
 				ret->count = 0;
 			}
 
-			ret->array[ret->count++] = pdl_node->xrelnode;
-			pdl_node_dsa = pdl_node->next;
+			for (dsa_pointer pdl_node_dsa = list->head;
+				 DsaPointerIsValid(pdl_node_dsa);)
+			{
+				const PendingDeleteListNode *pdl_node = dsa_get_address(dsa,
+																  pdl_node_dsa);
+
+				ret->array[ret->count++] = pdl_node->xrelnode;
+				pdl_node_dsa = pdl_node->next;
+			}
 		}
 
 		LWLockRelease(list->lock);

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -41,6 +41,7 @@ typedef struct BackendsPendingDeletesArray
 static BackendsPendingDeletesArray *BackendsPendingDeletes = NULL;
 static dsa_area *pendingDeletesDsa = NULL;	/* ptr to DSA area attached by
 											 * current process */
+
 static inline bool is_tracking_enabled()
 {
 	return !IsBootstrapProcessingMode() &&
@@ -48,48 +49,9 @@ static inline bool is_tracking_enabled()
 		   dynamic_shared_memory_type != DSM_IMPL_NONE;
 }
 
-static void PdlAttachDsa(void);
-
-PendingRelXactDeleteArray *
-PdlXLogShmemDump(void)
-{
-	PdlAttachDsa();
-
-	PendingRelXactDeleteArray *ret = NULL;
-
-	Size size = offsetof(PendingRelXactDeleteArray, array);
-	for (int i = 0; i < MaxBackends; i++)
-	{
-		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
-
-		LWLockAcquire(list->lock, LW_SHARED);
-
-		for (dsa_pointer pdl_node_dsa = list->head; DsaPointerIsValid(pdl_node_dsa);)
-		{
-			PendingDeleteListNode *pdl_node = dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
-
-			size += sizeof(*ret->array);
-			if (ret != NULL)
-				ret = repalloc(ret, size);
-			else
-			{
-				ret = palloc(size);
-				ret->count = 0;
-			}
-
-			ret->array[ret->count++] = pdl_node->xrelnode;
-			pdl_node_dsa = pdl_node->next;
-		}
-
-		LWLockRelease(list->lock);
-	}
-
-	return ret;
-}
-
 /*
- * Calculate size for pending delete shmem.
- * The flexible array member should fit DSA.
+ * Calculate shmem size for pending deletes.
+ * BackendsPendingDeletesArray.dsa_mem should fit DSA.
  */
 Size
 PdlShmemSize(void)
@@ -102,6 +64,7 @@ PdlShmemSize(void)
 	return add_size(size, mul_size(sizeof(PendingDeletesList), MaxBackends));
 }
 
+/* Initialize shared memory pending delete lists for all backends */
 void
 PdlShmemInit(void)
 {
@@ -117,7 +80,7 @@ PdlShmemInit(void)
 	if (found)
 		return;
 
-	Size pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
+	const Size pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
 	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
 	for (int i = 0; i < MaxBackends; i++)
 	{
@@ -135,15 +98,20 @@ PdlShmemInit(void)
 	dsa_detach(dsa);
 }
 
-
+/*
+ * Cleanup pending deletes list.
+ * When the function is called, the list should be empty
+ */
 static void
 pdl_beshutdown_hook(int code, Datum arg)
 {
+	dsa_release_in_place(BackendsPendingDeletes->dsa_mem);
+
 	if (MyBackendId == InvalidBackendId)
 		return;
 
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
-	if (list->head == InvalidDsaPointer)
+	if (!DsaPointerIsValid(list->head))
 		return;
 
 	/* Assert on debug build and warning on release */
@@ -152,12 +120,10 @@ pdl_beshutdown_hook(int code, Datum arg)
 		(errcode(ERRCODE_INTERNAL_ERROR),
 		 errmsg("Pending deletes list is not empty. "
 				"MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
-
 	list->head = InvalidDsaPointer;
 }
-/*
- * Attach dsa once per process.
- */
+
+/* Attach DSA once per process. */
 static void
 PdlAttachDsa(void)
 {
@@ -176,18 +142,15 @@ PdlAttachDsa(void)
 	/* pin mappings, so they can survive res owner life end */
 	dsa_pin_mapping(pendingDeletesDsa);
 
-	/* disconnect from dsa on shmem exit */
-	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
-		(Datum) BackendsPendingDeletes->dsa_mem);
 	on_shmem_exit(pdl_beshutdown_hook, 0);
 }
 
 /*
- * Add pending delete node to shmem.
- * Return dsa ptr of newly created node. This ptr can be used for fast remove.
+ * Add pending delete node to the list of current backend.
+ * Return DSA ptr of a created node. This ptr can be passed to PdlShmemRemove.
  */
 dsa_pointer
-PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
+PdlShmemAdd(const RelFileNodePendingDelete *relnode, TransactionId xid)
 {
 	if (!is_tracking_enabled() || xid == InvalidTransactionId ||
 		MyBackendId == InvalidBackendId)
@@ -196,8 +159,8 @@ PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
 	PdlAttachDsa();
 
 	PendingDeleteListNode *node;
-	dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
-										sizeof(*node));
+	const dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
+											  sizeof(*node));
 	node = dsa_get_address(pendingDeletesDsa, node_dsa);
 	*node = (PendingDeleteListNode)	{
 		.xrelnode = {
@@ -223,8 +186,8 @@ PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
 }
 
 /*
- * Fast remove pending delete node from shmem.
- * node_ptr is a ptr to already added node.
+ * Remove pending delete node from the list of current backend.
+ * node_ptr is a ptr to already added node (see PdlShmemAdd)
  */
 void
 PdlShmemRemove(dsa_pointer node_ptr)
@@ -235,18 +198,21 @@ PdlShmemRemove(dsa_pointer node_ptr)
 	Assert(DsaPointerIsValid(node_ptr));
 
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
-	PendingDeleteListNode *node = dsa_get_address(pendingDeletesDsa, node_ptr);
+	const PendingDeleteListNode *node =
+		dsa_get_address(pendingDeletesDsa, node_ptr);
 
 	LWLockAcquire(list->lock, LW_EXCLUSIVE);
 	if (DsaPointerIsValid(node->next))
 	{
-		PendingDeleteListNode *next_node = dsa_get_address(pendingDeletesDsa, node->next);
+		PendingDeleteListNode *next_node = dsa_get_address(pendingDeletesDsa,
+														   node->next);
 		next_node->prev = node->prev;
 	}
 
 	if (DsaPointerIsValid(node->prev))
 	{
-		PendingDeleteListNode *prev_node = dsa_get_address(pendingDeletesDsa, node->prev);
+		PendingDeleteListNode *prev_node = dsa_get_address(pendingDeletesDsa,
+														   node->prev);
 		prev_node->next = node->next;
 	}
 	else
@@ -254,6 +220,48 @@ PdlShmemRemove(dsa_pointer node_ptr)
 
 	LWLockRelease(list->lock);
 
-
 	dsa_free(pendingDeletesDsa, node_ptr);
+}
+
+/*
+ * Dump pending delete nodes from all backends to array.
+ * Return NULL if there are no nodes.
+ */
+PendingRelXactDeleteArray *
+PdlXLogShmemDump(void)
+{
+	PdlAttachDsa();
+
+	PendingRelXactDeleteArray *ret = NULL;
+
+	Size size = offsetof(PendingRelXactDeleteArray, array);
+	for (int i = 0; i < MaxBackends; i++)
+	{
+		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
+
+		LWLockAcquire(list->lock, LW_SHARED);
+
+		for (dsa_pointer pdl_node_dsa = list->head;
+			 DsaPointerIsValid(pdl_node_dsa);)
+		{
+			const PendingDeleteListNode *pdl_node = 
+				dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
+
+			size += sizeof(*ret->array);
+			if (ret != NULL)
+				ret = repalloc(ret, size);
+			else
+			{
+				ret = palloc(size);
+				ret->count = 0;
+			}
+
+			ret->array[ret->count++] = pdl_node->xrelnode;
+			pdl_node_dsa = pdl_node->next;
+		}
+
+		LWLockRelease(list->lock);
+	}
+
+	return ret;
 }

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -9,7 +9,47 @@
  *
  *-------------------------------------------------------------------------
  */
+#include "postgres.h"
+
 #include "catalog/storage_pending_deletes.h"
+#include "miscadmin.h"
+#include "storage/ipc.h"
+#include "storage/lwlock.h"
+#include "storage/shmem.h"
+#include "utils/dsa.h"
+#include "utils/guc.h"
+
+typedef struct PendingDeleteListNode
+{
+	PendingRelXactDelete xrelnode;
+	dsa_pointer next;
+	dsa_pointer prev;
+} PendingDeleteListNode;
+
+typedef struct PendingDeletesList 
+{
+	LWLock *lock; /* protects the fields below */
+	dsa_pointer head; /* ptr to list head of PendingDeleteListNode */
+	Size count; /* count of PendingDeleteListNode nodes */
+} PendingDeletesList;
+
+typedef struct BackendsPendingDeletesArray
+{
+	PendingDeletesList 	*list;
+	char				dsa_mem[FLEXIBLE_ARRAY_MEMBER];
+} BackendsPendingDeletesArray;
+
+static BackendsPendingDeletesArray *BackendsPendingDeletes = NULL;
+static dsa_area *pendingDeletesDsa = NULL;	/* ptr to DSA area attached by
+											 * current process */
+static inline bool is_tracking_enabled()
+{
+	return !IsBootstrapProcessingMode() &&
+		   gp_track_pending_delete &&
+		   dynamic_shared_memory_type != DSM_IMPL_NONE;
+}
+
+static void PdlAttachDsa(void);
 
 PendingRelXactDeleteArray *
 PdlXLogShmemDump(Size *size)
@@ -20,4 +60,139 @@ PdlXLogShmemDump(Size *size)
 	 */
 	*size = 0;
 	return NULL;
+}
+
+/*
+ * Calculate size for pending delete shmem.
+ * The flexible array member should fit DSA.
+ */
+Size
+PdlShmemSize(void)
+{
+	if (!gp_track_pending_delete)
+		return 0;
+
+	Size size = add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
+						 dsa_minimum_size());
+	return add_size(size, mul_size(sizeof(PendingDeletesList), MaxBackends));
+}
+
+void
+PdlShmemInit(void)
+{
+	if (!is_tracking_enabled())
+		return;
+
+	bool		found;
+	BackendsPendingDeletes = (BackendsPendingDeletesArray *)
+		ShmemInitStruct("Pending deletes array", 
+			add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
+					 dsa_minimum_size()),
+			&found);
+	if (found)
+		return;
+
+	Size pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
+	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
+	for (int i = 0; i < MaxBackends; i++)
+	{
+		BackendsPendingDeletes->list[i] = (PendingDeletesList){
+			.head = InvalidDsaPointer,
+			.count = 0,
+			.lock = LWLockAssign()
+		};
+	}
+
+	dsa_area   *dsa = dsa_create_in_place(
+		BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
+		LWLockNewTrancheId(), "storage_pending_dsa", NULL);
+	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
+		(Datum) BackendsPendingDeletes->dsa_mem);
+	dsa_detach(dsa);
+}
+
+
+static void
+pdl_beshutdown_hook(int code, Datum arg)
+{
+	if (MyBackendId == InvalidBackendId)
+		return;
+
+	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	if (list->head == InvalidDsaPointer && list->count == 0)
+		return;
+
+	/* Assert on debug build and warning on release */
+	Assert(false);
+	ereport(WARNING,
+		(errcode(ERRCODE_INTERNAL_ERROR),
+		 errmsg("Pending deletes list is not empty. "
+				"MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
+
+	list->head = InvalidDsaPointer;
+	list->count = 0;
+}
+/*
+ * Attach dsa once per process.
+ */
+static void
+PdlAttachDsa(void)
+{
+	if (pendingDeletesDsa)
+		return;
+
+	/*
+	 * Keep the DSA area ptr in TopMemoryContext to avoid excessive
+	 * attach/detach at every add/remove
+	 */
+	MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+	pendingDeletesDsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem, NULL);
+	MemoryContextSwitchTo(oldcxt);
+
+	/* pin mappings, so they can survive res owner life end */
+	dsa_pin_mapping(pendingDeletesDsa);
+
+	/* disconnect from dsa on shmem exit */
+	on_shmem_exit(dsa_on_shmem_exit_release_in_place, (Datum) BackendsPendingDeletes->dsa_mem);
+	on_shmem_exit(pdl_beshutdown_hook, 0);
+}
+
+/*
+ * Add pending delete node to shmem.
+ * Return dsa ptr of newly created node. This ptr can be used for fast remove.
+ */
+dsa_pointer
+PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
+{
+	if (!is_tracking_enabled() || xid == InvalidTransactionId)
+		return InvalidDsaPointer;
+
+	PdlAttachDsa();
+
+	PendingDeleteListNode *node;
+	dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
+											sizeof(*node));
+	node = dsa_get_address(pendingDeletesDsa, node_dsa);
+	*node = (PendingDeleteListNode) {
+		.xrelnode = {
+			.relnode = *relnode,
+			.xid = xid
+		},
+		.prev = InvalidDsaPointer
+	};
+	
+	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	LWLockAcquire(list->lock, LW_EXCLUSIVE);
+	node->next = list->head;
+	if (DsaPointerIsValid(node->next))
+	{
+		PendingDeleteListNode *next_node = (PendingDeleteListNode *)
+			dsa_get_address(pendingDeletesDsa, node->next);
+		next_node->prev = node_dsa;
+	}
+	list->head = node_dsa;
+	list->count++;
+	LWLockRelease(list->lock);
+	
+	return node_dsa;
 }

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -93,20 +93,16 @@ PdlShmemInit(void)
 	BackendsPendingDeletes->list = (PendingDeletesList *)
 		ShmemAlloc(PdlListArraySize());
 	if (BackendsPendingDeletes->list == NULL)
-	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OUT_OF_MEMORY),
 				 errmsg("Not enough memory to create pending deletes lists.")));
-	}
 	
 	for (int i = 0; i < MaxBackends; i++)
-	{
 		BackendsPendingDeletes->list[i] = (PendingDeletesList)
 		{
 			.head = InvalidDsaPointer,
 			.lock = LWLockAssign()
 		};
-	}
 
 	dsa_area   *dsa = dsa_create_in_place(
 						 BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
@@ -186,12 +182,10 @@ PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 	const dsa_pointer node_dsa = dsa_allocate(dsa, sizeof(*node));
 
 	if (!DsaPointerIsValid(node_dsa))
-	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OUT_OF_MEMORY),
 				 errmsg("Not enough memory to add pending delete node. "
 				   "MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
-	}
 
 	node = dsa_get_address(dsa, node_dsa);
 	*node = (PendingDeleteListNode)

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -83,7 +83,7 @@ PdlShmemInit(void)
 	if (!is_tracking_enabled())
 		return;
 
-	bool		found;
+	bool found;
 	BackendsPendingDeletes = (BackendsPendingDeletesArray *)
 		ShmemInitStruct("Pending deletes array", 
 			add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
@@ -96,14 +96,14 @@ PdlShmemInit(void)
 	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
 	for (int i = 0; i < MaxBackends; i++)
 	{
-		BackendsPendingDeletes->list[i] = (PendingDeletesList){
+		BackendsPendingDeletes->list[i] = (PendingDeletesList) {
 			.head = InvalidDsaPointer,
 			.count = 0,
 			.lock = LWLockAssign()
 		};
 	}
 
-	dsa_area   *dsa = dsa_create_in_place(
+	dsa_area *dsa = dsa_create_in_place(
 		BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
 		LWLockNewTrancheId(), "storage_pending_dsa", NULL);
 	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
@@ -146,14 +146,16 @@ PdlAttachDsa(void)
 	 * attach/detach at every add/remove
 	 */
 	MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-	pendingDeletesDsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem, NULL);
+	pendingDeletesDsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem,
+											NULL);
 	MemoryContextSwitchTo(oldcxt);
 
 	/* pin mappings, so they can survive res owner life end */
 	dsa_pin_mapping(pendingDeletesDsa);
 
 	/* disconnect from dsa on shmem exit */
-	on_shmem_exit(dsa_on_shmem_exit_release_in_place, (Datum) BackendsPendingDeletes->dsa_mem);
+	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
+		(Datum) BackendsPendingDeletes->dsa_mem);
 	on_shmem_exit(pdl_beshutdown_hook, 0);
 }
 
@@ -164,16 +166,17 @@ PdlAttachDsa(void)
 dsa_pointer
 PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
 {
-	if (!is_tracking_enabled() || xid == InvalidTransactionId)
+	if (!is_tracking_enabled() || xid == InvalidTransactionId ||
+		MyBackendId == InvalidBackendId)
 		return InvalidDsaPointer;
 
 	PdlAttachDsa();
 
 	PendingDeleteListNode *node;
 	dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
-											sizeof(*node));
+										sizeof(*node));
 	node = dsa_get_address(pendingDeletesDsa, node_dsa);
-	*node = (PendingDeleteListNode) {
+	*node = (PendingDeleteListNode)	{
 		.xrelnode = {
 			.relnode = *relnode,
 			.xid = xid
@@ -195,4 +198,41 @@ PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
 	LWLockRelease(list->lock);
 	
 	return node_dsa;
+}
+
+/*
+ * Fast remove pending delete node from shmem.
+ * node_ptr is a ptr to already added node.
+ */
+void
+PdlShmemRemove(dsa_pointer node_ptr)
+{
+	if (!is_tracking_enabled() || MyBackendId == InvalidBackendId)
+		return;
+
+	Assert(DsaPointerIsValid(node_ptr));
+
+	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+	PendingDeleteListNode *node = dsa_get_address(pendingDeletesDsa, node_ptr);
+
+	LWLockAcquire(list->lock, LW_EXCLUSIVE);
+	if (DsaPointerIsValid(node->next))
+	{
+		PendingDeleteListNode *next_node = dsa_get_address(pendingDeletesDsa, node->next);
+		next_node->prev = node->prev;
+	}
+
+	if (DsaPointerIsValid(node->prev))
+	{
+		PendingDeleteListNode *prev_node = dsa_get_address(pendingDeletesDsa, node->prev);
+		prev_node->next = node->next;
+	}
+	else
+		list->head = node->next;
+
+	list->count--;
+	LWLockRelease(list->lock);
+
+
+	dsa_free(pendingDeletesDsa, node_ptr);
 }

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -244,7 +244,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
  * Note: the returned result is palloc'ed. Caller is responsible for
  * freeing it.
  */
-PendingRelXactDeleteArra *
+PendingRelXactDeleteArray *
 PdlXLogShmemDump(void)
 {
 	PdlAttachDsa();

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -28,9 +28,8 @@ typedef struct PendingDeleteListNode
 
 typedef struct PendingDeletesList 
 {
-	LWLock *lock; /* protects the fields below */
-	dsa_pointer head; /* ptr to list head of PendingDeleteListNode */
-	Size count; /* count of PendingDeleteListNode nodes */
+	LWLock *lock; /* protects the list */
+	dsa_pointer head; /* ptr to PendingDeleteListNode list head */
 } PendingDeletesList;
 
 typedef struct BackendsPendingDeletesArray
@@ -52,47 +51,37 @@ static inline bool is_tracking_enabled()
 static void PdlAttachDsa(void);
 
 PendingRelXactDeleteArray *
-PdlXLogShmemDump(Size *size)
+PdlXLogShmemDump(void)
 {
 	PdlAttachDsa();
 
 	PendingRelXactDeleteArray *ret = NULL;
 
-	*size = offsetof(PendingRelXactDeleteArray, array);
+	Size size = offsetof(PendingRelXactDeleteArray, array);
 	for (int i = 0; i < MaxBackends; i++)
 	{
 		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
 
 		LWLockAcquire(list->lock, LW_SHARED);
 
-		if (list->count > 0 && DsaPointerIsValid(list->head))
+		for (dsa_pointer pdl_node_dsa = list->head; DsaPointerIsValid(pdl_node_dsa);)
 		{
-			*size += sizeof(*ret->array) * list->count;
+			PendingDeleteListNode *pdl_node = dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
+
+			size += sizeof(*ret->array);
 			if (ret != NULL)
-				ret = repalloc(ret, *size);
+				ret = repalloc(ret, size);
 			else
 			{
-				ret = palloc(*size);
+				ret = palloc(size);
 				ret->count = 0;
 			}
-			
 
-			for (dsa_pointer pdl_node_dsa = list->head; DsaPointerIsValid(pdl_node_dsa);)
-			{
-				PendingDeleteListNode *pdl_node = dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
-
-				ret->array[ret->count++] = pdl_node->xrelnode;
-				pdl_node_dsa = pdl_node->next;
-			}
+			ret->array[ret->count++] = pdl_node->xrelnode;
+			pdl_node_dsa = pdl_node->next;
 		}
 
 		LWLockRelease(list->lock);
-	}
-
-	if (ret == NULL)
-	{
-		*size = 0;
-		return NULL;
 	}
 
 	return ret;
@@ -134,7 +123,6 @@ PdlShmemInit(void)
 	{
 		BackendsPendingDeletes->list[i] = (PendingDeletesList) {
 			.head = InvalidDsaPointer,
-			.count = 0,
 			.lock = LWLockAssign()
 		};
 	}
@@ -155,7 +143,7 @@ pdl_beshutdown_hook(int code, Datum arg)
 		return;
 
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
-	if (list->head == InvalidDsaPointer && list->count == 0)
+	if (list->head == InvalidDsaPointer)
 		return;
 
 	/* Assert on debug build and warning on release */
@@ -166,7 +154,6 @@ pdl_beshutdown_hook(int code, Datum arg)
 				"MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
 
 	list->head = InvalidDsaPointer;
-	list->count = 0;
 }
 /*
  * Attach dsa once per process.
@@ -230,7 +217,6 @@ PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid)
 		next_node->prev = node_dsa;
 	}
 	list->head = node_dsa;
-	list->count++;
 	LWLockRelease(list->lock);
 	
 	return node_dsa;
@@ -266,7 +252,6 @@ PdlShmemRemove(dsa_pointer node_ptr)
 	else
 		list->head = node->next;
 
-	list->count--;
 	LWLockRelease(list->lock);
 
 

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -24,29 +24,30 @@ typedef struct PendingDeleteListNode
 	PendingRelXactDelete xrelnode;
 	dsa_pointer next;
 	dsa_pointer prev;
-} PendingDeleteListNode;
+}	PendingDeleteListNode;
 
-typedef struct PendingDeletesList 
+typedef struct PendingDeletesList
 {
-	LWLock *lock; /* protects the list */
-	dsa_pointer head; /* ptr to PendingDeleteListNode list head */
-} PendingDeletesList;
+	LWLock	   *lock;			/* protects the list */
+	dsa_pointer head;			/* ptr to PendingDeleteListNode list head */
+}	PendingDeletesList;
 
 typedef struct BackendsPendingDeletesArray
 {
-	PendingDeletesList 	*list;
-	char				dsa_mem[FLEXIBLE_ARRAY_MEMBER];
-} BackendsPendingDeletesArray;
+	PendingDeletesList *list;
+	char		dsa_mem[FLEXIBLE_ARRAY_MEMBER];
+}	BackendsPendingDeletesArray;
 
 static BackendsPendingDeletesArray *BackendsPendingDeletes = NULL;
-static dsa_area *pendingDeletesDsa = NULL;	/* ptr to DSA area attached by
-											 * current process */
+static dsa_area *pendingDeletesDsa = NULL;		/* ptr to DSA area attached by
+												 * current process */
 
-static inline bool is_tracking_enabled()
+static inline bool
+is_tracking_enabled()
 {
 	return !IsBootstrapProcessingMode() &&
-		   gp_track_pending_delete &&
-		   dynamic_shared_memory_type != DSM_IMPL_NONE;
+		gp_track_pending_delete &&
+		dynamic_shared_memory_type != DSM_IMPL_NONE;
 }
 
 /*
@@ -59,8 +60,9 @@ PdlShmemSize(void)
 	if (!gp_track_pending_delete)
 		return 0;
 
-	Size size = add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
-						 dsa_minimum_size());
+	Size		size = add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
+								dsa_minimum_size());
+
 	return add_size(size, mul_size(sizeof(PendingDeletesList), MaxBackends));
 }
 
@@ -71,30 +73,34 @@ PdlShmemInit(void)
 	if (!is_tracking_enabled())
 		return;
 
-	bool found;
+	bool		found;
+
 	BackendsPendingDeletes = (BackendsPendingDeletesArray *)
-		ShmemInitStruct("Pending deletes array", 
-			add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
-					 dsa_minimum_size()),
-			&found);
+		ShmemInitStruct("Pending deletes array",
+						add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
+								 dsa_minimum_size()),
+						&found);
 	if (found)
 		return;
 
-	const Size pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
+	const Size	pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
+
 	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
 	for (int i = 0; i < MaxBackends; i++)
 	{
-		BackendsPendingDeletes->list[i] = (PendingDeletesList) {
+		BackendsPendingDeletes->list[i] = (PendingDeletesList)
+		{
 			.head = InvalidDsaPointer,
 			.lock = LWLockAssign()
 		};
 	}
 
-	dsa_area *dsa = dsa_create_in_place(
-		BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
-		LWLockNewTrancheId(), "storage_pending_deletes", NULL);
+	dsa_area   *dsa = dsa_create_in_place(
+						 BackendsPendingDeletes->dsa_mem, dsa_minimum_size(),
+						 LWLockNewTrancheId(), "storage_pending_deletes", NULL);
+
 	on_shmem_exit(dsa_on_shmem_exit_release_in_place,
-		(Datum) BackendsPendingDeletes->dsa_mem);
+				  (Datum) BackendsPendingDeletes->dsa_mem);
 	dsa_detach(dsa);
 }
 
@@ -111,15 +117,16 @@ pdl_beshutdown_hook(int code, Datum arg)
 		return;
 
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+
 	if (!DsaPointerIsValid(list->head))
 		return;
 
 	/* Assert on debug build and warning on release */
 	Assert(false);
 	ereport(WARNING,
-		(errcode(ERRCODE_INTERNAL_ERROR),
-		 errmsg("Pending deletes list is not empty. "
-				"MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
+			(errcode(ERRCODE_INTERNAL_ERROR),
+			 errmsg("Pending deletes list is not empty. "
+					"MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
 	list->head = InvalidDsaPointer;
 }
 
@@ -135,6 +142,7 @@ PdlAttachDsa(void)
 	 * attach/detach at every add/remove
 	 */
 	MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
 	pendingDeletesDsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem,
 											NULL);
 	MemoryContextSwitchTo(oldcxt);
@@ -150,7 +158,7 @@ PdlAttachDsa(void)
  * Return DSA ptr of a created node. This ptr can be passed to PdlShmemRemove.
  */
 dsa_pointer
-PdlShmemAdd(const RelFileNodePendingDelete *relnode, TransactionId xid)
+PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 {
 	if (!is_tracking_enabled() || xid == InvalidTransactionId ||
 		MyBackendId == InvalidBackendId)
@@ -161,27 +169,32 @@ PdlShmemAdd(const RelFileNodePendingDelete *relnode, TransactionId xid)
 	PendingDeleteListNode *node;
 	const dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
 											  sizeof(*node));
+
 	node = dsa_get_address(pendingDeletesDsa, node_dsa);
-	*node = (PendingDeleteListNode)	{
-		.xrelnode = {
+	*node = (PendingDeleteListNode)
+	{
+		.xrelnode =
+		{
 			.relnode = *relnode,
 			.xid = xid
 		},
 		.prev = InvalidDsaPointer
 	};
-	
+
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
+
 	LWLockAcquire(list->lock, LW_EXCLUSIVE);
 	node->next = list->head;
 	if (DsaPointerIsValid(node->next))
 	{
 		PendingDeleteListNode *next_node = (PendingDeleteListNode *)
 			dsa_get_address(pendingDeletesDsa, node->next);
+
 		next_node->prev = node_dsa;
 	}
 	list->head = node_dsa;
 	LWLockRelease(list->lock);
-	
+
 	return node_dsa;
 }
 
@@ -206,6 +219,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
 	{
 		PendingDeleteListNode *next_node = dsa_get_address(pendingDeletesDsa,
 														   node->next);
+
 		next_node->prev = node->prev;
 	}
 
@@ -213,6 +227,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
 	{
 		PendingDeleteListNode *prev_node = dsa_get_address(pendingDeletesDsa,
 														   node->prev);
+
 		prev_node->next = node->next;
 	}
 	else
@@ -224,8 +239,10 @@ PdlShmemRemove(dsa_pointer node_ptr)
 }
 
 /*
- * Dump pending delete nodes from all backends to array.
- * Return NULL if there are no nodes.
+ * Collect info about pending deletes from all backends and return
+ * the accumulated result. Return NULL if there are no nodes in the lists.
+ * Note: the returned result is palloc'ed. Caller is responsible for
+ * freeing it.
  */
 PendingRelXactDeleteArray *
 PdlXLogShmemDump(void)
@@ -234,7 +251,8 @@ PdlXLogShmemDump(void)
 
 	PendingRelXactDeleteArray *ret = NULL;
 
-	Size size = offsetof(PendingRelXactDeleteArray, array);
+	Size		size = offsetof(PendingRelXactDeleteArray, array);
+
 	for (int i = 0; i < MaxBackends; i++)
 	{
 		PendingDeletesList *list = &BackendsPendingDeletes->list[i];
@@ -244,7 +262,7 @@ PdlXLogShmemDump(void)
 		for (dsa_pointer pdl_node_dsa = list->head;
 			 DsaPointerIsValid(pdl_node_dsa);)
 		{
-			const PendingDeleteListNode *pdl_node = 
+			const PendingDeleteListNode *pdl_node =
 				dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
 
 			size += sizeof(*ret->array);

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -244,7 +244,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
  * Note: the returned result is palloc'ed. Caller is responsible for
  * freeing it.
  */
-PendingRelXactDeleteArray *
+PendingRelXactDeleteArra *
 PdlXLogShmemDump(void)
 {
 	PdlAttachDsa();

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -48,6 +48,21 @@ is_tracking_enabled()
 		dynamic_shared_memory_type != DSM_IMPL_NONE;
 }
 
+/* Memory required for the BackendsPendingDeletesArray structure */
+static inline Size
+PdlStructSize(void)
+{
+	return add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
+					dsa_minimum_size());
+}
+
+/* Memory required for array of PendingDeletesList-s */
+static inline Size
+PdlListArraySize(void)
+{
+	return mul_size(sizeof(PendingDeletesList), MaxBackends);
+}
+
 /*
  * Calculate shmem size for pending deletes.
  * BackendsPendingDeletesArray.dsa_mem should fit DSA.
@@ -58,10 +73,7 @@ PdlShmemSize(void)
 	if (!gp_track_pending_delete)
 		return 0;
 
-	Size		size = add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
-								dsa_minimum_size());
-
-	return add_size(size, mul_size(sizeof(PendingDeletesList), MaxBackends));
+	return add_size(PdlStructSize(), PdlListArraySize());
 }
 
 /* Initialize shared memory pending delete lists for all backends */
@@ -74,16 +86,12 @@ PdlShmemInit(void)
 	bool		found;
 
 	BackendsPendingDeletes = (BackendsPendingDeletesArray *)
-		ShmemInitStruct("Pending deletes array",
-						add_size(offsetof(BackendsPendingDeletesArray, dsa_mem),
-								 dsa_minimum_size()),
-						&found);
+		ShmemInitStruct("Pending deletes array", PdlStructSize(), &found);
 	if (found)
 		return;
 
-	const Size	pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
-
-	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
+	BackendsPendingDeletes->list = (PendingDeletesList *)
+		ShmemAlloc(PdlListArraySize());
 	if (BackendsPendingDeletes->list == NULL)
 	{
 		ereport(ERROR,

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -39,8 +39,6 @@ typedef struct BackendsPendingDeletesArray
 }	BackendsPendingDeletesArray;
 
 static BackendsPendingDeletesArray *BackendsPendingDeletes = NULL;
-static dsa_area *pendingDeletesDsa = NULL;		/* ptr to DSA area attached by
-												 * current process */
 
 static inline bool
 is_tracking_enabled()
@@ -131,11 +129,14 @@ pdl_beshutdown_hook(int code, Datum arg)
 }
 
 /* Attach DSA once per process. */
-static void
+static dsa_area *
 PdlAttachDsa(void)
 {
-	if (pendingDeletesDsa)
-		return;
+	static dsa_area *dsa = NULL;	/* ptr to DSA area attached by
+									 * current process */
+
+	if (dsa)
+		return dsa;
 
 	/*
 	 * Keep the DSA area ptr in TopMemoryContext to avoid excessive
@@ -143,14 +144,15 @@ PdlAttachDsa(void)
 	 */
 	MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
 
-	pendingDeletesDsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem,
-											NULL);
+	dsa = dsa_attach_in_place(BackendsPendingDeletes->dsa_mem, NULL);
 	MemoryContextSwitchTo(oldcxt);
 
 	/* pin mappings, so they can survive res owner life end */
-	dsa_pin_mapping(pendingDeletesDsa);
+	dsa_pin_mapping(dsa);
 
 	on_shmem_exit(pdl_beshutdown_hook, 0);
+
+	return dsa;
 }
 
 /*
@@ -164,21 +166,19 @@ PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 		MyBackendId == InvalidBackendId)
 		return InvalidDsaPointer;
 
-	PdlAttachDsa();
-
 	PendingDeleteListNode *node;
-	const dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
-											  sizeof(*node));
+	dsa_area   *dsa = PdlAttachDsa();
+	const dsa_pointer node_dsa = dsa_allocate(dsa, sizeof(*node));
 
 	if (!DsaPointerIsValid(node_dsa))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OUT_OF_MEMORY),
-				errmsg("Not enough memory to add pending delete node. "
-					   "MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
+				 errmsg("Not enough memory to add pending delete node. "
+				   "MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
 	}
 
-	node = dsa_get_address(pendingDeletesDsa, node_dsa);
+	node = dsa_get_address(dsa, node_dsa);
 	*node = (PendingDeleteListNode)
 	{
 		.xrelnode =
@@ -196,7 +196,7 @@ PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 	if (DsaPointerIsValid(node->next))
 	{
 		PendingDeleteListNode *next_node = (PendingDeleteListNode *)
-			dsa_get_address(pendingDeletesDsa, node->next);
+			dsa_get_address(dsa, node->next);
 
 		next_node->prev = node_dsa;
 	}
@@ -218,23 +218,21 @@ PdlShmemRemove(dsa_pointer node_ptr)
 
 	Assert(DsaPointerIsValid(node_ptr));
 
+	dsa_area   *dsa = PdlAttachDsa();
 	PendingDeletesList *list = &BackendsPendingDeletes->list[MyBackendId];
-	const PendingDeleteListNode *node =
-		dsa_get_address(pendingDeletesDsa, node_ptr);
+	const PendingDeleteListNode *node = dsa_get_address(dsa, node_ptr);
 
 	LWLockAcquire(list->lock, LW_EXCLUSIVE);
 	if (DsaPointerIsValid(node->next))
 	{
-		PendingDeleteListNode *next_node = dsa_get_address(pendingDeletesDsa,
-														   node->next);
+		PendingDeleteListNode *next_node = dsa_get_address(dsa, node->next);
 
 		next_node->prev = node->prev;
 	}
 
 	if (DsaPointerIsValid(node->prev))
 	{
-		PendingDeleteListNode *prev_node = dsa_get_address(pendingDeletesDsa,
-														   node->prev);
+		PendingDeleteListNode *prev_node = dsa_get_address(dsa, node->prev);
 
 		prev_node->next = node->next;
 	}
@@ -243,7 +241,7 @@ PdlShmemRemove(dsa_pointer node_ptr)
 
 	LWLockRelease(list->lock);
 
-	dsa_free(pendingDeletesDsa, node_ptr);
+	dsa_free(dsa, node_ptr);
 }
 
 /*
@@ -255,10 +253,8 @@ PdlShmemRemove(dsa_pointer node_ptr)
 PendingRelXactDeleteArray *
 PdlXLogShmemDump(void)
 {
-	PdlAttachDsa();
-
+	dsa_area   *dsa = PdlAttachDsa();
 	PendingRelXactDeleteArray *ret = NULL;
-
 	Size		size = offsetof(PendingRelXactDeleteArray, array);
 
 	for (int i = 0; i < MaxBackends; i++)
@@ -270,8 +266,8 @@ PdlXLogShmemDump(void)
 		for (dsa_pointer pdl_node_dsa = list->head;
 			 DsaPointerIsValid(pdl_node_dsa);)
 		{
-			const PendingDeleteListNode *pdl_node =
-				dsa_get_address(pendingDeletesDsa, pdl_node_dsa);
+			const PendingDeleteListNode *pdl_node = dsa_get_address(dsa,
+															   pdl_node_dsa);
 
 			size += sizeof(*ret->array);
 			if (ret != NULL)

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -84,6 +84,13 @@ PdlShmemInit(void)
 	const Size	pdl_size = mul_size(sizeof(PendingDeletesList), MaxBackends);
 
 	BackendsPendingDeletes->list = (PendingDeletesList *) ShmemAlloc(pdl_size);
+	if (BackendsPendingDeletes->list == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("Not enough memory to create pending deletes lists.")));
+	}
+	
 	for (int i = 0; i < MaxBackends; i++)
 	{
 		BackendsPendingDeletes->list[i] = (PendingDeletesList)

--- a/src/backend/catalog/storage_pending_deletes.c
+++ b/src/backend/catalog/storage_pending_deletes.c
@@ -170,6 +170,14 @@ PdlShmemAdd(const RelFileNodePendingDelete * relnode, TransactionId xid)
 	const dsa_pointer node_dsa = dsa_allocate(pendingDeletesDsa,
 											  sizeof(*node));
 
+	if (!DsaPointerIsValid(node_dsa))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				errmsg("Not enough memory to add pending delete node. "
+					   "MyBackend: %d, MyProcPid: %d", MyBackendId, MyProcPid)));
+	}
+
 	node = dsa_get_address(pendingDeletesDsa, node_dsa);
 	*node = (PendingDeleteListNode)
 	{

--- a/src/backend/catalog/storage_pending_deletes_redo.c
+++ b/src/backend/catalog/storage_pending_deletes_redo.c
@@ -59,8 +59,7 @@ PdlXLogInsert()
 		{
 			.buffer = InvalidBuffer,
 			.data = (char *) arr,
-			.len = offsetof(PendingRelXactDeleteArray, array) + 
-				   sizeof(*arr->array) * arr->count,
+			.len = PdlDumpSize(arr->count),
 			.next = NULL,
 			.buffer_std = false
 		};

--- a/src/backend/catalog/storage_pending_deletes_redo.c
+++ b/src/backend/catalog/storage_pending_deletes_redo.c
@@ -47,21 +47,20 @@ PdlTrackingDisabled()
 void
 PdlXLogInsert()
 {
-	Size		size = 0;
-
 	if (PdlTrackingDisabled())
 		return;
 
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump(&size);
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
 
-	if (size > 0 && arr != NULL)
+	if (arr != NULL)
 	{
 		XLogRecPtr	rec;
 		XLogRecData rdata =
 		{
 			.buffer = InvalidBuffer,
 			.data = (char *) arr,
-			.len = size,
+			.len = offsetof(PendingRelXactDeleteArray, array) + 
+				   sizeof(*arr->array) * arr->count,
 			.next = NULL,
 			.buffer_std = false
 		};

--- a/src/backend/catalog/test/Makefile
+++ b/src/backend/catalog/test/Makefile
@@ -6,6 +6,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/src/Makefile.mock
 
 TARGETS += storage_tablespace
+TARGETS += storage_pending_deletes
 TARGETS += storage_pending_deletes_redo
 
 include $(top_builddir)/src/backend/mock.mk
@@ -16,6 +17,9 @@ storage_tablespace.t: $(top_srcdir)/src/backend/catalog/storage_tablespace.o
 		$(top_srcdir)/src/backend/catalog/storage_tablespace.o \
 		storage_tablespace_test.c \
 		-o storage_tablespace.t
+
+storage_pending_deletes.t: \
+	$(top_builddir)/src/backend/catalog/storage_pending_deletes.o
 
 storage_pending_deletes_redo.t: \
 	$(top_builddir)/src/backend/catalog/storage_pending_deletes_redo.o \

--- a/src/backend/catalog/test/storage_pending_deletes_redo_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_redo_test.c
@@ -270,8 +270,7 @@ __wrap_PdlXLogShmemDump(void)
 	/* return something valid */
 	int			node_count = 1;
 
-	char	   *buffer = palloc(offsetof(PendingRelXactDeleteArray, array) +
-								sizeof(PendingRelXactDelete) * node_count);
+	char	   *buffer = palloc(PdlDumpSize(node_count));
 
 	PendingRelXactDeleteArray *pending_deletes =
 		(PendingRelXactDeleteArray *) buffer;

--- a/src/backend/catalog/test/storage_pending_deletes_redo_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_redo_test.c
@@ -44,7 +44,7 @@ XidStatus
 __wrap_TransactionIdGetStatus(TransactionId xid, XLogRecPtr *lsn);
 
 PendingRelXactDeleteArray *
-__wrap_PdlXLogShmemDump(Size *size);
+__wrap_PdlXLogShmemDump(void);
 
 XLogRecPtr
 __wrap_XLogInsert(RmgrId rmid, uint8 info, XLogRecData *rdata);
@@ -261,32 +261,17 @@ __wrap_TransactionIdGetStatus(TransactionId xid, XLogRecPtr *lsn)
 }
 
 PendingRelXactDeleteArray *
-__wrap_PdlXLogShmemDump(Size *size)
+__wrap_PdlXLogShmemDump(void)
 {
 	PdlXLogShmemDump_call_count++;
-	switch (test_number)
-	{
-		case 15:
-			{
-				/* return 0 size, and the returned pointer points to some junk */
-				*size = 0;
-				return (PendingRelXactDeleteArray *) 0xFFFFFFFF;
-			}
-		case 16:
-			{
-				/* return not 0 size, but the returned pointer is NULL */
-				*size = 1;
-				return NULL;
-			}
-		default:
-			break;
-	}
+	if (test_number == 16)
+		return NULL;
 
 	/* return something valid */
 	int			node_count = 1;
 
-	*size = sizeof(Size) + sizeof(PendingRelXactDelete) * (node_count);
-	char	   *buffer = palloc(*size);
+	char	   *buffer = palloc(offsetof(PendingRelXactDeleteArray, array) +
+								sizeof(PendingRelXactDelete) * node_count);
 
 	PendingRelXactDeleteArray *pending_deletes =
 		(PendingRelXactDeleteArray *) buffer;
@@ -959,23 +944,7 @@ test_14(void **state)
 
 /*
  * Scenario:
- * check PdlXlogInsert() if PdlXLogShmemDump provided 0 nodes.
- */
-static void
-test_15(void **state)
-{
-	setup(15);
-
-	PdlXLogInsert();
-
-	assert_int_equal(PdlXLogShmemDump_call_count, 1);
-	assert_int_equal(XLogInsert_call_count, 0);
-}
-
-/*
- * Scenario:
- * check PdlXlogInsert() if PdlXLogShmemDump provided not 0 nodes, but returned
- * pointer is NULL.
+ * check PdlXlogInsert() if PdlXLogShmemDump returned NULL.
  */
 static void
 test_16(void **state)
@@ -1123,7 +1092,6 @@ main(int argc, char *argv[])
 		unit_test(test_12),
 		unit_test(test_13),
 		unit_test(test_14),
-		unit_test(test_15),
 		unit_test(test_16),
 		unit_test(test_17),
 		unit_test(test_18),

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -52,11 +52,10 @@ cmp_pdl(const void *p1, const void *p2)
 	return memcmp(p1, p2, sizeof(PendingRelXactDelete));
 }
 
-/* Check and clean up when PdlXLogShmemDump returns not NULL */
+/* Check if PdlXLogShmemDump returns expected array */
 static void 
-check_and_clean(PendingRelXactDeleteArray *arr,
-				PendingRelXactDelete *expected, Size expectedCnt,
-				dsa_pointer *p, Size pCnt)
+check_array(PendingRelXactDeleteArray *arr,
+			PendingRelXactDelete *expected, Size expectedCnt)
 {
 	assert_true(arr != NULL);
 
@@ -66,9 +65,12 @@ check_and_clean(PendingRelXactDeleteArray *arr,
 	qsort (expected,   expectedCnt, sizeof(*expected), cmp_pdl);
 	qsort (arr->array, expectedCnt, sizeof(*expected), cmp_pdl);
 	assert_memory_equal(arr->array, expected, expectedCnt*sizeof(*expected));
+}
 
-	/* Clean up */
-	pfree(arr);
+/* Remove nodes received in the p array from backends lists */
+static void 
+clean_lists(dsa_pointer *p, Size pCnt)
+{
 	for (int i = 0; i < pCnt; i++)
 		PdlShmemRemove(p[i]);
 
@@ -78,10 +80,12 @@ check_and_clean(PendingRelXactDeleteArray *arr,
 
 /* Call PdlXLogShmemDump(), check its result and clean up */
 static void 
-dump_and_clean(PendingRelXactDelete *expected, Size expectedCnt,
-			   dsa_pointer *p, Size pCnt)
+check_dump(PendingRelXactDelete *expected, Size expectedCnt)
 {
-	check_and_clean(PdlXLogShmemDump(), expected, expectedCnt, p, pCnt);
+	PendingRelXactDeleteArray   *arr = PdlXLogShmemDump();
+
+	check_array(arr, expected, expectedCnt);
+	pfree(arr);
 }
 
 
@@ -115,7 +119,8 @@ test_1(void **state)
 		.xid = TEST_XID1
 	};
 
-	dump_and_clean(&expected, 1, &p, 1);
+	check_dump(&expected, 1);
+	clean_lists(&p, 1);
 }
 
 /* Add nodes, remove the first one, add a node */
@@ -170,7 +175,8 @@ test_remove_fisrt(void **state)
 		},
 	};
 
-	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	check_dump(expected, ARRAY_SIZE(expected));
+	clean_lists(p, ARRAY_SIZE(p));
 }
 
 /* Add nodes, remove a node from the middle, add a node */
@@ -225,7 +231,8 @@ test_remove_middle(void **state)
 		},
 	};
 
-	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	check_dump(expected, ARRAY_SIZE(expected));
+	clean_lists(p, ARRAY_SIZE(p));
 }
 
 /* Add nodes, remove the last one, add a node */
@@ -280,7 +287,8 @@ test_remove_last(void **state)
 		},
 	};
 
-	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	check_dump(expected, ARRAY_SIZE(expected));
+	clean_lists(p, ARRAY_SIZE(p));
 }
 
 /* Add node with invalid transaction id */
@@ -465,7 +473,7 @@ test_2_backends(void **state)
 	/* 
 	 * Clean up.
 	 * Elements which were added for backend 3 should be removed
-	 * when MyBackendId is 3. Other elements are removed in check_and_clean
+	 * when MyBackendId is 3. Other elements are removed in clean_lists
 	 * after restoring MyBackendId.
 	 */
 	PdlShmemRemove(p[3]);
@@ -473,7 +481,43 @@ test_2_backends(void **state)
 
 	MyBackendId = old;
 
-	check_and_clean(arr, expected, ARRAY_SIZE(expected), p, 3);
+	check_array(arr, expected, ARRAY_SIZE(expected));
+	pfree(arr);
+
+	clean_lists(p, 3);
+}
+
+/* Add nodes to use repalloc twice in PdlXLogShmemDump() */
+static void
+test_repalloc(void **state)
+{
+	RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p[100]; /* 100 > 32 + 64 */
+	PendingRelXactDelete expected[ARRAY_SIZE(p)];
+	
+	for(int i = 0; i < ARRAY_SIZE(p); i++)
+	{
+		relnode.node.spcNode += i;
+		relnode.node.dbNode  += i;
+		relnode.node.relNode += i;
+
+		p[i] = PdlShmemAdd(&relnode, TEST_XID1 + i);
+
+		expected[i].relnode = relnode;
+		expected[i].xid = TEST_XID1 + i;
+	}
+
+	check_dump(expected, ARRAY_SIZE(expected));
+	clean_lists(p, ARRAY_SIZE(p));
 }
 
 int
@@ -492,7 +536,8 @@ main(int argc, char *argv[])
 		unit_test(test_invalid_mode),
 		unit_test(test_tracking_disabled),
 		unit_test(test_shmem_type),
-		unit_test(test_2_backends)
+		unit_test(test_2_backends),
+		unit_test(test_repalloc)
 	};
 
 	MemoryContextInit();

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -74,7 +74,7 @@ test_1(void **state)
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode, &relnode, sizeof(relnode));
 
-/* clean up */
+	/* clean up */
 	pfree(arr);
 	PdlShmemRemove(p);
 }
@@ -140,7 +140,7 @@ test_remove_fisrt(void **state)
 						}),
 						sizeof(RelFileNodePendingDelete));
 
-/* clean up */
+	/* clean up */
 	pfree(arr);
 	for (int i = 1; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
@@ -209,7 +209,7 @@ test_remove_middle(void **state)
 						}),
 						sizeof(RelFileNodePendingDelete));
 
-/* clean up */
+	/* clean up */
 	pfree(arr);
 	for (int i = 0; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
@@ -277,7 +277,7 @@ test_remove_last(void **state)
 						}),
 						sizeof(RelFileNodePendingDelete));
 
-/* clean up */
+	/* clean up */
 	pfree(arr);
 	for (int i = 0; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
@@ -323,7 +323,7 @@ test_invalid_backend(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-/* clean up */
+	/* clean up */
 	MyBackendId = old;
 }
 
@@ -348,7 +348,7 @@ test_invalid_mode(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-/* clean up */
+	/* clean up */
 	Mode = old;
 }
 
@@ -373,7 +373,7 @@ test_tracking_disabled(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-/* clean up */
+	/* clean up */
 	gp_track_pending_delete = old;
 }
 
@@ -398,7 +398,7 @@ test_shmem_type(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-/* clean up */
+	/* clean up */
 	dynamic_shared_memory_type = old;
 }
 
@@ -472,7 +472,7 @@ test_2_backends(void **state)
 						}),
 						sizeof(RelFileNodePendingDelete));
 
-/* clean up */
+	/* clean up */
 	MyBackendId = old;
 	pfree(arr);
 	for (int i = 0; i < ARRAY_SIZE(p); i++)

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -76,6 +76,14 @@ check_and_clean(PendingRelXactDeleteArray *arr,
 	assert_true(PdlXLogShmemDump() == NULL);
 }
 
+/* Call PdlXLogShmemDump(), check its result and clean up */
+static void 
+dump_and_clean(PendingRelXactDelete *expected, Size expectedCnt,
+			   dsa_pointer *p, Size pCnt)
+{
+	check_and_clean(PdlXLogShmemDump(), expected, expectedCnt, p, pCnt);
+}
+
 
 /* Dump without additions */
 static void
@@ -107,7 +115,7 @@ test_1(void **state)
 		.xid = TEST_XID1
 	};
 
-	check_and_clean(PdlXLogShmemDump(), &expected, 1, &p, 1);
+	dump_and_clean(&expected, 1, &p, 1);
 }
 
 /* Add nodes and remove the first one before dump */
@@ -162,8 +170,7 @@ test_remove_fisrt(void **state)
 		},
 	};
 
-	check_and_clean(PdlXLogShmemDump(),
-					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add nodes and remove a node from the middle before dump */
@@ -218,8 +225,7 @@ test_remove_middle(void **state)
 		},
 	};
 
-	check_and_clean(PdlXLogShmemDump(),
-					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add nodes and remove the last one before dump */
@@ -274,8 +280,7 @@ test_remove_last(void **state)
 		},
 	};
 
-	check_and_clean(PdlXLogShmemDump(),
-					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
+	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add node with invalid transaction id */

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -118,7 +118,7 @@ test_1(void **state)
 	dump_and_clean(&expected, 1, &p, 1);
 }
 
-/* Add nodes and remove the first one before dump */
+/* Add nodes, remove the first one, add a node */
 static void
 test_remove_fisrt(void **state)
 {
@@ -145,10 +145,10 @@ test_remove_fisrt(void **state)
 	relnode.node.relNode = TEST_REL_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID1);
 
+	PdlShmemRemove(p_first);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID1;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
-
-	PdlShmemRemove(p_first);
 
 	PendingRelXactDelete expected[] = 
 	{
@@ -173,7 +173,7 @@ test_remove_fisrt(void **state)
 	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
-/* Add nodes and remove a node from the middle before dump */
+/* Add nodes, remove a node from the middle, add a node */
 static void
 test_remove_middle(void **state)
 {
@@ -200,27 +200,27 @@ test_remove_middle(void **state)
 	relnode.node.relNode = TEST_REL_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
 
+	PdlShmemRemove(p_middle);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID1;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
-
-	PdlShmemRemove(p_middle);
 
 	PendingRelXactDelete expected[] = 
 	{
 		{
-			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
 			.xid = TEST_XID1
-		},
-		{
-			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
-			.xid = TEST_XID3
 		},
 		{
 			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
 			.xid = TEST_XID2
 		},
 		{
-			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
 			.xid = TEST_XID1
 		},
 	};
@@ -228,7 +228,7 @@ test_remove_middle(void **state)
 	dump_and_clean(expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
-/* Add nodes and remove the last one before dump */
+/* Add nodes, remove the last one, add a node */
 static void
 test_remove_last(void **state)
 {
@@ -253,29 +253,29 @@ test_remove_last(void **state)
 	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
 
 	relnode.node.relNode = TEST_REL_OID2;
-	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
-
-	relnode.node.relNode = TEST_REL_OID1;
 	dsa_pointer p_last = PdlShmemAdd(&relnode, TEST_XID1);
 
 	PdlShmemRemove(p_last);
 
+	relnode.node.dbNode = TEST_DB_OID1;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
+
 	PendingRelXactDelete expected[] = 
 	{
 		{
-			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
 			.xid = TEST_XID1
-		},
-		{
-			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
-			.xid = TEST_XID3
 		},
 		{
 			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
 			.xid = TEST_XID2
 		},
 		{
-			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
+			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID2}},
 			.xid = TEST_XID1
 		},
 	};
@@ -439,7 +439,7 @@ test_2_backends(void **state)
 	PendingRelXactDelete expected[] = 
 	{
 		{
-			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
 			.xid = TEST_XID1
 		},
 		{
@@ -447,16 +447,16 @@ test_2_backends(void **state)
 			.xid = TEST_XID2
 		},
 		{
-			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
 			.xid = TEST_XID1
-		},
-		{
-			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
-			.xid = TEST_XID4
 		},
 		{
 			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
 			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID4
 		},
 	};
 

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -1,0 +1,349 @@
+/*-------------------------------------------------------------------------
+ *
+ * storage_pending_deletes_test.c
+ *	  code to test functionality from storage_pending_deletes.c
+ *
+ * Copyright (c) 2025 Greengage Community
+ *
+ *	  src/backend/catalog/test/storage_pending_deletes_test.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "postgres.h"
+
+#include "access/clog.h"
+#include "access/transam.h"
+#include "catalog/storage_pending_deletes.h"
+#include "storage/pg_shmem.h"
+#include "storage/proc.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+
+#define TEST_TABLESPACE_OID1	11111
+#define TEST_TABLESPACE_OID2	11112
+
+#define TEST_DB_OID1			11121
+#define TEST_DB_OID2			11122
+
+#define TEST_REL_OID1			11211
+#define TEST_REL_OID2			11212
+
+#define TEST_XID 10
+
+
+
+/*
+ * Tests
+ */
+
+/*
+ * Dump without additions
+ */
+static void
+test_empty(void **state)
+{
+	assert_true(PdlXLogShmemDump() == NULL);
+}
+
+/*
+  * Add single pending delete node
+ */
+static void
+test_1(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p = PdlShmemAdd(&relnode, TEST_XID);
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+
+	assert_true(arr != NULL);
+	assert_int_equal(arr->count, 1);
+	assert_int_equal(arr->array[0].xid, TEST_XID);
+	assert_memory_equal(&arr->array[0].relnode, &relnode, sizeof(relnode));
+	
+/* clean up */
+	pfree(arr);
+	PdlShmemRemove(p);
+}
+
+/*
+  * Add nodes and remove the first one before dump
+ */
+static void
+test_remove_fisrt(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p[5];
+	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	relnode.node.spcNode = TEST_TABLESPACE_OID2;
+	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	relnode.node.dbNode = TEST_DB_OID2;
+	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
+	relnode.node.relNode = TEST_REL_OID2;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID);
+	relnode.node.relNode = TEST_REL_OID1;
+	p[4] = PdlShmemAdd(&relnode, TEST_XID);
+
+	PdlShmemRemove(p[0]);
+
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	assert_true(arr != NULL);
+	assert_int_equal(arr->count, 4);
+	
+/* clean up */
+	for (int i = 1; i < ARRAY_SIZE(p); i++)
+		PdlShmemRemove(p[i]);
+}
+
+/*
+  * Add nodes and remove a node from the middle before dump
+ */
+static void
+test_remove_middle(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p[4];
+	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	relnode.node.spcNode = TEST_TABLESPACE_OID2;
+	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	
+	relnode.node.dbNode = TEST_DB_OID2;
+	dsa_pointer p_middle = PdlShmemAdd(&relnode, TEST_XID);
+
+	relnode.node.relNode = TEST_REL_OID2;
+	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
+	relnode.node.relNode = TEST_REL_OID1;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID);
+
+	PdlShmemRemove(p_middle);
+
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	assert_true(arr != NULL);
+	assert_int_equal(arr->count, 4);
+	
+/* clean up */
+	for (int i = 0; i < ARRAY_SIZE(p); i++)
+		PdlShmemRemove(p[i]);
+}
+
+/*
+  * Add nodes and remove the lastest one before dump
+ */
+static void
+test_remove_lastest(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p[4];
+	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	relnode.node.spcNode = TEST_TABLESPACE_OID2;
+	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	relnode.node.dbNode = TEST_DB_OID2;
+	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
+	relnode.node.relNode = TEST_REL_OID2;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID);
+
+	relnode.node.relNode = TEST_REL_OID1;
+	dsa_pointer p_lastest = PdlShmemAdd(&relnode, TEST_XID);
+	PdlShmemRemove(p_lastest);
+
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	assert_true(arr != NULL);
+	assert_int_equal(arr->count, 4);
+	
+/* clean up */
+	for (int i = 0; i < ARRAY_SIZE(p); i++)
+		PdlShmemRemove(p[i]);
+}
+
+/*
+  * Add node with invalid transaction id
+ */
+static void
+test_invalid_xid(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	assert_false(DsaPointerIsValid(
+					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_true(PdlXLogShmemDump() == NULL);
+}
+
+/*
+  * Add node when MyBackendId is invalid
+ */
+static void
+test_invalid_backend(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	BackendId old = MyBackendId;
+	MyBackendId = InvalidBackendId;
+
+	assert_false(DsaPointerIsValid(
+					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_true(PdlXLogShmemDump() == NULL);
+
+/* clean up */
+	MyBackendId = old;
+}
+
+
+/*
+  * Add node when Mode == BootstrapProcessing
+ */
+static void
+test_invalid_mode(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	ProcessingMode old = Mode;
+	Mode = BootstrapProcessing;
+
+	assert_false(DsaPointerIsValid(
+					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_true(PdlXLogShmemDump() == NULL);
+
+/* clean up */
+	Mode = old;
+}
+
+/*
+  * Add node when tracking is disabled
+ */
+static void
+test_tracking_disabled(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	bool old = gp_track_pending_delete;
+	gp_track_pending_delete = false;
+
+	assert_false(DsaPointerIsValid(
+					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_true(PdlXLogShmemDump() == NULL);
+
+/* clean up */
+	gp_track_pending_delete = old;
+}
+
+/*
+  * Add node when dynamic_shared_memory_type == DSM_IMPL_NONE
+ */
+static void
+test_shmem_type(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	int old = dynamic_shared_memory_type;
+	dynamic_shared_memory_type = DSM_IMPL_NONE;
+
+	assert_false(DsaPointerIsValid(
+					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_true(PdlXLogShmemDump() == NULL);
+
+/* clean up */
+	dynamic_shared_memory_type = old;
+}
+
+int
+main(int argc, char *argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+			unit_test(test_empty),
+			unit_test(test_1),
+			unit_test(test_remove_fisrt),
+			unit_test(test_remove_middle),
+			unit_test(test_remove_lastest),
+			unit_test(test_invalid_xid),
+			unit_test(test_invalid_backend),
+			unit_test(test_invalid_mode),
+			unit_test(test_tracking_disabled),
+			unit_test(test_shmem_type)
+	};
+
+	MemoryContextInit();
+
+	gp_track_pending_delete = true;
+	dynamic_shared_memory_type = DSM_IMPL_POSIX;
+	DataDir=".";
+	MaxBackends = 5;
+
+	PGShmemHeader *shim = NULL;
+	InitShmemAccess(PGSharedMemoryCreate(10000000, 5432, &shim));
+	InitShmemAllocation();
+	CreateLWLocks();
+	InitShmemIndex();
+	dsm_postmaster_startup(shim);
+
+	PdlShmemInit();
+
+	IsUnderPostmaster = true;
+	MyBackendId = 1;
+	PGPROC proc = { .backendId = MyBackendId };
+	MyProc = &proc;
+	return run_tests(tests);
+}

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -20,7 +20,8 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 
-enum {
+enum
+{
 	TEST_TABLESPACE_OID1 = 11111,
 	TEST_TABLESPACE_OID2 = 11112,
 
@@ -37,8 +38,11 @@ enum {
 };
 
 /* Don't try to read a non-existent postmaster.pid file */
-void __wrap_AddToDataDirLockFile(int target_line, const char *str);
-void __wrap_AddToDataDirLockFile(int target_line, const char *str){}
+void		__wrap_AddToDataDirLockFile(int target_line, const char *str);
+void
+__wrap_AddToDataDirLockFile(int target_line, const char *str)
+{
+}
 
 /* Dump without additions */
 static void
@@ -51,10 +55,12 @@ test_empty(void **state)
 static void
 test_1(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		},
 		.relstorage = RELSTORAGE_HEAP
@@ -67,7 +73,7 @@ test_1(void **state)
 	assert_int_equal(arr->count, 1);
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode, &relnode, sizeof(relnode));
-	
+
 /* clean up */
 	pfree(arr);
 	PdlShmemRemove(p);
@@ -77,8 +83,10 @@ test_1(void **state)
 static void
 test_remove_fisrt(void **state)
 {
-	RelFileNodePendingDelete relnode = {
-		.node = {
+	RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
@@ -86,6 +94,7 @@ test_remove_fisrt(void **state)
 	};
 
 	dsa_pointer p[5];
+
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
@@ -99,29 +108,38 @@ test_remove_fisrt(void **state)
 	PdlShmemRemove(p[0]);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[1].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[1].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[2].xid, TEST_XID3);
 	assert_memory_equal(&arr->array[2].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[3].xid, TEST_XID2);
 	assert_memory_equal(&arr->array[3].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
-	
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
+
 /* clean up */
 	pfree(arr);
 	for (int i = 1; i < ARRAY_SIZE(p); i++)
@@ -132,19 +150,22 @@ test_remove_fisrt(void **state)
 static void
 test_remove_middle(void **state)
 {
-	RelFileNodePendingDelete relnode = {
-		.node = {
+	RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
 	dsa_pointer p[4];
+
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
-	
+
 	relnode.node.dbNode = TEST_DB_OID2;
 	dsa_pointer p_middle = PdlShmemAdd(&relnode, TEST_XID1);
 
@@ -156,28 +177,37 @@ test_remove_middle(void **state)
 	PdlShmemRemove(p_middle);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[1].xid, TEST_XID3);
 	assert_memory_equal(&arr->array[1].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[2].xid, TEST_XID2);
 	assert_memory_equal(&arr->array[2].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[3].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[3].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 
 /* clean up */
 	pfree(arr);
@@ -189,15 +219,18 @@ test_remove_middle(void **state)
 static void
 test_remove_last(void **state)
 {
-	RelFileNodePendingDelete relnode = {
-		.node = {
+	RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
 	dsa_pointer p[4];
+
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
@@ -208,31 +241,41 @@ test_remove_last(void **state)
 
 	relnode.node.relNode = TEST_REL_OID1;
 	dsa_pointer p_last = PdlShmemAdd(&relnode, TEST_XID1);
+
 	PdlShmemRemove(p_last);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[1].xid, TEST_XID3);
 	assert_memory_equal(&arr->array[1].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[2].xid, TEST_XID2);
 	assert_memory_equal(&arr->array[2].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[3].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[3].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 
 /* clean up */
 	pfree(arr);
@@ -244,16 +287,18 @@ test_remove_last(void **state)
 static void
 test_invalid_xid(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
 	assert_false(DsaPointerIsValid(
-					PdlShmemAdd(&relnode, InvalidTransactionId)));
+							   PdlShmemAdd(&relnode, InvalidTransactionId)));
 	assert_true(PdlXLogShmemDump() == NULL);
 }
 
@@ -261,15 +306,18 @@ test_invalid_xid(void **state)
 static void
 test_invalid_backend(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
-	BackendId old = MyBackendId;
+	BackendId	old = MyBackendId;
+
 	MyBackendId = InvalidBackendId;
 
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
@@ -283,15 +331,18 @@ test_invalid_backend(void **state)
 static void
 test_invalid_mode(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
 	ProcessingMode old = Mode;
+
 	Mode = BootstrapProcessing;
 
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
@@ -305,15 +356,18 @@ test_invalid_mode(void **state)
 static void
 test_tracking_disabled(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
-	bool old = gp_track_pending_delete;
+	bool		old = gp_track_pending_delete;
+
 	gp_track_pending_delete = false;
 
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
@@ -327,15 +381,18 @@ test_tracking_disabled(void **state)
 static void
 test_shmem_type(void **state)
 {
-	const RelFileNodePendingDelete relnode = {
-		.node = {
+	const RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
-	int old = dynamic_shared_memory_type;
+	int			old = dynamic_shared_memory_type;
+
 	dynamic_shared_memory_type = DSM_IMPL_NONE;
 
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
@@ -349,22 +406,26 @@ test_shmem_type(void **state)
 static void
 test_2_backends(void **state)
 {
-	RelFileNodePendingDelete relnode = {
-		.node = {
+	RelFileNodePendingDelete relnode =
+	{
+		.node =
+		{
 			.spcNode = TEST_TABLESPACE_OID1,
-			.dbNode = TEST_DB_OID1,
+			.dbNode  = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
 		}
 	};
 
 	dsa_pointer p[5];
+
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
 	relnode.node.dbNode = TEST_DB_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID1);
 
-	BackendId old = MyBackendId;
+	BackendId	old = MyBackendId;
+
 	MyBackendId = 3;
 	relnode.node.relNode = TEST_REL_OID2;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID3);
@@ -372,33 +433,44 @@ test_2_backends(void **state)
 	p[4] = PdlShmemAdd(&relnode, TEST_XID4);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 5);
 	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[1].xid, TEST_XID2);
 	assert_memory_equal(&arr->array[1].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[2].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[2].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[3].xid, TEST_XID4);
 	assert_memory_equal(&arr->array[3].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 	assert_int_equal(arr->array[4].xid, TEST_XID3);
 	assert_memory_equal(&arr->array[4].relnode,
-		&((RelFileNodePendingDelete){
-			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
-		sizeof(RelFileNodePendingDelete));
+						&((RelFileNodePendingDelete)
+						{
+							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
+						}),
+						sizeof(RelFileNodePendingDelete));
 
 /* clean up */
 	MyBackendId = old;
@@ -430,10 +502,11 @@ main(int argc, char *argv[])
 
 	gp_track_pending_delete = true;
 	dynamic_shared_memory_type = DSM_IMPL_POSIX;
-	DataDir=".";
+	DataDir = ".";
 	MaxBackends = 5;
 
 	PGShmemHeader *shim = NULL;
+
 	InitShmemAccess(PGSharedMemoryCreate(300000, 6000, &shim));
 	InitShmemAllocation();
 	CreateLWLocks();
@@ -444,7 +517,9 @@ main(int argc, char *argv[])
 
 	IsUnderPostmaster = true;
 	MyBackendId = 1;
-	PGPROC proc = { .backendId = MyBackendId };
+
+	PGPROC		proc = {.backendId = MyBackendId};
+
 	MyProc = &proc;
 	return run_tests(tests);
 }

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -44,6 +44,39 @@ __wrap_AddToDataDirLockFile(int target_line, const char *str)
 {
 }
 
+
+/* Function to sort array of PendingRelXactDelete using qsort */
+static int
+cmp_pdl(const void *p1, const void *p2)
+{
+	return memcmp(p1, p2, sizeof(PendingRelXactDelete));
+}
+
+/* Check and clean up when PdlXLogShmemDump returns not NULL */
+static void 
+check_and_clean(PendingRelXactDeleteArray *arr,
+				PendingRelXactDelete *expected, Size expectedCnt,
+				dsa_pointer *p, Size pCnt)
+{
+	assert_true(arr != NULL);
+
+	assert_int_equal(arr->count, expectedCnt);
+
+	/* Order doesn't matter */
+	qsort (expected,   expectedCnt, sizeof(*expected), cmp_pdl);
+	qsort (arr->array, expectedCnt, sizeof(*expected), cmp_pdl);
+	assert_memory_equal(arr->array, expected, expectedCnt*sizeof(*expected));
+
+	/* Clean up */
+	pfree(arr);
+	for (int i = 0; i < pCnt; i++)
+		PdlShmemRemove(p[i]);
+
+	/* Check whether cleanup is ok */
+	assert_true(PdlXLogShmemDump() == NULL);
+}
+
+
 /* Dump without additions */
 static void
 test_empty(void **state)
@@ -67,16 +100,14 @@ test_1(void **state)
 	};
 
 	dsa_pointer p = PdlShmemAdd(&relnode, TEST_XID1);
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	
+	PendingRelXactDelete expected = 
+	{
+		.relnode = relnode,
+		.xid = TEST_XID1
+	};
 
-	assert_true(arr != NULL);
-	assert_int_equal(arr->count, 1);
-	assert_int_equal(arr->array[0].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[0].relnode, &relnode, sizeof(relnode));
-
-	/* clean up */
-	pfree(arr);
-	PdlShmemRemove(p);
+	check_and_clean(PdlXLogShmemDump(), &expected, 1, &p, 1);
 }
 
 /* Add nodes and remove the first one before dump */
@@ -93,57 +124,46 @@ test_remove_fisrt(void **state)
 		}
 	};
 
-	dsa_pointer p[5];
+	dsa_pointer p_first = PdlShmemAdd(&relnode, TEST_XID1);
 
-	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
+	dsa_pointer p[4];
+	
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
-	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
+	p[0] = PdlShmemAdd(&relnode, TEST_XID2);
+
 	relnode.node.dbNode = TEST_DB_OID2;
-	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
+	p[1] = PdlShmemAdd(&relnode, TEST_XID3);
+
 	relnode.node.relNode = TEST_REL_OID2;
-	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
+	p[2] = PdlShmemAdd(&relnode, TEST_XID1);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID1;
-	p[4] = PdlShmemAdd(&relnode, TEST_XID1);
+	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
 
-	PdlShmemRemove(p[0]);
+	PdlShmemRemove(p_first);
 
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	PendingRelXactDelete expected[] = 
+	{
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID2
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
+			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID1
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID1
+		},
+	};
 
-	assert_true(arr != NULL);
-	assert_int_equal(arr->count, 4);
-	assert_int_equal(arr->array[0].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[0].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[1].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[1].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[2].xid, TEST_XID3);
-	assert_memory_equal(&arr->array[2].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[3].xid, TEST_XID2);
-	assert_memory_equal(&arr->array[3].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-
-	/* clean up */
-	pfree(arr);
-	for (int i = 1; i < ARRAY_SIZE(p); i++)
-		PdlShmemRemove(p[i]);
+	check_and_clean(PdlXLogShmemDump(),
+					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add nodes and remove a node from the middle before dump */
@@ -163,6 +183,7 @@ test_remove_middle(void **state)
 	dsa_pointer p[4];
 
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
 
@@ -171,48 +192,34 @@ test_remove_middle(void **state)
 
 	relnode.node.relNode = TEST_REL_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID1;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
 
 	PdlShmemRemove(p_middle);
 
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	PendingRelXactDelete expected[] = 
+	{
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID1
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID2
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID1
+		},
+	};
 
-	assert_true(arr != NULL);
-	assert_int_equal(arr->count, 4);
-	assert_int_equal(arr->array[0].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[0].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[1].xid, TEST_XID3);
-	assert_memory_equal(&arr->array[1].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[2].xid, TEST_XID2);
-	assert_memory_equal(&arr->array[2].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[3].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[3].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-
-	/* clean up */
-	pfree(arr);
-	for (int i = 0; i < ARRAY_SIZE(p); i++)
-		PdlShmemRemove(p[i]);
+	check_and_clean(PdlXLogShmemDump(),
+					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add nodes and remove the last one before dump */
@@ -232,10 +239,13 @@ test_remove_last(void **state)
 	dsa_pointer p[4];
 
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
+
 	relnode.node.dbNode = TEST_DB_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
+
 	relnode.node.relNode = TEST_REL_OID2;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
 
@@ -244,43 +254,28 @@ test_remove_last(void **state)
 
 	PdlShmemRemove(p_last);
 
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	PendingRelXactDelete expected[] = 
+	{
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID1
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
+			.xid = TEST_XID3
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID2
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID1
+		},
+	};
 
-	assert_true(arr != NULL);
-	assert_int_equal(arr->count, 4);
-	assert_int_equal(arr->array[0].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[0].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[1].xid, TEST_XID3);
-	assert_memory_equal(&arr->array[1].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[2].xid, TEST_XID2);
-	assert_memory_equal(&arr->array[2].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[3].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[3].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-
-	/* clean up */
-	pfree(arr);
-	for (int i = 0; i < ARRAY_SIZE(p); i++)
-		PdlShmemRemove(p[i]);
+	check_and_clean(PdlXLogShmemDump(),
+					expected, ARRAY_SIZE(expected), p, ARRAY_SIZE(p));
 }
 
 /* Add node with invalid transaction id */
@@ -323,7 +318,7 @@ test_invalid_backend(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-	/* clean up */
+	/* Clean up */
 	MyBackendId = old;
 }
 
@@ -348,7 +343,7 @@ test_invalid_mode(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-	/* clean up */
+	/* Clean up */
 	Mode = old;
 }
 
@@ -373,7 +368,7 @@ test_tracking_disabled(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-	/* clean up */
+	/* Clean up */
 	gp_track_pending_delete = old;
 }
 
@@ -398,7 +393,7 @@ test_shmem_type(void **state)
 	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
-	/* clean up */
+	/* Clean up */
 	dynamic_shared_memory_type = old;
 }
 
@@ -419,64 +414,61 @@ test_2_backends(void **state)
 	dsa_pointer p[5];
 
 	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
 	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
+
 	relnode.node.dbNode = TEST_DB_OID2;
 	p[2] = PdlShmemAdd(&relnode, TEST_XID1);
 
 	BackendId	old = MyBackendId;
 
 	MyBackendId = 3;
+
 	relnode.node.relNode = TEST_REL_OID2;
 	p[3] = PdlShmemAdd(&relnode, TEST_XID3);
+
 	relnode.node.spcNode = TEST_TABLESPACE_OID1;
 	p[4] = PdlShmemAdd(&relnode, TEST_XID4);
 
-	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	PendingRelXactDelete expected[] = 
+	{
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}},
+			.xid = TEST_XID1
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID2
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}},
+			.xid = TEST_XID1
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID4
+		},
+		{
+			.relnode = {{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}},
+			.xid = TEST_XID3
+		},
+	};
 
-	assert_true(arr != NULL);
-	assert_int_equal(arr->count, 5);
-	assert_int_equal(arr->array[0].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[0].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[1].xid, TEST_XID2);
-	assert_memory_equal(&arr->array[1].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[2].xid, TEST_XID1);
-	assert_memory_equal(&arr->array[2].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[3].xid, TEST_XID4);
-	assert_memory_equal(&arr->array[3].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
-	assert_int_equal(arr->array[4].xid, TEST_XID3);
-	assert_memory_equal(&arr->array[4].relnode,
-						&((RelFileNodePendingDelete)
-						{
-							{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}
-						}),
-						sizeof(RelFileNodePendingDelete));
+	PendingRelXactDeleteArray	*arr = PdlXLogShmemDump();
 
-	/* clean up */
+	/* 
+	 * Clean up.
+	 * Elements which were added for backend 3 should be removed
+	 * when MyBackendId is 3. Other elements are removed in check_and_clean
+	 * after restoring MyBackendId.
+	 */
+	PdlShmemRemove(p[3]);
+	PdlShmemRemove(p[4]);
+
 	MyBackendId = old;
-	pfree(arr);
-	for (int i = 0; i < ARRAY_SIZE(p); i++)
-		PdlShmemRemove(p[i]);
+
+	check_and_clean(arr, expected, ARRAY_SIZE(expected), p, 3);
 }
 
 int

--- a/src/backend/catalog/test/storage_pending_deletes_test.c
+++ b/src/backend/catalog/test/storage_pending_deletes_test.c
@@ -14,62 +14,58 @@
 #include <setjmp.h>
 #include "cmockery.h"
 
-#include "postgres.h"
-
-#include "access/clog.h"
-#include "access/transam.h"
 #include "catalog/storage_pending_deletes.h"
 #include "storage/pg_shmem.h"
 #include "storage/proc.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
 
-#define TEST_TABLESPACE_OID1	11111
-#define TEST_TABLESPACE_OID2	11112
+enum {
+	TEST_TABLESPACE_OID1 = 11111,
+	TEST_TABLESPACE_OID2 = 11112,
 
-#define TEST_DB_OID1			11121
-#define TEST_DB_OID2			11122
+	TEST_DB_OID1 = 11121,
+	TEST_DB_OID2 = 11122,
 
-#define TEST_REL_OID1			11211
-#define TEST_REL_OID2			11212
+	TEST_REL_OID1 = 11211,
+	TEST_REL_OID2 = 11212,
 
-#define TEST_XID 10
+	TEST_XID1 = 10,
+	TEST_XID2 = TEST_XID1 + 1,
+	TEST_XID3 = TEST_XID1 + 3,
+	TEST_XID4 = TEST_XID1 + 8,
+};
 
+/* Don't try to read a non-existent postmaster.pid file */
+void __wrap_AddToDataDirLockFile(int target_line, const char *str);
+void __wrap_AddToDataDirLockFile(int target_line, const char *str){}
 
-
-/*
- * Tests
- */
-
-/*
- * Dump without additions
- */
+/* Dump without additions */
 static void
 test_empty(void **state)
 {
 	assert_true(PdlXLogShmemDump() == NULL);
 }
 
-/*
-  * Add single pending delete node
- */
+/* Add single pending delete node */
 static void
 test_1(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
 			.relNode = TEST_REL_OID1
-		}
+		},
+		.relstorage = RELSTORAGE_HEAP
 	};
 
-	dsa_pointer p = PdlShmemAdd(&relnode, TEST_XID);
+	dsa_pointer p = PdlShmemAdd(&relnode, TEST_XID1);
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
 
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 1);
-	assert_int_equal(arr->array[0].xid, TEST_XID);
+	assert_int_equal(arr->array[0].xid, TEST_XID1);
 	assert_memory_equal(&arr->array[0].relnode, &relnode, sizeof(relnode));
 	
 /* clean up */
@@ -77,9 +73,7 @@ test_1(void **state)
 	PdlShmemRemove(p);
 }
 
-/*
-  * Add nodes and remove the first one before dump
- */
+/* Add nodes and remove the first one before dump */
 static void
 test_remove_fisrt(void **state)
 {
@@ -92,30 +86,49 @@ test_remove_fisrt(void **state)
 	};
 
 	dsa_pointer p[5];
-	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
-	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
 	relnode.node.dbNode = TEST_DB_OID2;
-	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
+	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
 	relnode.node.relNode = TEST_REL_OID2;
-	p[3] = PdlShmemAdd(&relnode, TEST_XID);
-	relnode.node.relNode = TEST_REL_OID1;
-	p[4] = PdlShmemAdd(&relnode, TEST_XID);
+	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
+	relnode.node.spcNode = TEST_TABLESPACE_OID1;
+	p[4] = PdlShmemAdd(&relnode, TEST_XID1);
 
 	PdlShmemRemove(p[0]);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
+	assert_int_equal(arr->array[0].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[0].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[1].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[1].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[2].xid, TEST_XID3);
+	assert_memory_equal(&arr->array[2].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[3].xid, TEST_XID2);
+	assert_memory_equal(&arr->array[3].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
 	
 /* clean up */
+	pfree(arr);
 	for (int i = 1; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
 }
 
-/*
-  * Add nodes and remove a node from the middle before dump
- */
+/* Add nodes and remove a node from the middle before dump */
 static void
 test_remove_middle(void **state)
 {
@@ -128,34 +141,53 @@ test_remove_middle(void **state)
 	};
 
 	dsa_pointer p[4];
-	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
-	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
 	
 	relnode.node.dbNode = TEST_DB_OID2;
-	dsa_pointer p_middle = PdlShmemAdd(&relnode, TEST_XID);
+	dsa_pointer p_middle = PdlShmemAdd(&relnode, TEST_XID1);
 
 	relnode.node.relNode = TEST_REL_OID2;
-	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
-	relnode.node.relNode = TEST_REL_OID1;
-	p[3] = PdlShmemAdd(&relnode, TEST_XID);
+	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
+	relnode.node.spcNode = TEST_TABLESPACE_OID1;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
 
 	PdlShmemRemove(p_middle);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
-	
+	assert_int_equal(arr->array[0].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[0].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[1].xid, TEST_XID3);
+	assert_memory_equal(&arr->array[1].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[2].xid, TEST_XID2);
+	assert_memory_equal(&arr->array[2].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[3].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[3].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+
 /* clean up */
+	pfree(arr);
 	for (int i = 0; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
 }
 
-/*
-  * Add nodes and remove the lastest one before dump
- */
+/* Add nodes and remove the last one before dump */
 static void
-test_remove_lastest(void **state)
+test_remove_last(void **state)
 {
 	RelFileNodePendingDelete relnode = {
 		.node = {
@@ -166,34 +198,53 @@ test_remove_lastest(void **state)
 	};
 
 	dsa_pointer p[4];
-	p[0] = PdlShmemAdd(&relnode, TEST_XID);
+	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
 	relnode.node.spcNode = TEST_TABLESPACE_OID2;
-	p[1] = PdlShmemAdd(&relnode, TEST_XID + 1);
+	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
 	relnode.node.dbNode = TEST_DB_OID2;
-	p[2] = PdlShmemAdd(&relnode, TEST_XID + 3);
+	p[2] = PdlShmemAdd(&relnode, TEST_XID3);
 	relnode.node.relNode = TEST_REL_OID2;
-	p[3] = PdlShmemAdd(&relnode, TEST_XID);
+	p[3] = PdlShmemAdd(&relnode, TEST_XID1);
 
 	relnode.node.relNode = TEST_REL_OID1;
-	dsa_pointer p_lastest = PdlShmemAdd(&relnode, TEST_XID);
-	PdlShmemRemove(p_lastest);
+	dsa_pointer p_last = PdlShmemAdd(&relnode, TEST_XID1);
+	PdlShmemRemove(p_last);
 
 	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
 	assert_true(arr != NULL);
 	assert_int_equal(arr->count, 4);
-	
+	assert_int_equal(arr->array[0].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[0].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[1].xid, TEST_XID3);
+	assert_memory_equal(&arr->array[1].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[2].xid, TEST_XID2);
+	assert_memory_equal(&arr->array[2].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[3].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[3].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+
 /* clean up */
+	pfree(arr);
 	for (int i = 0; i < ARRAY_SIZE(p); i++)
 		PdlShmemRemove(p[i]);
 }
 
-/*
-  * Add node with invalid transaction id
- */
+/* Add node with invalid transaction id */
 static void
 test_invalid_xid(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
@@ -206,13 +257,11 @@ test_invalid_xid(void **state)
 	assert_true(PdlXLogShmemDump() == NULL);
 }
 
-/*
-  * Add node when MyBackendId is invalid
- */
+/* Add node when MyBackendId is invalid */
 static void
 test_invalid_backend(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
@@ -223,22 +272,18 @@ test_invalid_backend(void **state)
 	BackendId old = MyBackendId;
 	MyBackendId = InvalidBackendId;
 
-	assert_false(DsaPointerIsValid(
-					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
 /* clean up */
 	MyBackendId = old;
 }
 
-
-/*
-  * Add node when Mode == BootstrapProcessing
- */
+/* Add node when Mode == BootstrapProcessing */
 static void
 test_invalid_mode(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
@@ -249,21 +294,18 @@ test_invalid_mode(void **state)
 	ProcessingMode old = Mode;
 	Mode = BootstrapProcessing;
 
-	assert_false(DsaPointerIsValid(
-					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
 /* clean up */
 	Mode = old;
 }
 
-/*
-  * Add node when tracking is disabled
- */
+/* Add node when tracking is disabled */
 static void
 test_tracking_disabled(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
@@ -274,21 +316,18 @@ test_tracking_disabled(void **state)
 	bool old = gp_track_pending_delete;
 	gp_track_pending_delete = false;
 
-	assert_false(DsaPointerIsValid(
-					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
 /* clean up */
 	gp_track_pending_delete = old;
 }
 
-/*
-  * Add node when dynamic_shared_memory_type == DSM_IMPL_NONE
- */
+/* Add node when dynamic_shared_memory_type == DSM_IMPL_NONE */
 static void
 test_shmem_type(void **state)
 {
-	RelFileNodePendingDelete relnode = {
+	const RelFileNodePendingDelete relnode = {
 		.node = {
 			.spcNode = TEST_TABLESPACE_OID1,
 			.dbNode = TEST_DB_OID1,
@@ -299,12 +338,73 @@ test_shmem_type(void **state)
 	int old = dynamic_shared_memory_type;
 	dynamic_shared_memory_type = DSM_IMPL_NONE;
 
-	assert_false(DsaPointerIsValid(
-					PdlShmemAdd(&relnode, InvalidTransactionId)));
+	assert_false(DsaPointerIsValid(PdlShmemAdd(&relnode, TEST_XID1)));
 	assert_true(PdlXLogShmemDump() == NULL);
 
 /* clean up */
 	dynamic_shared_memory_type = old;
+}
+
+/* Add nodes for two backends */
+static void
+test_2_backends(void **state)
+{
+	RelFileNodePendingDelete relnode = {
+		.node = {
+			.spcNode = TEST_TABLESPACE_OID1,
+			.dbNode = TEST_DB_OID1,
+			.relNode = TEST_REL_OID1
+		}
+	};
+
+	dsa_pointer p[5];
+	p[0] = PdlShmemAdd(&relnode, TEST_XID1);
+	relnode.node.spcNode = TEST_TABLESPACE_OID2;
+	p[1] = PdlShmemAdd(&relnode, TEST_XID2);
+	relnode.node.dbNode = TEST_DB_OID2;
+	p[2] = PdlShmemAdd(&relnode, TEST_XID1);
+
+	BackendId old = MyBackendId;
+	MyBackendId = 3;
+	relnode.node.relNode = TEST_REL_OID2;
+	p[3] = PdlShmemAdd(&relnode, TEST_XID3);
+	relnode.node.spcNode = TEST_TABLESPACE_OID1;
+	p[4] = PdlShmemAdd(&relnode, TEST_XID4);
+
+	PendingRelXactDeleteArray *arr = PdlXLogShmemDump();
+	assert_true(arr != NULL);
+	assert_int_equal(arr->count, 5);
+	assert_int_equal(arr->array[0].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[0].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[1].xid, TEST_XID2);
+	assert_memory_equal(&arr->array[1].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[2].xid, TEST_XID1);
+	assert_memory_equal(&arr->array[2].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID1, TEST_REL_OID1}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[3].xid, TEST_XID4);
+	assert_memory_equal(&arr->array[3].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID1, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+	assert_int_equal(arr->array[4].xid, TEST_XID3);
+	assert_memory_equal(&arr->array[4].relnode,
+		&((RelFileNodePendingDelete){
+			{TEST_TABLESPACE_OID2, TEST_DB_OID2, TEST_REL_OID2}}),
+		sizeof(RelFileNodePendingDelete));
+
+/* clean up */
+	MyBackendId = old;
+	pfree(arr);
+	for (int i = 0; i < ARRAY_SIZE(p); i++)
+		PdlShmemRemove(p[i]);
 }
 
 int
@@ -313,16 +413,17 @@ main(int argc, char *argv[])
 	cmockery_parse_arguments(argc, argv);
 
 	const UnitTest tests[] = {
-			unit_test(test_empty),
-			unit_test(test_1),
-			unit_test(test_remove_fisrt),
-			unit_test(test_remove_middle),
-			unit_test(test_remove_lastest),
-			unit_test(test_invalid_xid),
-			unit_test(test_invalid_backend),
-			unit_test(test_invalid_mode),
-			unit_test(test_tracking_disabled),
-			unit_test(test_shmem_type)
+		unit_test(test_empty),
+		unit_test(test_1),
+		unit_test(test_remove_fisrt),
+		unit_test(test_remove_middle),
+		unit_test(test_remove_last),
+		unit_test(test_invalid_xid),
+		unit_test(test_invalid_backend),
+		unit_test(test_invalid_mode),
+		unit_test(test_tracking_disabled),
+		unit_test(test_shmem_type),
+		unit_test(test_2_backends)
 	};
 
 	MemoryContextInit();
@@ -333,7 +434,7 @@ main(int argc, char *argv[])
 	MaxBackends = 5;
 
 	PGShmemHeader *shim = NULL;
-	InitShmemAccess(PGSharedMemoryCreate(10000000, 5432, &shim));
+	InitShmemAccess(PGSharedMemoryCreate(300000, 6000, &shim));
 	InitShmemAllocation();
 	CreateLWLocks();
 	InitShmemIndex();

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -41,6 +41,6 @@ extern PendingRelXactDeleteArray *PdlXLogShmemDump(Size *size);
 extern Size PdlShmemSize(void);
 extern void PdlShmemInit(void);
 extern dsa_pointer PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid);
-extern void PdlShmemRemove(PendingRelXactDelete node);
+extern void PdlShmemRemove(dsa_pointer node_ptr);
 
 #endif   /* STORAGE_PENDING_DELETES_H */

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -40,7 +40,8 @@ extern PendingRelXactDeleteArray *PdlXLogShmemDump(void);
 
 extern Size PdlShmemSize(void);
 extern void PdlShmemInit(void);
-extern dsa_pointer PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid);
+extern dsa_pointer PdlShmemAdd(const RelFileNodePendingDelete *relnode,
+							   TransactionId xid);
 extern void PdlShmemRemove(dsa_pointer node_ptr);
 
 #endif   /* STORAGE_PENDING_DELETES_H */

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -30,6 +30,14 @@ typedef struct PendingRelXactDeleteArray
 	PendingRelXactDelete array[FLEXIBLE_ARRAY_MEMBER];
 }	PendingRelXactDeleteArray;
 
+static inline Size
+PdlDumpSize(Size count)
+{
+	Size array_size = sizeof(PendingRelXactDelete) * count;
+
+	return offsetof(PendingRelXactDeleteArray, array) + array_size;
+}
+
 extern Size PdlShmemSize(void);
 extern void PdlShmemInit(void);
 extern dsa_pointer PdlShmemAdd(const RelFileNodePendingDelete * relnode,

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -30,18 +30,11 @@ typedef struct PendingRelXactDeleteArray
 	PendingRelXactDelete array[FLEXIBLE_ARRAY_MEMBER];
 }	PendingRelXactDeleteArray;
 
-/*
- * This function collects info about pending deletes from all backends and
- * returns the accumulated result.
- * Note: the returned result is always palloc'ed. Caller is responsible for
- * freeing it.
- */
-extern PendingRelXactDeleteArray *PdlXLogShmemDump(void);
-
 extern Size PdlShmemSize(void);
 extern void PdlShmemInit(void);
-extern dsa_pointer PdlShmemAdd(const RelFileNodePendingDelete *relnode,
-							   TransactionId xid);
+extern dsa_pointer PdlShmemAdd(const RelFileNodePendingDelete * relnode,
+			TransactionId xid);
 extern void PdlShmemRemove(dsa_pointer node_ptr);
+extern PendingRelXactDeleteArray *PdlXLogShmemDump(void);
 
 #endif   /* STORAGE_PENDING_DELETES_H */

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -15,6 +15,7 @@
 #include "postgres.h"
 
 #include "storage/relfilenode.h"
+#include "utils/dsa.h"
 
 /* Pending delete node linked to xact which created it */
 typedef struct PendingRelXactDelete
@@ -36,5 +37,10 @@ typedef struct PendingRelXactDeleteArray
  * freeing it.
  */
 extern PendingRelXactDeleteArray *PdlXLogShmemDump(Size *size);
+
+extern Size PdlShmemSize(void);
+extern void PdlShmemInit(void);
+extern dsa_pointer PdlShmemAdd(RelFileNodePendingDelete *relnode, TransactionId xid);
+extern void PdlShmemRemove(PendingRelXactDelete node);
 
 #endif   /* STORAGE_PENDING_DELETES_H */

--- a/src/include/catalog/storage_pending_deletes.h
+++ b/src/include/catalog/storage_pending_deletes.h
@@ -36,7 +36,7 @@ typedef struct PendingRelXactDeleteArray
  * Note: the returned result is always palloc'ed. Caller is responsible for
  * freeing it.
  */
-extern PendingRelXactDeleteArray *PdlXLogShmemDump(Size *size);
+extern PendingRelXactDeleteArray *PdlXLogShmemDump(void);
 
 extern Size PdlShmemSize(void);
 extern void PdlShmemInit(void);


### PR DESCRIPTION
Implement storage pending deletes module

The module contains functions to maintain doubly linked lists of
(RelFileNodePendingDelete, transaction id) pairs for all backends in shared
memory. The shared memory can be initialized using the PdlShmemSize and
PdlShmemInit functions. Backend can add and remove pairs to its own list using
PdlShmemAdd and PdlShmemRemove respectively. The backends lists can be got in
the format suitable for XLOG_PENDING_DELETE using PdlXLogShmemDump.

When backend stops, the module cleanups its pending deletes list.

The size argument is removed from PdlXLogShmemDump, because this value can be
calculated by caller using the function return value.

Ticket: ADBDEV-7303