### PR TITLE
ADBDEV-7422: Fix test psql_gp_commands

### DIFF
--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -179,7 +179,7 @@ ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
  test_psql_schema | d_bogus_heap      | table         | test_psql_de_role | bogus     | permanent   | 0 bytes | 
  test_psql_schema | d_heap            | table         | test_psql_de_role | heap      | permanent   | 0 bytes | 
  test_psql_schema | d_view            | view          | test_psql_de_role |           | permanent   | 0 bytes | 
- (7 rows)
+(7 rows)
 
 -- The Storage column is not interesting for indexes, so it's omitted with
 -- \di
@@ -195,7 +195,7 @@ ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
       Schema      |  Name   | Type  |       Owner       | Table  | Persistence |  Size  | Description 
 ------------------+---------+-------+-------------------+--------+-------------+--------+-------------
  test_psql_schema | d_index | index | test_psql_de_role | d_heap | permanent   | 128 kB | 
- (1 row)
+(1 row)
 
 -- But if tables are shown, too, then it's interesting again.
 \dti

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -169,17 +169,17 @@ ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
 (7 rows)
 
 \d+
-                                              List of relations
-      Schema      |       Name        |     Type      |       Owner       |  Storage  |  Size   | Description 
-------------------+-------------------+---------------+-------------------+-----------+---------+-------------
- test_psql_schema | dE_external_table | foreign table | test_psql_de_role |           | 0 bytes | 
- test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role |           | 0 bytes | 
- test_psql_schema | d_ao              | table         | test_psql_de_role | ao_row    | 128 kB  | 
- test_psql_schema | d_aocs            | table         | test_psql_de_role | ao_column | 128 kB  | 
- test_psql_schema | d_bogus_heap      | table         | test_psql_de_role | bogus     | 0 bytes | 
- test_psql_schema | d_heap            | table         | test_psql_de_role | heap      | 0 bytes | 
- test_psql_schema | d_view            | view          | test_psql_de_role |           | 0 bytes | 
-(7 rows)
+                                                     List of relations
+      Schema      |       Name        |     Type      |       Owner       |  Storage  | Persistence |  Size   | Description 
+------------------+-------------------+---------------+-------------------+-----------+-------------+---------+-------------
+ test_psql_schema | dE_external_table | foreign table | test_psql_de_role |           | permanent   | 0 bytes | 
+ test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role |           | permanent   | 0 bytes | 
+ test_psql_schema | d_ao              | table         | test_psql_de_role | ao_row    | permanent   | 128 kB  | 
+ test_psql_schema | d_aocs            | table         | test_psql_de_role | ao_column | permanent   | 128 kB  | 
+ test_psql_schema | d_bogus_heap      | table         | test_psql_de_role | bogus     | permanent   | 0 bytes | 
+ test_psql_schema | d_heap            | table         | test_psql_de_role | heap      | permanent   | 0 bytes | 
+ test_psql_schema | d_view            | view          | test_psql_de_role |           | permanent   | 0 bytes | 
+ (7 rows)
 
 -- The Storage column is not interesting for indexes, so it's omitted with
 -- \di
@@ -191,11 +191,11 @@ ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
 (1 row)
 
 \di+
-                                   List of relations
-      Schema      |  Name   | Type  |       Owner       | Table  |  Size  | Description 
-------------------+---------+-------+-------------------+--------+--------+-------------
- test_psql_schema | d_index | index | test_psql_de_role | d_heap | 128 kB | 
-(1 row)
+                                          List of relations
+      Schema      |  Name   | Type  |       Owner       | Table  | Persistence |  Size  | Description 
+------------------+---------+-------+-------------------+--------+-------------+--------+-------------
+ test_psql_schema | d_index | index | test_psql_de_role | d_heap | permanent   | 128 kB | 
+ (1 row)
 
 -- But if tables are shown, too, then it's interesting again.
 \dti


### PR DESCRIPTION
Fix test psql_gp_commands

Commit 9a2ea618323a4cf8ca7eb6a828b08c6e39b95cdd added a new Persistence column
to the output of \d+ psql command, GPDB test has to be updated.