### PR TITLE
ADBDEV-7372 Fix permission error for synchronization SET in GPDB 7

### DIFF
--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -606,6 +606,9 @@ DROP ROLE IF EXISTS dispatch_test_user2;
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
 
+-- Make sure the gang wasn't dropped by a silent error.
+CREATE TEMP TABLE gang_is_the_same();
+
 CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
 RETURNS table (guc_name text, guc_setting text)
 EXECUTE ON ALL SEGMENTS AS $$
@@ -669,6 +672,9 @@ SELECT * from show_on_segments('log_min_messages');
 SHOW constraint_exclusion;
 SELECT * from show_on_segments('constraint_exclusion');
 
+SELECT FROM gang_is_the_same;
+
+DROP TABLE gang_is_the_same;
 RESET SESSION AUTHORIZATION;
 
 DROP FUNCTION show_on_segments(show_name text);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -1019,6 +1019,8 @@ drop table t_create_gang_time;
 -- Use a separate user without any priveleges to catch possible context issues.
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
+-- Make sure the gang wasn't dropped by a silent error.
+CREATE TEMP TABLE gang_is_the_same();
 CREATE OR REPLACE FUNCTION show_on_segments(show_name text)
 RETURNS table (guc_name text, guc_setting text)
 EXECUTE ON ALL SEGMENTS AS $$
@@ -1137,6 +1139,11 @@ SELECT * from show_on_segments('constraint_exclusion');
  constraint_exclusion | on
 (3 rows)
 
+SELECT FROM gang_is_the_same;
+--
+(0 rows)
+
+DROP TABLE gang_is_the_same;
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;


### PR DESCRIPTION
Adopt 0b6db72 to GPDB 7.

Changes from original commit:
Remove excess misleading call of CdbDispatchSetCommandForSync from
set_config_by_name because is_sync can not be true on the QD. Add
assert. Supplement the comment before if(is_sync) condition.

Do not squash to preserve authorship.