### PR TITLE
Fix tests in src/test/regress/expected/groupingsets.out

### DIFF
--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1553,19 +1553,22 @@ explain (costs off)
 BEGIN;
 SET LOCAL enable_hashagg = false;
 EXPLAIN (COSTS OFF) SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
-              QUERY PLAN               
----------------------------------------
- Sort
-   Sort Key: a, b
-   ->  GroupAggregate
-         Group Key: a
-         Group Key: ()
-         Sort Key: b
-           Group Key: b
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: a, b, (GROUPINGSET_ID())
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: a, b, (GROUPINGSET_ID())
          ->  Sort
-               Sort Key: a
-               ->  Seq Scan on gstest3
-(10 rows)
+               Sort Key: a, b, (GROUPINGSET_ID())
+               ->  Partial GroupAggregate
+                     Group Key: a
+                     Group Key: ()
+                     Sort Key: b
+                       Group Key: b
+                     ->  Index Scan using gstest3_pkey on gstest3
+ Optimizer: Postgres query optimizer
+(13 rows)
 
 SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
  a | b | count | max | max 
@@ -1579,17 +1582,22 @@ SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,(
 
 SET LOCAL enable_seqscan = false;
 EXPLAIN (COSTS OFF) SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
-                      QUERY PLAN                      
-------------------------------------------------------
- Sort
-   Sort Key: a, b
-   ->  GroupAggregate
-         Group Key: a
-         Group Key: ()
-         Sort Key: b
-           Group Key: b
-         ->  Index Scan using gstest3_pkey on gstest3
-(8 rows)
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize GroupAggregate
+   Group Key: a, b, (GROUPINGSET_ID())
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: a, b, (GROUPINGSET_ID())
+         ->  Sort
+               Sort Key: a, b, (GROUPINGSET_ID())
+               ->  Partial GroupAggregate
+                     Group Key: a
+                     Group Key: ()
+                     Sort Key: b
+                       Group Key: b
+                     ->  Index Scan using gstest3_pkey on gstest3
+ Optimizer: Postgres query optimizer
+(13 rows)
 
 SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
  a | b | count | max | max 

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -1724,6 +1724,83 @@ DETAIL:  Feature not supported: LATERAL
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- Verify that we correctly handle the child node returning a
+-- non-minimal slot, which happens if the input is pre-sorted,
+-- e.g. due to an index scan.
+BEGIN;
+SET LOCAL enable_hashagg = false;
+EXPLAIN (COSTS OFF) SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Sort
+   Sort Key: (NULL::integer), (NULL::integer)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on gstest3
+         ->  Append
+               ->  Aggregate
+                     ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref3.b
+                     ->  Sort
+                           Sort Key: share0_ref3.b
+                           ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref4.a
+                     ->  Sort
+                           Sort Key: share0_ref4.a
+                           ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
+ a | b | count | max | max 
+---+---+-------+-----+-----
+ 1 |   |     1 |   1 |   1
+ 2 |   |     1 |   2 |   2
+   | 1 |     1 |   1 |   1
+   | 2 |     1 |   2 |   2
+   |   |     2 |   2 |   2
+(5 rows)
+
+SET LOCAL enable_seqscan = false;
+EXPLAIN (COSTS OFF) SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Sort
+   Sort Key: (NULL::integer), (NULL::integer)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 0:0)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     ->  Seq Scan on gstest3
+         ->  Append
+               ->  Aggregate
+                     ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref3.b
+                     ->  Sort
+                           Sort Key: share0_ref3.b
+                           ->  Shared Scan (share slice:id 0:0)
+               ->  GroupAggregate
+                     Group Key: share0_ref4.a
+                     ->  Sort
+                           Sort Key: share0_ref4.a
+                           ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
+
+SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,()) ORDER BY a, b;
+ a | b | count | max | max 
+---+---+-------+-----+-----
+ 1 |   |     1 |   1 |   1
+ 2 |   |     1 |   2 |   2
+   | 1 |     1 |   1 |   1
+   | 2 |     1 |   2 |   2
+   |   |     2 |   2 |   2
+(5 rows)
+
+COMMIT;
 -- More rescan tests
 -- start_ignore
 -- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans


### PR DESCRIPTION
Fix tests in src/test/regress/expected/groupingsets.out

Commit af3deff added new tests to src/test/regress/sql/groupingsets.sql, and
commit f63d9e6 added COSTS OFF, in GPDB plans should include motion nodes, as
well as ORCA-specific output.