### PR TITLE
Fix tests in src/test/regress/expected/partition_prune.out

### DIFF
--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -1286,11 +1286,13 @@ create table boolrangep_ff1 partition of boolrangep for values from ('false', 'f
 create table boolrangep_ff2 partition of boolrangep for values from ('false', 'false', 50) to ('false', 'false', 100);
 -- try a more complex case that's been known to trip up pruning in the past
 explain (costs off)  select * from boolrangep where not a and not b and c = 25;
-                  QUERY PLAN                  
-----------------------------------------------
- Seq Scan on boolrangep_ff1
-   Filter: ((NOT a) AND (NOT b) AND (c = 25))
-(2 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on boolrangep_ff1
+         Filter: ((NOT a) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres query optimizer
+(4 rows)
 
 -- test scalar-to-array operators
 create table coercepart (a varchar) partition by list (a);

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -1236,6 +1236,21 @@ explain (costs off) select * from boolpart where a is not unknown;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+create table boolrangep (a bool, b bool, c int) partition by range (a,b,c);
+create table boolrangep_tf partition of boolrangep for values from ('true', 'false', 0) to ('true', 'false', 100);
+create table boolrangep_ft partition of boolrangep for values from ('false', 'true', 0) to ('false', 'true', 100);
+create table boolrangep_ff1 partition of boolrangep for values from ('false', 'false', 0) to ('false', 'false', 50);
+create table boolrangep_ff2 partition of boolrangep for values from ('false', 'false', 50) to ('false', 'false', 100);
+-- try a more complex case that's been known to trip up pruning in the past
+explain (costs off)  select * from boolrangep where not a and not b and c = 25;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on boolrangep_ff1
+         Filter: ((NOT a) AND (NOT b) AND (c = 25))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
 -- test scalar-to-array operators
 create table coercepart (a varchar) partition by list (a);
 create table coercepart_ab partition of coercepart for values in ('ab');
@@ -1580,7 +1595,7 @@ explain (costs off) select * from rparted_by_int2 where a > 100000000000000;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
-drop table lp, coll_pruning, rlp, mc3p, mc2p, boolpart, rp, coll_pruning_multi, like_op_noprune, lparted_by_int2, rparted_by_int2;
+drop table lp, coll_pruning, rlp, mc3p, mc2p, boolpart, boolrangep, rp, coll_pruning_multi, like_op_noprune, lparted_by_int2, rparted_by_int2;
 --
 -- Test Partition pruning for HASH partitioning
 --


### PR DESCRIPTION
Fix tests in src/test/regress/expected/partition_prune.out

Commit cfde234 added new tests to src/test/regress/sql/partition_prune.sql, in
GPDB plans should include motion nodes, and ORCA-specific output.