### PR TITLE
ADBDEV-7440: Fix deprecation warning in gp_replica_check.py

### DIFF
--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -77,7 +77,7 @@ class ReplicaCheck(threading.Thread):
     def __str__(self):
         return '\n(%s) ---------\nHost: %s, Port: %s, Database: %s\n\
 Primary Location: %s\n\
-Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
+Mirror  Location: %s' % (self.name, self.host, self.port, self.datname,
                                           self.ploc, self.mloc)
 
     def run(self):
@@ -91,9 +91,9 @@ Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
                 with self.lock:
                     print(self)
                     if self.result:
-                        print("(%s) ** passed **" % (self.getName()))
+                        print("(%s) ** passed **" % (self.name))
                     else:
-                        print("(%s) --> failed <--" % (self.getName()))
+                        print("(%s) --> failed <--" % (self.name))
                         print (res)
             except:
                 with self.lock:


### PR DESCRIPTION
Fix deprecation warning in gp_replica_check.py

self.getName() produces a warning. To eliminate this, self.name is used.