### PR TITLE
Support new XLOG_SMGR_CREATE_PDL WAL record

### DIFF
--- a/.abi-check/6.27.1_arenadata61/postgres.symbols.ignore
+++ b/.abi-check/6.27.1_arenadata61/postgres.symbols.ignore
@@ -1,1 +1,2 @@
 ConfigureNamesBool_gp
+log_smgrcreate

--- a/src/backend/access/rmgrdesc/smgrdesc.c
+++ b/src/backend/access/rmgrdesc/smgrdesc.c
@@ -24,18 +24,10 @@ smgr_desc(StringInfo buf, XLogRecord *record)
 	uint8           info = record->xl_info & ~XLR_INFO_MASK;
 	char            *rec = XLogRecGetData(record);
 
-	if (info == XLOG_SMGR_CREATE)
+	if ((info == XLOG_SMGR_CREATE) || (info == XLOG_SMGR_CREATE_PDL))
 	{
 		xl_smgr_create *xlrec = (xl_smgr_create *) rec;
 		char	   *path = relpathperm(xlrec->rnode, xlrec->forkNum);
-
-		appendStringInfo(buf, "file create: %s", path);
-		pfree(path);
-	}
-	else if (info == XLOG_SMGR_CREATE_PDL)
-	{
-		xl_smgr_create_pdl *xlrec = (xl_smgr_create_pdl *) rec;
-		char	   *path = relpathperm(xlrec->relnode.node, xlrec->forkNum);
 
 		appendStringInfo(buf, "file create: %s", path);
 		pfree(path);

--- a/src/backend/access/rmgrdesc/smgrdesc.c
+++ b/src/backend/access/rmgrdesc/smgrdesc.c
@@ -32,6 +32,14 @@ smgr_desc(StringInfo buf, XLogRecord *record)
 		appendStringInfo(buf, "file create: %s", path);
 		pfree(path);
 	}
+	else if (info == XLOG_SMGR_CREATE_PDL)
+	{
+		xl_smgr_create_pdl *xlrec = (xl_smgr_create_pdl *) rec;
+		char	   *path = relpathperm(xlrec->relnode.node, xlrec->forkNum);
+
+		appendStringInfo(buf, "file create: %s", path);
+		pfree(path);
+	}
 	else if (info == XLOG_SMGR_TRUNCATE)
 	{
 		xl_smgr_truncate *xlrec = (xl_smgr_truncate *) rec;

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1895,10 +1895,9 @@ heap_create_init_fork(Relation rel)
 {
 	RelationOpenSmgr(rel);
 	smgrcreate(rel->rd_smgr, INIT_FORKNUM, false);
-	XLogRecPtr recptr = log_smgrcreate(&rel->rd_smgr->smgr_rnode.node,
-									   INIT_FORKNUM,
-									   rel->rd_rel->relstorage);
-	XLogFlush(recptr);
+	log_smgrcreate(&rel->rd_smgr->smgr_rnode.node,
+				   INIT_FORKNUM,
+				   rel->rd_rel->relstorage);
 	smgrimmedsync(rel->rd_smgr, INIT_FORKNUM);
 }
 

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1893,9 +1893,13 @@ heap_create_with_catalog(const char *relname,
 void
 heap_create_init_fork(Relation rel)
 {
+	XLogRecPtr recptr;
 	RelationOpenSmgr(rel);
 	smgrcreate(rel->rd_smgr, INIT_FORKNUM, false);
-	log_smgrcreate(&rel->rd_smgr->smgr_rnode.node, INIT_FORKNUM);
+	recptr = log_smgrcreate(&rel->rd_smgr->smgr_rnode.node,
+							INIT_FORKNUM,
+							rel->rd_rel->relstorage);
+	XLogFlush(recptr);
 	smgrimmedsync(rel->rd_smgr, INIT_FORKNUM);
 }
 

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1893,12 +1893,11 @@ heap_create_with_catalog(const char *relname,
 void
 heap_create_init_fork(Relation rel)
 {
-	XLogRecPtr recptr;
 	RelationOpenSmgr(rel);
 	smgrcreate(rel->rd_smgr, INIT_FORKNUM, false);
-	recptr = log_smgrcreate(&rel->rd_smgr->smgr_rnode.node,
-							INIT_FORKNUM,
-							rel->rd_rel->relstorage);
+	XLogRecPtr recptr = log_smgrcreate(&rel->rd_smgr->smgr_rnode.node,
+									   INIT_FORKNUM,
+									   rel->rd_rel->relstorage);
 	XLogFlush(recptr);
 	smgrimmedsync(rel->rd_smgr, INIT_FORKNUM);
 }

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -527,7 +527,7 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 		reln = smgropen(xlrec->rnode, InvalidBackendId);
 		smgrcreate(reln, xlrec->forkNum, true);
 	}
-	if (info == XLOG_SMGR_CREATE_PDL)
+	else if (info == XLOG_SMGR_CREATE_PDL)
 	{
 		xl_smgr_create_pdl *xlrec =
 			(xl_smgr_create_pdl *) XLogRecGetData(record);

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -105,7 +105,12 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	smgrcreate(srel, MAIN_FORKNUM, false);
 
 	if (needs_wal)
-		log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM);
+	{
+		XLogRecPtr recptr =
+			log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM, relstorage);
+
+		XLogFlush(recptr);
+	}
 
 	/* Add the relation to the list of stuff to delete at abort */
 	pending = (PendingRelDelete *)
@@ -122,16 +127,19 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 /*
  * Perform XLogInsert of a XLOG_SMGR_CREATE record to WAL.
  */
-void
-log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum)
+XLogRecPtr
+log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage)
 {
-	xl_smgr_create xlrec;
+	xl_smgr_create_pdl xlrec;
 	XLogRecData rdata;
 
 	/*
 	 * Make an XLOG entry reporting the file creation.
 	 */
-	xlrec.rnode = *rnode;
+	xlrec.relnode.node = *rnode;
+	/* temp relations are not logged in WAL, so it is always false here */
+	xlrec.relnode.isTempRelation = false;
+	xlrec.relnode.relstorage = relstorage;
 	xlrec.forkNum = forkNum;
 
 	rdata.data = (char *) &xlrec;
@@ -139,7 +147,7 @@ log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum)
 	rdata.buffer = InvalidBuffer;
 	rdata.next = NULL;
 
-	XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE, &rdata);
+	return XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE_PDL, &rdata);
 }
 
 /*
@@ -514,28 +522,23 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 	if (info == XLOG_SMGR_CREATE)
 	{
 		xl_smgr_create *xlrec = (xl_smgr_create *) XLogRecGetData(record);
+		SMgrRelation reln;
+
+		reln = smgropen(xlrec->rnode, InvalidBackendId);
+		smgrcreate(reln, xlrec->forkNum, true);
+	}
+	if (info == XLOG_SMGR_CREATE_PDL)
+	{
+		xl_smgr_create_pdl *xlrec =
+			(xl_smgr_create_pdl *) XLogRecGetData(record);
 		PendingRelXactDelete pd =
 		{
-			.relnode =
-			{
-				.node = xlrec->rnode,
-				/*
-				 * Temp relations are not logged in WAL, so it is always false
-				 * here.
-				 */
-				.isTempRelation = false,
-				/*
-				 * TODO: We do not have info about relstorage from the record.
-				 * Need to handle it somehow - decision is yet pending.
-				 * Until then we can't handle AO tables properly...
-				 */
-				.relstorage = RELSTORAGE_HEAP
-			},
+			.relnode = xlrec->relnode,
 			.xid = record->xl_xid
 		};
 		SMgrRelation reln;
 
-		reln = smgropen(xlrec->rnode, InvalidBackendId);
+		reln = smgropen(xlrec->relnode.node, InvalidBackendId);
 		smgrcreate(reln, xlrec->forkNum, true);
 
 		PdlRedoAdd(&pd);

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -105,12 +105,7 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	smgrcreate(srel, MAIN_FORKNUM, false);
 
 	if (needs_wal)
-	{
-		XLogRecPtr recptr =
-			log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM, relstorage);
-
-		XLogFlush(recptr);
-	}
+		log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM, relstorage);
 
 	/* Add the relation to the list of stuff to delete at abort */
 	pending = (PendingRelDelete *)
@@ -125,9 +120,9 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 }
 
 /*
- * Perform XLogInsert of a XLOG_SMGR_CREATE record to WAL.
+ * Perform XLogInsert of a XLOG_SMGR_CREATE_PDL record to WAL.
  */
-XLogRecPtr
+void
 log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage)
 {
 	xl_smgr_create_pdl xlrec;
@@ -136,18 +131,18 @@ log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage)
 	/*
 	 * Make an XLOG entry reporting the file creation.
 	 */
-	xlrec.relnode.node = *rnode;
-	/* temp relations are not logged in WAL, so it is always false here */
-	xlrec.relnode.isTempRelation = false;
-	xlrec.relnode.relstorage = relstorage;
-	xlrec.forkNum = forkNum;
+	xlrec.createrec.rnode = *rnode;
+	xlrec.createrec.forkNum = forkNum;
+	xlrec.relstorage = relstorage;
 
 	rdata.data = (char *) &xlrec;
 	rdata.len = sizeof(xlrec);
 	rdata.buffer = InvalidBuffer;
 	rdata.next = NULL;
 
-	return XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE_PDL, &rdata);
+	XLogRecPtr recptr = XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE_PDL, &rdata);
+
+	XLogFlush(recptr);
 }
 
 /*
@@ -533,12 +528,21 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 			(xl_smgr_create_pdl *) XLogRecGetData(record);
 		PendingRelXactDelete pd =
 		{
-			.relnode = xlrec->relnode,
+			.relnode =
+			{
+				.node = xlrec->createrec.rnode,
+				/*
+				 * Temp relations are not logged in WAL, so it is always false
+				 * here.
+				 */
+				.isTempRelation = false,
+				.relstorage = xlrec->relstorage
+			},
 			.xid = record->xl_xid
 		};
 
-		SMgrRelation reln = smgropen(xlrec->relnode.node, InvalidBackendId);
-		smgrcreate(reln, xlrec->forkNum, true);
+		SMgrRelation reln = smgropen(xlrec->createrec.rnode, InvalidBackendId);
+		smgrcreate(reln, xlrec->createrec.forkNum, true);
 
 		PdlRedoAdd(&pd);
 	}

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -536,9 +536,8 @@ smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record)
 			.relnode = xlrec->relnode,
 			.xid = record->xl_xid
 		};
-		SMgrRelation reln;
 
-		reln = smgropen(xlrec->relnode.node, InvalidBackendId);
+		SMgrRelation reln = smgropen(xlrec->relnode.node, InvalidBackendId);
 		smgrcreate(reln, xlrec->forkNum, true);
 
 		PdlRedoAdd(&pd);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13196,7 +13196,12 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 			if (rel->rd_rel->relpersistence == RELPERSISTENCE_PERMANENT ||
 				(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED &&
 				 forkNum == INIT_FORKNUM))
-				log_smgrcreate(&newrnode, forkNum);
+			{
+				XLogRecPtr recptr = log_smgrcreate(&newrnode,
+												   forkNum,
+												   rel->rd_rel->relstorage);
+				XLogFlush(recptr);
+			}
 			copy_relation_data(rel->rd_smgr, dstrel, forkNum,
 							   rel->rd_rel->relpersistence);
 		}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13196,12 +13196,7 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 			if (rel->rd_rel->relpersistence == RELPERSISTENCE_PERMANENT ||
 				(rel->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED &&
 				 forkNum == INIT_FORKNUM))
-			{
-				XLogRecPtr recptr = log_smgrcreate(&newrnode,
-												   forkNum,
-												   rel->rd_rel->relstorage);
-				XLogFlush(recptr);
-			}
+				log_smgrcreate(&newrnode, forkNum, rel->rd_rel->relstorage);
 			copy_relation_data(rel->rd_smgr, dstrel, forkNum,
 							   rel->rd_rel->relpersistence);
 		}

--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -889,6 +889,7 @@ extractPageInfo(XLogRecord *record)
 			switch (info)
 			{
 				case XLOG_SMGR_CREATE:
+				case XLOG_SMGR_CREATE_PDL:
 					/*
 					 * We can safely ignore these. The local file will be
 					 * removed, if it doesn't exist in remote system. If a

--- a/src/include/catalog/storage_xlog.h
+++ b/src/include/catalog/storage_xlog.h
@@ -43,8 +43,8 @@ typedef struct xl_smgr_create
 
 typedef struct xl_smgr_create_pdl
 {
-	RelFileNodePendingDelete relnode;
-	ForkNumber	forkNum;
+	xl_smgr_create createrec;
+	char relstorage;
 } xl_smgr_create_pdl;
 
 typedef struct xl_smgr_truncate
@@ -53,7 +53,7 @@ typedef struct xl_smgr_truncate
 	RelFileNode rnode;
 } xl_smgr_truncate;
 
-extern XLogRecPtr log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage);
+extern void log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage);
 
 extern void smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void smgr_desc(StringInfo buf, XLogRecord *record);

--- a/src/include/catalog/storage_xlog.h
+++ b/src/include/catalog/storage_xlog.h
@@ -26,14 +26,26 @@
  */
 
 /* XLOG gives us high 4 bits */
-#define XLOG_SMGR_CREATE	0x10
-#define XLOG_SMGR_TRUNCATE	0x20
+#define XLOG_SMGR_CREATE		0x10
+#define XLOG_SMGR_TRUNCATE		0x20
+#define XLOG_SMGR_CREATE_PDL	0x30
 
+/*
+ * We do not create `xl_smgr_create` records anymore. We use
+ * `xl_smgr_create_pdl` instead. But we still process `xl_smgr_create` records
+ * for backward compatibility.
+ */
 typedef struct xl_smgr_create
 {
 	RelFileNode rnode;
 	ForkNumber	forkNum;
 } xl_smgr_create;
+
+typedef struct xl_smgr_create_pdl
+{
+	RelFileNodePendingDelete relnode;
+	ForkNumber	forkNum;
+} xl_smgr_create_pdl;
 
 typedef struct xl_smgr_truncate
 {
@@ -41,7 +53,7 @@ typedef struct xl_smgr_truncate
 	RelFileNode rnode;
 } xl_smgr_truncate;
 
-extern void log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum);
+extern XLogRecPtr log_smgrcreate(RelFileNode *rnode, ForkNumber forkNum, char relstorage);
 
 extern void smgr_redo(XLogRecPtr beginLoc, XLogRecPtr lsn, XLogRecord *record);
 extern void smgr_desc(StringInfo buf, XLogRecord *record);


### PR DESCRIPTION
Support new XLOG_SMGR_CREATE_PDL WAL record

Problem description:
XLOG_SMGR_CREATE WAL record doesn't contain information about relstorage for
the created relation. Orphaned files removal feature requires knowing the
relstorage info, otherwise it can't properly handle the removal of all orphaned
files for AO tables.

Fix:
In order to store relation's relstorage in xlog record and keep backward
compatibility with previous versions we introduce a new xlog record type 
XLOG_SMGR_CREATE_PDL. This new record type contains info about relstorage and
is used instead of XLOG_SMGR_CREATE.
Plus, this patch updates 'log_smgrcreate()' - now it creates
XLOG_SMGR_CREATE_PDL record and flushes it right after the creation (otherwise,
in case of a crash after file creation, the file may be orphaned).

No special tests are presented in this patch, as the added functionality will
be tested later together with other parts for the orphaned file removal feature.
At this point, it is enough to pass the current standard test set.