### PR TITLE
ADBDEV-7422: Fix test src/test/regress/expected/join_hash_optimizer.out

### DIFF
--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -9,6 +9,7 @@ begin;
 set allow_system_table_mods=on;
 set local min_parallel_table_scan_size = 0;
 set local parallel_setup_cost = 0;
+set local enable_hashjoin = on;
 -- Extract bucket and batch counts from an explain analyze plan.  In
 -- general we can't make assertions about how many batches (or
 -- buckets) will be required because it can vary, but we can in some


### PR DESCRIPTION
Fix test src/test/regress/expected/join_hash_optimizer.out

Commit cba0fe024e35839688e3a3d256d1dcdf50baadaf added set enable_hashjoin =
on, we need to add it to ORCA output too.