### PR TITLE
Fix incorrect SPI_INNER_QUERY tagging for top-level SPI calls

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1534,12 +1534,19 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 	cplan = GetCachedPlan(plansource, paramLI, false, _SPI_current->queryEnv, NULL);
 	stmt_list = cplan->stmt_list;
 
-	/* GPDB: Mark all queries as SPI inner queries for extension usage */
-	foreach(lc, stmt_list)
+	/*
+	 * GPDB: Mark all queries as SPI inner queries for extension usage. But
+	 * make sure that SPI is not top level itself.
+	 */
+	if (already_under_executor_run())
 	{
-		Node *stmt = (Node *) lfirst(lc);
-		if (IsA(stmt, PlannedStmt))
-			((PlannedStmt*)stmt)->metricsQueryType = SPI_INNER_QUERY;
+		foreach(lc, stmt_list)
+		{
+			Node	   *stmt = (Node *) lfirst(lc);
+
+			if (IsA(stmt, PlannedStmt))
+				((PlannedStmt *) stmt)->metricsQueryType = SPI_INNER_QUERY;
+		}
 	}
 
 	if (!plan->saved)
@@ -2485,8 +2492,12 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 			_SPI_current->processed = 0;
 			_SPI_current->tuptable = NULL;
 
-			/* GPDB: Mark all queries as SPI inner query for extension usage */
-			stmt->metricsQueryType = SPI_INNER_QUERY;
+			/*
+			 * GPDB: Mark all queries as SPI inner query for extension usage
+			 * But make sure that SPI is not top level itself.
+			 */
+			if (already_under_executor_run())
+				stmt->metricsQueryType = SPI_INNER_QUERY;
 
 			/* Check for unsupported cases. */
 			if (stmt->utilityStmt)


### PR DESCRIPTION
Fix incorrect SPI_INNER_QUERY tagging for top-level SPI calls

Some extensions, such as ADCC, rely on the metricsQueryType field in
PlannedStmt to detect top-level query execution. However, queries executed
via SPI are always marked as SPI_INNER_QUERY, regardless of whether the SPI
call is initiated directly or nested within another SPI invocation.

This behavior leads to incorrect top-level query detection in background
workers that use SPI directly, potentially causing issues such as memory
leaks in extensions relying on accurate query lifecycle tracking.

This commit updates the tagging logic to avoid setting SPI_INNER_QUERY when the
SPI is a top-level SPI call.

Automated testing of this change is non-trivial. Testing SPI top-level detection
requires a real background worker process, which must be registered and started
within the server — a pattern not yet used in existing tests. Unit testing with
CMockery is not viable either, as SPI requires a fully initialized backend
environment including shared memory, lock manager, and memory contexts.
Emulating this in isolation is impractical without broader infrastructure
changes.

ADBDEV-7415

(cherry picked from commit https://github.com/arenadata/gpdb/commit/f8c4d5334e4f5227a000e5a8d46606b83d13c315)