### PR TITLE
Fix compilation of src/bin/scripts/common.h

### DIFF
--- a/src/bin/scripts/common.h
+++ b/src/bin/scripts/common.h
@@ -58,9 +58,6 @@ extern void splitTableColumnsSpec(const char *spec, int encoding,
 extern void appendQualifiedRelation(PQExpBuffer buf, const char *name,
 									PGconn *conn, bool echo);
 
-extern void appendQualifiedRelation(PQExpBuffer buf, const char *name,
-						PGconn *conn, const char *progname, bool echo);
-
 extern bool yesno_prompt(const char *question);
 
 extern void setup_cancel_handler(void);


### PR DESCRIPTION
Fix compilation of src/bin/scripts/common.h

Commit 5f38403 removed the penultimate argument progname in the
appendQualifiedRelation function.