### PR TITLE
Fix conflicts in src/test/regress/expected alter_table.out, create_index.out, replica_identity.out

### DIFF
--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -1989,11 +1989,8 @@ Indexes:
     "anothertab_f3_excl" EXCLUDE USING btree (f3 WITH =)
     "anothertab_f4_excl" EXCLUDE USING btree (f4 WITH =) WHERE (f4 IS NOT NULL)
     "anothertab_f4_excl1" EXCLUDE USING btree (f4 WITH =) WHERE (f5 > 0)
-<<<<<<< HEAD
-Distributed Replicated
-=======
     "anothertab_f4_idx" UNIQUE, btree (f4)
->>>>>>> sync-pg-phase1
+Distributed Replicated
 
 -- In GPDB, you cannot change the type of a column that's part of a unique key
 alter table anothertab drop constraint anothertab_pkey;
@@ -2028,11 +2025,8 @@ Indexes:
     "anothertab_f3_excl" EXCLUDE USING btree (f3 WITH =)
     "anothertab_f4_excl" EXCLUDE USING btree (f4 WITH =) WHERE (f4 IS NOT NULL)
     "anothertab_f4_excl1" EXCLUDE USING btree (f4 WITH =) WHERE (f5 > 0)
-<<<<<<< HEAD
-Distributed Replicated
-=======
     "anothertab_f4_idx" UNIQUE, btree (f4)
->>>>>>> sync-pg-phase1
+Distributed Replicated
 
 drop table anothertab;
 create table another (f1 int, f2 text);

--- a/src/test/regress/expected/create_index.out
+++ b/src/test/regress/expected/create_index.out
@@ -1446,11 +1446,8 @@ Table "public.concur_heap"
  f1     | text | 
  f2     | text | 
 Indexes:
-<<<<<<< HEAD
     "concur_index2" UNIQUE, btree (dk, f1)
     "concur_index3" UNIQUE, btree (dk, f2) INVALID
-=======
->>>>>>> sync-pg-phase1
     "concur_heap_expr_idx" btree ((f2 || f1))
     "concur_index1" btree (f2, f1)
     "concur_index2" UNIQUE, btree (f1)
@@ -2430,12 +2427,8 @@ ERROR:  REINDEX CONCURRENTLY is not supported
  c2     | text    |           |          | 
 Indexes:
     "concur_reindex_ind1" PRIMARY KEY, btree (c1)
-<<<<<<< HEAD
-    "concur_reindex_ind3" UNIQUE, btree (c1, abs(c1))
-=======
->>>>>>> sync-pg-phase1
     "concur_reindex_ind2" btree (c2)
-    "concur_reindex_ind3" UNIQUE, btree (abs(c1))
+    "concur_reindex_ind3" UNIQUE, btree (c1, abs(c1))
     "concur_reindex_ind4" btree (c1, c1, c2)
 Referenced by:
     TABLE "concur_reindex_tab2" CONSTRAINT "concur_reindex_tab2_c1_fkey" FOREIGN KEY (c1) REFERENCES concur_reindex_tab(c1)
@@ -2484,21 +2477,21 @@ DROP TABLE concur_reindex_tab4;
 -- Check handling of indexes with expressions and predicates.  The
 -- definitions of the rebuilt indexes should match the original
 -- definitions.
-CREATE TABLE concur_exprs_tab (c1 int , c2 boolean);
+CREATE TABLE concur_exprs_tab (c1 int , c2 boolean) DISTRIBUTED BY (c1);
 INSERT INTO concur_exprs_tab (c1, c2) VALUES (1369652450, FALSE),
   (414515746, TRUE),
   (897778963, FALSE);
 CREATE UNIQUE INDEX concur_exprs_index_expr
-  ON concur_exprs_tab ((c1::text COLLATE "C"));
+  ON concur_exprs_tab (c1, (c1::text COLLATE "C"));
 CREATE UNIQUE INDEX concur_exprs_index_pred ON concur_exprs_tab (c1)
   WHERE (c1::text > 500000000::text COLLATE "C");
 CREATE UNIQUE INDEX concur_exprs_index_pred_2
-  ON concur_exprs_tab ((1 / c1))
+  ON concur_exprs_tab (c1, (1 / c1))
   WHERE ('-H') >= (c2::TEXT) COLLATE "C";
 SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
-                                                pg_get_indexdef                                                
----------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (((c1)::text) COLLATE "C")
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
@@ -2508,16 +2501,17 @@ SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
-                                                                 pg_get_indexdef                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
+                                                                   pg_get_indexdef                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
 (1 row)
 
 REINDEX TABLE CONCURRENTLY concur_exprs_tab;
+ERROR:  REINDEX CONCURRENTLY is not supported
 SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
-                                                pg_get_indexdef                                                
----------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (((c1)::text) COLLATE "C")
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
@@ -2527,17 +2521,17 @@ SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
-                                                                 pg_get_indexdef                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
+                                                                   pg_get_indexdef                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
 (1 row)
 
 -- ALTER TABLE recreates the indexes, which should keep their collations.
 ALTER TABLE concur_exprs_tab ALTER c2 TYPE TEXT;
 SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
-                                                pg_get_indexdef                                                
----------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (((c1)::text) COLLATE "C")
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
@@ -2547,9 +2541,9 @@ SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
 (1 row)
 
 SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
-                                                             pg_get_indexdef                                                              
-------------------------------------------------------------------------------------------------------------------------------------------
- CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (((1 / c1))) WHERE ('-H'::text >= (c2 COLLATE "C"))
+                                                               pg_get_indexdef                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= (c2 COLLATE "C"))
 (1 row)
 
 DROP TABLE concur_exprs_tab;

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -2452,8 +2452,8 @@ ERROR:  REINDEX CONCURRENTLY is not supported
  c2     | text    |           |          | 
 Indexes:
     "concur_reindex_ind1" PRIMARY KEY, btree (c1)
-    "concur_reindex_ind3" UNIQUE, btree (c1, abs(c1))
     "concur_reindex_ind2" btree (c2)
+    "concur_reindex_ind3" UNIQUE, btree (c1, abs(c1))
     "concur_reindex_ind4" btree (c1, c1, c2)
 Referenced by:
     TABLE "concur_reindex_tab2" CONSTRAINT "concur_reindex_tab2_c1_fkey" FOREIGN KEY (c1) REFERENCES concur_reindex_tab(c1)
@@ -2502,6 +2502,79 @@ ERROR:  REINDEX CONCURRENTLY is not supported
 Distributed by: (c1)
 
 DROP TABLE concur_reindex_tab4;
+-- Check handling of indexes with expressions and predicates.  The
+-- definitions of the rebuilt indexes should match the original
+-- definitions.
+CREATE TABLE concur_exprs_tab (c1 int , c2 boolean) DISTRIBUTED BY (c1);
+INSERT INTO concur_exprs_tab (c1, c2) VALUES (1369652450, FALSE),
+  (414515746, TRUE),
+  (897778963, FALSE);
+CREATE UNIQUE INDEX concur_exprs_index_expr
+  ON concur_exprs_tab (c1, (c1::text COLLATE "C"));
+CREATE UNIQUE INDEX concur_exprs_index_pred ON concur_exprs_tab (c1)
+  WHERE (c1::text > 500000000::text COLLATE "C");
+CREATE UNIQUE INDEX concur_exprs_index_pred_2
+  ON concur_exprs_tab (c1, (1 / c1))
+  WHERE ('-H') >= (c2::TEXT) COLLATE "C";
+SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
+                                                               pg_get_indexdef                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
+                                                                   pg_get_indexdef                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
+(1 row)
+
+REINDEX TABLE CONCURRENTLY concur_exprs_tab;
+ERROR:  REINDEX CONCURRENTLY is not supported
+SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
+                                                               pg_get_indexdef                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
+                                                                   pg_get_indexdef                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= ((c2)::text COLLATE "C"))
+(1 row)
+
+-- ALTER TABLE recreates the indexes, which should keep their collations.
+ALTER TABLE concur_exprs_tab ALTER c2 TYPE TEXT;
+SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
+                                                  pg_get_indexdef                                                  
+-------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_expr ON public.concur_exprs_tab USING btree (c1, ((c1)::text) COLLATE "C")
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);
+                                                               pg_get_indexdef                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
+(1 row)
+
+SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
+                                                               pg_get_indexdef                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE UNIQUE INDEX concur_exprs_index_pred_2 ON public.concur_exprs_tab USING btree (c1, ((1 / c1))) WHERE ('-H'::text >= (c2 COLLATE "C"))
+(1 row)
+
+DROP TABLE concur_exprs_tab;
 --
 -- REINDEX SCHEMA
 --

--- a/src/test/regress/expected/replica_identity.out
+++ b/src/test/regress/expected/replica_identity.out
@@ -99,12 +99,7 @@ Indexes:
     "test_replica_identity_partial" UNIQUE, btree (keya, keyb) WHERE keyb <> '3'::text
     "test_replica_identity_unique_defer" UNIQUE CONSTRAINT, btree (keya, keyb) DEFERRABLE
     "test_replica_identity_unique_nondefer" UNIQUE CONSTRAINT, btree (keya, keyb)
-<<<<<<< HEAD
-    "test_replica_identity_hash" hash (nonkey)
-    "test_replica_identity_keyab" btree (keya, keyb)
 Distributed by: (keya)
-=======
->>>>>>> sync-pg-phase1
 
 -- succeed, nondeferrable unique constraint over nonnullable cols
 ALTER TABLE test_replica_identity REPLICA IDENTITY USING INDEX test_replica_identity_unique_nondefer;
@@ -135,12 +130,7 @@ Indexes:
     "test_replica_identity_partial" UNIQUE, btree (keya, keyb) WHERE keyb <> '3'::text
     "test_replica_identity_unique_defer" UNIQUE CONSTRAINT, btree (keya, keyb) DEFERRABLE
     "test_replica_identity_unique_nondefer" UNIQUE CONSTRAINT, btree (keya, keyb)
-<<<<<<< HEAD
-    "test_replica_identity_hash" hash (nonkey)
-    "test_replica_identity_keyab" btree (keya, keyb)
 Distributed by: (keya)
-=======
->>>>>>> sync-pg-phase1
 
 SELECT count(*) FROM pg_index WHERE indrelid = 'test_replica_identity'::regclass AND indisreplident;
  count 

--- a/src/test/regress/sql/create_index.sql
+++ b/src/test/regress/sql/create_index.sql
@@ -984,16 +984,16 @@ DROP TABLE concur_reindex_tab4;
 -- Check handling of indexes with expressions and predicates.  The
 -- definitions of the rebuilt indexes should match the original
 -- definitions.
-CREATE TABLE concur_exprs_tab (c1 int , c2 boolean);
+CREATE TABLE concur_exprs_tab (c1 int , c2 boolean) DISTRIBUTED BY (c1);
 INSERT INTO concur_exprs_tab (c1, c2) VALUES (1369652450, FALSE),
   (414515746, TRUE),
   (897778963, FALSE);
 CREATE UNIQUE INDEX concur_exprs_index_expr
-  ON concur_exprs_tab ((c1::text COLLATE "C"));
+  ON concur_exprs_tab (c1, (c1::text COLLATE "C"));
 CREATE UNIQUE INDEX concur_exprs_index_pred ON concur_exprs_tab (c1)
   WHERE (c1::text > 500000000::text COLLATE "C");
 CREATE UNIQUE INDEX concur_exprs_index_pred_2
-  ON concur_exprs_tab ((1 / c1))
+  ON concur_exprs_tab (c1, (1 / c1))
   WHERE ('-H') >= (c2::TEXT) COLLATE "C";
 SELECT pg_get_indexdef('concur_exprs_index_expr'::regclass);
 SELECT pg_get_indexdef('concur_exprs_index_pred'::regclass);


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected alter_table.out, create_index.out, replica_identity.out

1) Commit 4d6603f changed the order of index output, while earlier commit
19cd1cf added GPDB-specific output to the same places.

2) Commit 7cce159 added new tests to src/test/regress/sql/create_index.sql,
which uses the creation of a unique index, for GPDB in this case we need to
specify the distribution, and concurrent reindex in GPDB is not supported at
all.