### PR TITLE
Fix tests in src/test/regress/expected/gp_metadata.out

### DIFF
--- a/src/test/regress/expected/gp_metadata.out
+++ b/src/test/regress/expected/gp_metadata.out
@@ -1,4 +1,4 @@
-select version() ~ '^PostgreSQL (1[0-9]+)(\.[0-9]+)?(devel)?(beta[0-9])? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
+select version() ~ '^PostgreSQL (1[0-9]+)(\.[0-9]+)?(devel)?((alpha|beta)[0-9])? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
  version 
 ---------
  t

--- a/src/test/regress/sql/gp_metadata.sql
+++ b/src/test/regress/sql/gp_metadata.sql
@@ -1,2 +1,2 @@
-select version() ~ '^PostgreSQL (1[0-9]+)(\.[0-9]+)?(devel)?(beta[0-9])? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
+select version() ~ '^PostgreSQL (1[0-9]+)(\.[0-9]+)?(devel)?((alpha|beta)[0-9])? \(Greenplum Database ([0-9]+\.){2}[0-9]+.+' as version;
 select gp_opt_version() ~ '^(GPOPT version: 4.0.0, Xerces version: ([0-9]+\.){2}[0-9]+|Server has been compiled without ORCA)$' as version;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/gp_metadata.out

When resolving conflicts, commit a8f51b5 changed PG_PACKAGE_VERSION from
12beta2 to 13alpha0, but forgot to change the test
src/test/regress/sql/gp_metadata.sql accordingly.