### PR TITLE
Fix tests in src/test/regress/expected/aggregates.out

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -1211,23 +1211,27 @@ explain (costs off) select * from t3 group by a,b,c;
 create temp table t1c () inherits (t1);
 -- Ensure we don't remove any columns when t1 has a child table
 explain (costs off) select * from t1 group by a,b,c,d;
-             QUERY PLAN              
--------------------------------------
- HashAggregate
-   Group Key: t1.a, t1.b, t1.c, t1.d
-   ->  Append
-         ->  Seq Scan on t1
-         ->  Seq Scan on t1c
-(5 rows)
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: t1.a, t1.b, t1.c, t1.d
+         ->  Append
+               ->  Seq Scan on t1
+               ->  Seq Scan on t1c
+ Optimizer: Postgres query optimizer
+(7 rows)
 
 -- Okay to remove columns if we're only querying the parent.
 explain (costs off) select * from only t1 group by a,b,c,d;
-      QUERY PLAN      
-----------------------
- HashAggregate
-   Group Key: a, b
-   ->  Seq Scan on t1
-(3 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a, b
+         ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 create temp table p_t1 (
   a int,
@@ -1240,14 +1244,16 @@ create temp table p_t1_1 partition of p_t1 for values in(1);
 create temp table p_t1_2 partition of p_t1 for values in(2);
 -- Ensure we can remove non-PK columns for partitioned tables.
 explain (costs off) select * from p_t1 group by a,b,c,d;
-           QUERY PLAN            
----------------------------------
- HashAggregate
-   Group Key: p_t1_1.a, p_t1_1.b
-   ->  Append
-         ->  Seq Scan on p_t1_1
-         ->  Seq Scan on p_t1_2
-(5 rows)
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: p_t1_1.a, p_t1_1.b
+         ->  Append
+               ->  Seq Scan on p_t1_1
+               ->  Seq Scan on p_t1_2
+ Optimizer: Postgres query optimizer
+(7 rows)
 
 drop table t1 cascade;
 NOTICE:  drop cascades to table t1c

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1211,9 +1211,59 @@ explain (costs off) select * from t3 group by a,b,c;
  Optimizer: Pivotal Optimizer (GPORCA) version 3.78.0
 (3 rows)
 
-drop table t1;
+create temp table t1c () inherits (t1);
+-- Ensure we don't remove any columns when t1 has a child table
+explain (costs off) select * from t1 group by a,b,c,d;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: t1.a, t1.b, t1.c, t1.d
+         ->  Append
+               ->  Seq Scan on t1
+               ->  Seq Scan on t1c
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+-- Okay to remove columns if we're only querying the parent.
+explain (costs off) select * from only t1 group by a,b,c,d;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: ONLY in the FROM clause
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: a, b
+         ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+create temp table p_t1 (
+  a int,
+  b int,
+  c int,
+  d int,
+  primary key(a,b)
+) partition by list(a);
+create temp table p_t1_1 partition of p_t1 for values in(1);
+create temp table p_t1_2 partition of p_t1 for values in(2);
+-- Ensure we can remove non-PK columns for partitioned tables.
+explain (costs off) select * from p_t1 group by a,b,c,d;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Dynamic Seq Scan on p_t1
+         Number of partitions to scan: 2 (out of 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+drop table t1 cascade;
+NOTICE:  drop cascades to table t1c
 drop table t2;
 drop table t3;
+drop table p_t1;
 --
 -- Test combinations of DISTINCT and/or ORDER BY
 --


### PR DESCRIPTION
Fix tests in src/test/regress/expected/aggregates.out

Commit a5be406 added new tests to src/test/regress/sql/aggregates.sql, in GPDB
plans should include motion nodes, as well as ORCA-specific output.