### PR TITLE
Fix tests in src/test/regress/expected/gist.out

### DIFF
--- a/src/test/regress/expected/gist.out
+++ b/src/test/regress/expected/gist.out
@@ -216,12 +216,15 @@ select b from gist_tbl where b <@ box(point(5,5), point(6,6));
 explain (costs off)
 select b from gist_tbl where b <@ box(point(5,5), point(6,6))
 order by b <-> point(5.2, 5.91);
-                      QUERY PLAN                      
-------------------------------------------------------
- Index Only Scan using gist_tbl_box_index on gist_tbl
-   Index Cond: (b <@ '(6,6),(5,5)'::box)
-   Order By: (b <-> '(5.2,5.91)'::point)
-(3 rows)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: ((b <-> '(5.2,5.91)'::point))
+   ->  Index Only Scan using gist_tbl_box_index on gist_tbl
+         Index Cond: (b <@ '(6,6),(5,5)'::box)
+         Order By: (b <-> '(5.2,5.91)'::point)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select b from gist_tbl where b <@ box(point(5,5), point(6,6))
 order by b <-> point(5.2, 5.91);
@@ -254,12 +257,15 @@ order by b <-> point(5.2, 5.91);
 explain (costs off)
 select b from gist_tbl where b <@ box(point(5,5), point(6,6))
 order by point(5.2, 5.91) <-> b;
-                      QUERY PLAN                      
-------------------------------------------------------
- Index Only Scan using gist_tbl_box_index on gist_tbl
-   Index Cond: (b <@ '(6,6),(5,5)'::box)
-   Order By: (b <-> '(5.2,5.91)'::point)
-(3 rows)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: (('(5.2,5.91)'::point <-> b))
+   ->  Index Only Scan using gist_tbl_box_index on gist_tbl
+         Index Cond: (b <@ '(6,6),(5,5)'::box)
+         Order By: (b <-> '(5.2,5.91)'::point)
+ Optimizer: Postgres query optimizer
+(6 rows)
 
 select b from gist_tbl where b <@ box(point(5,5), point(6,6))
 order by point(5.2, 5.91) <-> b;

--- a/src/test/regress/expected/gist_optimizer.out
+++ b/src/test/regress/expected/gist_optimizer.out
@@ -220,6 +220,94 @@ select b from gist_tbl where b <@ box(point(5,5), point(6,6));
  (6,6),(6,6)
 (21 rows)
 
+-- Also test an index-only knn-search
+explain (costs off)
+select b from gist_tbl where b <@ box(point(5,5), point(6,6))
+order by b <-> point(5.2, 5.91);
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: ((b <-> '(5.2,5.91)'::point))
+         ->  Sort
+               Sort Key: ((b <-> '(5.2,5.91)'::point))
+               ->  Index Scan using gist_tbl_box_index on gist_tbl
+                     Index Cond: (b <@ '(6,6),(5,5)'::box)
+                     Filter: (b <@ '(6,6),(5,5)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select b from gist_tbl where b <@ box(point(5,5), point(6,6))
+order by b <-> point(5.2, 5.91);
+            b            
+-------------------------
+ (5.55,5.55),(5.55,5.55)
+ (5.6,5.6),(5.6,5.6)
+ (5.5,5.5),(5.5,5.5)
+ (5.65,5.65),(5.65,5.65)
+ (5.45,5.45),(5.45,5.45)
+ (5.7,5.7),(5.7,5.7)
+ (5.4,5.4),(5.4,5.4)
+ (5.75,5.75),(5.75,5.75)
+ (5.35,5.35),(5.35,5.35)
+ (5.8,5.8),(5.8,5.8)
+ (5.3,5.3),(5.3,5.3)
+ (5.85,5.85),(5.85,5.85)
+ (5.25,5.25),(5.25,5.25)
+ (5.9,5.9),(5.9,5.9)
+ (5.2,5.2),(5.2,5.2)
+ (5.95,5.95),(5.95,5.95)
+ (5.15,5.15),(5.15,5.15)
+ (6,6),(6,6)
+ (5.1,5.1),(5.1,5.1)
+ (5.05,5.05),(5.05,5.05)
+ (5,5),(5,5)
+(21 rows)
+
+-- Check commuted case as well
+explain (costs off)
+select b from gist_tbl where b <@ box(point(5,5), point(6,6))
+order by point(5.2, 5.91) <-> b;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: (('(5.2,5.91)'::point <-> b))
+         ->  Sort
+               Sort Key: (('(5.2,5.91)'::point <-> b))
+               ->  Index Scan using gist_tbl_box_index on gist_tbl
+                     Index Cond: (b <@ '(6,6),(5,5)'::box)
+                     Filter: (b <@ '(6,6),(5,5)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select b from gist_tbl where b <@ box(point(5,5), point(6,6))
+order by point(5.2, 5.91) <-> b;
+            b            
+-------------------------
+ (5.55,5.55),(5.55,5.55)
+ (5.6,5.6),(5.6,5.6)
+ (5.5,5.5),(5.5,5.5)
+ (5.65,5.65),(5.65,5.65)
+ (5.45,5.45),(5.45,5.45)
+ (5.7,5.7),(5.7,5.7)
+ (5.4,5.4),(5.4,5.4)
+ (5.75,5.75),(5.75,5.75)
+ (5.35,5.35),(5.35,5.35)
+ (5.8,5.8),(5.8,5.8)
+ (5.3,5.3),(5.3,5.3)
+ (5.85,5.85),(5.85,5.85)
+ (5.25,5.25),(5.25,5.25)
+ (5.9,5.9),(5.9,5.9)
+ (5.2,5.2),(5.2,5.2)
+ (5.95,5.95),(5.95,5.95)
+ (5.15,5.15),(5.15,5.15)
+ (6,6),(6,6)
+ (5.1,5.1),(5.1,5.1)
+ (5.05,5.05),(5.05,5.05)
+ (5,5),(5,5)
+(21 rows)
+
 drop index gist_tbl_box_index;
 -- Test that an index-only scan is not chosen, when the query involves the
 -- circle column (the circle opclass does not support index-only scans).


### PR DESCRIPTION
Fix tests in src/test/regress/expected/gist.out

Commit c085e1c added new tests to src/test/regress/sql/gist.sql, in GPDB plans
should include motion nodes, as well as ORCA-specific output.