### PR TITLE
Integrate storage_pending_deletes module into the core code

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -68,7 +68,8 @@ static void
 PendingRelDeleteFree(PendingRelDelete *pending)
 {
 	Assert(pending != NULL);
-	PdlShmemRemove(pending->shmem_ptr);
+	if (DsaPointerIsValid(pending->shmem_ptr))
+		PdlShmemRemove(pending->shmem_ptr);
 	pfree(pending);
 }
 
@@ -171,6 +172,7 @@ RelationDropStorage(Relation rel)
 	pending->atCommit = true;	/* delete if commit */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;
+	pending->shmem_ptr = InvalidDsaPointer;
 	pendingDeletes = pending;
 
 	/*

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -58,7 +58,7 @@ typedef struct PendingRelDelete
 	RelFileNodePendingDelete relnode;		/* relation that may need to be deleted */
 	bool		atCommit;		/* T=delete at commit; F=delete at abort */
 	int			nestLevel;		/* xact nesting level of request */
-	dsa_pointer shmem_ptr;		/* ptr to shared pending delete list node */
+	dsa_pointer shmemPtr;		/* ptr to shared pending delete list node */
 	struct PendingRelDelete *next;		/* linked-list link */
 } PendingRelDelete;
 
@@ -68,8 +68,8 @@ static void
 PendingRelDeleteFree(PendingRelDelete *pending)
 {
 	Assert(pending != NULL);
-	if (DsaPointerIsValid(pending->shmem_ptr))
-		PdlShmemRemove(pending->shmem_ptr);
+	if (DsaPointerIsValid(pending->shmemPtr))
+		PdlShmemRemove(pending->shmemPtr);
 	pfree(pending);
 }
 
@@ -126,8 +126,8 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	pending->atCommit = false;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;
-	pending->shmem_ptr = PdlShmemAdd(&pending->relnode,
-									 GetCurrentTransactionId());
+	pending->shmemPtr = PdlShmemAdd(&pending->relnode,
+									GetCurrentTransactionId());
 	pendingDeletes = pending;
 }
 
@@ -172,7 +172,7 @@ RelationDropStorage(Relation rel)
 	pending->atCommit = true;	/* delete if commit */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;
-	pending->shmem_ptr = InvalidDsaPointer;
+	pending->shmemPtr = InvalidDsaPointer;
 	pendingDeletes = pending;
 
 	/*

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -58,10 +58,19 @@ typedef struct PendingRelDelete
 	RelFileNodePendingDelete relnode;		/* relation that may need to be deleted */
 	bool		atCommit;		/* T=delete at commit; F=delete at abort */
 	int			nestLevel;		/* xact nesting level of request */
+	dsa_pointer shmem_ptr;		/* ptr to shared pending delete list */
 	struct PendingRelDelete *next;		/* linked-list link */
 } PendingRelDelete;
 
 static PendingRelDelete *pendingDeletes = NULL; /* head of linked list */
+
+static void
+PendingRelDeleteFree(PendingRelDelete *pending)
+{
+	Assert(pending != NULL);
+	PdlShmemRemove(pending->shmem_ptr);
+	pfree(pending);
+}
 
 /*
  * RelationCreateStorage
@@ -116,6 +125,8 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	pending->atCommit = false;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;
+	pending->shmem_ptr = PdlShmemAdd(&pending->relnode,
+									 GetCurrentTransactionId());
 	pendingDeletes = pending;
 }
 
@@ -211,7 +222,7 @@ RelationPreserveStorage(RelFileNode rnode, bool atCommit)
 				prev->next = next;
 			else
 				pendingDeletes = next;
-			pfree(pending);
+			PendingRelDeleteFree(pending);
 			/* prev does not change */
 		}
 		else
@@ -367,7 +378,7 @@ smgrDoPendingDeletes(bool isCommit)
 				srels[nrels++] = srel;
 			}
 			/* must explicitly free the list entry */
-			pfree(pending);
+			PendingRelDeleteFree(pending);
 			/* prev does not change */
 		}
 	}
@@ -468,7 +479,7 @@ PostPrepare_smgr(void)
 		next = pending->next;
 		pendingDeletes = next;
 		/* must explicitly free the list entry */
-		pfree(pending);
+		PendingRelDeleteFree(pending);
 	}
 }
 

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -58,7 +58,7 @@ typedef struct PendingRelDelete
 	RelFileNodePendingDelete relnode;		/* relation that may need to be deleted */
 	bool		atCommit;		/* T=delete at commit; F=delete at abort */
 	int			nestLevel;		/* xact nesting level of request */
-	dsa_pointer shmem_ptr;		/* ptr to shared pending delete list */
+	dsa_pointer shmem_ptr;		/* ptr to shared pending delete list node */
 	struct PendingRelDelete *next;		/* linked-list link */
 } PendingRelDelete;
 

--- a/src/backend/storage/ipc/dsm.c
+++ b/src/backend/storage/ipc/dsm.c
@@ -468,8 +468,8 @@ dsm_create(Size size)
 	uint32		i;
 	uint32		nitems;
 
-	/* Unsafe in postmaster (and pointless in a stand-alone backend). */
-	Assert(IsUnderPostmaster);
+	/* Unsafe in postmaster. */
+	Assert(!IsPostmasterEnvironment || IsUnderPostmaster);
 
 	if (!dsm_init_done)
 		dsm_backend_startup();

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -40,6 +40,7 @@
 #include "storage/bufmgr.h"
 #include "storage/dsm.h"
 #include "storage/ipc.h"
+#include "catalog/storage_pending_deletes.h"
 #include "storage/pg_shmem.h"
 #include "storage/pmsignal.h"
 #include "storage/predicate.h"
@@ -216,6 +217,9 @@ CreateSharedMemoryAndSemaphores(int port)
 		/* size of parallel cursor count */
 		size = add_size(size, ParallelCursorCountSize());
 
+		/* size of pending deletes */
+		size = add_size(size, PdlShmemSize());
+
 		elog(DEBUG3, "invoking IpcMemoryCreate(size=%zu)", size);
 
 		/*
@@ -387,6 +391,8 @@ CreateSharedMemoryAndSemaphores(int port)
 	
 	if (Gp_role == GP_ROLE_DISPATCH)
 		ParallelCursorCountInit();
+
+	PdlShmemInit();
 
 	/*
 	 * Now give loadable modules a chance to set up their shmem allocations

--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -279,6 +279,9 @@ NumLWLocks(void)
 	lock_addin_request_allowed = false;
 	numLocks += Max(lock_addin_request, NUM_USER_DEFINED_LWLOCKS);
 
+	/* storage_pending.c needs one for each backend */
+	numLocks += MaxBackends;
+
 	return numLocks;
 }
 

--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -279,7 +279,7 @@ NumLWLocks(void)
 	lock_addin_request_allowed = false;
 	numLocks += Max(lock_addin_request, NUM_USER_DEFINED_LWLOCKS);
 
-	/* storage_pending.c needs one for each backend */
+	/* storage_pending_deletes.c needs one for each backend */
 	numLocks += MaxBackends;
 
 	return numLocks;


### PR DESCRIPTION
Integrate storage_pending_deletes module into the core code

Extend the PendingRelDelete structure. Now it stores the shmemPtr pointer to
the corresponding shared pending deletes list node. The pointer is filled in
RelationCreateStorage as a return value of PdlShmemAdd. The pointer is set as 
invalid in RelationDropStorage, because storage dropping can't lead to orphaned
relfilenode. 
Replace pfree for the pendingDeletes list entry with a new PendingRelDeleteFree
function which calls PdlShmemRemove before pfree when shmemPtr is valid.
Add initialization of shared memory for the storage_pending_deletes module.
Increase number of LWLocks by MaxBackends to add LWLocks for the module.
Fix Assert in the dsm_create function, because the module is used in the
stand-alone mode, for example, when initdb runs 'postgres --single'.

No special tests are presented in this patch, as the added functionality will
be tested later together with other parts for the orphaned file removal feature.
At this point, it is enough to pass the current standard test set.

Ticket: ADBDEV-7410