### PR TITLE
Fix conflicts in isolation specs/async-notify.spec and expected/async…

### DIFF
--- a/src/test/isolation/expected/async-notify.out
+++ b/src/test/isolation/expected/async-notify.out
@@ -92,17 +92,10 @@ step usage: SELECT pg_notification_queue_usage() > 0 AS nonzero;
 nonzero        
 
 f              
-<<<<<<< HEAD
 step bignotify: SELECT count(pg_notify('c1', s::text)) FROM generate_series(1, 10000) s;
 count          
 
 10000          
-=======
-step bignotify: SELECT count(pg_notify('c1', s::text)) FROM generate_series(1, 1000) s;
-count          
-
-1000           
->>>>>>> sync-pg-phase1
 step usage: SELECT pg_notification_queue_usage() > 0 AS nonzero;
 nonzero        
 

--- a/src/test/isolation/specs/async-notify.spec
+++ b/src/test/isolation/specs/async-notify.spec
@@ -32,14 +32,10 @@ step "notifys1"	{
 	COMMIT;
 }
 step "usage"	{ SELECT pg_notification_queue_usage() > 0 AS nonzero; }
-<<<<<<< HEAD
 # GPDB: use more rows than in upstream, because Greenplum is compiled with a
 # larger SLRU block size, and we need to fill at least one page to make
 # pg_notification_queue_usage() non-zero.
 step "bignotify"	{ SELECT count(pg_notify('c1', s::text)) FROM generate_series(1, 10000) s; }
-=======
-step "bignotify"	{ SELECT count(pg_notify('c1', s::text)) FROM generate_series(1, 1000) s; }
->>>>>>> sync-pg-phase1
 teardown		{ UNLISTEN *; }
 
 # The listener session is used for cross-backend notify checks.


### PR DESCRIPTION
Fix conflicts in isolation specs/async-notify.spec and expected/async-notify.out

Commit b10f40b renamed the notify step to bignotify, while earlier commit
e760d37 had already done so.