### PR TITLE
Fix conflicts in src/Makefile.global.in

### DIFF
--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -23,11 +23,7 @@ standard_targets = all install installdirs uninstall distprep clean distclean ma
 # these targets should recurse even into subdirectories not being built:
 standard_always_targets = distprep clean distclean maintainer-clean
 
-<<<<<<< HEAD
-.PHONY: $(standard_targets) install-strip html man installcheck-parallel maintainer-check installcheck-good
-=======
-.PHONY: $(standard_targets) install-strip html man installcheck-parallel
->>>>>>> sync-pg-phase1
+.PHONY: $(standard_targets) install-strip html man installcheck-parallel installcheck-good
 
 # make `all' the default target
 all:


### PR DESCRIPTION
Fix conflicts in src/Makefile.global.in

Commit eb43f3d removed maintainer-check from src/Makefile.global.in, while
earlier commit 6b0e52b added installcheck-good to the same location.