### PR TITLE
Initial changes

### DIFF
--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -387,16 +387,8 @@ def main(options, args, parser):
         # create pid file
         create_pid_file(options.coordinator_data_directory)
         
-        gprebalance_db_status = None
-
-        try:
-            gprebalance_db_status = GPRebalance.prepare_gpdb_state(
-            logger, dburl, options)
-        except:
-            pass
-        
         global gprebalance
-        gprebalance = GPRebalance(logger, gparray, dburl, options)
+        gprebalance = GPRebalance(logger, gparray, dburl, options, gpEnv)
 
         # dump existing hosts configuration
         if options.genconf:
@@ -407,60 +399,54 @@ def main(options, args, parser):
 
         if options.clean:
             gprebalance.remove_status_file()
-            gprebalance.cleanup_schema()
             gprebalance.cleanup_directory()
             logger.info('Cleanup Finished.  exiting...')
             sys.exit(0)
 
         from gprebalance_modules.rebalance_status import RebalanceStatus  # nopep8
 
-        if (gprebalance_db_status == RebalanceStatus.COMPLETED or
-            gprebalance_file_status == 'EXECUTION_DONE') and not options.rollback:
+        if gprebalance_file_status == RebalanceStatus.DONE and not options.rollback:
             logger.info('Rebalance has already completed')
             logger.info(
                 'If you want to rebalance again, run gprebalance -c to perform cleanup')
-        elif options.rollback and gprebalance_file_status == 'ROLLBACK_DONE':
+        elif options.rollback and gprebalance_file_status == RebalanceStatus.ROLLBACK_DONE:
             logger.info('Rollback has already completed')
             logger.info(
                 'If you want to rebalance again, run gprebalance -c to perform cleanup')
-        elif (gprebalance_file_status is None and gprebalance_db_status is None) or \
-            gprebalance_file_status == 'UNINITIALIZED':
+        elif gprebalance_file_status is None or gprebalance_file_status == RebalanceStatus.UNINITIALIZED:
             if options.rollback:
                 logger.error("Cannot perform rollback operation. Rebalance session status files are absent.")
                 sys.exit(1)
             gprebalance.statusManager.create_status_file()
             possibility_checks(gprebalance)
             logger.info('Validation passed. Preparing rebalance...')
-            gprebalance.statusManager.set_status('VALIDATED', os.path.abspath(
+            gprebalance.statusManager.set_status(RebalanceStatus.VALIDATED, os.path.abspath(
                 options.filename) if options.filename else None)
             plan = gprebalance.createPlan()
             gprebalance.save_plan(plan)
             if options.show_plan:
                 logger.info(f"Resulting plan: \n{str(plan)}")
                 sys.exit(0)
-            gprebalance.setup_schema()
             gprebalance.execute_plan(plan)
         elif gprebalance.statusManager.conf_dir:
             plan = gprebalance.load_plan(gprebalance.statusManager.conf_dir, False)
             if options.show_plan:
                 logger.info(f"Resulting plan: \n{str(plan)}")
                 sys.exit(0)
-            if gprebalance_file_status == 'PLANNED':
-                gprebalance.setup_schema()
+            if gprebalance_file_status == RebalanceStatus.PREPARED:
                 gprebalance.execute_plan(plan)
                 sys.exit(0)
-            elif gprebalance_file_status == 'ROLLBACK_FAILED' or \
-                gprebalance_file_status == 'ROLLBACK_STOPPED':
+            elif gprebalance_file_status == RebalanceStatus.ROLLBACK_FAILED:
                 logger.info('Previous rollback session was interrupted due to an error. Trying to resume...')
                 plan = gprebalance.load_plan(gprebalance.statusManager.conf_dir, True)
                 gprebalance.resume(plan)
                 sys.exit(0)
-            elif gprebalance_file_status == 'EXECUTION_FAILED':
+            elif gprebalance_file_status == RebalanceStatus.FAILED:
                 if not options.rollback:
                     logger.info('Previous rebalance session was interrupted due to an error. Trying to resume...')
                     gprebalance.resume(plan)
                     sys.exit(0)
-            elif gprebalance_file_status == 'EXECUTION_STOPPED':
+            elif gprebalance_file_status == RebalanceStatus.STOPPED:
                 if not options.rollback:
                     logger.info('Previous rebalance session was interrupted due to an timeout or user signal. Trying to resume...')
                     gprebalance.resume(plan)

--- a/gpMgmt/bin/gprebalance
+++ b/gpMgmt/bin/gprebalance
@@ -426,6 +426,8 @@ def main(options, args, parser):
             gprebalance.save_plan(plan)
             if options.show_plan:
                 logger.info(f"Resulting plan: \n{str(plan)}")
+                # should be removed when state machine will be ready
+                gprebalance.statusManager.set_status(RebalanceStatus.UNINITIALIZED)
                 sys.exit(0)
             gprebalance.execute_plan(plan)
         elif gprebalance.statusManager.conf_dir:

--- a/gpMgmt/bin/gprebalance_modules/rebalance.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance.py
@@ -100,7 +100,7 @@ from gprebalance_modules.rebalance_status import StatusManager, RebalanceStatus 
 
 
 class GPRebalance:
-    def __init__(self, logger, gparray, dburl, options):
+    def __init__(self, logger, gparray, dburl, options, gpEnv):
         self.logger = logger
         self.dburl = dburl
         self.options = options
@@ -155,8 +155,7 @@ class GPRebalance:
         self.unpreferred_segments = self.getSegmentsUnpreferredRole()
         self.segmentMap = {SegmentId(
             seg.dbid, seg.content): seg for seg in self.original_gparray.getSegmentsAsLoadedFromDb()}
-        self.statusManager = StatusManager(
-            self.conn, self.options, self.logger)
+        self.statusManager = StatusManager(self.options, self.logger, self.original_gparray, self.conn, gpEnv)
 
         self.executor = None
 
@@ -228,8 +227,7 @@ class GPRebalance:
         datadir = self.options.coordinator_data_directory + CONF_DIR
         os.makedirs(datadir, exist_ok=True)
         plan.save_to_file(datadir, "plan")
-        self.statusManager.set_status('PLANNED', datadir)
-
+    
     def load_plan(self, datadir, rollback):
         filename = datadir 
         if rollback:
@@ -254,72 +252,12 @@ class GPRebalance:
                                      self.options)
         self.executor.execute_moves()
 
-    @staticmethod
-    def prepare_gpdb_state(logger, dburl, options) -> str:
-        gprebalance_db_status = None
-
-        try:
-            gprebalance_db_status = GPRebalance.get_status_from_db(
-                dburl, options)
-            logger.debug('Expansion status returned is %s' %
-                     gprebalance_db_status)
-        except Exception as e:
-            raise Exception(
-                'Error while trying to query the gprebalance schema: %s' % e)
-
-        return gprebalance_db_status
-
-    @staticmethod
-    def get_status_from_db(dburl, options) -> RebalanceStatus:
-        """Gets gprebalance status from the gprebalance schema"""
-        status_conn = None
-        gprebalance_db_status = None
-        if get_local_db_mode(options.coordinator_data_directory) == 'NORMAL':
-            try:
-                status_conn = dbconn.connect(dburl, encoding='UTF8')
-                # Get the last status entry
-                cursor = dbconn.query(
-                    status_conn, 'SELECT status FROM gprebalance.status ORDER BY updated DESC LIMIT 1')
-                if cursor.rowcount == 1:
-                    gprebalance_db_status = cursor.fetchone()[0]
-
-            except Exception:
-                # rebalance schema doesn't exists or there was a connection failure.
-                pass
-            finally:
-                if status_conn:
-                    status_conn.close()
-
-        # make sure gprebalance schema doesn't exist since it wasn't in DB provided
-        if not gprebalance_db_status:
-            conn = dbconn.connect(dburl, encoding='UTF8', utility=True)
-            try:
-                count = dbconn.querySingleton(conn,
-                                              "SELECT count(n.nspname) FROM pg_catalog.pg_namespace n WHERE n.nspname = 'gprebalance'")
-                if count > 0:
-                    raise Exception(
-                        "Existing rebalance state could not be determined, but a gprebalance schema already exists. Cannot proceed.")
-            finally:
-                conn.close()
-
-        return RebalanceStatus(gprebalance_db_status)
-
     def get_state_from_file(self):
         """Returns expansion state from status file"""
-        return self.statusManager.get_current_status()[0]
-
-    def setup_schema(self):
-        self.statusManager.set_status('REBALANCE_PREPARE_SCHEMA_STARTED')
-        self.logger.info('Creating expansion schema')
-        self.statusManager.setup_schema()
-        self.statusManager.set_status('REBALANCE_PREPARE_SCHEMA_DONE')
-        self.statusManager.set_db_status(RebalanceStatus.INITIALIZED)
-
-    def cleanup_schema(self):
-        if not self.conn:
-            return
-        self.logger.info('Dropping rebalance schema')
-        self.statusManager.cleanup_schema()
+        status = self.statusManager.get_current_status()[0]
+        if status:
+            return RebalanceStatus(status)
+        return None
 
     def cleanup_directory(self):
         self.logger.info('Dropping rebalance directory')

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import pickle
 from typing import List, Dict, Optional, Set, Tuple
 from gprebalance_modules.rebalance_plan import Move, Plan  # nopep8
-from gprebalance_modules.rebalance_status import StatusManager, RebalanceStatus, MoveStatus, SqlError
+from gprebalance_modules.rebalance_status import StatusManager, RebalanceStatus, MoveStatus
 from gprebalance_modules.rebalance import ClusterState, SegmentId, SegmentSize, Host
 from gppylib.gparray import GpArray, Segment
 from gppylib.db import dbconn
@@ -107,8 +107,8 @@ class RecoveryProcess:
 
 
 class SingleMoveCommand(SQLCommand):
-    def __init__(self, name: str, status_url: dbconn.DbURL, step_details, logger):
-        self.status_url = status_url
+    def __init__(self, name: str, step_details, logger, statusManager: StatusManager):
+        self.status_manager = statusManager
         self.logger = logger
         (self.segment, self.move, self.segmentSize,
          self.conf_dir, self.needs_switch, self.options) = step_details
@@ -134,12 +134,11 @@ class SingleMoveCommand(SQLCommand):
     def run(self, validateAfter=False):
         status_conn = None
         try:
-            status_conn = dbconn.connect(self.status_url, encoding='UTF8')
+            
             segsize = self.segmentSize.source_data_dir_usage
             if self.segmentSize.source_tablespace_usage:
                 segsize += sum(self.segmentSize.source_tablespace_usage.values())
-            StatusManager.record_move(status_conn, self.move, self.segment,
-                                      segsize, datetime.datetime.now())
+            self.status_manager.update_move_status([self.segment.dbid], MoveStatus.IN_PROGRESS)
 
             filename = self.write_gprecoverseg_config()
 
@@ -166,12 +165,6 @@ class SingleMoveCommand(SQLCommand):
             ]
             if self.options.hba_hostnames:
                 cmd_args.append('--hba-hostnames')
-            try:
-                StatusManager.update_record_status(
-                    status_conn, [self.segment.dbid], MoveStatus.IN_PROGRESS)
-            except SqlError:
-                raise Exception(
-                    f"Could not update status for move with dbid={self.segment.dbid}: ")
 
             result_queue = multiprocessing.Queue()
             recovery_process = multiprocessing.Process(
@@ -179,8 +172,36 @@ class SingleMoveCommand(SQLCommand):
                 args=(cmd_args, result_queue, log_file)
             )
             recovery_process.start()
-            result = result_queue.get()
-            recovery_process.join()
+            result = None
+            while recovery_process.is_alive():
+            # Check if result is available without blocking
+                try:
+                    if not result_queue.empty():
+                        result = result_queue.get(block=False)
+                        recovery_process.join()
+                except Exception:
+                    pass
+                time.sleep(20)
+            
+            if result is None:
+                exit_code = recovery_process.exitcode
+                if exit_code < 0:
+                    self.logger.error(
+                    f"Could not perform mirror dbid={self.segment.dbid} "
+                    f"move with content {self.segment.content} due to "
+                    f"recoverseg error: Process terminated by signal {-exit_code}\n"
+                    f"Check the gprecoverseg log file {log_file}, fix any problems, and re-run"
+                )
+                else:
+                    self.logger.error(
+                    f"Could not perform mirror dbid={self.segment.dbid} "
+                    f"move with content {self.segment.content} due to "
+                    f"recoverseg error: Process exited with code {exit_code}\n"
+                    f"Check the gprecoverseg log file {log_file}, fix any problems, and re-run")
+                self.status_manager.update_move_status([self.segment.dbid], MoveStatus.FAILED)
+                self.move_error = True
+                return
+            
             if result["status"] == "FAILED":
                 self.logger.error(
                     f"Could not perform mirror dbid={self.segment.dbid} "
@@ -188,30 +209,15 @@ class SingleMoveCommand(SQLCommand):
                     f"recoverseg error: {result['error']}\n"
                     f"Check the gprecoverseg log file {log_file}, fix any problems, and re-run"
                 )
-                try:
-                    StatusManager.update_record_status(
-                        status_conn, [self.segment.dbid], MoveStatus.FAILED)
-                except SqlError:
-                    raise Exception(
-                        f"Could not update status for move with dbid={self.segment.dbid}: ")
+                self.status_manager.update_move_status([self.segment.dbid], MoveStatus.FAILED)
 
                 self.move_error = True
-                status_conn.close()
                 return
             if self.needs_switch:
-                try:
-                    StatusManager.update_record_status(
-                        status_conn, [self.segment.dbid], MoveStatus.AWAITS_SWITCH)
-                except SqlError:
-                    raise Exception(
-                        f"Could not update status for move with dbid={self.segment.dbid}: ")
-
-            try:
-                StatusManager.update_record_status(
-                    status_conn, [self.segment.dbid], MoveStatus.COMPLETED)
-            except SqlError:
-                raise Exception(
-                    f"Could not update status for move with dbid={self.segment.dbid}: ")
+                self.status_manager.update_move_status([self.segment.dbid], MoveStatus.AWAITS_SWITCH)
+            else:
+                self.status_manager.update_move_status([self.segment.dbid], MoveStatus.COMPLETED)
+           
 
             self.logger.info("Removing old segment's datadir (dbidi = %d): %s",
                              self.segment.dbid, self.segment.datadir)
@@ -225,12 +231,10 @@ class SingleMoveCommand(SQLCommand):
                     self.logger.info("Removing old segment's tablespace datadir (dbidi = %d): %s",
                                      self.segment.dbid, tblspdir)
                     cmd.run(validateAfter=True)
-            status_conn.close()
 
         except Exception as ex:
             self.logger.error(ex.__str__().strip())
             self.move_error = True
-            status_conn.close()
             return
         
 
@@ -889,6 +893,23 @@ class RebalanceExecutor:
             begining_timestamp = datetime.datetime.now()
 
             conf_dir = self.options.coordinator_data_directory + CONF_DIR
+
+            #record moves in status file
+            detail_list = []
+            for seq_no, seq in enumerate(move_sequences):
+                if not isinstance(seq[0], str):
+                    for move in seq:
+                        needs_switch = False
+                        if move.segid.contentid in former_switches or move.segid.contentid in latter_switches:
+                            needs_switch = True
+                        if move.segid.contentid in former_switches and move.segid.contentid in latter_switches:
+                            needs_switch = False
+                        detail_list.append((seq_no, self.segmentMap[move.segid],
+                                move,
+                                self.segmentSizes[move.segid].source_data_dir_usage,
+                                needs_switch))
+            self.statusManager.record_moves_batch(detail_list)
+
             hosts = set()
             for move in self.moves:
                 hosts.add(move.srcHost.hostname)
@@ -896,7 +917,8 @@ class RebalanceExecutor:
             
             if firstRun:
                 # in order to run gprecoverseg processes separately and avoid any races
-                # for resources gprecoverseg generates, we create separate log directories.
+                # for resources gprecoverseg generates (progress file), we create
+                # separate log directories.
                 mkdirCmd = MakeDirectory("rebalance log dir", GPRECOVERSEG_DIR)
                 mkdirCmd.run(validateAfter=True)
                 for host in hosts:
@@ -904,17 +926,11 @@ class RebalanceExecutor:
                     mkdirCmd.run(validateAfter=True)
                 
                 if self.options.rollback:
-                    self.statusManager.set_status('ROLLBACK_PREPARED')
+                    self.statusManager.set_status(RebalanceStatus.ROLLBACK_PREPARED, conf_dir)
                     self.plan.save_to_file(conf_dir, "rollback_plan")
                 else:
-                    self.statusManager.set_status('EXECUTION_PREPARED')
-                    self.statusManager.set_db_status(
-                    RebalanceStatus.PREPARED, begining_timestamp)
+                    self.statusManager.set_status(RebalanceStatus.PREPARED, conf_dir)
                     self.plan.save_to_file(conf_dir, "plan")
-            
-
-            self.statusManager.set_db_status(
-                RebalanceStatus.IN_PROGRESS)
 
             self.queue = WorkerPool(self.options.parallel)
 
@@ -924,9 +940,9 @@ class RebalanceExecutor:
             if self.options.end:
                 stopTime = self.options.end
             if self.options.rollback:
-                self.statusManager.set_status('ROLLBACK_STARTED')
+                self.statusManager.set_status(RebalanceStatus.ROLLBACK_IN_PROGRESS)
             else:
-                self.statusManager.set_status('EXECUTION_STARTED')
+                self.statusManager.set_status(RebalanceStatus.IN_PROGRESS)
             for sequence in move_sequences:
                 if self.shutdown_requested:
                     break
@@ -949,17 +965,21 @@ class RebalanceExecutor:
                     if self.shutdown_requested:
                         break
 
-                    self.statusManager.set_db_status(
+                    self.statusManager.set_status(
                         RebalanceStatus.AWAITS_SWITCH)
                     self.logger.info(
                         f"Executing role swaps for {len(sequence[1])} segments")
                     try:
                         self._execute_role_swaps(sequence[1])
+                        for segid in sequence[1]:
+                            if segid in former_switches and segid not in latter_switches:
+                                self.statusManager.update_move_status(sequence[1], MoveStatus.COMPLETED)
+                                break
                     except Exception as e:
                         had_error = True
                         self.logger.error(f"Could not execute role swaps:{str(e)}")
                         break
-                    self.statusManager.set_db_status(
+                    self.statusManager.set_status(
                         RebalanceStatus.IN_PROGRESS)
                 else:
                     for move in sequence:
@@ -978,7 +998,7 @@ class RebalanceExecutor:
                                         )
 
                         cmd = SingleMoveCommand(
-                            "name", self.dburl, step_details, self.logger)
+                            "name", step_details, self.logger, self.statusManager)
                         self.queue.addCommand(cmd)
 
                 while not self.queue.isDone():
@@ -1001,25 +1021,23 @@ class RebalanceExecutor:
                 self.queue = None
             
             if stoppedEarly or self.shutdown_requested:
-                self.statusManager.set_db_status(
-                    RebalanceStatus.STOPPED)
-                if self.options.rollback:
-                    self.statusManager.set_status('ROLLBACK_STOPPED')
-                else:
-                    self.statusManager.set_status('EXECUTION_STOPPED')
+                self.statusManager.set_status(RebalanceStatus.STOPPED)
                 if not self.shutdown_requested:
                     self.logger.info("Rebalance stopped due to timeout")
             elif had_error:
-                self.statusManager.set_db_status(
+                if self.options.rollback:
+                    self.statusManager.set_status(
+                    RebalanceStatus.ROLLBACK_FAILED)
+                else:
+                    self.statusManager.set_status(
                     RebalanceStatus.FAILED)
                 raise Exception("execution encountered movement erorrs")
             else:
                 if self.options.rollback:
-                    self.statusManager.set_status('ROLLBACK_DONE')
+                    self.statusManager.set_status(RebalanceStatus.ROLLBACK_DONE)
                 else:
-                    self.statusManager.set_status('EXECUTION_DONE')
-                self.statusManager.set_db_status(
-                    RebalanceStatus.COMPLETED)
+                    self.statusManager.set_status(RebalanceStatus.DONE)
+
                 rmdirCmd = RemoveDirectory("remove recoverseg log dir",  f"{os.path.join(os.environ.get('HOME', '.'),GPRECOVERSEG_DIR)}")
                 rmdirCmd.run()
                 for host in hosts:
@@ -1029,9 +1047,9 @@ class RebalanceExecutor:
 
         except Exception as e:
             if self.options.rollback:
-                self.statusManager.set_status('ROLLBACK_FAILED')
+                self.statusManager.set_status(RebalanceStatus.ROLLBACK_FAILED)
             else:
-                self.statusManager.set_status('EXECUTION_FAILED')
+                self.statusManager.set_status(RebalanceStatus.FAILED)
             raise
     
     def _execute_role_swaps(self, segids: List[SegmentId]):
@@ -1049,8 +1067,6 @@ class RebalanceExecutor:
                             "content IN %s AND preferred_role = 'p'", (data,))
                 cur.execute("UPDATE gp_segment_configuration SET preferred_role = 'p' WHERE "
                             "content IN %s AND preferred_role = 't'", (data,))
-                cur.execute("UPDATE gprebalance.status_detail SET status = 'PENDING' WHERE "
-                            "status = 'awaits_switch'")
                 cur.execute("COMMIT")
         except Exception as e:
             raise Exception('could not execute SQL : %s' % str(e))

--- a/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_executor.py
@@ -181,8 +181,11 @@ class SingleMoveCommand(SQLCommand):
                         recovery_process.join()
                 except Exception:
                     pass
-                time.sleep(20)
+                time.sleep(10)
             
+            if not result_queue.empty():
+                result = result_queue.get(block=False)
+           
             if result is None:
                 exit_code = recovery_process.exitcode
                 if exit_code < 0:

--- a/gpMgmt/bin/gprebalance_modules/rebalance_status.py
+++ b/gpMgmt/bin/gprebalance_modules/rebalance_status.py
@@ -1,213 +1,681 @@
+import atexit
+import copy
 from datetime import datetime
+import json
 import os
-from gppylib.db import dbconn
 from enum import Enum
-from typing import Dict, List
+import pickle
+import threading
+import time
+from typing import Dict, List, Tuple, Any, Optional
 
 from gprebalance_modules.rebalance_plan import Move
-from gprebalance_modules.rebalance import SegmentId, Segment, SegmentSize
+from gprebalance_modules.rebalance import SegmentId, Segment
+import gppylib.operations.update_pg_hba_on_segments as hba_upd
+from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts, update_unreachable_flag_for_segments
 
-create_schema_sql = "CREATE SCHEMA gprebalance"
-drop_schema_sql = "DROP SCHEMA IF EXISTS gprebalance CASCADE"
-
-status_table_sql = """CREATE TABLE gprebalance.status
-                        ( status varchar(255),
-                          updated timestamp ) """
-
-status_detail_table_sql = """CREATE TABLE gprebalance.status_detail
-                        ( step_id serial,
-                          dbid smallint,
-                          content smallint,
-                          role char,
-                          preferred_role char,
-                          source_hostname varchar(255),
-                          source_port integer,
-                          source_datadir varchar(255),
-                          dest_hostname varchar(255),
-                          target_datadir varchar(255),
-                          target_port integer,
-                          status varchar(255),
-                          rebalance_started timestamp,
-                          rebalance_finished timestamp,
-                          source_kbytes numeric )"""
-
+from gppylib.commands import pg
+from gppylib.commands.base import Command, REMOTE
+from gppylib.userinput import *
+from gppylib.db import dbconn
+from gppylib.system import configurationInterface as configInterface
+from gppylib.parseutils import *
 
 class MoveStatus(Enum):
-    PENDING = "pending"
-    IN_PROGRESS = "in_progress"
-    AWAITS_SWITCH = "awaits_switch"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    STOPPED = "stopped"
-    REVERTED = "reverted"
-
+    PENDING = "PENDING"
+    IN_PROGRESS = "IN_PROGRESS"
+    AWAITS_SWITCH = "AWAITS_SWITCH"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    STOPPED = "STOPPED"
+    REVERTED = "REVERTED"
+    ASK_ROLLBACK_OR_SKIP = "ASK_USER"
+    SKIPPED = "NEEDS_MANUAL_RECOVERY"
 
 class RebalanceStatus(Enum):
-    INITIALIZED = "initialized"
-    PREPARED = "prepared"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    STOPPED = "stopped"
-    AWAITS_SWITCH = "awaits_switch"
-
+    UNKNOWN = "UNKNOWN"
+    UNINITIALIZED = "UNINITIALIZED"
+    VALIDATED = "VALIDATED"
+    PRE_EXECUTE_FAILED= "PRE_EXECUTE_NOT_PASSED"
+    PREPARED = "EXECUTION_PREPARED"
+    IN_PROGRESS = "EXECUTION_IN_PROGRESS"
+    AWAITS_SWITCH_APPROVE = "EXECUTION_AWAITING_SWITCHOVER_APPROVE"
+    AWAITS_SWITCH = "EXECUTION_AWAITING_SWITCHOVER"
+    STEPS_FAILED = "EXECUTION_STEPS_FAILED"
+    FAILED = "EXECUTION_FAILED"
+    DONE = "EXECUTION_DONE"
+    AWAITS_ROLLBACK_APPROVE = "EXECUTION_AWAITING_ROLLBACK_APPROVE"
+    STOPPED = "EXECUTION_STOPPED"
+    ROLLBACK_PREPARED = "EXECUTION_ROLLBACK_PREPARED"
+    ROLLBACK_IN_PROGRESS = "EXECUTION_ROLLBACK_PREPARED"
+    ROLLBACK_DONE = "EXECUTION_ROLLBACK_DONE"
+    ROLLBACK_FAILED = "EXECUTION_ROLLBACK_FAILED"
 
 class InvalidStatusError(Exception):
     pass
 
+def load_plan(datadir, rollback):
+    filename = datadir 
+    if rollback:
+        filename += "/rollback_plan.pkl"
+    else:
+        filename += "/plan.pkl"
+    if not os.path.exists(filename):
+        raise FileNotFoundError(f"No pickle file found at {filename}")
+    with open(filename, 'rb') as f:
+        plan = pickle.load(f)
+    return plan
 
-class SqlError(Exception):
-    pass
-
+wait_timeout_s = 5
 
 class StatusManager:
-    def __init__(self, conn: dbconn.Connection, options, logger):
-
-        self.main_conn = conn
+    # Class variable for the singleton instance
+    _instance = None
+    _instance_lock = threading.Lock()
+    
+    @classmethod
+    def get_instance(cls, options=None, logger=None):
+        """
+        Get or create the singleton instance of StatusManager.
+        
+        Args:
+            options: Configuration options (required first time)
+            logger: Logger object (required first time)
+            
+        Returns:
+            The singleton StatusManager instance
+        """
+        with cls._instance_lock:
+            if cls._instance is None:
+                if options is None or logger is None:
+                    raise ValueError("options and logger required for initial instance creation")
+                cls._instance = cls(options, logger)
+            return cls._instance
+    
+    def __init__(self, options, logger, gparray, conn, gpEnv):
         self.options = options
         self.logger = logger
+        self._status_filename = self.options.coordinator_data_directory + '/gprebalance.status.json'
+        self.initial_gparray= gparray
+        self._flush_interval = 2.0
+        self._last_flush_time = 0
+        self._dirty = False
+        self._lock = threading.RLock()
+        self.conn = conn
+        self.gpenv = gpEnv
 
-        self._status_filename = self.options.coordinator_data_directory + '/gprebalance.status'
-        self._fp = None
-        self._status = []
-        self._status_info = []
-        self._status_values = {'UNINITIALIZED': 1,
-                               'VALIDATED': 2,
-                               'PLANNED': 3,
-                               'REBALANCE_PREPARE_SCHEMA_STARTED': 4,
-                               'REBALANCE_PREPARE_SCHEMA_DONE': 5,
-                               'EXECUTION_PREPARED': 6,
-                               'EXECUTION_STARTED': 7,
-                               'EXECUTION_FAILED' : 8,
-                               'EXECUTION_STOPPED' : 9,
-                               'EXECUTION_DONE': 10,
-                                'ROLLBACK_PREPARED' : 11,
-                               'ROLLBACK_STARTED' : 12,
-                               'ROLLBACK_FAILED' : 13,
-                               'ROLLBACK_STOPPED' : 14,
-                               'ROLLBACK_DONE' : 15,
-                               }
+        # Initialize the status data structure
+        self.status_data = {
+            "current_status": None,
+            "rebalance_dir" :None,
+            "hosts_file" : None,
+            "status_history": [],
+            "moves": [],
+            "last_modified": datetime.now().isoformat()
+        }
+        
         self.conf_dir = None
         self.target_hosts_filename = None
+        
+        # Load existing status file if it exists
         if os.path.exists(self._status_filename):
             self._read_status_file()
+            self.analyze_gprecoverseg_states()
 
+        
+        atexit.register(self._ensure_flush)
+        self._lock_timeout = 10  # seconds to wait for lock acquisition
+        self._max_retries = 3    # maximum number of retries for operations
+        self._retry_delay = 0.5  # seconds between retries
+
+        self._stop_flush_thread = False
+        self._flush_thread = threading.Thread(target=self._auto_flush_worker, daemon=True)
+        self._flush_thread.start()
+    
+    def _auto_flush_worker(self):
+        """Background thread that periodically flushes dirty status to disk"""
+        while not self._stop_flush_thread:
+            if self._dirty and time.time() - self._last_flush_time >= self._flush_interval:
+                try:
+                    self._flush_to_disk()
+                except Exception as e:
+                    self.logger.error(f"Auto-flush failed: {str(e)}")
+            time.sleep(0.5)  # Check every half second
+    
+    def _ensure_flush(self):
+        """Ensure any pending changes are flushed to disk"""
+        if self._dirty:
+            try:
+                self._flush_to_disk()
+            except Exception as e:
+                self.logger.error(f"Final flush failed: {str(e)}")
+    
     def _read_status_file(self):
-        self.logger.debug(
-            "Trying to read in a pre-existing gprebalance status file")
+        """Load status data from disk once"""
+        self.logger.debug(f"Loading status file: {self._status_filename}")
         try:
-            self._fp = open(self._status_filename, 'a+')
-            self._fp.seek(0)
-
-            for line in self._fp:
-                (status, status_info) = line.rstrip().split(':')
-                if status == 'PLANNED':
-                    self.conf_dir = status_info
-                elif status == 'VALIDATED':
-                    self.target_hosts_filename = status_info
-                self._status.append(status)
-                self._status_info.append(status_info)
-        except IOError:
+            with open(self._status_filename, 'r') as fp:
+                data = json.load(fp)
+                
+                # Basic validation
+                required_keys = ["current_status", "status_history", "moves"]
+                for key in required_keys:
+                    if key not in data:
+                        raise InvalidStatusError(f"Status file missing required key: {key}")
+                
+                # Store the data
+                self.status_data = data
+                self.conf_dir = self.status_data["rebalance_dir"]
+                
+                self._dirty = False
+                self._last_flush_time = time.time()
+                
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Invalid JSON in status file: {str(e)}")
+            raise InvalidStatusError(f"Status file contains invalid JSON: {str(e)}")
+        except Exception as e:
+            self.logger.error(f"Failed to load status file: {str(e)}")
             raise
-
-        if self._status[-1] not in self._status_values:
-            raise InvalidStatusError(
-                'Invalid status file.  Unknown status %s' % self._status)
-
+        
+    def _flush_to_disk(self):
+        """Write current status data to disk with file locking"""
+        with self._lock:
+            if not self._dirty:
+                return
+                
+            self.logger.debug("Flushing status data to disk")
+            # Update last modified timestamp
+            self.status_data["last_modified"] = datetime.now().isoformat()            
+            # Create temporary file
+            temp_file = f"{self._status_filename}.tmp"
+            try:
+                # Write to temp file first
+                with open(temp_file, 'w') as fp:
+                    json.dump(self.status_data, fp, indent=2)
+                    fp.flush()
+                    os.fsync(fp.fileno())
+                
+                # Atomic rename for safer file updates
+                os.rename(temp_file, self._status_filename)
+                
+                self._dirty = False
+                self._last_flush_time = time.time()
+                self.logger.debug("Status data flushed successfully")
+            except Exception as e:
+                self.logger.error(f"Failed to flush status data: {str(e)}")
+                # Clean up temp file if it exists
+                if os.path.exists(temp_file):
+                    try:
+                        os.unlink(temp_file)
+                    except:
+                        pass
+                raise
+    
     def create_status_file(self):
-        """Creates a new gprebalance status file"""
-        try:
-            self._fp = open(self._status_filename, 'w')
-            self._fp.write('UNINITIALIZED:None\n')
-            self._fp.flush()
-            os.fsync(self._fp)
-            self._status.append('UNINITIALIZED')
-            self._status_info.append('None')
-        except IOError:
-            raise
+        """Creates a new status file with initial state"""
+        with self._lock:
+            self.status_data = {
+                "current_status": "UNINITIALIZED",
+                "rebalance_dir" : None,
+                "hosts_file" : None,
+                "status_history": [
+                    {
+                        "status": "UNINITIALIZED",
+                        "timestamp": datetime.now().isoformat(),
+                        "info": None
+                    }
+                ],
+                "moves": [],
+                "last_modified": datetime.now().isoformat()
+            }
+            self._dirty = True
+            self._flush_to_disk()  # Immediate flush for initial creation
+    
+    def get_current_status(self) -> Tuple[str, str]:
+        """Gets the current status"""
+        with self._lock:
+            if not self.status_data["status_history"]:
+                return (None, None)
+            
+            last_status = self.status_data["status_history"][-1]
+            return (last_status["status"], last_status["info"])
+    
+    def set_status(self, statusEnum: RebalanceStatus, status_info=None):
+        """Set overall rebalance status"""
+        status = statusEnum.value
+        with self._lock:
+            status_entry = {
+                "status": status,
+                "timestamp": datetime.now().isoformat(),
+                "info": status_info
+            }
+            
+            self.status_data["current_status"] = status
+            self.status_data["status_history"].append(status_entry)
+            
+            # Update conf_dir or target_hosts_filename if applicable
+            if statusEnum == RebalanceStatus.PREPARED:
+                self.status_data["rebalance_dir"] = status_info
+            elif statusEnum == RebalanceStatus.VALIDATED:
+                self.status_data["hosts_file"] = status_info
+                
+            self._dirty = True
+            
+            # Consider immediate flush for important status changes
+            if statusEnum in [RebalanceStatus.FAILED, RebalanceStatus.PRE_EXECUTE_FAILED, RebalanceStatus.STEPS_FAILED, RebalanceStatus.ROLLBACK_FAILED]:
+                self._flush_to_disk()
+    
+    def record_moves_batch(self, moves_data):
 
-    def get_current_status(self):
-        """Gets the current status that has been written to the gpexpand
-           status file"""
-        if (len(self._status) > 0 and len(self._status_info) > 0):
-            return (self._status[-1], self._status_info[-1])
-        else:
-            return (None, None)
+        with self._lock:
+            for seq_no, segment, move, size, needs_switch in moves_data:
+                move_entry = {
+                    "dbid": segment.dbid,
+                    "content": segment.content,
+                    "role": segment.role,
+                    "role_after_switch": ('p' if move.is_mirror else 'm') if needs_switch else segment.role,
+                    "status": MoveStatus.PENDING.value,
+                    "source_kbytes": size,
+                    "seq_id": seq_no,
+                }
 
-    def set_status(self, status, status_info=None):
-        if not self._fp:
-            raise InvalidStatusError(
-                'The status file is invalid and cannot be written to')
-        if status not in self._status_values:
-            raise InvalidStatusError(
-                '%s is an invalid gprebalance status' % status)
-        self._fp.write('%s:%s\n' % (status, status_info))
-        self._fp.flush()
-        os.fsync(self._fp)
-        self._status.append(status)
-        self._status_info.append(status_info)
+                self.status_data["moves"].append(move_entry)
 
-    def setup_schema(self):
-        dbconn.execSQL(self.main_conn, create_schema_sql)
-        dbconn.execSQL(self.main_conn, status_table_sql)
-        dbconn.execSQL(self.main_conn, status_detail_table_sql)
-
-    def cleanup_schema(self):
-        dbconn.execSQL(self.main_conn, drop_schema_sql)
-
-    def set_db_status(self, status: RebalanceStatus, stamp: datetime = None):
-        if not stamp:
-            stamp = datetime.now()
-        sql = "INSERT INTO gprebalance.status VALUES ('%s', '%s')" % (
-            status.value, stamp)
-        dbconn.execSQL(self.main_conn, sql)
-
-    @staticmethod
-    def record_move(conn: dbconn.Connection, move: Move, segment: Segment, source_kbytes: int, start_time: datetime):
-        """Record initial move details"""
-
-        sql = """
-                    INSERT INTO gprebalance.status_detail (
-                        dbid, content, role, preferred_role,
-                        source_hostname, source_port, source_datadir,
-                        dest_hostname, target_datadir, target_port, status, rebalance_started, source_kbytes
-                    ) VALUES (
-                        %d, %d, '%s', '%s', '%s', %d, '%s', '%s', '%s', %d, '%s', '%s', %d
-                    )
-                """ % (
-            segment.dbid,
-            segment.content,
-            segment.role,
-            segment.preferred_role,
-            move.srcHost.hostname,
-            segment.port,
-            segment.datadir,
-            move.dstHost.hostname,
-            move.target_datadir,
-            move.target_port,
-            MoveStatus.PENDING.value,
-            str(start_time),
-            source_kbytes
-        )
-        dbconn.execSQL(conn, sql)
-
-    @staticmethod
-    def update_record_status(conn: dbconn.Connection, dbids: List[int], status: MoveStatus):
-        """Record initial move details"""
-        dbid_str = ','.join(str(dbid) for dbid in dbids)
-        if status == MoveStatus.COMPLETED:
-            sql = "UPDATE gprebalance.status_detail SET status = '%s' , rebalance_finished = '%s' WHERE dbid IN (%s)" % (
-                status.value, datetime.now(), dbid_str
-            )
-        else:
-            sql = "UPDATE gprebalance.status_detail SET status = '%s' WHERE dbid IN (%s)" % (
-                status.value, dbid_str
-            )
-        dbconn.execSQL(conn, sql)
-
+            if moves_data:
+                self._dirty = True
+                self._flush_to_disk()
+    
+    def update_move_status(self, dbids: List[int], status: MoveStatus):
+        """Update status for specified moves"""
+        with self._lock:
+            updated = False
+            for move in self.status_data["moves"]:
+                if move["dbid"] in dbids:
+                    move["status"] = status.value
+                    updated = True
+            
+            if updated:
+                self._dirty = True
+                
+                # Consider immediate flush for completion status
+                if status in [MoveStatus.COMPLETED, MoveStatus.FAILED]:
+                    self._flush_to_disk()
+    
+    def get_moves_by_status(self, status: MoveStatus) -> List[Dict[str, Any]]:
+        """Get all moves with the specified status"""
+        with self._lock:
+            return [move.copy() for move in self.status_data["moves"] 
+                   if move["status"] == status.value]
+    
+    def get_move_by_dbid(self, dbid: int) -> Optional[Dict[str, Any]]:
+        """Get a specific move by dbid"""
+        with self._lock:
+            for move in self.status_data["moves"]:
+                if move["dbid"] == dbid:
+                    return move.copy()
+            return None
+    
+    def flush(self):
+        """Manually flush status data to disk"""
+        self._flush_to_disk()
+    
     def remove_all(self):
-        if self._fp:
-            self._fp.close()
-            self._fp = None
-        if os.path.exists(self._status_filename):
-            os.unlink(self._status_filename)
+        """Remove the status file and reset state"""
+        with self._lock:
+            self._stop_flush_thread = True
+            if self._flush_thread.is_alive():
+                self._flush_thread.join(timeout=2.0)
+                
+            if os.path.exists(self._status_filename):
+                try:
+                    os.unlink(self._status_filename)
+                except Exception as e:
+                    self.logger.error(f"Failed to remove status file: {str(e)}")
+            
+            # Reset internal state
+            self.status_data = {
+                "current_status": None,
+                "status_history": [],
+                "moves": [],
+                "last_modified": datetime.now().isoformat()
+            }
+            self._dirty = False
+            self.conf_dir = None
+            self.target_hosts_filename = None
+    
+    def analyze_gprecoverseg_states(self):
+        if not self.conf_dir:
+            return
+        is_rollback = self.options.rollback
+        plan = load_plan(self.conf_dir, is_rollback)
+        failed_moves = []
+        in_progress_moves = []
+        not_started_moves = []
+        completed_moves = []
+        for move in self.status_data.get("moves", []):
+            move_status = move["status"]
+            if move_status == "FAILED":
+                failed_moves.append(move)
+            elif move_status == "IN_PROGRESS":
+                in_progress_moves.append(move)
+            elif move_status == "PENDING":
+                not_started_moves.append(move)
+            elif move_status == "COMPLETED":
+                completed_moves.append(move)
+        if failed_moves or in_progress_moves:
+            self.logger.info(f"Found {len(failed_moves)} failed moves and {len(in_progress_moves)} in-progress moves")
+            moves_to_analyze = failed_moves + in_progress_moves
+            self._analyze_failed_segments(moves_to_analyze, plan)
+            moves_to_recover = []
+            for move in moves_to_analyze:
+                if move["status"] == "ASK_USER":
+                    if ask_yesno('', f"Failed mirror move (dbid={move['dbid']}, content={move['content']}) cannot be rerun"
+                                     f" properly. Do you want to try to rollback it to original state?", "N"):
+                        moves_to_recover.append(move)
+                else:
+                    move["status"] = MoveStatus.SKIPPED.value
+            self._try_restore_config(moves_to_recover, plan)
+            self._dirty = True
+            self._flush_to_disk()
+
+            for move in moves_to_analyze:
+                if move["status"] == MoveStatus.SKIPPED.value:
+                    self.logger.info(f"Couldn't revert the move (dbid={move['dbid']}, content={move['content']})."
+                                     " Please, restore the required state and re-run")
+
+
+    def _analyze_failed_segments(self, moves, plan):
+        
+        self.logger.info(f"Analyzing {len(moves)} moves for state recovery")
+        segmentMap = {SegmentId(
+            seg.dbid, seg.content): seg for seg in self.initial_gparray.getSegmentsAsLoadedFromDb()}
+        hosts = set(self.initial_gparray.get_hostlist(includeCoordinator=False))
+        unreachable_hosts = get_unreachable_segment_hosts(hosts, self.options.parallel)
+        update_unreachable_flag_for_segments(self.initial_gparray, unreachable_hosts)
+        plan_moves = {move.segid.dbid: move for move in plan.moves}
+        for move in moves:
+            segid = SegmentId(move["dbid"], move["content"])
+            original_segment = plan.segmentMap[segid]
+            current_segment = segmentMap[segid]
+
+            peer = None
+            is_mirror = False
+            for pair in self.initial_gparray.segmentPairs:
+                if pair.primaryDB.dbid == segid.dbid:
+                    peer = pair.mirrorDB
+                    break
+                elif pair.mirrorDB.dbid == segid.dbid:
+                    peer = pair.primaryDB
+                    is_mirror = True
+                    break
+
+            if is_mirror:
+                self.logger.info(f"Analyzing failed mirror move (dbid={original_segment.dbid}, content={original_segment.content}) "
+                         f"to host {plan_moves[original_segment.dbid].dstHost.hostname}, directory {plan_moves[original_segment.dbid].target_datadir}")
+                if original_segment.hostname == current_segment.hostname and\
+                    original_segment.address == current_segment.address and\
+                    original_segment.dbid == current_segment.dbid and\
+                    (original_segment.role == current_segment.role or move["role_after_switch"] == current_segment.role) and\
+                    original_segment.datadir == current_segment.datadir and\
+                    peer.valid and not current_segment.valid:
+                    # case 1 gprecoverseg could only have updated pg_hba_conf
+                    # of corresponding primary before failure
+                    # check that current_segment is running
+                    if current_segment.unreachable:
+                        move["status"] = MoveStatus.FAILED.value
+                        continue
+                    commandStr = f"pg_ctl status -D {current_segment.datadir}"
+                    cmd_status = Command("pid", commandStr, REMOTE, current_segment.hostname)
+                    cmd_status.run()
+                    if cmd_status.get_return_code() != 0:
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+
+                    #restore primary's pg_hba_conf
+                    entries = hba_upd.create_entries(peer.hostname, original_segment.hostname, self.options.hba_hostnames)
+                    updatecmd = hba_upd.SegUpdateHba(entries, peer.datadir, REMOTE, peer.hostname)
+                    updatecmd.run()
+                    if updatecmd.get_return_code() != 0:
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+                    host_port_tuple = (peer.hostname, peer.port)
+                    pg.kill_existing_walsenders_on_primary([host_port_tuple])
+                    time.sleep(wait_timeout_s)
+                    cmd_status = Command("pid", commandStr, REMOTE, current_segment.hostname)
+                    cmd_status.run()
+                    if cmd_status.get_return_code() != 0:
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+                    move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                    continue
+                # case 2 : gp_segment_configuration has been updated by gprecoverseg
+                # from buildMirrorSegments.py:295 and we need to define whether
+                # basebackup was launched, completed or interrupred
+                elif original_segment.dbid == current_segment.dbid and\
+                    (original_segment.role == current_segment.role or\
+                    # case when seg is moved after 1st switch
+                    move["role_after_switch"] == current_segment.role or
+                    #primary only move. 2 switches, case when seg is moved after 1st switch
+                    move["role_after_switch"] == move["role"]) and\
+                    (original_segment.hostname != current_segment.hostname or\
+                     original_segment.address != current_segment.address or\
+                     original_segment.datadir != current_segment.datadir):
+                    
+                    if current_segment.valid and current_segment.mode == 's':
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+
+                    # check whether target directory exists
+                    cmd = Command(
+                         name="check_directory",
+                         cmdStr=f"test -d {current_segment.datadir} && echo 'exists' || echo 'not_exists'",
+                         ctxt=REMOTE,
+                        remoteHost=current_segment.hostname)
+                    cmd.run()
+                    if not cmd.was_successful() or cmd.get_stdout().strip() != 'exists':
+                        self.logger.info(f"Failed to check directory on {current_segment.hostname}")
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+
+                    #check the port update
+                    cmd = Command(
+                    name="get_postgresql_conf_port",
+                    cmdStr=f"grep -E '^port\\s*=' {current_segment.datadir}/postgresql.conf | sed -E 's/^port\\s*=\\s*([0-9]+).*/\\1/'",
+                    ctxt=REMOTE,
+                    remoteHost=current_segment.hostname
+                     )
+                    cmd.run()
+                    if not cmd.was_successful():
+                        self.logger.info(f"Failed to get port from postgresql.conf on {current_segment.hostname}: {cmd.get_stderr()}")
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+                    output = cmd.get_stdout().strip()
+                    if not output or not output.isdigit():
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+                    datadir_port = int(output)
+                    if datadir_port != current_segment.port:
+                        self.logger.info(f"Port mismatch in postgresql.conf: expected {current_segment.port}, got {datadir_port}")
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+
+                    #check if server is running
+                    process_running = self._check_postgres_process(current_segment.hostname, current_segment.datadir)
+                    if not process_running:
+
+                        is_started = self._wait_for_pg_startup(current_segment.hostname, current_segment.datadir, timeout_seconds=20)
+                        if not is_started:
+                            attemp_start = self._attempt_start_mirror(current_segment)
+                            if not attemp_start and not self._wait_for_pg_startup(current_segment.hostname, current_segment.datadir, timeout_seconds=20):
+                                self.logger.info("Failed to start the mirror")
+                                move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                                continue
+                        if not self._wait_for_config_update(current_segment.dbid, 60):
+                            move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                            continue
+                    elif not self._wait_for_config_update(current_segment.dbid, 60):
+                        move["status"] = MoveStatus.ASK_ROLLBACK_OR_SKIP.value
+                        continue
+                    
+                    move["status"] = MoveStatus.COMPLETED.value
+
+
+    def _check_postgres_process(self, host, data_dir):
+        try:
+            # First check with pg_ctl status
+            pg_ctl_cmd = Command(
+                name="check_pg_ctl_status",
+                cmdStr=f"pg_ctl status -D {data_dir}",
+                ctxt=REMOTE,
+                remoteHost=host
+            )
+            pg_ctl_cmd.run()
+
+            # pg_ctl status returns 0 if server is running
+            if pg_ctl_cmd.get_return_code() == 0:
+                return True
+
+            # If pg_ctl status failed, check for actual process
+            # Get postmaster.pid contents if it exists
+            pid_cmd = Command(
+                name="check_postmaster_pid",
+                cmdStr=f"test -f {data_dir}/postmaster.pid && cat {data_dir}/postmaster.pid | head -1",
+                ctxt=REMOTE,
+                remoteHost=host
+            )
+            pid_cmd.run()
+
+            if not pid_cmd.was_successful() or not pid_cmd.get_stdout().strip():
+                return False
+
+            pid = pid_cmd.get_stdout().strip()
+            if not pid.isdigit():
+                return False
+
+            # Check if process with that PID exists and is postgres
+            process_cmd = Command(
+                name="check_postgres_process",
+                cmdStr=f"ps -p {pid} -o cmd= | grep postgres",
+                ctxt=REMOTE,
+                remoteHost=host
+            )
+            process_cmd.run()
+
+            return process_cmd.was_successful() and process_cmd.get_stdout().strip()
+
+        except Exception as e:
+            self.logger.error(f"Error checking postgres process on {host}: {str(e)}")
+            return False
+        
+    def _wait_for_pg_startup(self, host, data_dir, timeout_seconds=120):
+       
+        self.logger.info(f"Waiting for PostgreSQL to start on {host}:{data_dir}")
+
+        start_time = time.time()
+        check_interval = 5  # Check every 5 seconds
+
+        while time.time() - start_time < timeout_seconds:
+            if self._check_postgres_process(host, data_dir):
+                elapsed = int(time.time() - start_time)
+                self.logger.info(f"PostgreSQL started on {host}:{data_dir} after {elapsed} seconds")
+                return True
+
+            # Wait before next check
+            time.sleep(check_interval)
+            elapsed = int(time.time() - start_time)
+
+        self.logger.info(f"Timeout waiting for PostgreSQL to start on {host}:{data_dir}")
+        return False
+    
+    def _wait_for_config_update(self, dbid, timeout_seconds=120):
+       
+        start_time = time.time()
+        check_interval = 5
+
+        conf_sql = """
+                SELECT c.mode, c.status
+                FROM gp_segment_configuration AS c WHERE c.dbid = {sdbid}
+                """ .format(sdbid=dbid)
+        while time.time() - start_time < timeout_seconds:
+            cursor = dbconn.query(self.conn, conf_sql)
+            for mode, status in cursor:
+                if mode == 's' and status == 'u':
+                    return True
+
+            # Wait before next check
+            time.sleep(check_interval)
+            elapsed = int(time.time() - start_time)
+
+        return False
+    
+    def _try_restore_config(self, moves_to_recover, plan):
+        from gppylib.commands.gp import GpRecoverSeg
+        gparray = copy.deepcopy(self.initial_gparray)
+        def write_gprecoverseg_config(segment, conf_dir):
+            filename = self.conf_dir + "_revert_" + "dbid" + str(segment.dbid)
+            with open(filename, 'w') as fp:
+                line = (f"{canonicalize_address(segment.address)}|"
+                    f"{segment.port}|{segment.datadir}")
+                self.logger.info(
+                "About to run gprecoverseg for recovering mirror  "
+                f"(dbid = {segment.dbid}, content = {segment.content}) {line}")
+                fp.write(line)
+            return filename
+        for move in moves_to_recover:
+            segid = SegmentId(move["dbid"], move["content"])
+            original_segment = plan.segmentMap[segid]
+            dbids = {}
+            seg = None
+            peer = None
+            for pair in gparray.segmentPairs:
+                if pair.mirrorDB.dbid == segid.dbid:
+                    pair.mirrorDB = copy.copy(original_segment)
+                    pair.mirrorDB.status = 'd'
+                    pair.mirrorDB.mode = 'n'
+                    dbids[pair.mirrorDB.dbid] = True
+                    pair.mirrorDB.role = 'm'
+                    seg=pair.mirrorDB
+                    peer = pair.primaryDB
+            configInterface.getConfigurationProvider().updateSystemConfig(
+                gparray,
+                "gprebalance: segment config for resync",
+                dbIdToForceMirrorRemoveAdd=dbids,
+                useUtilityMode=False,
+                allowPrimary=False
+            )
+            #host_port_tuple = (peer.hostname, peer.port)
+            #pg.kill_existing_walsenders_on_primary([host_port_tuple])
+            filename = write_gprecoverseg_config(seg, self.conf_dir)
+
+            recoversegOptions = f"-a -l {os.path.join(os.environ.get('HOME', '.'),'gpAdminLogs/rebalance')} "\
+                            f"-i {filename}"
+            if self.options.hba_hostnames:
+                recoversegOptions += " --hba-hostnames"
+            cmd = GpRecoverSeg("Running gprecoverseg", options=recoversegOptions)
+            cmd.run()
+            recordStatus = MoveStatus.REVERTED.value
+            if not cmd.was_successful():
+                self.logger.info(f"Failed to rollback mirror moves (dbid = {seg.dbid}, content = {seg.content}): {cmd.get_stderr()}, skipping...")
+                recordStatus = MoveStatus.SKIPPED.value
+            move["status"] = recordStatus
+            os.unlink(filename)
+    
+    def _attempt_start_mirror(self, segment):
+        from gppylib.commands.gp import SegmentStart
+        from gppylib.gp_era import read_era
+        seg = Segment(None, None, None, None, None, None, None, None,
+                  segment.port, segment.datadir)
+        cmd =  cmd = SegmentStart(
+                name="Attemping to start segment with dbid %s:" % (str(segment.dbid))
+                , gpdb=seg
+                , numContentsInCluster=0
+                , era=read_era(self.gpenv.getCoordinatorDataDir(), logger=self.logger)
+                , mirrormode="mirror"
+                , utilityMode=False
+                , ctxt=REMOTE
+                , remoteHost=segment.hostname)
+        self.logger.info(str(cmd))
+        cmd.run()
+        if not cmd.was_successful():
+            return False
+        return True


### PR DESCRIPTION
Partial implementation of gprecoverseg state recovery

The changes of this PR provide the prototype for status tracking of mirror moves
during rebalance. Firstly , this patch removes the usage of gpdb table for
whole execution status. Secondly, the status manager is rewritten in order to
track execution process with status file only. If the movement step, presented
by gprecoverseg process, fails, the corresponging status (FAILED) will be
written to the internal status struct first, then will be flushed to disk.

The main purpose of these changes is also implementation of gprecoverseg
determination. The code in analyze_gprecoverseg_states() tries to implement
the SRS diagram for gprecoverseg status definition. It processes the following
scenarios:
1. A mirror move failed after pg_hba conf had been updated at primary. In this case
primary marks the mirror as being down.
2. A mirror move failed after gp_segment_configuration had been updated. Here our code
tries to determine whether pg_basebackup was executed succesfully or not.

Depending on the basebackup state, the algorithm tries to either startup the 
backuped mirror or rollback the configuration changes with recovering old mirror

How to test. You can try to insert   os.kill(os.getpid(), signal.SIGKILL)
to gprecoverseg code to emulate failure at different stages (described in the flow diagram in wiki). E.x. in clsRecoverSegment.py: 439 ; buildMirrorSegments.py:295 ;
sbin/gpsegrecovery.py : 62 . 

Then checkout the gp_segment_configuration restoration and rebalance status file for
the final state. 
