### PR TITLE
Fix conflicts in src/bin/pgbench/pgbench.c

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -5154,11 +5154,8 @@ main(int argc, char **argv)
 		{"log-prefix", required_argument, NULL, 7},
 		{"foreign-keys", no_argument, NULL, 8},
 		{"random-seed", required_argument, NULL, 9},
-<<<<<<< HEAD
 		{"use-unique-keys", no_argument, &use_unique_key, 1},
-=======
 		{"show-script", required_argument, NULL, 10},
->>>>>>> sync-pg-phase1
 		{NULL, 0, NULL, 0}
 	};
 


### PR DESCRIPTION
Fix conflicts in src/bin/pgbench/pgbench.c

Commit 5823677 added a new option show-script to pgbench, while earlier commit
19cd1cf had already added another new option use-unique-keys in the same place.