### PR TITLE
Fix conflicts in src/bin/scripts/common.c and src/bin/scripts/vacuumdb.c

### DIFF
--- a/src/bin/scripts/common.c
+++ b/src/bin/scripts/common.c
@@ -22,12 +22,9 @@
 #include "fe_utils/connect.h"
 #include "fe_utils/string_utils.h"
 
-<<<<<<< HEAD
-=======
 #define ERRCODE_UNDEFINED_TABLE  "42P01"
 
 
->>>>>>> sync-pg-phase1
 static PGcancel *volatile cancelConn = NULL;
 bool		CancelRequested = false;
 

--- a/src/bin/scripts/vacuumdb.c
+++ b/src/bin/scripts/vacuumdb.c
@@ -598,24 +598,9 @@ vacuum_one_database(const char *dbname, vacuumingOptions *vacopts,
 	 */
 	if (concurrentCons <= 0)
 		concurrentCons = 1;
-<<<<<<< HEAD
-	slots = (ParallelSlot *) pg_malloc(sizeof(ParallelSlot) * concurrentCons);
-	init_slot(slots, conn);
-	if (parallel)
-	{
-		for (i = 1; i < concurrentCons; i++)
-		{
-			conn = connectDatabase(dbname, host, port, username, prompt_password,
-								   progname, echo, false, true);
-			init_slot(slots + i, conn);
-		}
-
-	}
-=======
 
 	slots = ParallelSlotsSetup(dbname, host, port, username, prompt_password,
 							   progname, echo, conn, concurrentCons);
->>>>>>> sync-pg-phase1
 
 	/*
 	 * Prepare all the connections to run the appropriate analyze stage, if

--- a/src/bin/scripts/vacuumdb.c
+++ b/src/bin/scripts/vacuumdb.c
@@ -21,17 +21,6 @@
 #include "fe_utils/string_utils.h"
 #include "scripts_parallel.h"
 
-<<<<<<< HEAD
-#define ERRCODE_UNDEFINED_TABLE  "42P01"
-
-/* Parallel vacuuming stuff */
-typedef struct ParallelSlot
-{
-	PGconn	   *connection;		/* One connection */
-	bool		isFree;			/* Is it known to be idle? */
-} ParallelSlot;
-=======
->>>>>>> sync-pg-phase1
 
 /* vacuum options controlled by user flags */
 typedef struct vacuumingOptions


### PR DESCRIPTION
Fix conflicts in src/bin/scripts/common.c and src/bin/scripts/vacuumdb.c

1) Commit 5f38403 moved the ERRCODE_UNDEFINED_TABLE define from
src/bin/scripts/vacuumdb.c to src/bin/scripts/common.c, and the ParallelSlot
struct definition to src/bin/scripts/scripts_parallel.h.

2) Commit 5f38403 optimized the vacuum_one_database function, while earlier
commit 8ae22d1 added one extra line break.