### PR TITLE
Fix conflicts in src/backend/commands/publicationcmds.c

### DIFF
--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -237,7 +237,14 @@ CreatePublication(CreatePublicationStmt *stmt)
 
 	InvokeObjectPostCreateHook(PublicationRelationId, puboid, 0);
 
-<<<<<<< HEAD
+	if (wal_level != WAL_LEVEL_LOGICAL)
+	{
+		ereport(WARNING,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("wal_level is insufficient to publish logical changes"),
+				 errhint("Set wal_level to logical before creating subscriptions.")));
+	}
+
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		CdbDispatchUtilityStatement((Node *) stmt,
@@ -249,14 +256,6 @@ CreatePublication(CreatePublicationStmt *stmt)
 
 		/* MPP-6929: metadata tracking */
 		MetaTrackAddObject(PublicationRelationId, myself.objectId, GetUserId(), "CREATE", "PUBLICATION");
-=======
-	if (wal_level != WAL_LEVEL_LOGICAL)
-	{
-		ereport(WARNING,
-				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("wal_level is insufficient to publish logical changes"),
-				 errhint("Set wal_level to logical before creating subscriptions.")));
->>>>>>> sync-pg-phase1
 	}
 
 	return myself;


### PR DESCRIPTION
Fix conflicts in src/backend/commands/publicationcmds.c

Commit b31fbe8 added a warning to the CreatePublication function, while earlier
commit 19cd1cf added dispatching to the same place.