### PR TITLE
The XLOG_SMGR_CREATE_PDL WAL record should be always linked to XID

### DIFF
--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -19,6 +19,7 @@
 
 #include "postgres.h"
 
+#include "access/transam.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlogutils.h"
@@ -91,6 +92,7 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	SMgrRelation srel;
 	BackendId	backend;
 	bool		needs_wal;
+	TransactionId xid = InvalidTransactionId;
 
 	switch (relpersistence)
 	{
@@ -115,7 +117,10 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	smgrcreate(srel, MAIN_FORKNUM, false);
 
 	if (needs_wal)
+	{
+		xid = GetCurrentTransactionId();
 		log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM, relstorage);
+	}
 
 	/* Add the relation to the list of stuff to delete at abort */
 	pending = (PendingRelDelete *)
@@ -126,8 +131,7 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 	pending->atCommit = false;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;
-	pending->shmemPtr = PdlShmemAdd(&pending->relnode,
-									GetCurrentTransactionId());
+	pending->shmemPtr = PdlShmemAdd(&pending->relnode, xid);
 	pendingDeletes = pending;
 }
 

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -118,6 +118,10 @@ RelationCreateStorage(RelFileNode rnode, char relpersistence, char relstorage)
 
 	if (needs_wal)
 	{
+		/* 
+		 * Call GetCurrentTransactionId before log_smgrcreate, because
+		 * XLOG_SMGR_CREATE_PDL WAL record should be always linked to XID
+		 */
 		xid = GetCurrentTransactionId();
 		log_smgrcreate(&srel->smgr_rnode.node, MAIN_FORKNUM, relstorage);
 	}


### PR DESCRIPTION
The XLOG_SMGR_CREATE_PDL WAL record should be always linked to XID

When a table was created right after transaction beginning, then the 
XLOG_SMGR_CREATE_PDL record was added with InvalidTransactionId, because
XLogInsert calls GetCurrentTransactionIdIfAny and the transaction id has not
been got at this moment.

Get the transaction id before the log_smgrcreate function is called.

No special tests are presented in this patch, as the added functionality will
be tested later together with other parts for the orphaned file removal feature.
At this point, it is enough to pass the current standard test set.

Ticket: ADBDEV-7458

--------------------------------
PR to run the tests https://github.com/arenadata/gpdb/pull/1548