### PR TITLE
Fix conflicts in src/include/nodes/pg_list.h and src/backend/nodes/list.c

### DIFF
--- a/contrib/formatter_fixedwidth/fixedwidth.c
+++ b/contrib/formatter_fixedwidth/fixedwidth.c
@@ -829,7 +829,7 @@ fixedwidth_in(PG_FUNCTION_ARGS)
 			extract_field(data_buf + data_cur, field_size, true, &(myData->one_val));
 
 			null_val_with_blanks = strVal(lfirst(cur_null_with_blanks));
-			cur_null_with_blanks = lnext(cur_null_with_blanks);
+			cur_null_with_blanks = lnext(format_in_config.fldNullsWithBlanks, cur_null_with_blanks);
 			
 			if (strcmp(myData->one_val.data, null_val_with_blanks) != 0)
 			{

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -1086,7 +1086,6 @@ static Oid
 lookupCustomFormatter(List **options, bool iswritable)
 {
 	ListCell   *cell;
-	ListCell   *prev = NULL;
 	char	   *formatter_name;
 	List	   *funcname = NIL;
 	Oid			procOid = InvalidOid;
@@ -1106,10 +1105,9 @@ lookupCustomFormatter(List **options, bool iswritable)
 		{
 			formatter_name = defGetString(defel);
 			funcname = list_make1(makeString(formatter_name));
-			*options = list_delete_cell(*options, cell, prev);
+			*options = list_delete_cell(*options, cell);
 			break;
 		}
-		prev = cell;
 	}
 	if (list_length(funcname) == 0)
 		ereport(ERROR,

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -1105,7 +1105,7 @@ lookupCustomFormatter(List **options, bool iswritable)
 		{
 			formatter_name = defGetString(defel);
 			funcname = list_make1(makeString(formatter_name));
-			foreach_delete_current(*options, cell);
+			*options = foreach_delete_current(*options, cell);
 			break;
 		}
 	}

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -1105,7 +1105,7 @@ lookupCustomFormatter(List **options, bool iswritable)
 		{
 			formatter_name = defGetString(defel);
 			funcname = list_make1(makeString(formatter_name));
-			*options = list_delete_cell(*options, cell);
+			foreach_delete_current(*options, cell);
 			break;
 		}
 	}

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1397,7 +1397,7 @@ _bitmap_write_new_bitmapwords(Relation rel,
 			MarkBufferDirty(buffer);
 
 			/* Update the 'next' pointer on this page, before moving on */
-			buffer_cell = lnext(buffer_cell);
+			buffer_cell = lnext(perpage_buffers, buffer_cell);
 			Assert(buffer_cell);
 			nextBlkNo = BufferGetBlockNumber((Buffer) lfirst_int(buffer_cell));
 

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -168,13 +168,13 @@ base16_encode(char *raw, int len, char *encoded)
 static char *
 get_eol_delimiter(List *params)
 {
-	ListCell   *lc = params->head;
+	ListCell   *lc = list_head(params);
 
 	while (lc)
 	{
-		if (pg_strcasecmp(((DefElem *) lc->data.ptr_value)->defname, "line_delim") == 0)
-			return pstrdup(((Value *) ((DefElem *) lc->data.ptr_value)->arg)->val.str);
-		lc = lc->next;
+		if (pg_strcasecmp(((DefElem *) lc->ptr_value)->defname, "line_delim") == 0)
+			return pstrdup(((Value *) ((DefElem *) lc->ptr_value)->arg)->val.str);
+		lc = lnext(params, lc);
 	}
 	return pstrdup("");
 }

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -359,7 +359,6 @@ static Oid
 GetPreassignedOid(OidAssignment *searchkey)
 {
 	ListCell   *cur_item;
-	ListCell   *prev_item;
 	Oid			oid;
 
 	/*
@@ -376,7 +375,6 @@ GetPreassignedOid(OidAssignment *searchkey)
 			return AssignBinaryUpgradeReservedOid();
 	}
 
-	prev_item = NULL;
 	cur_item = list_head(preassigned_oids);
 
 	while (cur_item != NULL)
@@ -396,12 +394,11 @@ GetPreassignedOid(OidAssignment *searchkey)
 #endif
 
 			oid = p->oid;
-			preassigned_oids = list_delete_cell(preassigned_oids, cur_item, prev_item);
+			preassigned_oids = list_delete_cell(preassigned_oids, cur_item);
 			pfree(p);
 			return oid;
 		}
-		prev_item = cur_item;
-		cur_item = lnext(cur_item);
+		cur_item = lnext(preassigned_oids, cur_item);
 	}
 
 	return InvalidOid;
@@ -1255,10 +1252,8 @@ char *
 GetPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid childRelId)
 {
 	ListCell   *cur_item;
-	ListCell   *prev_item;
 	char	   *result = NULL;
 
-	prev_item = NULL;
 	cur_item = list_head(preassigned_oids);
 
 	while (cur_item != NULL)
@@ -1275,12 +1270,11 @@ GetPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid childRelId)
 #endif
 
 			result = pstrdup(p->objname);
-			preassigned_oids = list_delete_cell(preassigned_oids, cur_item, prev_item);
+			preassigned_oids = list_delete_cell(preassigned_oids, cur_item);
 			pfree(p);
 			return result;
 		}
-		prev_item = cur_item;
-		cur_item = lnext(cur_item);
+		cur_item = lnext(preassigned_oids, cur_item);
 	}
 
 	if (result == NULL)

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -394,7 +394,7 @@ GetPreassignedOid(OidAssignment *searchkey)
 #endif
 
 			oid = p->oid;
-			preassigned_oids = list_delete_cell(preassigned_oids, cur_item);
+			preassigned_oids = foreach_delete_current(preassigned_oids, cur_item);
 			pfree(p);
 			return oid;
 		}
@@ -1270,7 +1270,7 @@ GetPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid childRelId)
 #endif
 
 			result = pstrdup(p->objname);
-			preassigned_oids = list_delete_cell(preassigned_oids, cur_item);
+			preassigned_oids = foreach_delete_current(preassigned_oids, cur_item);
 			pfree(p);
 			return result;
 		}

--- a/src/backend/catalog/oid_dispatch.c
+++ b/src/backend/catalog/oid_dispatch.c
@@ -375,9 +375,7 @@ GetPreassignedOid(OidAssignment *searchkey)
 			return AssignBinaryUpgradeReservedOid();
 	}
 
-	cur_item = list_head(preassigned_oids);
-
-	while (cur_item != NULL)
+	foreach(cur_item, preassigned_oids)
 	{
 		OidAssignment *p = (OidAssignment *) lfirst(cur_item);
 
@@ -398,7 +396,6 @@ GetPreassignedOid(OidAssignment *searchkey)
 			pfree(p);
 			return oid;
 		}
-		cur_item = lnext(preassigned_oids, cur_item);
 	}
 
 	return InvalidOid;
@@ -1254,9 +1251,7 @@ GetPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid childRelId)
 	ListCell   *cur_item;
 	char	   *result = NULL;
 
-	cur_item = list_head(preassigned_oids);
-
-	while (cur_item != NULL)
+	foreach(cur_item, preassigned_oids)
 	{
 		OidAssignment *p = (OidAssignment *) lfirst(cur_item);
 
@@ -1274,7 +1269,6 @@ GetPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid childRelId)
 			pfree(p);
 			return result;
 		}
-		cur_item = lnext(preassigned_oids, cur_item);
 	}
 
 	if (result == NULL)

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -782,6 +782,7 @@ cdbpath_eclass_constant_is_hashable(EquivalenceClass *ec, Oid hashOpFamily)
 
 static bool
 cdbpath_match_preds_to_distkey_tail(CdbpathMatchPredsContext *ctx,
+									List *lst,
 									ListCell *distkeycell)
 {
 	DistributionKey *distkey = (DistributionKey *) lfirst(distkeycell);
@@ -864,10 +865,10 @@ cdbpath_match_preds_to_distkey_tail(CdbpathMatchPredsContext *ctx,
 		ctx->colocus_eq_locus = false;
 
 	/* Match remaining partkey items. */
-	distkeycell = lnext(distkeycell);
+	distkeycell = lnext(lst, distkeycell);
 	if (distkeycell)
 	{
-		if (!cdbpath_match_preds_to_distkey_tail(ctx, distkeycell))
+		if (!cdbpath_match_preds_to_distkey_tail(ctx, lst, distkeycell))
 			return false;
 	}
 
@@ -924,7 +925,7 @@ cdbpath_match_preds_to_distkey(PlannerInfo *root,
 	ctx.colocus = colocus;
 	ctx.colocus_eq_locus = true;
 
-	return cdbpath_match_preds_to_distkey_tail(&ctx, list_head(locus.distkey));
+	return cdbpath_match_preds_to_distkey_tail(&ctx, locus.distkey, list_head(locus.distkey));
 }
 
 

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -454,7 +454,7 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 			if (parentrel)
 			{
 				parentexpr = lfirst(lc2);
-				lc2 = lnext(lc2);
+				lc2 = lnext(parentrel->reltarget->exprs, lc2);
 			}
 
 			if (!IsA(expr, Var))

--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -239,7 +239,7 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 		if (subpath != adjusted_path)
 		{
 			subpath = adjusted_path;
-			pathcell->data.ptr_value = subpath;
+			pathcell->ptr_value = subpath;
 		}
 	}
 

--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -731,7 +731,7 @@ inline static bool
 has_resjunk(List *tlist)
 {
 	bool		resjunk = false;
-	Node	   *tlnode = (Node *) (lfirst(tlist->tail));
+	Node	   *tlnode = (Node *) (lfirst(list_tail(tlist)));
 
 	if (IsA(tlnode, TargetEntry))
 	{

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -929,7 +929,8 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 			 lastWriter = cell, cell = lnext(segdbDesc->segment_database_info->freelist, cell)) ;
 
 		if (lastWriter)
-			lappend(segdbDesc->segment_database_info->freelist, segdbDesc);
+			segdbDesc->segment_database_info->freelist =
+				lappend(segdbDesc->segment_database_info->freelist, segdbDesc);
 		else
 			segdbDesc->segment_database_info->freelist =
 				lcons(segdbDesc, segdbDesc->segment_database_info->freelist);

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -929,8 +929,7 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 			 lastWriter = cell, cell = lnext(segdbDesc->segment_database_info->freelist, cell)) ;
 
 		if (lastWriter)
-			lappend_cell(segdbDesc->segment_database_info->freelist,
-						 lastWriter, segdbDesc);
+			lappend(segdbDesc->segment_database_info->freelist, segdbDesc);
 		else
 			segdbDesc->segment_database_info->freelist =
 				lcons(segdbDesc, segdbDesc->segment_database_info->freelist);

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -582,7 +582,6 @@ cleanupComponentIdleQEs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
 	MemoryContext				oldContext;
 	ListCell 					*curItem = NULL;
 	ListCell					*nextItem = NULL;
-	ListCell 					*prevItem = NULL;
 
 	Assert(CdbComponentsContext);
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
@@ -591,17 +590,16 @@ cleanupComponentIdleQEs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
 	while (curItem != NULL)
 	{
 		segdbDesc = (SegmentDatabaseDescriptor *)lfirst(curItem);
-		nextItem = lnext(curItem);
+		nextItem = lnext(cdi->freelist, curItem);
 		Assert(segdbDesc);
 
 		if (segdbDesc->isWriter && !includeWriter)
 		{
-			prevItem = curItem;
 			curItem = nextItem;
 			continue;
 		}
 
-		cdi->freelist = list_delete_cell(cdi->freelist, curItem, prevItem); 
+		cdi->freelist = list_delete_cell(cdi->freelist, curItem);
 		DECR_COUNT(cdi, numIdleQEs);
 
 		cdbconn_termSegmentDescriptor(segdbDesc);
@@ -780,7 +778,6 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 	CdbComponentDatabaseInfo	*cdbinfo;
 	ListCell 					*curItem = NULL;
 	ListCell 					*nextItem = NULL;
-	ListCell					*prevItem = NULL;
 	MemoryContext 				oldContext;
 	bool						isWriter;
 
@@ -798,18 +795,17 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 		SegmentDatabaseDescriptor *tmp =
 				(SegmentDatabaseDescriptor *)lfirst(curItem);
 
-		nextItem = lnext(curItem);
+		nextItem = lnext(cdbinfo->freelist, curItem);
 		Assert(tmp);
 
 		if ((segmentType == SEGMENTTYPE_EXPLICT_WRITER && !tmp->isWriter) ||
 			(segmentType == SEGMENTTYPE_EXPLICT_READER && tmp->isWriter))
 		{
-			prevItem = curItem;
 			curItem = nextItem;
 			continue;
 		}
 
-		cdbinfo->freelist = list_delete_cell(cdbinfo->freelist, curItem, prevItem); 
+		cdbinfo->freelist = list_delete_cell(cdbinfo->freelist, curItem);
 		/* update numIdleQEs */
 		DECR_COUNT(cdbinfo, numIdleQEs);
 
@@ -930,7 +926,7 @@ cdbcomponent_recycleIdleQE(SegmentDatabaseDescriptor *segdbDesc, bool forceDestr
 
 		for (cell = list_head(segdbDesc->segment_database_info->freelist);
 			 cell && ((SegmentDatabaseDescriptor *) lfirst(cell))->isWriter;
-			 lastWriter = cell, cell = lnext(cell)) ;
+			 lastWriter = cell, cell = lnext(segdbDesc->segment_database_info->freelist, cell)) ;
 
 		if (lastWriter)
 			lappend_cell(segdbDesc->segment_database_info->freelist,

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -581,21 +581,17 @@ cleanupComponentIdleQEs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
 	SegmentDatabaseDescriptor	*segdbDesc;
 	MemoryContext				oldContext;
 	ListCell 					*curItem = NULL;
-	ListCell					*nextItem = NULL;
 
 	Assert(CdbComponentsContext);
 	oldContext = MemoryContextSwitchTo(CdbComponentsContext);
-	curItem = list_head(cdi->freelist);
 
-	while (curItem != NULL)
+	foreach(curItem, cdi->freelist)
 	{
 		segdbDesc = (SegmentDatabaseDescriptor *)lfirst(curItem);
-		nextItem = lnext(cdi->freelist, curItem);
 		Assert(segdbDesc);
 
 		if (segdbDesc->isWriter && !includeWriter)
 		{
-			curItem = nextItem;
 			continue;
 		}
 
@@ -603,9 +599,6 @@ cleanupComponentIdleQEs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
 		DECR_COUNT(cdi, numIdleQEs);
 
 		cdbconn_termSegmentDescriptor(segdbDesc);
-
-		curItem = nextItem;
-
 	}
 
 	MemoryContextSwitchTo(oldContext);
@@ -777,7 +770,6 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 	SegmentDatabaseDescriptor	*segdbDesc = NULL;
 	CdbComponentDatabaseInfo	*cdbinfo;
 	ListCell 					*curItem = NULL;
-	ListCell 					*nextItem = NULL;
 	MemoryContext 				oldContext;
 	bool						isWriter;
 
@@ -789,19 +781,16 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 	 * Always try to pop from the head.  Make sure to push them back to head
 	 * in cdbcomponent_recycleIdleQE().
 	 */
-	curItem = list_head(cdbinfo->freelist);
-	while (curItem != NULL)
+	foreach(curItem, cdbinfo->freelist)
 	{
 		SegmentDatabaseDescriptor *tmp =
 				(SegmentDatabaseDescriptor *)lfirst(curItem);
 
-		nextItem = lnext(cdbinfo->freelist, curItem);
 		Assert(tmp);
 
 		if ((segmentType == SEGMENTTYPE_EXPLICT_WRITER && !tmp->isWriter) ||
 			(segmentType == SEGMENTTYPE_EXPLICT_READER && tmp->isWriter))
 		{
-			curItem = nextItem;
 			continue;
 		}
 

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -599,7 +599,7 @@ cleanupComponentIdleQEs(CdbComponentDatabaseInfo *cdi, bool includeWriter)
 			continue;
 		}
 
-		cdi->freelist = list_delete_cell(cdi->freelist, curItem);
+		cdi->freelist = foreach_delete_current(cdi->freelist, curItem);
 		DECR_COUNT(cdi, numIdleQEs);
 
 		cdbconn_termSegmentDescriptor(segdbDesc);
@@ -805,7 +805,7 @@ cdbcomponent_allocateIdleQE(int contentId, SegmentType segmentType)
 			continue;
 		}
 
-		cdbinfo->freelist = list_delete_cell(cdbinfo->freelist, curItem);
+		cdbinfo->freelist = foreach_delete_current(cdbinfo->freelist, curItem);
 		/* update numIdleQEs */
 		DECR_COUNT(cdbinfo, numIdleQEs);
 

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -978,10 +978,10 @@ backend_type(SegmentDatabaseDescriptor *segdb)
  * qsort comparator for SegmentDatabaseDescriptors. Sorts by descriptor ID.
  */
 static int
-compare_segdb_id(const void *v1, const void *v2)
+compare_segdb_id(const ListCell *v1, const ListCell *v2)
 {
-	SegmentDatabaseDescriptor *d1 = (SegmentDatabaseDescriptor *) lfirst(*(ListCell **) v1);
-	SegmentDatabaseDescriptor *d2 = (SegmentDatabaseDescriptor *) lfirst(*(ListCell **) v2);
+	SegmentDatabaseDescriptor *d1 = (SegmentDatabaseDescriptor *) lfirst(v1);
+	SegmentDatabaseDescriptor *d2 = (SegmentDatabaseDescriptor *) lfirst(v2);
 
 	return d1->identifier - d2->identifier;
 }
@@ -1063,7 +1063,7 @@ gp_backend_info(PG_FUNCTION_ARGS)
 		 * For a slightly better default user experience, sort by descriptor ID.
 		 * Users may of course specify their own ORDER BY if they don't like it.
 		 */
-		user_fctx->segdbs = list_qsort(user_fctx->segdbs, compare_segdb_id);
+		list_sort(user_fctx->segdbs, compare_segdb_id);
 		user_fctx->curpos = list_head(user_fctx->segdbs);
 
 		/* Create a descriptor for the records we'll be returning. */
@@ -1098,7 +1098,7 @@ gp_backend_info(PG_FUNCTION_ARGS)
 
 		/* Get the next descriptor. */
 		dbdesc = lfirst(user_fctx->curpos);
-		user_fctx->curpos = lnext(user_fctx->curpos);
+		user_fctx->curpos = lnext(user_fctx->segdbs, user_fctx->curpos);
 
 		/* Fill in the row attributes. */
 		dbinfo = dbdesc->segment_database_info;

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -65,15 +65,13 @@ static List *ic_proxy_unknown_addrs = NIL;
 static ICProxyAddr *ic_proxy_my_addr = NULL;
 
 /*
- * Compare function for list_qsort().
- *
- * The real type of the arguments is "const ListCell **".
+ * Compare function for list_sort().
  */
 static int
-ic_proxy_addr_compare_dbid(const void *a, const void *b)
+ic_proxy_addr_compare_dbid(const ListCell *a, const ListCell *b)
 {
-	const ICProxyAddr *addr1 = lfirst(*(const ListCell **) a);
-	const ICProxyAddr *addr2 = lfirst(*(const ListCell **) b);
+	const ICProxyAddr *addr1 = lfirst(a);
+	const ICProxyAddr *addr2 = lfirst(b);
 
 	return addr1->dbid - addr2->dbid;
 }
@@ -104,13 +102,13 @@ ic_proxy_classify_addresses(List *oldaddrs, List *newaddrs)
 		{
 			/* the address is removed */
 			ic_proxy_removed_addrs = lappend(ic_proxy_removed_addrs, old);
-			lcold = lnext(lcold);
+			lcold = lnext(oldaddrs, lcold);
 		}
 		else if (old->dbid > new->dbid)
 		{
 			/* the address is newly added */
 			ic_proxy_added_addrs = lappend(ic_proxy_added_addrs, new);
-			lcnew = lnext(lcnew);
+			lcnew = lnext(newaddrs, lcnew);
 		}
 		/*
 		 * note that the new->sockaddr is not filled yet, so we must compare
@@ -122,19 +120,19 @@ ic_proxy_classify_addresses(List *oldaddrs, List *newaddrs)
 			/* the address is updated */
 			ic_proxy_removed_addrs = lappend(ic_proxy_removed_addrs, old);
 			ic_proxy_added_addrs = lappend(ic_proxy_added_addrs, new);
-			lcold = lnext(lcold);
-			lcnew = lnext(lcnew);
+			lcold = lnext(oldaddrs, lcold);
+			lcnew = lnext(newaddrs, lcnew);
 		}
 		else
 		{
 			/* the address is unchanged */
-			lcold = lnext(lcold);
-			lcnew = lnext(lcnew);
+			lcold = lnext(oldaddrs, lcold);
+			lcnew = lnext(newaddrs, lcnew);
 		}
 	}
 
 	/* all the addresses remaining in the old list are removed */
-	for ( ; lcold; lcold = lnext(lcold))
+	for ( ; lcold; lcold = lnext(oldaddrs, lcold))
 	{
 		ICProxyAddr *old = lfirst(lcold);
 
@@ -142,7 +140,7 @@ ic_proxy_classify_addresses(List *oldaddrs, List *newaddrs)
 	}
 
 	/* all the addresses remaining in the new list are newly added */
-	for ( ; lcnew; lcnew = lnext(lcnew))
+	for ( ; lcnew; lcnew = lnext(newaddrs, lcnew))
 	{
 		ICProxyAddr *new = lfirst(lcnew);
 
@@ -252,7 +250,7 @@ ic_proxy_reload_addresses(uv_loop_t *loop)
 	 * before reloading the config file. we should sort ic_proxy_addrs by dbid to
 	 * avoid mis-disconnecting of addrs.
 	 */
-	ic_proxy_addrs = list_qsort(ic_proxy_addrs, ic_proxy_addr_compare_dbid);
+	list_sort(ic_proxy_addrs, ic_proxy_addr_compare_dbid);
 	ic_proxy_prev_addrs = ic_proxy_addrs;
 	ic_proxy_addrs = NULL;
 
@@ -326,8 +324,7 @@ ic_proxy_reload_addresses(uv_loop_t *loop)
 	}
 
 	/* sort the new addrs so it's easy to diff */
-	ic_proxy_unknown_addrs = list_qsort(ic_proxy_unknown_addrs,
-										ic_proxy_addr_compare_dbid);
+	list_sort(ic_proxy_unknown_addrs, ic_proxy_addr_compare_dbid);
 
 	/* the last thing is to classify the addrs */
 	ic_proxy_classify_addresses(ic_proxy_prev_addrs /* oldaddrs */,

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1969,7 +1969,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates, bool hasErrors)
 	/*
 	 * These are connected inbound peers that we haven't dealt with quite yet
 	 */
-	while ((cell = list_head(transportStates->incompleteConns)) != NULL)
+	foreach(cell, transportStates->incompleteConns)
 	{
 		MotionConn *conn = (MotionConn *) lfirst(cell);
 
@@ -1997,7 +1997,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates, bool hasErrors)
 		 * incompleteConns = list_delete_first(incompleteConns); or
 		 * incompleteConns = list_delete_ptr(incompleteConns, conn)
 		 */
-		transportStates->incompleteConns = list_delete(transportStates->incompleteConns, conn);
+		transportStates->incompleteConns = foreach_delete_current(transportStates->incompleteConns, cell);
 	}
 
 	list_free(transportStates->incompleteConns);

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1727,7 +1727,7 @@ SetupTCPInterconnect(EState *estate)
 			 * we'll get the next cell ready now in case we need to delete the
 			 * cell that corresponds to our MotionConn
 			 */
-			cell = lnext(cell);
+			cell = lnext(interconnect_context->incompleteConns, cell);
 
 			if (MPP_FD_ISSET(conn->sockfd, &rset))
 			{
@@ -1993,7 +1993,7 @@ TeardownTCPInterconnect(ChunkTransportState *transportStates, bool hasErrors)
 		 * The list operations are kind of confusing (see list.c), we could
 		 * alternatively write the following line as:
 		 *
-		 * incompleteConns = list_delete_cell(incompleteConns, cell, NULL); or
+		 * incompleteConns = list_delete_cell(incompleteConns, cell); or
 		 * incompleteConns = list_delete_first(incompleteConns); or
 		 * incompleteConns = list_delete_ptr(incompleteConns, conn)
 		 */

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -798,18 +798,16 @@ static bool
 ExtractErrorLogPersistent(List **options)
 {
 	ListCell   *cell;
-	ListCell *prev = NULL;
 
 	foreach(cell, *options)
 	{
 		DefElem    *def = (DefElem *) lfirst(cell);
 		if (pg_strcasecmp(def->defname, "error_log_persistent") == 0)
 		{
-			*options = list_delete_cell(*options, cell, prev);
+			*options = list_delete_cell(*options, cell);
 			/* these accept only boolean values */
 			return defGetBoolean(def);
 		}
-		prev = cell;
 	}
 	return false;
 }

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -804,7 +804,7 @@ ExtractErrorLogPersistent(List **options)
 		DefElem    *def = (DefElem *) lfirst(cell);
 		if (pg_strcasecmp(def->defname, "error_log_persistent") == 0)
 		{
-			*options = list_delete_cell(*options, cell);
+			foreach_delete_current(*options, cell);
 			/* these accept only boolean values */
 			return defGetBoolean(def);
 		}

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -804,7 +804,7 @@ ExtractErrorLogPersistent(List **options)
 		DefElem    *def = (DefElem *) lfirst(cell);
 		if (pg_strcasecmp(def->defname, "error_log_persistent") == 0)
 		{
-			foreach_delete_current(*options, cell);
+			*options = foreach_delete_current(*options, cell);
 			/* these accept only boolean values */
 			return defGetBoolean(def);
 		}

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -273,6 +273,7 @@ AddUpdResqueueCapabilityEntryInternal(
 /* MPP-6923: */				  
 static void
 AlterResqueueCapabilityEntry(Oid queueid,
+							 List *lst,
 							 ListCell *initcell,
 							 bool bCreate)
 {
@@ -292,11 +293,11 @@ AlterResqueueCapabilityEntry(Oid queueid,
 	}
 #endif
 
-	initcell = lnext(initcell);
+	initcell = lnext(lst, initcell);
 
 	/* walk the original list and build a list of valid entries */
 
-	for_each_cell(lc, initcell)
+	for_each_cell(lc, lst, initcell)
 	{
 		DefElem *defel		= (DefElem *) lfirst(lc);
 		Oid		 resTypeOid = InvalidOid;
@@ -531,7 +532,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		
 		resTypeInt = intVal(lfirst(lc2));
 
-		lc2 = lnext(lc2);
+		lc2 = lnext(pentry, lc2);
 		
 		pVal = lfirst(lc2);
 
@@ -598,7 +599,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		
 		resTypeInt = intVal(lfirst(lc2));
 
-		lc2 = lnext(lc2);
+		lc2 = lnext(pentry, lc2);
 		
 		pVal = lfirst(lc2);
 
@@ -923,7 +924,7 @@ CreateQueue(CreateQueueStmt *stmt)
 
 	/* process the remainder of the WITH (...) list items */
 	if (bWith)
-		AlterResqueueCapabilityEntry(queueid, pWithList, true);
+		AlterResqueueCapabilityEntry(queueid, stmt->options, pWithList, true);
 
 	/* 
 	 * We must bump the command counter to make the new entry 
@@ -1208,7 +1209,7 @@ AlterQueue(AlterQueueStmt *stmt)
 	{
 		ListCell		*initcell = pWithList;
 
-		if (bWith && initcell && lnext(initcell))
+		if (bWith && initcell && lnext(stmt->options, initcell))
 		{
 			/* if have an item on the "with list", don't need to set a
 			 * threshold 
@@ -1330,7 +1331,7 @@ AlterQueue(AlterQueueStmt *stmt)
 
 	/* process the remainder of the WITH (...) list items */
 	if (bWith)
-		AlterResqueueCapabilityEntry(queueid, pWithList, false);
+		AlterResqueueCapabilityEntry(queueid, stmt->options, pWithList, false);
 
 	/* 
 	 * We must bump the command counter to make the altered memory limit 

--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -118,8 +118,8 @@ SplitTupleTableSlot(TupleTableSlot *slot,
 			insert_values[attno - 1] = values[insertAttNo - 1];
 			insert_nulls[attno - 1] = nulls[insertAttNo - 1];
 
-			deleteAtt = lnext(deleteAtt);
-			insertAtt = lnext(insertAtt);
+			deleteAtt = lnext(plannode->deleteColIdx, deleteAtt);
+			insertAtt = lnext(plannode->insertColIdx, insertAtt);
 		}
 		else if (attno == node->output_segid_attno)
 		{

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -65,7 +65,7 @@ SeparateOutMppExecute(List **options)
 								mpp_execute)));
 			}
 
-			foreach_delete_current(*options, lc);
+			*options = foreach_delete_current(*options, lc);
 			break;
 		}
 	}
@@ -98,7 +98,7 @@ SeparateOutNumSegments(List **options)
 								num_segments)));
 			}
 
-			foreach_delete_current(*options, lc);
+			*options = foreach_delete_current(*options, lc);
 			break;
 		}
 	}

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -65,7 +65,7 @@ SeparateOutMppExecute(List **options)
 								mpp_execute)));
 			}
 
-			*options = list_delete_cell(*options, lc);
+			foreach_delete_current(*options, lc);
 			break;
 		}
 	}
@@ -98,7 +98,7 @@ SeparateOutNumSegments(List **options)
 								num_segments)));
 			}
 
-			*options = list_delete_cell(*options, lc);
+			foreach_delete_current(*options, lc);
 			break;
 		}
 	}

--- a/src/backend/foreign/foreign.c
+++ b/src/backend/foreign/foreign.c
@@ -38,7 +38,6 @@ char
 SeparateOutMppExecute(List **options)
 {
 	ListCell *lc = NULL;
-	ListCell *prev = NULL;
 	char *mpp_execute = NULL;
 	char exec_location = FTEXECLOCATION_NOT_DEFINED;
 
@@ -66,10 +65,9 @@ SeparateOutMppExecute(List **options)
 								mpp_execute)));
 			}
 
-			*options = list_delete_cell(*options, lc, prev);
+			*options = list_delete_cell(*options, lc);
 			break;
 		}
-		prev = lc;
 	}
 
 	return exec_location;
@@ -80,7 +78,6 @@ int32
 SeparateOutNumSegments(List **options)
 {
 	ListCell *lc = NULL;
-	ListCell *prev = NULL;
 	char *num_segments_str = NULL;
 	int32 num_segments = 0;
 
@@ -101,11 +98,9 @@ SeparateOutNumSegments(List **options)
 								num_segments)));
 			}
 
-			*options = list_delete_cell(*options, lc, prev);
+			*options = list_delete_cell(*options, lc);
 			break;
 		}
-
-		prev = lc;
 	}
 	return num_segments;
 }

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -484,10 +484,10 @@ guc_options_include_retrieve_conn(List *guc_options)
 		char       *value;
 
 		name = lfirst(gucopts);
-		gucopts = lnext(gucopts);
+		gucopts = lnext(guc_options, gucopts);
 
 		value = lfirst(gucopts);
-		gucopts = lnext(gucopts);
+		gucopts = lnext(guc_options, gucopts);
 
 		if (guc_name_compare(name, "gp_retrieve_conn") == 0)
 		{

--- a/src/backend/nodes/list.c
+++ b/src/backend/nodes/list.c
@@ -567,31 +567,6 @@ list_truncate(List *list, int new_size)
 }
 
 /*
-<<<<<<< HEAD
- * Locate the n'th cell (counting from 0) of the list.  It is an assertion
- * failure if there is no such cell.
- */
-ListCell *
-list_nth_cell(const List *list, int n)
-{
-	ListCell   *match;
-
-	Assert(list != NIL);
-	Assert(n >= 0);
-	Assert(n < list->length);
-	check_list_invariants(list);
-
-	/* Does the caller actually mean to fetch the tail? */
-	if (n == list->length - 1)
-		return list->tail;
-
-	for (match = list->head; n-- > 0; match = match->next)
-		;
-
-	return match;
-}
-
-/**
  * Replace the n-th data pointer in the list with newvalue.
  * Returns oldvalue. Assumes that n is a valid offset.
  */
@@ -601,47 +576,12 @@ list_nth_replace(List *list, int n, void *new_data)
 	ListCell *lc = NULL;
 	lc = list_nth_cell(list, n);
 	Assert(lc);
-	void *old_data = lc->data.ptr_value;
-	lc->data.ptr_value = new_data;
+	void *old_data = lc->ptr_value;
+	lc->ptr_value = new_data;
 	return old_data;
 }
 
 /*
- * Return the data value contained in the n'th element of the
- * specified list. (List elements begin at 0.)
- */
-void *
-list_nth(const List *list, int n)
-{
-	Assert(IsPointerList(list));
-	return lfirst(list_nth_cell(list, n));
-}
-
-/*
- * Return the integer value contained in the n'th element of the
- * specified list.
- */
-int
-list_nth_int(const List *list, int n)
-{
-	Assert(IsIntegerList(list));
-	return lfirst_int(list_nth_cell(list, n));
-}
-
-/*
- * Return the OID value contained in the n'th element of the specified
- * list.
- */
-Oid
-list_nth_oid(const List *list, int n)
-{
-	Assert(IsOidList(list));
-	return lfirst_oid(list_nth_cell(list, n));
-}
-
-/*
-=======
->>>>>>> sync-pg-phase1
  * Return true iff 'datum' is a member of the list. Equality is
  * determined via equal(), so callers should ensure that they pass a
  * Node as 'datum'.

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3228,7 +3228,7 @@ create_splitupdate_plan(PlannerInfo *root, SplitUpdatePath *path)
 		Form_pg_attribute	attr;
 
 		tle = (TargetEntry *) lfirst(lc);
-		lc = lnext(lc);
+		lc = lnext(subplan->targetlist, lc);
 		Assert(tle);
 
 		attr = &resultDesc->attrs[attrIdx - 1];
@@ -3249,7 +3249,7 @@ create_splitupdate_plan(PlannerInfo *root, SplitUpdatePath *path)
 	lastresno = list_length(splitupdate->plan.targetlist);
 
 	/* Copy all junk attributes. */
-	for (; lc != NULL; lc = lnext(lc))
+	for (; lc != NULL; lc = lnext(subplan->targetlist, lc))
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(lc);
 		TargetEntry *newtle;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -8605,12 +8605,12 @@ make_new_rollups_for_hash_grouping_set(PlannerInfo        *root,
 		pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
 	{
 		unhashed_rollup = lfirst_node(RollupData, l_start);
-		l_start = lnext(l_start);
+		l_start = lnext(gd->rollups, l_start);
 	}
 
 	sets_data = list_copy(gd->unsortable_sets);
 
-	for_each_cell(lc, l_start)
+	for_each_cell(lc, gd->rollups, l_start)
 	{
 		RollupData *rollup = lfirst_node(RollupData, lc);
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -5318,7 +5318,7 @@ adjust_modifytable_subpaths(PlannerInfo *root, CmdType operation,
 			else
 				subpath = create_motion_path_for_upddel(root, rti, targetPolicy, subpath);
 
-			lci = lnext(lci);
+			lci = lnext(is_split_updates, lci);
 		}
 		lfirst(lcp) = subpath;
 	}

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2604,8 +2604,8 @@ coerceSetOpTypes(ParseState *pstate, Node *sop,
 				*targetlist = lappend(*targetlist, restle);
 			}
 
-			pct = pct ? lnext(pct) : NULL;
-			pcm = pcm ? lnext(pcm) : NULL;
+			pct = pct ? lnext(preselected_coltypes, pct) : NULL;
+			pcm = pcm ? lnext(preselected_coltypmods, pcm) : NULL;
 		}
 	}
 }

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -409,7 +409,7 @@ deduceImplicitRangeBounds(ParseState *pstate, Relation parentrel, List *stmts, b
 			}
 			if (!stmt->partbound->upperdatums)
 			{
-				Node *next = lc->next ? lfirst(lc->next) : NULL;
+				Node *next = lnext(stmts, lc) ? lfirst(lnext(stmts, lc)) : NULL;
 				if (next)
 				{
 					CreateStmt *nextstmt = (CreateStmt *)next;

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -979,7 +979,6 @@ static char *
 extract_tablename_from_options(List **options)
 {
 	ListCell *o_lc;
-	ListCell *prev_lc = NULL;
 	char *tablename = NULL;
 
 	foreach (o_lc, *options)
@@ -999,11 +998,10 @@ extract_tablename_from_options(List **options)
 						 errmsg("invalid tablename specification")));
 
 			char *relname_str = defGetString(pDef);
-			*options = list_delete_cell(*options, o_lc, prev_lc);
+			*options = list_delete_cell(*options, o_lc);
 			tablename = pstrdup(relname_str);
 			break;
 		}
-		prev_lc = o_lc;
 	}
 
 	return tablename;

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -341,7 +341,7 @@ list_qsort_arg(List *list, qsort_arg_comparator cmp, void *arg)
 
 	i = 0;
 	foreach(cell, list)
-		cell->data.ptr_value = create_stmts[i++];
+		cell->ptr_value = create_stmts[i++];
 
 	pfree(create_stmts);
 }

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -998,7 +998,7 @@ extract_tablename_from_options(List **options)
 						 errmsg("invalid tablename specification")));
 
 			char *relname_str = defGetString(pDef);
-			foreach_delete_current(*options, o_lc);
+			*options = foreach_delete_current(*options, o_lc);
 			tablename = pstrdup(relname_str);
 			break;
 		}

--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -998,7 +998,7 @@ extract_tablename_from_options(List **options)
 						 errmsg("invalid tablename specification")));
 
 			char *relname_str = defGetString(pDef);
-			*options = list_delete_cell(*options, o_lc);
+			foreach_delete_current(*options, o_lc);
 			tablename = pstrdup(relname_str);
 			break;
 		}

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5385,7 +5385,7 @@ get_select_query_def(Query *query, deparse_context *context,
 				Node *expr = (Node *) lfirst(lc);
 
 				get_rule_expr(expr, context, false);
-				if (lc->next)
+				if (lnext(query->scatterClause, lc))
 					appendStringInfo(buf, ", ");
 			}
 		}

--- a/src/backend/utils/cache/test/lsyscache_test.c
+++ b/src/backend/utils/cache/test/lsyscache_test.c
@@ -44,7 +44,7 @@ test_get_func_arg_types_can_correctly_return_more_than_one_argtype(void **state)
 	assert_int_equal(2, result->length);
 
 	assert_int_equal(11, lfirst_oid(list_head(result)));
-	assert_int_equal(22, lfirst_oid(lnext(list_head(result))));
+	assert_int_equal(22, lfirst_oid(lnext(result, list_head(result))));
 }
 
 int

--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -423,7 +423,7 @@ dumpCancelResult(StringInfo str, List *xids)
 
 		appendStringInfo(str, UINT64_FORMAT"(Master Pid: %d)", xid, GetPidByGxid(xid));
 
-		if (lnext(cell))
+		if (lnext(xids, cell))
 			appendStringInfo(str, ",");
 	}
 }

--- a/src/backend/utils/gdd/gdddetectorpriv.h
+++ b/src/backend/utils/gdd/gdddetectorpriv.h
@@ -26,7 +26,7 @@
 		 (iter).cell = list_head((iter).list); \
 		 (iter).cell != NULL; \
 		 (iter).prev = (iter).cell, \
-		 (iter).cell = (iter).cell ? lnext((iter).cell) : list_head((iter).list))
+		 (iter).cell = (iter).cell ? lnext((iter).list, (iter).cell) : list_head((iter).list))
 
 /*
  * Helper functions to get the information stored in iter.
@@ -46,7 +46,7 @@
  */
 #define gdd_list_iter_delete(iter) do \
 { \
-	(iter).list = list_delete_cell((iter).list, (iter).cell, (iter).prev); \
+	(iter).list = list_delete_cell((iter).list, (iter).cell); \
 	(iter).prev = (iter).list != NIL ? (iter).prev : NULL; \
 	(iter).cell = (iter).prev; \
 } while (0)

--- a/src/backend/utils/gdd/gdddetectorpriv.h
+++ b/src/backend/utils/gdd/gdddetectorpriv.h
@@ -21,10 +21,12 @@
  * Safe list foreach which supports in-place deletion.
  */
 #define gdd_list_foreach_safe(iter, _list) \
-	for ((iter).list = (_list), \
-		 (iter).cell = list_head((iter).list); \
-		 (iter).cell != NULL; \
-		 (iter).cell = (iter).cell ? lnext((iter).list, (iter).cell) : list_head((iter).list))
+	for ((iter).list = (_list), (iter).i = 0; \
+		 ((iter).list != NIL && \
+		 (iter).i < (iter).list->length) ? \
+		 ((iter).cell = &(iter).list->elements[(iter).i], true) : \
+		 ((iter).cell = NULL, false); \
+		 (iter).i++)
 
 /*
  * Helper functions to get the information stored in iter.
@@ -41,11 +43,9 @@
  * In-place delete the list cell at iter.
  * By using this you must re-get the list via gdd_list_iter_get_list().
  */
-#define gdd_list_iter_delete(iter) do \
-{ \
-	(iter).list = list_delete_cell((iter).list, (iter).cell); \
-	(iter).cell = (iter).list != NIL ? (iter).cell : NULL; \
-} while (0)
+#define gdd_list_iter_delete(iter) \
+	((iter).i--, \
+	 (List *) ((iter).list = list_delete_cell((iter).list, (iter).cell)))
 
 
 /*
@@ -167,6 +167,7 @@ struct GddListIter
 {
 	List		*list;
 	ListCell	*cell;
+	int			i;				/* current element index */
 };
 
 /*

--- a/src/backend/utils/gdd/gdddetectorpriv.h
+++ b/src/backend/utils/gdd/gdddetectorpriv.h
@@ -22,10 +22,8 @@
  */
 #define gdd_list_foreach_safe(iter, _list) \
 	for ((iter).list = (_list), \
-		 (iter).prev = NULL, \
 		 (iter).cell = list_head((iter).list); \
 		 (iter).cell != NULL; \
-		 (iter).prev = (iter).cell, \
 		 (iter).cell = (iter).cell ? lnext((iter).list, (iter).cell) : list_head((iter).list))
 
 /*
@@ -33,7 +31,6 @@
  */
 #define gdd_list_iter_get_list(iter) ((iter).list)
 #define gdd_list_iter_get_cell(iter) ((iter).cell)
-#define gdd_list_iter_get_prev(iter) ((iter).prev)
 
 /*
  * Helper function to get the current pointer at iter.
@@ -47,8 +44,7 @@
 #define gdd_list_iter_delete(iter) do \
 { \
 	(iter).list = list_delete_cell((iter).list, (iter).cell); \
-	(iter).prev = (iter).list != NIL ? (iter).prev : NULL; \
-	(iter).cell = (iter).prev; \
+	(iter).cell = (iter).list != NIL ? (iter).cell : NULL; \
 } while (0)
 
 
@@ -171,7 +167,6 @@ struct GddListIter
 {
 	List		*list;
 	ListCell	*cell;
-	ListCell	*prev;
 };
 
 /*

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -5144,7 +5144,7 @@ DispatchSyncPGVariable(struct config_generic * gconfig)
 					char	   *curname = (char *) lfirst(lc);
 
 					appendStringInfoString(&buffer, quote_literal_cstr(curname));
-					if (lnext(lc))
+					if (lnext(namelist, lc))
 						appendStringInfoString(&buffer, ", ");
 				}
 			}

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -666,23 +666,23 @@ void GPDBLockRelationOid(Oid reloid, int lockmode);
 }  //namespace gpdb
 
 #define ForEach(cell, l) \
-	for ((cell) = gpdb::ListHead(l); (cell) != NULL; (cell) = lnext(cell))
+	for ((cell) = gpdb::ListHead(l); (cell) != NULL; (cell) = lnext(l, cell))
 
 #define ForBoth(cell1, list1, cell2, list2)                                \
 	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2); \
 		 (cell1) != NULL && (cell2) != NULL;                               \
-		 (cell1) = lnext(cell1), (cell2) = lnext(cell2))
+		 (cell1) = lnext(list1, cell1), (cell2) = lnext(list2, cell2))
 
 #define ForThree(cell1, list1, cell2, list2, cell3, list3)                 \
 	for ((cell1) = gpdb::ListHead(list1), (cell2) = gpdb::ListHead(list2), \
 		(cell3) = gpdb::ListHead(list3);                                   \
 		 (cell1) != NULL && (cell2) != NULL && (cell3) != NULL;            \
-		 (cell1) = lnext(cell1), (cell2) = lnext(cell2),                   \
-		(cell3) = lnext(cell3))
+		 (cell1) = lnext(list1, cell1), (cell2) = lnext(list2, cell2),     \
+		(cell3) = lnext(list3, cell3))
 
 #define ForEachWithCount(cell, list, counter)                          \
 	for ((cell) = gpdb::ListHead(list), (counter) = 0; (cell) != NULL; \
-		 (cell) = lnext(cell), ++(counter))
+		 (cell) = lnext(list, cell), ++(counter))
 
 #define ListMake1(x1) gpdb::LPrepend(x1, NIL)
 

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -38,7 +38,6 @@ struct Query;
 using ScanKey = struct ScanKeyData *;
 struct Bitmapset;
 struct Plan;
-struct ListCell;
 struct TargetEntry;
 struct Expr;
 struct ExtTableEntry;

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -576,7 +576,7 @@ static inline struct PlannerInfo *planner_subplan_get_root(struct PlannerInfo *r
 static inline void planner_subplan_put_plan(struct PlannerInfo *root, SubPlan *subplan, Plan *plan) 
 {
 	ListCell *cell = list_nth_cell(root->glob->subplans, subplan->plan_id-1);
-	cell->data.ptr_value = plan;
+	cell->ptr_value = plan;
 }
 
 /*----------

--- a/src/include/nodes/pg_list.h
+++ b/src/include/nodes/pg_list.h
@@ -407,7 +407,7 @@ for_each_cell_setup(List *lst, ListCell *initcell)
 #define foreach_with_count(cell, list, counter) \
 	for ((cell) = list_head(list), (counter)=0; \
 	     (cell) != NULL; \
-	     (cell) = lnext(cell), ++(counter))
+	     (cell) = lnext(list, cell), ++(counter))
 
 
 /*
@@ -575,15 +575,10 @@ extern List *list_copy(const List *list);
 extern List *list_copy_tail(const List *list, int nskip);
 extern List *list_copy_deep(const List *oldlist);
 
-<<<<<<< HEAD
 extern void *list_nth_replace(List *list, int n, void *new_data);
 
-typedef int (*list_qsort_comparator) (const void *a, const void *b);
-extern List *list_qsort(const List *list, list_qsort_comparator cmp);
-=======
 typedef int (*list_sort_comparator) (const ListCell *a, const ListCell *b);
 extern void list_sort(List *list, list_sort_comparator cmp);
->>>>>>> sync-pg-phase1
 
 extern int	list_oid_cmp(const ListCell *p1, const ListCell *p2);
 

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -175,7 +175,7 @@ static inline struct Plan *exec_subplan_get_plan(struct PlannedStmt *plannedstmt
 static inline void exec_subplan_put_plan(struct PlannedStmt *plannedstmt, SubPlan *subplan, struct Plan *plan)
 {
 	ListCell *cell = list_nth_cell(plannedstmt->subplans, subplan->plan_id-1);
-	cell->data.ptr_value = plan;
+	cell->ptr_value = plan;
 }
 
 /*

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2199,10 +2199,11 @@ gp_keepalives_check(PG_FUNCTION_ARGS)
 		int socket_fd;
 		uint size = sizeof(int);
 		SegmentDatabaseDescriptor *segDesc;
+		List *freelist = context->cdbs->segment_db_info[context->index].freelist;
 
 		/* The QE segment freelist contains the idle QE info that stores the PGconn objects */
-		if (context->cdbs->segment_db_info[context->index].freelist == NULL
-			|| (context->currentQE != NULL && lnext(context->cdbs->segment_db_info[context->index].freelist, context->currentQE) == NULL))
+		if (freelist == NIL
+			|| (context->currentQE != NULL && lnext(freelist, context->currentQE) == NULL))
 		{
 			/* This QE segment freelist is empty or we've reached the end of the freelist */
 			context->currentQE = NULL;
@@ -2212,12 +2213,12 @@ gp_keepalives_check(PG_FUNCTION_ARGS)
 		else if (context->currentQE == NULL)
 		{
 			/* Start at the head of this QE segment freelist */
-			context->currentQE = list_head(context->cdbs->segment_db_info[context->index].freelist);
+			context->currentQE = list_head(freelist);
 		}
 		else
 		{
 			/* Continue to next item in the QE segment freelist (e.g. readers and writers) */
-			context->currentQE = lnext(context->cdbs->segment_db_info[context->index].freelist, context->currentQE);
+			context->currentQE = lnext(freelist, context->currentQE);
 		}
 
 		/* Obtain the socket file descriptor from each libpq connection */

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2202,7 +2202,7 @@ gp_keepalives_check(PG_FUNCTION_ARGS)
 
 		/* The QE segment freelist contains the idle QE info that stores the PGconn objects */
 		if (context->cdbs->segment_db_info[context->index].freelist == NULL
-			|| (context->currentQE != NULL && lnext(context->currentQE) == NULL))
+			|| (context->currentQE != NULL && lnext(context->cdbs->segment_db_info[context->index].freelist, context->currentQE) == NULL))
 		{
 			/* This QE segment freelist is empty or we've reached the end of the freelist */
 			context->currentQE = NULL;
@@ -2217,7 +2217,7 @@ gp_keepalives_check(PG_FUNCTION_ARGS)
 		else
 		{
 			/* Continue to next item in the QE segment freelist (e.g. readers and writers) */
-			context->currentQE = lnext(context->currentQE);
+			context->currentQE = lnext(context->cdbs->segment_db_info[context->index].freelist, context->currentQE);
 		}
 
 		/* Obtain the socket file descriptor from each libpq connection */


### PR DESCRIPTION
Fix conflicts in src/include/nodes/pg_list.h and src/backend/nodes/list.c

1) Commit 1cff1b9 changed the internal representation of lists, as well as
their API, including adding a third argument to for_each_cell, a second
argument to lnext, removed the third argument from list_delete_cell, and moved
list_nth_cell, list_nth, list_nth_int, list_nth_oid from
src/backend/nodes/list.c to src/include/nodes/pg_list.h, while earlier commit
6b0e52b added list_nth_replace.

2) Commit 569ed7f renamed list_qsort to list_sort and changed its API, while
earlier commit 6b0e52b added list_nth_replace declaration before that.

3) Commit 1cff1b9 changed the ListCell structure.