### PR TITLE
ADBDEV-7418: Fix calculation of block number for page verification in gp_replica_check

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -587,7 +587,6 @@ get_relfilenode_map()
 		rentry->relfilenode = rnode;
 		rentry->relam = classtuple->relam;
 		rentry->relkind = classtuple->relkind;
-		rentry->segments = NIL;
 		strlcpy(rentry->relname, NameStr(classtuple->relname), sizeof(rentry->relname));
 	}
 	table_endscan(scan);

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -77,7 +77,7 @@ class ReplicaCheck(threading.Thread):
     def __str__(self):
         return '\n(%s) ---------\nHost: %s, Port: %s, Database: %s\n\
 Primary Location: %s\n\
-Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
+Mirror  Location: %s' % (self.name, self.host, self.port, self.datname,
                                           self.ploc, self.mloc)
 
     def run(self):
@@ -91,9 +91,9 @@ Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
                 with self.lock:
                     print(self)
                     if self.result:
-                        print("(%s) ** passed **" % (self.getName()))
+                        print("(%s) ** passed **" % (self.name))
                     else:
-                        print("(%s) --> failed <--" % (self.getName()))
+                        print("(%s) --> failed <--" % (self.name))
                         print (res)
             except:
                 with self.lock:

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -77,7 +77,7 @@ class ReplicaCheck(threading.Thread):
     def __str__(self):
         return '\n(%s) ---------\nHost: %s, Port: %s, Database: %s\n\
 Primary Location: %s\n\
-Mirror  Location: %s' % (self.name, self.host, self.port, self.datname,
+Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
                                           self.ploc, self.mloc)
 
     def run(self):
@@ -91,9 +91,9 @@ Mirror  Location: %s' % (self.name, self.host, self.port, self.datname,
                 with self.lock:
                     print(self)
                     if self.result:
-                        print("(%s) ** passed **" % (self.name))
+                        print("(%s) ** passed **" % (self.getName()))
                     else:
-                        print("(%s) --> failed <--" % (self.name))
+                        print("(%s) --> failed <--" % (self.getName()))
                         print (res)
             except:
                 with self.lock:


### PR DESCRIPTION
Fix calculation of block num for page verification in gp_replica_check (#1514)

If the table consists of several segment files, this could lead to an error
when running the gp_replica_check utility. The root cause is that the segment
file number was not taken into account when calculating the checksum of the
page (block) in gp_replica_check. This caused a mismatch between the
checksum in the page header and the calculated checksum of the page. In
order to achieve a checksum match, blockno is passed to PageIsVerified()
taking into account the segment file number.

Ticket: ADBDEV-7418