### PR TITLE
Fix conflicts in src/backend/partitioning/partbounds.c

### DIFF
--- a/src/backend/partitioning/partbounds.c
+++ b/src/backend/partitioning/partbounds.c
@@ -2836,13 +2836,8 @@ satisfies_hash_partition(PG_FUNCTION_ARGS)
 		PartitionKey key;
 		int			j;
 
-<<<<<<< HEAD
-		/* Open parent relation and fetch partition keyinfo */
-		parent = try_relation_open(parentId, AccessShareLock, false);
-=======
 		/* Open parent relation and fetch partition key info */
-		parent = try_relation_open(parentId, AccessShareLock);
->>>>>>> sync-pg-phase1
+		parent = try_relation_open(parentId, AccessShareLock, false);
 		if (parent == NULL)
 			PG_RETURN_NULL();
 		key = RelationGetPartitionKey(parent);


### PR DESCRIPTION
Fix conflicts in src/backend/partitioning/partbounds.c

Commit da6f3e4 added a new file src/backend/partitioning/partbounds.c, while
the earlier commit da6f3e4 already added it, and commit 19cd1cf added a third
argument to the try_relation_open function.