### PR TITLE
Fix conflicts in src/tools/msvc/MSBuildProject.pm

### DIFF
--- a/src/tools/msvc/MSBuildProject.pm
+++ b/src/tools/msvc/MSBuildProject.pm
@@ -36,11 +36,6 @@ sub WriteHeader
 EOF
 	$self->WriteConfigurationHeader($f, 'Debug');
 	$self->WriteConfigurationHeader($f, 'Release');
-	my $sdkversion=$ENV{'WindowsSDKVersion'};
-	if ($sdkversion =~ /.*\\$/)
-	{
-		chop $sdkversion;
-	}
 	print $f <<EOF;
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/src/tools/msvc/MSBuildProject.pm
+++ b/src/tools/msvc/MSBuildProject.pm
@@ -45,9 +45,6 @@ EOF
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>$self->{guid}</ProjectGuid>
-<<<<<<< HEAD
-    <WindowsTargetPlatformVersion>$sdkversion</WindowsTargetPlatformVersion>
-=======
 EOF
 	# Check whether WindowsSDKVersion env variable is present.
 	# Add WindowsTargetPlatformVersion node if so.
@@ -61,7 +58,6 @@ EOF
 EOF
 	}
 	print $f <<EOF;
->>>>>>> sync-pg-phase1
   </PropertyGroup>
   <Import Project="\$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />
 EOF


### PR DESCRIPTION
Fix conflicts in src/tools/msvc/MSBuildProject.pm

Commit 20e99cd added a conditional option WindowsTargetPlatformVersion, and
commit cb9bb15 fixed the bug there, while earlier commit 8a5ad4b added the same
option as an unconditional one.