### PR TITLE
Fix conflicts in doc/src/sgml/ref/psql-ref.sgml

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -1375,14 +1375,9 @@ testdb=&gt;
         <para>
         In this group of commands, the letters <literal>E</literal>,
         <literal>i</literal>, <literal>m</literal>, <literal>s</literal>,
-<<<<<<< HEAD
         <literal>t</literal>, <literal>P</literal>, and <literal>v</literal>
-        stand for foreign table, index, materialized view, sequence, table, parent table, and view,
-=======
-        <literal>t</literal>, and <literal>v</literal>
         stand for foreign table, index, materialized view,
-        sequence, table, and view,
->>>>>>> sync-pg-phase1
+        sequence, table, parent table, and view,
         respectively.
         You can specify any or all of
         these letters, in any order, to obtain a listing of objects


### PR DESCRIPTION
Fix conflicts in doc/src/sgml/ref/psql-ref.sgml

Commit 03e7b30 fixed formatting in doc/src/sgml/ref/psql-ref.sgml, while
earlier commit c7649f1 already changed formatting in the same place.