### PR TITLE
Fix conflicts in src/backend/executor/nodeBitmapHeapscan.c

### DIFF
--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -69,13 +69,8 @@ static inline void BitmapAdjustPrefetchIterator(BitmapHeapScanState *node,
 static inline void BitmapAdjustPrefetchTarget(BitmapHeapScanState *node);
 static inline void BitmapPrefetch(BitmapHeapScanState *node,
 								  TableScanDesc scan);
-<<<<<<< HEAD
-static bool BitmapShouldInitializeSharedState(
-											  ParallelBitmapHeapState *pstate);
-static void ExecEagerFreeBitmapHeapScan(BitmapHeapScanState *node);
-=======
 static bool BitmapShouldInitializeSharedState(ParallelBitmapHeapState *pstate);
->>>>>>> sync-pg-phase1
+static void ExecEagerFreeBitmapHeapScan(BitmapHeapScanState *node);
 
 
 /*


### PR DESCRIPTION
Fix conflicts in src/backend/executor/nodeBitmapHeapscan.c

Commit 870b1d6 removed the extra line break in the
BitmapShouldInitializeSharedState function declaration, while earlier commit
6195b96 added the ExecEagerFreeBitmapHeapScan function declaration below.