### PR TITLE
Support XLOG_PENDING_DELETE record in xlog_desc()

### DIFF
--- a/src/backend/access/rmgrdesc/xlogdesc.c
+++ b/src/backend/access/rmgrdesc/xlogdesc.c
@@ -17,6 +17,7 @@
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #include "catalog/pg_control.h"
+#include "catalog/storage_pending_deletes.h"
 #include "utils/guc.h"
 #include "utils/timestamp.h"
 
@@ -232,6 +233,11 @@ xlog_desc(StringInfo buf, XLogRecord *record)
 						 (uint32) (xlrec.overwritten_lsn >> 32),
 						 (uint32) xlrec.overwritten_lsn,
 						 timestamptz_to_str(xlrec.overwrite_time));
+	}
+	else if (info == XLOG_PENDING_DELETE)
+	{
+		appendStringInfo(buf, "orphaned relfilenodes to delete: %zu",
+						 ((PendingRelXactDeleteArray *)rec)->count);
 	}
 	else
 		appendStringInfoString(buf, "UNKNOWN");


### PR DESCRIPTION
Support XLOG_PENDING_DELETE record in xlog_desc()

Tests are not added, because `xlog_desc` is used for debug purposes only.

Ticket: ADBDEV-7409