### PR TITLE
Fix conflicts in src/backend/commands/analyze.c

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -924,7 +924,6 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		}
 
 		/*
-<<<<<<< HEAD
 		 * Should we build extended statistics for this relation?
 		 *
 		 * The extended statistics catalog does not include an inheritance
@@ -940,18 +939,12 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		build_ext_stats = (onerel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE) ? inh : (!inh);
 
 		/*
-=======
->>>>>>> sync-pg-phase1
 		 * Build extended statistics (if there are any).
 		 *
 		 * For now we only build extended statistics on individual relations,
 		 * not for relations representing inheritance trees.
 		 */
-<<<<<<< HEAD
 		if (build_ext_stats)
-=======
-		if (!inh)
->>>>>>> sync-pg-phase1
 			BuildRelationExtStatistics(onerel, totalrows, numrows, rows,
 									   attr_cnt, vacattrstats);
 	}


### PR DESCRIPTION
Fix conflicts in src/backend/commands/analyze.c

Commit 14ef15a added a check for inheritance to the do_analyze_rel function,
while earlier commit a4926db already did this, and commit bd4a16e changed it by
adding additional conditions.