### PR TITLE
Fix conflicts in src/include/storage/lock.h

### DIFF
--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -666,11 +666,7 @@ extern void VirtualXactLockTableInsert(VirtualTransactionId vxid);
 extern void VirtualXactLockTableCleanup(void);
 extern bool VirtualXactLock(VirtualTransactionId vxid, bool wait);
 
-<<<<<<< HEAD
 /* Check whether a waiter's request lockmode conflict with the holder's hold mask */
 extern bool CheckWaitLockModeConflictHoldMask(LOCKTAG tag, LOCKMODE waitLockMode, LOCKMASK holderMask);
 
-#endif							/* LOCK_H */
-=======
 #endif							/* LOCK_H_ */
->>>>>>> sync-pg-phase1


### PR DESCRIPTION
Fix conflicts in src/include/storage/lock.h

Commit eb43f3d changed LOCK_H to LOCK_H_ at the very end of
src/include/storage/lock.h, while earlier commit 615aafb added a declaration of
a new function CheckWaitLockModeConflictHoldMask before that place.