### PR TITLE
ADBDEV-7422: Fix src/test/regress/expected/pg_lsn_optimizer.out

### DIFF
--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -26,6 +26,13 @@ INSERT INTO PG_LSN_TBL VALUES ('/ABCD');
 ERROR:  invalid input syntax for type pg_lsn: "/ABCD"
 LINE 1: INSERT INTO PG_LSN_TBL VALUES ('/ABCD');
                                        ^
+-- Min/Max aggregation
+SELECT MIN(f1), MAX(f1) FROM PG_LSN_TBL;
+ min |        max        
+-----+-------------------
+ 0/0 | FFFFFFFF/FFFFFFFF
+(1 row)
+
 DROP TABLE PG_LSN_TBL;
 -- Operators
 SELECT '0/16AE7F8' = '0/16AE7F8'::pg_lsn;


### PR DESCRIPTION
Fix src/test/regress/expected/pg_lsn_optimizer.out

Tests added in commit 313f87a17155a6dbd27a3ce687cf59bd171fe75e have to be
added to ORCA output too.
