### PR TITLE
Fix conflicts in regress sql/stats_ext.sql and expected/stats_ext.out

### DIFF
--- a/src/backend/optimizer/path/equivclass.c
+++ b/src/backend/optimizer/path/equivclass.c
@@ -762,6 +762,7 @@ get_eclass_for_sort_expr(PlannerInfo *root,
 			RelOptInfo *rel = root->simple_rel_array[i];
 
 			Assert(rel->reloptkind == RELOPT_BASEREL ||
+				   rel->reloptkind == RELOPT_OTHER_MEMBER_REL ||
 				   rel->reloptkind == RELOPT_DEADREL);
 
 			rel->eclass_indexes = bms_add_member(rel->eclass_indexes,

--- a/src/test/regress/expected/stats_ext.out
+++ b/src/test/regress/expected/stats_ext.out
@@ -117,7 +117,6 @@ CREATE STATISTICS ab1_a_b_stats ON a, b FROM ab1;
 ANALYZE ab1;
 DROP TABLE ab1 CASCADE;
 NOTICE:  drop cascades to table ab1c
-<<<<<<< HEAD
 -- Tests for stats with inheritance
 CREATE TABLE stxdinh(a int, b int);
 CREATE TABLE stxdinh1() INHERITS(stxdinh);
@@ -178,8 +177,6 @@ SELECT * FROM check_estimated_rows('SELECT a, b FROM stxdinp GROUP BY 1, 2');
 (1 row)
 
 DROP TABLE stxdinp;
-=======
->>>>>>> sync-pg-phase1
 -- Verify supported object types for extended statistics
 CREATE schema tststats;
 CREATE TABLE tststats.t (a int, b int, c text);

--- a/src/test/regress/expected/stats_ext_optimizer.out
+++ b/src/test/regress/expected/stats_ext_optimizer.out
@@ -710,9 +710,35 @@ SELECT m.*
        pg_mcv_list_items(d.stxdmcv) m
  WHERE s.stxname = 'mcv_lists_stats'
    AND d.stxoid = s.oid;
- index |  values   |  nulls  | frequency | base_frequency 
--------+-----------+---------+-----------+----------------
-     0 | {1, 2, 3} | {f,f,f} |         1 |              1
+ index | values  |  nulls  | frequency | base_frequency 
+-------+---------+---------+-----------+----------------
+     0 | {1,2,3} | {f,f,f} |         1 |              1
+(1 row)
+
+-- 2 distinct combinations with NULL values, all in the MCV list
+TRUNCATE mcv_lists;
+DROP STATISTICS mcv_lists_stats;
+INSERT INTO mcv_lists (a, b, c, d)
+     SELECT
+         (CASE WHEN mod(i,2) = 0 THEN NULL ELSE 0 END),
+         (CASE WHEN mod(i,2) = 0 THEN NULL ELSE 'x' END),
+         (CASE WHEN mod(i,2) = 0 THEN NULL ELSE 0 END),
+         (CASE WHEN mod(i,2) = 0 THEN NULL ELSE 'x' END)
+     FROM generate_series(1,5000) s(i);
+ANALYZE mcv_lists;
+SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists WHERE b = ''x'' OR d = ''x''');
+ estimated | actual 
+-----------+--------
+      3908 |   2500
+(1 row)
+
+-- create statistics
+CREATE STATISTICS mcv_lists_stats (mcv) ON b, d FROM mcv_lists;
+ANALYZE mcv_lists;
+SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists WHERE b = ''x'' OR d = ''x''');
+ estimated | actual 
+-----------+--------
+      3908 |   2500
 (1 row)
 
 -- mcv with arrays

--- a/src/test/regress/sql/stats_ext.sql
+++ b/src/test/regress/sql/stats_ext.sql
@@ -88,7 +88,6 @@ CREATE STATISTICS ab1_a_b_stats ON a, b FROM ab1;
 ANALYZE ab1;
 DROP TABLE ab1 CASCADE;
 
-<<<<<<< HEAD
 -- Tests for stats with inheritance
 CREATE TABLE stxdinh(a int, b int);
 CREATE TABLE stxdinh1() INHERITS(stxdinh);
@@ -121,8 +120,6 @@ SELECT 1 FROM pg_statistic_ext WHERE stxrelid = 'stxdinp'::regclass;
 SELECT * FROM check_estimated_rows('SELECT a, b FROM stxdinp GROUP BY 1, 2');
 DROP TABLE stxdinp;
 
-=======
->>>>>>> sync-pg-phase1
 -- Verify supported object types for extended statistics
 CREATE schema tststats;
 


### PR DESCRIPTION
Fix conflicts in regress sql/stats_ext.sql and expected/stats_ext.out

1) Commit a4926db added a new test to src/test/regress/sql/stats_ext.sql, while
earlier commits 14de72e and bd4a16e had already added other new tests to the
same location.

2) Commit 3373c71 added an assert to get_eclass_for_sort_expr, and commit
e1a0f6a extended it, while earlier commit 7a39b5e added the
RELOPT_OTHER_MEMBER_REL setting to reloptkind, and get_eclass_for_sort_expr is
called in GPDB for all relations in cdb_build_distribution_keys, not just for
base, as in Postgres.