### PR TITLE
Fix incorrect SPI_INNER_QUERY tagging for top-level SPI calls

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -46,6 +46,7 @@
 #include "executor/functions.h"
 #include "cdb/memquota.h"
 #include "parser/analyze.h"
+#include "storage/proc.h"
 
 /*
  * These global variables are part of the API for various SPI functions
@@ -2230,8 +2231,11 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			{
 				PlannedStmt* pstmt = (PlannedStmt *) stmt;
 				canSetTag = pstmt->canSetTag;
-				/* GPDB: Mark all queries as SPI inner query for extension usage */
-				((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
+				/* GPDB: Mark all queries as SPI inner query for extension usage 
+					But make sure that SPI is not top level itself by looking at queryCommandId
+				*/
+				if (MyProc->queryCommandId != 0)
+					((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
 			}
 			else
 			{

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -46,7 +46,6 @@
 #include "executor/functions.h"
 #include "cdb/memquota.h"
 #include "parser/analyze.h"
-#include "storage/proc.h"
 
 /*
  * These global variables are part of the API for various SPI functions
@@ -2231,10 +2230,10 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			{
 				PlannedStmt* pstmt = (PlannedStmt *) stmt;
 				canSetTag = pstmt->canSetTag;
-				/* GPDB: Mark all queries as SPI inner query for extension usage 
-					But make sure that SPI is not top level itself by looking at queryCommandId
+				/* GPDB: Mark all queries as SPI inner query for extension usage
+					But make sure that SPI is not top level itself
 				*/
-				if (MyProc->queryCommandId != 0)
+				if (!IsBackgroundWorker || _SPI_connected > 0)
 					((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
 			}
 			else

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1333,11 +1333,14 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	 * GPDB: Mark all queries as SPI inner queries for extension usage.
 	 * But make sure that SPI is not top level itself.
 	 */
-	foreach(lc, stmt_list)
+	if (!IsBackgroundWorker || _SPI_connected > 0)
 	{
-		Node *stmt = (Node *) lfirst(lc);
-		if (IsA(stmt, PlannedStmt) && (!IsBackgroundWorker || _SPI_connected > 0))
-			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
+		foreach(lc, stmt_list)
+		{
+			Node *stmt = (Node *) lfirst(lc);
+			if (IsA(stmt, PlannedStmt))
+				((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
+		}	
 	}
 
 	/* Pop the error context stack */

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1333,7 +1333,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	 * GPDB: Mark all queries as SPI inner queries for extension usage. But
 	 * make sure that SPI is not top level itself.
 	 */
-	if (!IsBackgroundWorker || _SPI_connected > 0)
+	if (already_under_executor_run())
 	{
 		foreach(lc, stmt_list)
 		{
@@ -2242,7 +2242,7 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 				 * GPDB: Mark all queries as SPI inner queries for extension
 				 * usage. But make sure that SPI is not top level itself.
 				 */
-				if (!IsBackgroundWorker || _SPI_connected > 0)
+				if (already_under_executor_run())
 					((PlannedStmt *) pstmt)->metricsQueryType = SPI_INNER_QUERY;
 			}
 			else

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1329,11 +1329,14 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	cplan = GetCachedPlan(plansource, paramLI, false, NULL);
 	stmt_list = cplan->stmt_list;
 
-	/* GPDB: Mark all queries as SPI inner queries for extension usage */
+	/*
+	 * GPDB: Mark all queries as SPI inner queries for extension usage.
+	 * But make sure that SPI is not top level itself.
+	 */
 	foreach(lc, stmt_list)
 	{
 		Node *stmt = (Node *) lfirst(lc);
-		if (IsA(stmt, PlannedStmt))
+		if (IsA(stmt, PlannedStmt) && (!IsBackgroundWorker || _SPI_connected > 0))
 			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
 	}
 

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1330,17 +1330,18 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	stmt_list = cplan->stmt_list;
 
 	/*
-	 * GPDB: Mark all queries as SPI inner queries for extension usage.
-	 * But make sure that SPI is not top level itself.
+	 * GPDB: Mark all queries as SPI inner queries for extension usage. But
+	 * make sure that SPI is not top level itself.
 	 */
 	if (!IsBackgroundWorker || _SPI_connected > 0)
 	{
 		foreach(lc, stmt_list)
 		{
-			Node *stmt = (Node *) lfirst(lc);
+			Node	   *stmt = (Node *) lfirst(lc);
+
 			if (IsA(stmt, PlannedStmt))
-				((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
-		}	
+				((PlannedStmt *) stmt)->metricsQueryType = SPI_INNER_QUERY;
+		}
 	}
 
 	/* Pop the error context stack */
@@ -2236,12 +2237,13 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			{
 				PlannedStmt* pstmt = (PlannedStmt *) stmt;
 				canSetTag = pstmt->canSetTag;
+
 				/*
-				* GPDB: Mark all queries as SPI inner queries for extension usage.
-				* But make sure that SPI is not top level itself.
-				*/
+				 * GPDB: Mark all queries as SPI inner queries for extension
+				 * usage. But make sure that SPI is not top level itself.
+				 */
 				if (!IsBackgroundWorker || _SPI_connected > 0)
-					((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;
+					((PlannedStmt *) pstmt)->metricsQueryType = SPI_INNER_QUERY;
 			}
 			else
 			{

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2236,8 +2236,9 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			{
 				PlannedStmt* pstmt = (PlannedStmt *) stmt;
 				canSetTag = pstmt->canSetTag;
-				/* GPDB: Mark all queries as SPI inner query for extension usage
-					But make sure that SPI is not top level itself
+				/*
+				* GPDB: Mark all queries as SPI inner queries for extension usage.
+				* But make sure that SPI is not top level itself.
 				*/
 				if (!IsBackgroundWorker || _SPI_connected > 0)
 					((PlannedStmt*)pstmt)->metricsQueryType = SPI_INNER_QUERY;


### PR DESCRIPTION
Fix incorrect SPI_INNER_QUERY tagging for top-level SPI calls

Some extensions, such as ADCC, rely on the metricsQueryType field in
PlannedStmt to detect top-level query execution. However, queries executed
via SPI are always marked as SPI_INNER_QUERY, regardless of whether the SPI
call is initiated directly or nested within another SPI invocation.

This behavior leads to incorrect top-level query detection in background
workers that use SPI directly, potentially causing issues such as memory
leaks in extensions relying on accurate query lifecycle tracking.

This commit updates the tagging logic to avoid setting SPI_INNER_QUERY when the
SPI is a top-level SPI call. 

Automated testing of this change is non-trivial. Testing SPI top-level detection
requires a real background worker process, which must be registered and started
within the server — a pattern not yet used in existing tests. Unit testing with
CMockery is not viable either, as SPI requires a fully initialized backend
environment including shared memory, lock manager, and memory contexts.
Emulating this in isolation is impractical without broader infrastructure
changes.

ADBDEV-7415