### PR TITLE
Fix conflicts in src/bin/psql/describe.c

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4623,7 +4623,7 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	PGresult   *res;
 	printQueryOpt myopt = pset.popt;
 	int			cols_so_far;
-	bool		translate_columns[] = {false, false, true, false, false /* Storage */, false, false, false, false};
+	bool		translate_columns[] = {false, false, true, false, false /* Storage */, false, false, false, false, false};
 
 	/* If tabtypes is empty, we default to \dtvmsE (but see also command.c) */
 	if (!(showTables || showIndexes || showViews || showMatViews || showSeq || showForeign))

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2683,14 +2683,11 @@ describeOneTableDetails(const char *schemaname,
 			 tableinfo.relkind == RELKIND_MATVIEW ||
 			 tableinfo.relkind == RELKIND_FOREIGN_TABLE ||
 			 tableinfo.relkind == RELKIND_PARTITIONED_TABLE ||
-<<<<<<< HEAD
+			 tableinfo.relkind == RELKIND_PARTITIONED_INDEX ||
+			 tableinfo.relkind == RELKIND_TOASTVALUE ||
 			 tableinfo.relkind == RELKIND_AOSEGMENTS ||
 			 tableinfo.relkind == RELKIND_AOBLOCKDIR ||
 			 tableinfo.relkind == RELKIND_AOVISIMAP)
-=======
-			 tableinfo.relkind == RELKIND_PARTITIONED_INDEX ||
-			 tableinfo.relkind == RELKIND_TOASTVALUE)
->>>>>>> sync-pg-phase1
 	{
 		/* Footer information about a table */
 		PGresult   *result = NULL;

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4622,12 +4622,8 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	PQExpBufferData buf;
 	PGresult   *res;
 	printQueryOpt myopt = pset.popt;
-<<<<<<< HEAD
-	static const bool translate_columns[] = {false, false, true, false, false /* Storage */, false, false, false, false};
-=======
 	int			cols_so_far;
-	bool		translate_columns[] = {false, false, true, false, false, false, false, false};
->>>>>>> sync-pg-phase1
+	bool		translate_columns[] = {false, false, true, false, false /* Storage */, false, false, false, false};
 
 	/* If tabtypes is empty, we default to \dtvmsE (but see also command.c) */
 	if (!(showTables || showIndexes || showViews || showMatViews || showSeq || showForeign))


### PR DESCRIPTION
Fix conflicts in src/bin/psql/describe.c

1) Commits 24f62e9 and eb5472d improved psql output for partitioned indexes and
toasts, while earlier commit e0f7833 had already improved psql output for
auxiliary AO tables in the same place.

2) Commit 9a2ea61 added a local variable cols_so_far to the listTables function
and removed the static const qualifier from the local array translate_columns,
while earlier commit 56bb376 added two elements and a comment to the same
array.