### PR TITLE
Fix conflicts in src/backend/access/transam/xlogreader.c

### DIFF
--- a/src/backend/access/transam/xlogreader.c
+++ b/src/backend/access/transam/xlogreader.c
@@ -1500,7 +1500,6 @@ RestoreBlockImage(XLogReaderState *record, uint8 block_id, char *page)
 	return true;
 }
 
-<<<<<<< HEAD
 bool
 zstd_decompress_backupblock(const char *source, int32 slen, char *dest,
 							int32 rawsize, char *errormessage)
@@ -1561,7 +1560,7 @@ zstd_decompress_backupblock(const char *source, int32 slen, char *dest,
 				 "binary not compiled with ZSTD support");
 		return false;
 }
-=======
+
 #ifndef FRONTEND
 
 /*
@@ -1595,4 +1594,3 @@ XLogRecGetFullXid(XLogReaderState *record)
 }
 
 #endif
->>>>>>> sync-pg-phase1


### PR DESCRIPTION
Fix conflicts in src/backend/access/transam/xlogreader.c

Commit 67b9b3c added a new function XLogRecGetFullXid to the end of
src/backend/access/transam/xlogreader.c, while earlier commit 60915ec already
added another new function zstd_decompress_backupblock to the same place.