### PR TITLE
ADBDEV-7422: Fix tests bfv_partition, tbale_statistics

### DIFF
--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1246,7 +1246,7 @@ alter table mpp3816 add column AAA int;
 alter table mpp3816 add column BBB int;
 alter table mpp3816 drop column BBB;
 alter table mpp3816 drop column startDate;
-ERROR:  cannot drop column named in partition key
+ERROR:  cannot drop column "startdate" because it is part of the partition key of relation "mpp3816"
 drop table mpp3816;
 CREATE TABLE mpp3762_cities (
         city     varchar(80) primary key,
@@ -2947,6 +2947,7 @@ Partitioned index "bfv_partition.mpp6573_pkey"
  id     | integer | yes  | id
  date   | date    | yes  | date
 primary key, btree, for table "bfv_partition.mpp6573"
+Number of partitions: 2 (Use \d+ to list them.)
 
 drop table mpp6573;
 -- MPP-6724

--- a/src/test/regress/expected/table_statistics.out
+++ b/src/test/regress/expected/table_statistics.out
@@ -949,7 +949,7 @@ select  count(*) from pg_class where relname like 'stat_part_heap_t7';
 
 -- Alter table alter type of a column
 Alter table stat_part_heap_t7 alter column j type numeric;
-ERROR:  cannot alter type of column named in partition key
+ERROR:  cannot alter column "j" because it is part of the partition key of relation "stat_part_heap_t7_1_prt_others"
 select  count(*) from pg_class where relname like 'stat_part_heap_t7';
  count 
 -------
@@ -1038,7 +1038,7 @@ select  count(*) from pg_class where relname like 'stat_part_co_t7';
 
 -- Alter table alter type
 Alter table stat_part_co_t7 alter column i type numeric;
-ERROR:  cannot alter type of column named in partition key
+ERROR:  cannot alter column "i" because it is part of the partition key of relation "stat_part_co_t7"
 select  count(*) from pg_class where relname like 'stat_part_co_t7';
  count 
 -------


### PR DESCRIPTION
Fix tests bfv_partition, tbale_statistics

Commit a0555ddab9b672a04681ce0d9f6c94104c01b15f changed error message for
dropping columns that are part of partition key, and commit
24f62e93f314c107b4fa679869e5ba9adb2d545f added partition info in output of \d
for indexes, GPDB-specific tests have to be updated too.