### PR TITLE
Fix conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302209061
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201907222
->>>>>>> sync-pg-phase1
+#define CATALOG_VERSION_NO	302504211
 
 #endif


### PR DESCRIPTION
Fix conflicts in src/include/catalog/catversion.h

Commit a0555dd changed the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.