### PR TITLE
ao/co: Decouple DML finish from finish_bulk_insert

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1062,10 +1062,8 @@ aoco_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 aoco_finish_bulk_insert(Relation relation, int options)
 {
-	aoco_dml_finish(relation);
+	/* nothing for co tables */
 }
-
-
 
 
 /* ------------------------------------------------------------------------

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -930,7 +930,7 @@ appendonly_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 appendonly_finish_bulk_insert(Relation relation, int options)
 {
-	appendonly_dml_finish(relation);
+	/* nothing for ao tables */
 }
 
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4752,6 +4752,9 @@ CopyFrom(CopyState cstate)
 
 	ExecCloseIndices(target_resultRelInfo);
 
+	if (target_resultRelInfo->ri_RelationDesc->rd_tableam)
+		table_dml_finish(target_resultRelInfo->ri_RelationDesc);
+
 	/* Close all the partitioned tables, leaf partitions, and their indices */
 	if (proute)
 		ExecCleanupTupleRouting(mtstate, proute);

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -759,6 +759,9 @@ intorel_shutdown(DestReceiver *self)
 
 	table_finish_bulk_insert(myState->rel, myState->ti_options);
 
+	if (myState->rel->rd_tableam)
+		table_dml_finish(myState->rel);
+
 	/* close rel, but keep lock until commit */
 	table_close(myState->rel, NoLock);
 	myState->rel = NULL;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -664,6 +664,9 @@ transientrel_shutdown(DestReceiver *self)
 
 	table_finish_bulk_insert(myState->transientrel, myState->ti_options);
 
+	if (myState->transientrel->rd_tableam)
+		table_dml_finish(myState->transientrel);
+
 	/* close transientrel, but keep lock until commit */
 	table_close(myState->transientrel, NoLock);
 	myState->transientrel = NULL;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6600,6 +6600,9 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 
 		table_finish_bulk_insert(newrel, ti_options);
 
+		if (newrel->rd_tableam)
+			table_dml_finish(newrel);
+
 		table_close(newrel, NoLock);
 	}
 }


### PR DESCRIPTION
Since upstream commit f7c830f1ab2645236ac2d6103fb3a88518bdc4fc the                                                                                                                                                                     finish_bulk_insert table AM API can be called multiple times for the same table
(for COPY). This leads to aoco_dml_finish and appendonly_dml_finish getting
called multiple times for the same table, which is undesirable. We want the DML
state to be set up and torn down once per COPY session for a given relation. So
decouple the two.

(cherry picked from commit e1b2ce7185191192e568f38f90388b611f7ac4e3)

---

Don't squash!