### PR TITLE
Fix compilation of src/backend/utils/hyperloglog/gp_hyperloglog.c

### DIFF
--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -1076,7 +1076,7 @@ gp_hyperloglog_out(PG_FUNCTION_ARGS)
 	datalen = VARSIZE_ANY_EXHDR(data);
 	resultlen = pg_b64_enc_len(datalen);
 	result = palloc(resultlen + 1);
-	res = pg_b64_encode(VARDATA_ANY(data),datalen, result);
+	res = pg_b64_encode(VARDATA_ANY(data),datalen, result, resultlen);
 
 	/* Make this FATAL 'cause we've trodden on memory ... */
 	if (res > resultlen)
@@ -1097,7 +1097,7 @@ gp_hyperloglog_in(PG_FUNCTION_ARGS)
 	datalen = strlen(data);
 	resultlen = pg_b64_dec_len(datalen);
 	result = palloc(VARHDRSZ + resultlen);
-	res = pg_b64_decode(data, datalen, VARDATA(result));
+	res = pg_b64_decode(data, datalen, VARDATA(result), resultlen);
 
 	/* Make this FATAL 'cause we've trodden on memory ... */
 	if (res > resultlen)


### PR DESCRIPTION
Fix compilation of src/backend/utils/hyperloglog/gp_hyperloglog.c

Commit cfc40d3 added a fourth argument dstlen to the pg_b64_encode and
pg_b64_decode functions, so we should update the GPDB-specific
gp_hyperloglog_out and gp_hyperloglog_in functions accordingly.