### PR TITLE
Fix conflicts in src/backend/storage/file/fd.c

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -1794,11 +1794,7 @@ FileClose(File file)
 	if (!FileIsNotOpen(file))
 	{
 		/* close the file */
-<<<<<<< HEAD
-		if (gp_retry_close(vfdP->fd))
-=======
-		if (close(vfdP->fd) != 0)
->>>>>>> sync-pg-phase1
+		if (gp_retry_close(vfdP->fd) != 0)
 		{
 			/*
 			 * We may need to panic on failure to close non-temporary files;


### PR DESCRIPTION
Fix conflicts in src/backend/storage/file/fd.c

Commit 7e9a4c5 added an explicit comparison with 0 in the FileClose function
when calling the close function, while the earlier commit 6b0e52b instead of
the close function began calling the gp_retry_close function in the same place.