### PR TITLE
ADBDEV-7419: Fix seg fault in gp_replica_check

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.c
+++ b/gpcontrib/gp_replica_check/gp_replica_check.c
@@ -585,6 +585,7 @@ get_relfilenode_map()
 		rentry->relfilenode = rnode;
 		rentry->relam = classtuple->relam;
 		rentry->relkind = classtuple->relkind;
+		rentry->segments = NIL;
 		strlcpy(rentry->relname, NameStr(classtuple->relname), sizeof(rentry->relname));
 	}
 	table_endscan(scan);


### PR DESCRIPTION
Fix seg fault in gp_replica_check (#1517)

A seg fault could occur when calling gp_replica_check() due to an
uninitialized segments list. To solve this, in get_relfilenode_map(),
the list of segments is explicitly assigned NIL when creating the
RelfilenodeEntry structure.