### PR TITLE
Fix conflicts in src/test/regress/expected/update.out

### DIFF
--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -223,14 +223,7 @@ ERROR:  modification of distribution columns in OnConflictUpdate is not supporte
 INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING *;
-<<<<<<< HEAD
 ERROR:  modification of distribution columns in OnConflictUpdate is not supported
-=======
- a |             b             
----+---------------------------
- 1 | Foo, Correlated, Excluded
-(1 row)
-
 -- ON CONFLICT using system attributes in RETURNING, testing both the
 -- inserting and updating paths. See bug report at:
 -- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
@@ -238,23 +231,14 @@ CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT (txid_current
 INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
-  tableoid   | xmin_correct | xmax_correct 
--------------+--------------+--------------
- upsert_test | t            | t
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 -- currently xmax is set after a conflict - that's probably not good,
 -- but it seems worthwhile to have to be explicit if that changes.
 INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
-  tableoid   | xmin_correct | xmax_correct 
--------------+--------------+--------------
- upsert_test | t            | t
-(1 row)
-
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
 DROP FUNCTION xid_current();
->>>>>>> sync-pg-phase1
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -224,6 +224,21 @@ INSERT INTO upsert_test VALUES (1, 'Bat') ON CONFLICT(a)
   DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
   RETURNING *;
 ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+-- ON CONFLICT using system attributes in RETURNING, testing both the
+-- inserting and updating paths. See bug report at:
+-- https://www.postgresql.org/message-id/73436355-6432-49B1-92ED-1FE4F7E7E100%40finefun.com.au
+CREATE FUNCTION xid_current() RETURNS xid LANGUAGE SQL AS $$SELECT (txid_current() % ((1::int8<<32)))::text::xid;$$;
+INSERT INTO upsert_test VALUES (2, 'Beeble') ON CONFLICT(a)
+  DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = 0 AS xmax_correct;
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+-- currently xmax is set after a conflict - that's probably not good,
+-- but it seems worthwhile to have to be explicit if that changes.
+INSERT INTO upsert_test VALUES (2, 'Brox') ON CONFLICT(a)
+  DO UPDATE SET (b, a) = (SELECT b || ', Excluded', a from upsert_test i WHERE i.a = excluded.a)
+  RETURNING tableoid::regclass, xmin = xid_current() AS xmin_correct, xmax = xid_current() AS xmax_correct;
+ERROR:  modification of distribution columns in OnConflictUpdate is not supported
+DROP FUNCTION xid_current();
 DROP TABLE update_test;
 DROP TABLE upsert_test;
 ---------------------------


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected/update.out

Commit ecbdd00 added new tests to src/test/regress/sql/update.sql, while
earlier commit 8bd2f1c prevented distribution modification when there was an
update conflict in the same place.