### PR TITLE
ADBDEV-7326: Fix integer overflow in explain

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -1859,7 +1859,7 @@ ExplainNode(PlanState *planstate, List *ancestors,
 
 	if (ResManagerPrintOperatorMemoryLimits())
 	{
-		ExplainPropertyInteger("operatorMem", PlanStateOperatorMemKB(planstate), es);
+		ExplainPropertyLong("operatorMem", PlanStateOperatorMemKB(planstate), es);
 	}
 	/*
 	 * We have to forcibly clean up the instrumentation state because we

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -2166,7 +2166,7 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
             }
             else
             {
-                ExplainPropertyInteger("Executor Memory", ss->peakmemused.vmax, es);
+                ExplainPropertyFloat("Executor Memory", ss->peakmemused.vmax, 0, es);
             }
         }
         else if (ss->peakmemused.vcnt > 1)
@@ -2185,9 +2185,9 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
             else
             {
                 ExplainOpenGroup("Executor Memory", "Executor Memory", true, es);
-                ExplainPropertyInteger("Average", cdbexplain_agg_avg(&ss->peakmemused), es);
+                ExplainPropertyFloat("Average", cdbexplain_agg_avg(&ss->peakmemused), 0, es);
                 ExplainPropertyInteger("Workers", ss->peakmemused.vcnt, es);
-                ExplainPropertyInteger("Maximum Memory Used", ss->peakmemused.vmax, es);
+                ExplainPropertyFloat("Maximum Memory Used", ss->peakmemused.vmax, 0, es);
                 ExplainCloseGroup("Executor Memory", "Executor Memory", true, es);
             }
         }
@@ -2227,7 +2227,7 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
                 } 
                 else
                 {
-                    ExplainPropertyInteger("Global Peak Memory", ss->memory_accounting_global_peak.vmax, es);
+                    ExplainPropertyFloat("Global Peak Memory", ss->memory_accounting_global_peak.vmax, 0, es);
                 }
             }
             else if (ss->memory_accounting_global_peak.vcnt > 1)
@@ -2249,9 +2249,9 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
 				else
                 {
                     ExplainOpenGroup("Global Peak Memory", "Global Peak Memory", true, es);
-                    ExplainPropertyInteger("Average", cdbexplain_agg_avg(&ss->memory_accounting_global_peak), es);
+                    ExplainPropertyFloat("Average", cdbexplain_agg_avg(&ss->memory_accounting_global_peak), 0, es);
                     ExplainPropertyInteger("Workers", ss->memory_accounting_global_peak.vcnt, es);
-                    ExplainPropertyInteger("Maximum Memory Used", ss->memory_accounting_global_peak.vmax, es);
+                    ExplainPropertyFloat("Maximum Memory Used", ss->memory_accounting_global_peak.vmax, 0, es);
                     ExplainCloseGroup("Global Peak Memory", "Global Peak Memory", true, es);
                 }
             }
@@ -2287,7 +2287,7 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
                 }
                 else
                 {
-                    ExplainPropertyInteger("Virtual Memory", ss->vmem_reserved.vmax, es);
+                    ExplainPropertyFloat("Virtual Memory", ss->vmem_reserved.vmax, 0, es);
                 }
             }
             else if (ss->vmem_reserved.vcnt > 1)
@@ -2306,9 +2306,9 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
                 else
                 {
                     ExplainOpenGroup("Virtual Memory", "Virtual Memory", true, es);
-                    ExplainPropertyInteger("Average", cdbexplain_agg_avg(&ss->vmem_reserved), es);
+                    ExplainPropertyFloat("Average", cdbexplain_agg_avg(&ss->vmem_reserved), 0, es);
                     ExplainPropertyInteger("Workers", ss->vmem_reserved.vcnt, es);
-                    ExplainPropertyInteger("Maximum Memory Used", ss->vmem_reserved.vmax, es);
+                    ExplainPropertyFloat("Maximum Memory Used", ss->vmem_reserved.vmax, 0, es);
                     ExplainCloseGroup("Virtual Memory", "Virtual Memory", true, es);
                 }
 
@@ -2332,7 +2332,7 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
             }
             else
             {
-                ExplainPropertyInteger("Work Maximum Memory", ss->workmemused_max, es);
+                ExplainPropertyFloat("Work Maximum Memory", ss->workmemused_max, 0, es);
             }
         }
 
@@ -2353,7 +2353,7 @@ gpexplain_formatSlicesOutput(struct CdbExplain_ShowStatCtx *showstatctx,
         }
         else
         {
-            ExplainPropertyInteger("Total memory used across slices", total_memory_across_slices, es);
+            ExplainPropertyFloat("Total memory used across slices", total_memory_across_slices, 0, es);
         }
     }
 }

--- a/src/backend/commands/test/Makefile
+++ b/src/backend/commands/test/Makefile
@@ -2,9 +2,12 @@ subdir=src/backend/commands
 top_builddir=../../../..
 include $(top_builddir)/src/Makefile.global
 
-TARGETS=tablecmds
+TARGETS=tablecmds explain
 
 include $(top_builddir)/src/backend/mock.mk
 
 tablecmds.t: \
 	$(MOCK_DIR)/backend/access/aocs/aocs_compaction_mock.o
+
+explain.t: \
+	$(MOCK_DIR)/backend/utils/cache/lsyscache_mock.o

--- a/src/backend/commands/test/explain_test.c
+++ b/src/backend/commands/test/explain_test.c
@@ -1,0 +1,213 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include "cmockery.h"
+
+#include "../explain.c"
+
+extern bool	*gp_resmanager_print_operator_memory_limits;
+extern int explain_memory_verbosity;
+
+static void
+test__explain_test(void **state)
+{
+	will_return(get_rel_name, "t1");
+	expect_any(get_rel_name, relid);
+
+	// Check the behavior of explain with memory counters if their values are
+	// greater than 4Gb.
+
+	// Test operatorMem
+	gp_resmanager_print_operator_memory_limits = palloc(sizeof(bool));
+	*gp_resmanager_print_operator_memory_limits = true;
+
+	PlanState *planState = makeNode(PlanState);
+	planState->plan = (Plan *) makeNode(SeqScan);
+	planState->plan->operatorMemKB = (1l << 35);
+
+	SeqScan* seqScan = (SeqScan *) planState->plan;
+	seqScan->scanrelid = 1;
+
+	ExplainState *es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	RangeTblEntry *rte = makeNode(RangeTblEntry);
+	rte->rtekind = RTE_RELATION;
+	rte->relid = 1;
+	char *tableName = "t1";
+	es->rtable = list_make1(rte);
+	es->rtable_names = list_make1(tableName);
+
+	ExplainNode(planState, NIL, NULL, NULL, es);
+	assert_string_equal(es->str->data,
+		"Seq Scan on t1  (cost=0.00..0.00 rows=0 width=0)  operatorMem: 34359738368\n\n");
+
+	// Test Executor Memory of slice
+	explain_memory_verbosity = false;
+	CdbExplain_ShowStatCtx showStatCtx = {};
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].peakmemused.vcnt = 1;
+	showStatCtx.slices[0].peakmemused.vmax = (1l << 35);
+
+	EState *eState = makeNode(EState);
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Executor Memory\": 34359738368\n"
+									   "  }\n"
+									   "]");
+
+	// Test Executor Memory with more than one worker
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].peakmemused.vcnt = 2;
+	showStatCtx.slices[0].peakmemused.vsum = (1l << 35);
+	showStatCtx.slices[0].peakmemused.vmax = (1l << 35);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Executor Memory\": {\n"
+									   "      \"Average\": 17179869184,\n"
+									   "      \"Workers\": 2,\n"
+									   "      \"Maximum Memory Used\": 34359738368\n"
+									   "    }\n"
+									   "  }\n"
+									   "]");
+
+	// Test Global Peak Memory and Total memory used across slices
+	explain_memory_verbosity = true;
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].memory_accounting_global_peak.vcnt = 1;
+	showStatCtx.slices[0].memory_accounting_global_peak.vmax = (1l << 50);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Global Peak Memory\": 1125899906842624\n"
+									   "  }\n"
+									   "],\n"
+									   "\"Total memory used across slices\": 1099511627776");
+
+	// Test Global Peak Memory with more than one worker
+	explain_memory_verbosity = true;
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].memory_accounting_global_peak.vcnt = 2;
+	showStatCtx.slices[0].memory_accounting_global_peak.vmax = (1l << 50);
+	showStatCtx.slices[0].memory_accounting_global_peak.vsum = (1l << 50);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Global Peak Memory\": {\n"
+									   "      \"Average\": 562949953421312,\n"
+									   "      \"Workers\": 2,\n"
+									   "      \"Maximum Memory Used\": 1125899906842624\n"
+									   "    }\n"
+									   "  }\n"
+									   "],\n"
+									   "\"Total memory used across slices\": 1099511627776");
+
+	// Test Virtual Memory
+	explain_memory_verbosity = true;
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].vmem_reserved.vcnt = 1;
+	showStatCtx.slices[0].vmem_reserved.vmax = (1l << 35);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Virtual Memory\": 34359738368\n"
+									   "  }\n"
+									   "]");
+
+	// Test Virtual Memory with more than one worker
+	explain_memory_verbosity = true;
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].vmem_reserved.vcnt = 2;
+	showStatCtx.slices[0].vmem_reserved.vmax = (1l << 35);
+	showStatCtx.slices[0].vmem_reserved.vsum = (1l << 35);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Virtual Memory\": {\n"
+									   "      \"Average\": 17179869184,\n"
+									   "      \"Workers\": 2,\n"
+									   "      \"Maximum Memory Used\": 34359738368\n"
+									   "    }\n"
+									   "  }\n"
+									   "]");
+
+	// Test Work Maximum Memory
+	explain_memory_verbosity = true;
+	showStatCtx.nslice = 1;
+	showStatCtx.slices = palloc0(sizeof(CdbExplain_SliceSummary));
+	showStatCtx.slices[0].workmemused_max = (1l << 35);
+
+	es = palloc0(sizeof(ExplainState));
+	ExplainInitState(es);
+	es->format = EXPLAIN_FORMAT_JSON;
+	es->extra->groupingstack = list_make1_int(0);
+	gpexplain_formatSlicesOutput(&showStatCtx, eState, es);
+	assert_string_equal(es->str->data, "\n"
+									   "\"Slice statistics\": [\n"
+									   "  {\n"
+									   "    \"Slice\": 0,\n"
+									   "    \"Work Maximum Memory\": 34359738368\n"
+									   "  }\n"
+									   "]");
+}
+
+int
+main(int argc, char* argv[])
+{
+	cmockery_parse_arguments(argc, argv);
+
+	const UnitTest tests[] = {
+			unit_test(test__explain_test)
+	};
+
+	MemoryContextInit();
+
+	return run_tests(tests);
+}


### PR DESCRIPTION
Fix integer overflow in explain

In a number of places in explain, the ExplainPropertyInteger function is used to
convert a double/long to a string, but since this function accepts an int,
verflow occurs, which in turn leads to an incorrect result.
Fix it by using the appropriate functions.