### PR TITLE
Fix conflicts in src/bin/psql/tab-complete.c

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -2702,7 +2702,6 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("CREATE", "ROLE|USER|GROUP", MatchAny, "IN"))
 		COMPLETE_WITH("GROUP", "ROLE");
 
-<<<<<<< HEAD
 /* CREATE/DROP RESOURCE GROUP/QUEUE */
 	else if (Matches("CREATE|DROP", "RESOURCE"))
 	 {
@@ -2725,8 +2724,6 @@ psql_completion(const char *text, int start, int end)
 		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
 	}
 
-
-=======
 /* CREATE TYPE */
 	else if (Matches("CREATE", "TYPE", MatchAny))
 		COMPLETE_WITH("(", "AS");
@@ -2766,7 +2763,6 @@ psql_completion(const char *text, int start, int end)
 			COMPLETE_WITH(",", ")");
 	}
 
->>>>>>> sync-pg-phase1
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */
 	/* Complete CREATE VIEW <name> with AS */
 	else if (TailMatches("CREATE", "VIEW", MatchAny))


### PR DESCRIPTION
Fix conflicts in src/bin/psql/tab-complete.c

Commit 7bdc655 added a completion tab for CREATE TYPE to psql, while earlier
commit 0c62d8b added a completion tab for CREATE/DROP RESOURCE GROUP to psql in
the same place.