### PR TITLE
Fix tests in src/test/regress/expected/expressions.out

### DIFF
--- a/src/test/regress/expected/expressions_optimizer.out
+++ b/src/test/regress/expected/expressions_optimizer.out
@@ -93,15 +93,14 @@ RESET search_path;
 explain (costs off)
 select count(*) from date_tbl
   where f1 between '1997-01-01' and '1998-01-01';
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on date_tbl
-                     Filter: ((f1 >= '01-01-1997'::date) AND (f1 <= '01-01-1998'::date))
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Seq Scan on date_tbl
+               Filter: ((f1 >= '01-01-1997'::date) AND (f1 <= '01-01-1998'::date))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 select count(*) from date_tbl
   where f1 between '1997-01-01' and '1998-01-01';
@@ -113,15 +112,14 @@ select count(*) from date_tbl
 explain (costs off)
 select count(*) from date_tbl
   where f1 not between '1997-01-01' and '1998-01-01';
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Finalize Aggregate
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on date_tbl
-                     Filter: ((f1 < '01-01-1997'::date) OR (f1 > '01-01-1998'::date))
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Seq Scan on date_tbl
+               Filter: ((f1 < '01-01-1997'::date) OR (f1 > '01-01-1998'::date))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 select count(*) from date_tbl
   where f1 not between '1997-01-01' and '1998-01-01';
@@ -133,15 +131,14 @@ select count(*) from date_tbl
 explain (costs off)
 select count(*) from date_tbl
   where f1 between symmetric '1997-01-01' and '1998-01-01';
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on date_tbl
-                     Filter: (((f1 >= '01-01-1997'::date) AND (f1 <= '01-01-1998'::date)) OR ((f1 >= '01-01-1998'::date) AND (f1 <= '01-01-1997'::date)))
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Seq Scan on date_tbl
+               Filter: (((f1 >= '01-01-1997'::date) AND (f1 <= '01-01-1998'::date)) OR ((f1 >= '01-01-1998'::date) AND (f1 <= '01-01-1997'::date)))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 select count(*) from date_tbl
   where f1 between symmetric '1997-01-01' and '1998-01-01';
@@ -153,15 +150,14 @@ select count(*) from date_tbl
 explain (costs off)
 select count(*) from date_tbl
   where f1 not between symmetric '1997-01-01' and '1998-01-01';
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Seq Scan on date_tbl
-                     Filter: (((f1 < '01-01-1997'::date) OR (f1 > '01-01-1998'::date)) AND ((f1 < '01-01-1998'::date) OR (f1 > '01-01-1997'::date)))
- Optimizer: Postgres query optimizer
-(6 rows)
+         ->  Seq Scan on date_tbl
+               Filter: (((f1 < '01-01-1997'::date) OR (f1 > '01-01-1998'::date)) AND ((f1 < '01-01-1998'::date) OR (f1 > '01-01-1997'::date)))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 select count(*) from date_tbl
   where f1 not between symmetric '1997-01-01' and '1998-01-01';


### PR DESCRIPTION
Fix tests in src/test/regress/expected/expressions.out

Commit cf20cc0 added new tests for BETWEEN to
src/test/regress/sql/expressions.sql, in GPDB plans should include motion
nodes, and ORCA-specific output.