### PR TITLE
ADBDEV-7370: Add comment explaining gp_replica_check error

### DIFF
--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -209,6 +209,11 @@ DROP TABLE
 -- which is the table column that we will have bitmap created on.
 -- Basically, we want to see if "SELECT b FROM pg_bitmapindex.pg_bm_xxx"
 -- returns the same result in seqscan and indexscan.
+
+-- Note: this can cause AO files to differ between primary and mirror,
+-- causing gp_replica_check to fail. This is expected and doesn't result
+-- in actual replication errors since the AO files are equivalent, but not
+-- exactly the same. The table can be dropped if this becomes an issue.
 CREATE OR REPLACE FUNCTION insert_bm_lov_res() RETURNS void AS $$ DECLARE lov_table text; /* in func */ sql text; /* in func */ BEGIN /* in func */ drop table if exists bm_lov_res; /* in func */ create temp table bm_lov_res(b int); /* in func */ SELECT c.relname INTO lov_table /* in func */ FROM bm_metap('tab_fi_idx') b /* in func */ JOIN pg_class c ON b.auxrelid = c.oid; /* in func */ sql := format('INSERT INTO bm_lov_res SELECT b FROM pg_bitmapindex.%I', lov_table); /* in func */ EXECUTE sql; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE FUNCTION
 

--- a/src/test/isolation2/sql/frozen_insert_crash.sql
+++ b/src/test/isolation2/sql/frozen_insert_crash.sql
@@ -106,6 +106,11 @@
 -- which is the table column that we will have bitmap created on.
 -- Basically, we want to see if "SELECT b FROM pg_bitmapindex.pg_bm_xxx"
 -- returns the same result in seqscan and indexscan.
+
+-- Note: this can cause AO files to differ between primary and mirror,
+-- causing gp_replica_check to fail. This is expected and doesn't result
+-- in actual replication errors since the AO files are equivalent, but not
+-- exactly the same. The table can be dropped if this becomes an issue.
 CREATE OR REPLACE FUNCTION insert_bm_lov_res() RETURNS void AS $$
 DECLARE
   lov_table text; /* in func */


### PR DESCRIPTION
Add comment explaining gp_replica_check error

frozen_insert_crash isolation test leaves an AO table tab_fi without cleaning
it up. When writing AO tables, the data is first written to disk and only then
added to WALs. This is acceptable because the visible state of the AO table is
determined by EOF field, which is stored in a regular heap table, and so is
transactional.  However, this means that if a crash happens after data is
written to disk, but before writing to WAL, primary's and mirror's segment
files will be different, with primary's file containing the new tuple and
mirror's file missing it.

If gp_replica_check is run after this test, it detects the difference and
signals it as an error. However, this mismatch is actually acceptable, since
EOF change was not committed due to the crash, and so the visible state is
actually identical. If new tuples are added after the crash, they overwrite
the data on primary and the files become identical again.

Unfortunately, making gp_replica_check properly support AO tables is
complicated, because that would require creating new interfaces. EOF is stored
in a different (heap) table, and has different values of each segment file,
and so isn't accessible through existing ones. Fixing gp_replica_check is not
a priority right now, so this patch adds a comment to the test as an
explanation for why this test may cause gp_replica_check errors.