### PR TITLE
Fix conflicts in pathnodes.h, planner.c and prepjointree.c

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -836,7 +836,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	root->cte_plan_ids = NIL;
 	root->multiexpr_params = NIL;
 	root->eq_classes = NIL;
-<<<<<<< HEAD
+	root->ec_merging_done = false;
 	root->non_eq_clauses = NIL;
 	root->init_plans = NIL;
 
@@ -846,9 +846,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 		root->list_cteplaninfo = init_list_cteplaninfo(list_length(parse->cteList));
 	}
 
-=======
-	root->ec_merging_done = false;
->>>>>>> sync-pg-phase1
 	root->append_rel_list = NIL;
 	root->rowMarks = NIL;
 	memset(root->upper_rels, 0, sizeof(root->upper_rels));
@@ -4877,7 +4874,6 @@ consider_groupingsets_paths(PlannerInfo *root,
 		 * Aggregate is distributed, then the number of groups in one segment
 		 * is only a fraction of the total.
 		 */
-<<<<<<< HEAD
 		if (CdbPathLocus_IsPartitioned(path->locus))
 			dNumGroups = clamp_row_est(dNumGroupsTotal /
 									   CdbPathLocus_NumSegments(path->locus));
@@ -4891,15 +4887,6 @@ consider_groupingsets_paths(PlannerInfo *root,
 
 		if (srd->unhashed_rollup)
 			exclude_groups = srd->unhashed_rollup->numGroups;
-=======
-		if (l_start != NULL &&
-			pathkeys_contained_in(root->group_pathkeys, path->pathkeys))
-		{
-			unhashed_rollup = lfirst_node(RollupData, l_start);
-			exclude_groups = unhashed_rollup->numGroups;
-			l_start = lnext(gd->rollups, l_start);
-		}
->>>>>>> sync-pg-phase1
 
 		hashsize = estimate_hashagg_tablesize(path,
 											  agg_costs,
@@ -4925,88 +4912,6 @@ consider_groupingsets_paths(PlannerInfo *root,
 											   parse->groupClause,
 											   srd->new_rollups);
 
-<<<<<<< HEAD
-=======
-		for_each_cell(lc, gd->rollups, l_start)
-		{
-			RollupData *rollup = lfirst_node(RollupData, lc);
-
-			/*
-			 * If we find an unhashable rollup that's not been skipped by the
-			 * "actually sorted" check above, we can't cope; we'd need sorted
-			 * input (with a different sort order) but we can't get that here.
-			 * So bail out; we'll get a valid path from the is_sorted case
-			 * instead.
-			 *
-			 * The mere presence of empty grouping sets doesn't make a rollup
-			 * unhashable (see preprocess_grouping_sets), we handle those
-			 * specially below.
-			 */
-			if (!rollup->hashable)
-				return;
-			else
-				sets_data = list_concat(sets_data, list_copy(rollup->gsets_data));
-		}
-		foreach(lc, sets_data)
-		{
-			GroupingSetData *gs = lfirst_node(GroupingSetData, lc);
-			List	   *gset = gs->set;
-			RollupData *rollup;
-
-			if (gset == NIL)
-			{
-				/* Empty grouping sets can't be hashed. */
-				empty_sets_data = lappend(empty_sets_data, gs);
-				empty_sets = lappend(empty_sets, NIL);
-			}
-			else
-			{
-				rollup = makeNode(RollupData);
-
-				rollup->groupClause = preprocess_groupclause(root, gset);
-				rollup->gsets_data = list_make1(gs);
-				rollup->gsets = remap_to_groupclause_idx(rollup->groupClause,
-														 rollup->gsets_data,
-														 gd->tleref_to_colnum_map);
-				rollup->numGroups = gs->numGroups;
-				rollup->hashable = true;
-				rollup->is_hashed = true;
-				new_rollups = lappend(new_rollups, rollup);
-			}
-		}
-
-		/*
-		 * If we didn't find anything nonempty to hash, then bail.  We'll
-		 * generate a path from the is_sorted case.
-		 */
-		if (new_rollups == NIL)
-			return;
-
-		/*
-		 * If there were empty grouping sets they should have been in the
-		 * first rollup.
-		 */
-		Assert(!unhashed_rollup || !empty_sets);
-
-		if (unhashed_rollup)
-		{
-			new_rollups = lappend(new_rollups, unhashed_rollup);
-			strat = AGG_MIXED;
-		}
-		else if (empty_sets)
-		{
-			RollupData *rollup = makeNode(RollupData);
-
-			rollup->groupClause = NIL;
-			rollup->gsets_data = empty_sets_data;
-			rollup->gsets = empty_sets;
-			rollup->numGroups = list_length(empty_sets);
-			rollup->hashable = false;
-			rollup->is_hashed = false;
-			new_rollups = lappend(new_rollups, rollup);
-			strat = AGG_MIXED;
-		}
->>>>>>> sync-pg-phase1
 
 		add_path(grouped_rel, (Path *)
 				 create_groupingsets_path(root,

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -1052,11 +1052,8 @@ pull_up_simple_subquery(PlannerInfo *root, Node *jtnode, RangeTblEntry *rte,
 	subroot->cte_plan_ids = NIL;
 	subroot->multiexpr_params = NIL;
 	subroot->eq_classes = NIL;
-<<<<<<< HEAD
-	subroot->non_eq_clauses = NIL;
-=======
 	subroot->ec_merging_done = false;
->>>>>>> sync-pg-phase1
+	subroot->non_eq_clauses = NIL;
 	subroot->append_rel_list = NIL;
 	subroot->rowMarks = NIL;
 	memset(subroot->upper_rels, 0, sizeof(subroot->upper_rels));

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -336,11 +336,9 @@ struct PlannerInfo
 
 	List	   *eq_classes;		/* list of active EquivalenceClasses */
 
-<<<<<<< HEAD
 	List	   *non_eq_clauses;	/* list of non-equivalence clauses */
-=======
+
 	bool		ec_merging_done;	/* set true once ECs are canonical */
->>>>>>> sync-pg-phase1
 
 	List	   *canon_pathkeys; /* list of "canonical" PathKeys */
 

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -859,13 +859,9 @@ typedef struct RelOptInfo
     struct GpPolicy   *cdbpolicy;      /* distribution of stored tuples */
 	Oid			relam;			/* form_pg_class access method */
 	double		allvisfrac;
-<<<<<<< HEAD
-	PlannerInfo *subroot;		/* if subquery (in GPDB: or CTE) */
-=======
 	Bitmapset  *eclass_indexes; /* Indexes in PlannerInfo's eq_classes list of
 								 * ECs that mention this rel */
-	PlannerInfo *subroot;		/* if subquery */
->>>>>>> sync-pg-phase1
+	PlannerInfo *subroot;		/* if subquery (in GPDB: or CTE) */
 	List	   *subplan_params; /* if subquery */
 	int			rel_parallel_workers;	/* wanted number of parallel workers */
 


### PR DESCRIPTION
Fix conflicts in pathnodes.h, planner.c and prepjointree.c

1) Commit 3373c71 added a new field ec_merging_done to the PlannerInfo
structure and new field eclass_indexes to the RelOptInfo structure, while
earlier commit 1c35fe0 added a new field non_eq_clauses to the PlannerInfo
structure in the same place, and earlier commit 598f4b0 added a comment to the
RelOptInfo structure in the same place.

2) Commit 3373c71 added initialization of the new field ec_merging_done to the
subquery_planner function and to the pull_up_simple_subquery function, while
earlier commit 1c35fe0 added initialization of the field non_eq_clauses in the
same places.

3) Commit 1cff1b9 added a second argument to the lnext call, a third argument
to the for_each_cell call in the consider_groupingsets_paths function, while
earlier commit 9a790f8 moved these pieces of code to the
make_new_rollups_for_hash_grouping_set function.