### PR TITLE
Enable orphaned files removal

### DIFF
--- a/.abi-check/6.27.1_arenadata62/postgres.symbols.ignore
+++ b/.abi-check/6.27.1_arenadata62/postgres.symbols.ignore
@@ -1,1 +1,2 @@
 ConfigureNamesBool_gp
+log_smgrcreate

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2467,7 +2467,7 @@ RemovePendingDeletesForPreparedTransactions()
 	HASH_SEQ_STATUS scan_status;
 	prpt_map   *entry;
 	XLogReaderState *xlogreader;
-	volatile bool result = true;
+	bool result = true;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
 	if (NULL == crashRecoverPostCheckpointPreparedTransactions_map_ht)
@@ -2485,7 +2485,7 @@ RemovePendingDeletesForPreparedTransactions()
 	while ((entry = (prpt_map *) hash_seq_search(&scan_status)) != NULL)
 	{
 		char	   *errormsg = NULL;
-		volatile XLogRecord *xlogrec = NULL;
+		XLogRecord *xlogrec = NULL;
 		TwoPhaseFileHeader *hdr;
 		TransactionId *subxids = NULL;
 

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2485,7 +2485,7 @@ RemovePendingDeletesForPreparedTransactions()
 	while ((entry = (prpt_map *) hash_seq_search(&scan_status)) != NULL)
 	{
 		char	   *errormsg = NULL;
-		volatile XLogRecord *xlogrec;
+		volatile XLogRecord *xlogrec = NULL;
 		TwoPhaseFileHeader *hdr;
 		TransactionId *subxids = NULL;
 

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2491,7 +2491,7 @@ RemovePendingDeletesForPreparedTransactions()
 		if (entry->xlogrecptr == InvalidXLogRecPtr)
 			continue;
 
-		int savedInterruptHoldoffCount = InterruptHoldoffCount;
+		volatile int savedInterruptHoldoffCount = InterruptHoldoffCount;
 		PG_TRY();
 		{
 			xlogrec = XLogReadRecord(xlogreader, entry->xlogrecptr, &errormsg);
@@ -2530,10 +2530,10 @@ RemovePendingDeletesForPreparedTransactions()
 
 		hdr = (TwoPhaseFileHeader *) XLogRecGetData(xlogrec);
 
-		TransactionId *subxids = NULL;
-		if (hdr->nsubxacts > 0)
-			subxids = (TransactionId *)
-				((char *) hdr + MAXALIGN(sizeof(TwoPhaseFileHeader)));
+		TransactionId *subxids = (hdr->nsubxacts > 0) ?
+			(TransactionId *)
+				((char *) hdr + MAXALIGN(sizeof(TwoPhaseFileHeader))) :
+			NULL;
 
 		PdlRedoRemoveTree(hdr->xid, subxids, hdr->nsubxacts);
 	}

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -56,6 +56,7 @@
 #include "access/xlogutils.h"
 #include "catalog/pg_type.h"
 #include "catalog/storage.h"
+#include "catalog/storage_pending_deletes_redo.h"
 #include "catalog/storage_tablespace.h"
 #include "catalog/storage_database.h"
 #include "funcapi.h"
@@ -2459,3 +2460,71 @@ getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *p
 	return oldest;
 
 }  /* end getTwoPhaseOldestPreparedTransactionXLogRecPtr */
+
+void
+RemovePendingDeletesForPreparedTransactions()
+{
+	HASH_SEQ_STATUS scan_status;
+	prpt_map *entry;
+	XLogReaderState *xlogreader;
+	XLogRecPtr xlogrec_ptr = InvalidXLogRecPtr;
+
+	if (NULL == crashRecoverPostCheckpointPreparedTransactions_map_ht)
+		return;
+
+	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
+	if (!xlogreader)
+		ereport(ERROR,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("out of memory"),
+			 errdetail("Failed while allocating an XLog reading processor.")));
+
+	hash_seq_init(&scan_status,
+				  crashRecoverPostCheckpointPreparedTransactions_map_ht);
+
+	entry = (prpt_map *)hash_seq_search(&scan_status);
+
+	if (entry != NULL)
+		xlogrec_ptr = entry->xlogrecptr;
+
+	while (xlogrec_ptr != InvalidXLogRecPtr)
+	{
+		char *errormsg = NULL;
+		XLogRecord *xlogrec;
+		TwoPhaseFileHeader *hdr;
+		TransactionId *subxids = NULL;
+
+		xlogrec = XLogReadRecord(xlogreader, xlogrec_ptr, &errormsg);
+		if (NULL == xlogrec)
+		{
+			if (errormsg)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("xlog record is invalid"),
+						 errdetail("%s", errormsg)));
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("xlog record is invalid")));
+		}
+
+		hdr = (TwoPhaseFileHeader *) XLogRecGetData(xlogrec);
+
+		if (hdr->nsubxacts > 0)
+			subxids = (TransactionId *)
+					  ((char *)hdr + MAXALIGN(sizeof(TwoPhaseFileHeader)));
+
+		PdlRedoRemoveTree(hdr->xid, subxids, hdr->nsubxacts);
+
+		/* Get the next entry */
+		entry = (prpt_map *)hash_seq_search(&scan_status);
+
+		if (entry != NULL)
+			xlogrec_ptr = entry->xlogrecptr;
+		else
+			xlogrec_ptr = InvalidXLogRecPtr;
+
+	}
+
+	XLogReaderFree(xlogreader);
+}  /* end RemovePendingDeletesForPreparedTransactions */

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2467,7 +2467,8 @@ RemovePendingDeletesForPreparedTransactions()
 	HASH_SEQ_STATUS scan_status;
 	prpt_map   *entry;
 	XLogReaderState *xlogreader;
-	bool result = true;
+	volatile bool result = true;
+	XLogRecord *xlogrec = NULL;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
 	if (NULL == crashRecoverPostCheckpointPreparedTransactions_map_ht)
@@ -2485,9 +2486,7 @@ RemovePendingDeletesForPreparedTransactions()
 	while ((entry = (prpt_map *) hash_seq_search(&scan_status)) != NULL)
 	{
 		char	   *errormsg = NULL;
-		XLogRecord *xlogrec = NULL;
 		TwoPhaseFileHeader *hdr;
-		TransactionId *subxids = NULL;
 
 		if (entry->xlogrecptr == InvalidXLogRecPtr)
 			continue;
@@ -2531,6 +2530,7 @@ RemovePendingDeletesForPreparedTransactions()
 
 		hdr = (TwoPhaseFileHeader *) XLogRecGetData(xlogrec);
 
+		TransactionId *subxids = NULL;
 		if (hdr->nsubxacts > 0)
 			subxids = (TransactionId *)
 				((char *) hdr + MAXALIGN(sizeof(TwoPhaseFileHeader)));

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2465,9 +2465,8 @@ void
 RemovePendingDeletesForPreparedTransactions()
 {
 	HASH_SEQ_STATUS scan_status;
-	prpt_map *entry;
+	prpt_map   *entry;
 	XLogReaderState *xlogreader;
-	XLogRecPtr xlogrec_ptr = InvalidXLogRecPtr;
 
 	if (NULL == crashRecoverPostCheckpointPreparedTransactions_map_ht)
 		return;
@@ -2475,26 +2474,23 @@ RemovePendingDeletesForPreparedTransactions()
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
 	if (!xlogreader)
 		ereport(ERROR,
-			(errcode(ERRCODE_OUT_OF_MEMORY),
-			 errmsg("out of memory"),
-			 errdetail("Failed while allocating an XLog reading processor.")));
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of memory"),
+		   errdetail("Failed while allocating an XLog reading processor.")));
 
 	hash_seq_init(&scan_status,
 				  crashRecoverPostCheckpointPreparedTransactions_map_ht);
-
-	entry = (prpt_map *)hash_seq_search(&scan_status);
-
-	if (entry != NULL)
-		xlogrec_ptr = entry->xlogrecptr;
-
-	while (xlogrec_ptr != InvalidXLogRecPtr)
+	while ((entry = (prpt_map *) hash_seq_search(&scan_status)) != NULL)
 	{
-		char *errormsg = NULL;
+		char	   *errormsg = NULL;
 		XLogRecord *xlogrec;
 		TwoPhaseFileHeader *hdr;
 		TransactionId *subxids = NULL;
 
-		xlogrec = XLogReadRecord(xlogreader, xlogrec_ptr, &errormsg);
+		if (entry->xlogrecptr == InvalidXLogRecPtr)
+			continue;
+
+		xlogrec = XLogReadRecord(xlogreader, entry->xlogrecptr, &errormsg);
 		if (NULL == xlogrec)
 		{
 			if (errormsg)
@@ -2512,18 +2508,9 @@ RemovePendingDeletesForPreparedTransactions()
 
 		if (hdr->nsubxacts > 0)
 			subxids = (TransactionId *)
-					  ((char *)hdr + MAXALIGN(sizeof(TwoPhaseFileHeader)));
+				((char *) hdr + MAXALIGN(sizeof(TwoPhaseFileHeader)));
 
 		PdlRedoRemoveTree(hdr->xid, subxids, hdr->nsubxacts);
-
-		/* Get the next entry */
-		entry = (prpt_map *)hash_seq_search(&scan_status);
-
-		if (entry != NULL)
-			xlogrec_ptr = entry->xlogrecptr;
-		else
-			xlogrec_ptr = InvalidXLogRecPtr;
-
 	}
 
 	XLogReaderFree(xlogreader);

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2461,15 +2461,17 @@ getTwoPhaseOldestPreparedTransactionXLogRecPtr(prepared_transaction_agg_state *p
 
 }  /* end getTwoPhaseOldestPreparedTransactionXLogRecPtr */
 
-void
+bool
 RemovePendingDeletesForPreparedTransactions()
 {
 	HASH_SEQ_STATUS scan_status;
 	prpt_map   *entry;
 	XLogReaderState *xlogreader;
+	volatile bool result = true;
+	MemoryContext oldcontext = CurrentMemoryContext;
 
 	if (NULL == crashRecoverPostCheckpointPreparedTransactions_map_ht)
-		return;
+		return result;
 
 	xlogreader = XLogReaderAllocate(&read_local_xlog_page, NULL);
 	if (!xlogreader)
@@ -2483,14 +2485,37 @@ RemovePendingDeletesForPreparedTransactions()
 	while ((entry = (prpt_map *) hash_seq_search(&scan_status)) != NULL)
 	{
 		char	   *errormsg = NULL;
-		XLogRecord *xlogrec;
+		volatile XLogRecord *xlogrec;
 		TwoPhaseFileHeader *hdr;
 		TransactionId *subxids = NULL;
 
 		if (entry->xlogrecptr == InvalidXLogRecPtr)
 			continue;
 
-		xlogrec = XLogReadRecord(xlogreader, entry->xlogrecptr, &errormsg);
+		int savedInterruptHoldoffCount = InterruptHoldoffCount;
+		PG_TRY();
+		{
+			xlogrec = XLogReadRecord(xlogreader, entry->xlogrecptr, &errormsg);
+		}
+		PG_CATCH();
+		{
+			MemoryContextSwitchTo(oldcontext);
+			InterruptHoldoffCount = savedInterruptHoldoffCount;
+			FlushErrorState();
+			result = false;
+		}
+		PG_END_TRY();
+
+		if (!result)
+		{
+			elog(LOG, "Failed to read WAL record %X/%X for XID %u in %s",
+				 (uint32) (entry->xlogrecptr >> 32),
+				 (uint32) entry->xlogrecptr,
+				 entry->xid,
+				 __func__);
+			break;
+		}
+
 		if (NULL == xlogrec)
 		{
 			if (errormsg)
@@ -2514,4 +2539,6 @@ RemovePendingDeletesForPreparedTransactions()
 	}
 
 	XLogReaderFree(xlogreader);
+
+	return result;
 }  /* end RemovePendingDeletesForPreparedTransactions */

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -2491,7 +2491,7 @@ RemovePendingDeletesForPreparedTransactions()
 		if (entry->xlogrecptr == InvalidXLogRecPtr)
 			continue;
 
-		volatile int savedInterruptHoldoffCount = InterruptHoldoffCount;
+		int savedInterruptHoldoffCount = InterruptHoldoffCount;
 		PG_TRY();
 		{
 			xlogrec = XLogReadRecord(xlogreader, entry->xlogrecptr, &errormsg);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7452,6 +7452,14 @@ StartupXLOG(void)
 					TimeLineID	newTLI = ThisTimeLineID;
 					TimeLineID	prevTLI = ThisTimeLineID;
 
+					if (info == XLOG_CHECKPOINT_SHUTDOWN ||
+					   info == XLOG_END_OF_RECOVERY)
+					{
+						RemovePendingDeletesForPreparedTransactions();
+						/* Clean up orphaned files */
+						PdlRedoDropFiles();
+					}
+
 					if (info == XLOG_CHECKPOINT_SHUTDOWN)
 					{
 						CheckPoint	checkPoint;
@@ -7506,17 +7514,7 @@ StartupXLOG(void)
 				 * xlogreader in this function.
 				 */
 				if (record->xl_rmid == RM_XLOG_ID)
-				{
 					VerifyOverwriteContrecord(record, xlogreader);
-
-					uint8 info = record->xl_info & ~XLR_INFO_MASK;
-					if (info == XLOG_CHECKPOINT_SHUTDOWN || info == XLOG_END_OF_RECOVERY)
-					{
-						RemovePendingDeletesForPreparedTransactions();
-						/* Clean up orphaned files */
-						PdlRedoDropFiles();
-					}
-				}
 
 				/* Pop the error context stack */
 				error_context_stack = errcallback.previous;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7455,6 +7455,31 @@ StartupXLOG(void)
 					if ((info == XLOG_CHECKPOINT_SHUTDOWN) ||
 						(info == XLOG_END_OF_RECOVERY))
 					{
+						/*
+						 * At this point we may encounter a situation, when some
+						 * prepared transaction is yet not committed/aborted,
+						 * but the respective WAL segment file is already
+						 * recycled. It may happen is some corner cases, like:
+						 * 1. Primary performs Prepare for a transaction;
+						 * 2. Primary fails and Mirror is promoted;
+						 * 3. New Primary (ex Mirror) commits the transaction;
+						 * 4. New Primary (ex Mirror) recycles WAL segment with
+						 * the Prepare record (because both Primary and Mirror
+						 * has done the Prepare);
+						 * 5. Ex Primary is recovered as new Mirror, it has the
+						 * the transaction in the list of prepared transactions,
+						 * but doesn't have the WAL segment. And the new Mirror
+						 * should soon see the commit REDO record from the new
+						 * Primary (and remove the transaction from the list of
+						 * prepared transactions).
+						 *
+						 * In such a case
+						 * RemovePendingDeletesForPreparedTransactions() will
+						 * return FALSE. And we postpone the removal of orphaned
+						 * files until all such prepared transactions without
+						 * WAL segment files are wiped out from the list of
+						 * prepared transactions.
+						 */
 						if (RemovePendingDeletesForPreparedTransactions())
 							/* Clean up orphaned files */
 							PdlRedoDropFiles();
@@ -7978,6 +8003,14 @@ StartupXLOG(void)
 
 		UtilityModeCloseDtmRedoFile();
 
+		/*
+		 * By this moment, there shouldn't be any prepared transaction with
+		 * missing respective WAL segment file, meaning
+		 * RemovePendingDeletesForPreparedTransactions() should return TRUE.
+		 * If not, most likely the respective WAL segment file is recycled
+		 * illegally, and we do not perform orphaned files removal (as we might
+		 * remove smth that is already committed). Instead, we emit a warning.
+		 */
 		if (RemovePendingDeletesForPreparedTransactions())
 			/* Clean up orphaned files */
 			PdlRedoDropFiles();

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7506,7 +7506,17 @@ StartupXLOG(void)
 				 * xlogreader in this function.
 				 */
 				if (record->xl_rmid == RM_XLOG_ID)
+				{
 					VerifyOverwriteContrecord(record, xlogreader);
+
+					uint8 info = record->xl_info & ~XLR_INFO_MASK;
+					if (info == XLOG_CHECKPOINT_SHUTDOWN || info == XLOG_END_OF_RECOVERY)
+					{
+						RemovePendingDeletesForPreparedTransactions();
+						/* Clean up orphaned files */
+						PdlRedoDropFiles();
+					}
+				}
 
 				/* Pop the error context stack */
 				error_context_stack = errcallback.previous;
@@ -7969,6 +7979,10 @@ StartupXLOG(void)
 			CreateCheckPoint(CHECKPOINT_END_OF_RECOVERY | CHECKPOINT_IMMEDIATE);
 
 		UtilityModeCloseDtmRedoFile();
+
+		RemovePendingDeletesForPreparedTransactions();
+		/* Clean up orphaned files */
+		PdlRedoDropFiles();
 
 		/*
 		 * And finally, execute the recovery_end_command, if any.

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7455,9 +7455,9 @@ StartupXLOG(void)
 					if ((info == XLOG_CHECKPOINT_SHUTDOWN) ||
 						(info == XLOG_END_OF_RECOVERY))
 					{
-						RemovePendingDeletesForPreparedTransactions();
-						/* Clean up orphaned files */
-						PdlRedoDropFiles();
+						if (RemovePendingDeletesForPreparedTransactions())
+							/* Clean up orphaned files */
+							PdlRedoDropFiles();
 					}
 
 					if (info == XLOG_CHECKPOINT_SHUTDOWN)
@@ -7978,9 +7978,12 @@ StartupXLOG(void)
 
 		UtilityModeCloseDtmRedoFile();
 
-		RemovePendingDeletesForPreparedTransactions();
-		/* Clean up orphaned files */
-		PdlRedoDropFiles();
+		if (RemovePendingDeletesForPreparedTransactions())
+			/* Clean up orphaned files */
+			PdlRedoDropFiles();
+		else
+			ereport(WARNING, (errmsg(
+					"Couldn't drop orphaned files")));
 
 		/*
 		 * And finally, execute the recovery_end_command, if any.

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7452,8 +7452,8 @@ StartupXLOG(void)
 					TimeLineID	newTLI = ThisTimeLineID;
 					TimeLineID	prevTLI = ThisTimeLineID;
 
-					if (info == XLOG_CHECKPOINT_SHUTDOWN ||
-					   info == XLOG_END_OF_RECOVERY)
+					if ((info == XLOG_CHECKPOINT_SHUTDOWN) ||
+						(info == XLOG_END_OF_RECOVERY))
 					{
 						RemovePendingDeletesForPreparedTransactions();
 						/* Clean up orphaned files */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7460,8 +7460,9 @@ StartupXLOG(void)
 						 * prepared transaction is yet not committed/aborted,
 						 * but the respective WAL segment file is already
 						 * recycled. It may happen is some corner cases, like:
-						 * 1. Primary performs Prepare for a transaction;
-						 * 2. Primary fails and Mirror is promoted;
+						 * 1. Primary successfully performs Prepare for a
+						 * transaction;
+						 * 2. Primary stops responding and Mirror is promoted;
 						 * 3. New Primary (ex Mirror) commits the transaction;
 						 * 4. New Primary (ex Mirror) recycles WAL segment with
 						 * the Prepare record (because both Primary and Mirror

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -108,7 +108,6 @@ extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **
 
 extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 
-
 extern bool RemovePendingDeletesForPreparedTransactions(void);
 
 #endif   /* TWOPHASE_H */

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -108,4 +108,7 @@ extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **
 
 extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 
+
+extern void RemovePendingDeletesForPreparedTransactions(void);
+
 #endif   /* TWOPHASE_H */

--- a/src/include/access/twophase.h
+++ b/src/include/access/twophase.h
@@ -109,6 +109,6 @@ extern void getTwoPhasePreparedTransactionData(prepared_transaction_agg_state **
 extern void SetupCheckpointPreparedTransactionList(prepared_transaction_agg_state *ptas);
 
 
-extern void RemovePendingDeletesForPreparedTransactions(void);
+extern bool RemovePendingDeletesForPreparedTransactions(void);
 
 #endif   /* TWOPHASE_H */


### PR DESCRIPTION
Enable orphaned files removal

This patch:
 - Adds clean up of orphaned files into `StartupXLOG()`.
 - Adds function RemovePendingDeletesForPreparedTransactions(), which removes
prepared transactions xids from redo pending deletes before the orphaned files
cleanup is performed. Orphaned files removal feature should consider prepared
transactions xids and remove them from redo pending deletes, because otherwise
some crash scenarios (for ex. 'crash_recovery_dtm' isolation2 test) would drop
files, that shouldn't be dropped.

No special tests are added. For now, it is enough to pass the standard test set.

Plus, abi-check is fixed.