### PR TITLE
Revert "Fix gp_replica_check test (#1459)"

### DIFF
--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -453,5 +453,3 @@ COMMIT
                                 ->  Index Scan using gp_fastsequence_objid_objmod_index on gp_fastsequence f
 
 
-1: drop table tab_fi;
-DROP TABLE

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -217,4 +217,3 @@ $$ LANGUAGE plpgsql;
 ! psql postgres -At -c "set enable_indexscan = off; set enable_seqscan = on; explain (costs off) select distinct f.gp_segment_id, f.objmod, f.last_sequence from gp_dist_random('gp_fastsequence') f left join gp_dist_random('pg_appendonly') a on segrelid = objid and a.gp_segment_id = f.gp_segment_id where a.gp_segment_id = 0 and relid = (select oid from pg_class where relname = 'tab_fi');" | grep "Seq Scan on gp_fastsequence";
 ! psql postgres -At -c "set enable_indexscan = on; set enable_seqscan = off; explain (costs off) select distinct f.gp_segment_id, f.objmod, f.last_sequence from gp_dist_random('gp_fastsequence') f left join gp_dist_random('pg_appendonly') a on segrelid = objid and a.gp_segment_id = f.gp_segment_id where a.gp_segment_id = 0 and relid = (select oid from pg_class where relname = 'tab_fi');" | grep "Index Scan using gp_fastsequence";
 
-1: drop table tab_fi;


### PR DESCRIPTION
Revert "Fix gp_replica_check test (#1459)"

Commit 31e5bc4 added a pointless table drop at the end of the test and was
therefore reverted.