### PR TITLE
Fix conflicts in src/include/access/xact.h

### DIFF
--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -308,14 +308,9 @@ typedef struct xl_xact_abort
 
 	/* xl_xact_xinfo follows if XLOG_XACT_HAS_INFO */
 	/* xl_xact_dbinfo follows if XINFO_HAS_DBINFO */
-<<<<<<< HEAD
-	/* xl_xact_subxacts follows if HAS_SUBXACT */
-	/* xl_xact_relfilenodes follows if HAS_RELFILENODES */
-	/* xl_xact_deldbs follows if HAS_DELDBS */
-=======
 	/* xl_xact_subxacts follows if XINFO_HAS_SUBXACT */
 	/* xl_xact_relfilenodes follows if XINFO_HAS_RELFILENODES */
->>>>>>> sync-pg-phase1
+	/* xl_xact_deldbs follows if XACT_XINFO_HAS_DELDBS */
 	/* No invalidation messages needed. */
 	/* xl_xact_twophase follows if XINFO_HAS_TWOPHASE */
 	/* twophase_gid follows if XINFO_HAS_GID. As a null-terminated string. */


### PR DESCRIPTION
Fix conflicts in src/include/access/xact.h

Commit 23bccc8 updated comments in the xl_xact_abort structure, while earlier
commit 8ae22d1 added another comment nearby.