### PR TITLE
ADBDEV-7422: Fix test src/test/regress/expected/rpt.out

### DIFF
--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -146,6 +146,9 @@ s/nodename nor servname provided, or not known/Name or service not known/
 m/ERROR:  could not devise a query plan for the given query \(.*\)/
 s/ERROR:  could not devise a query plan for the given query \(.*\)/ERROR:  could not devise a query plan for the given query/
 
+m/ERROR:  could not devise a plan\.? \(.*\)/
+s/ERROR:  could not devise a plan\.? \(.*\)/ERROR:  could not devise a plan/
+
 m/^DETAIL:.*gid=.*/
 s/gid=\d+/gid DUMMY/
 


### PR DESCRIPTION
Fix test src/test/regress/expected/rpt.out

GPDB 8 commit d1f9b96b97f7cd111fd85c4361ad93b0a5f6afe4 added error messages
`ERROR:  could not devise a plan` and `ERROR:  could not devise a plan.` to
cdbpath.c. After changes to the file, line numbers changed. Add new error
messages to the init_file to ignore line changes.

---

Suggestion: Maybe we should instead align the error messages with already existing `could not devise a query plan for the given query`?