### PR TITLE
Fix conflicts in src/interfaces/ecpg/include/ecpglib.h

### DIFF
--- a/src/interfaces/ecpg/include/ecpglib.h
+++ b/src/interfaces/ecpg/include/ecpglib.h
@@ -63,11 +63,6 @@ char	   *ECPGprepared_statement(const char *, const char *, int);
 PGconn	   *ECPGget_PGconn(const char *);
 PGTransactionStatusType ECPGtransactionStatus(const char *);
 
-<<<<<<< HEAD
-char		*ECPGerrmsg(void);
-
-=======
->>>>>>> sync-pg-phase1
  /* print an error message */
 void		sqlprint(void);
 


### PR DESCRIPTION
Fix conflicts in src/interfaces/ecpg/include/ecpglib.h

Commit 6b85489 removed the declaration of the ECPGerrmsg function.