### PR TITLE
Add check for scalar subplan in ORCA's translator Expr to DXL

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/CorrelatedInSubqueryWithUnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedInSubqueryWithUnionAll.mdp
@@ -21,20 +21,19 @@ explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a 
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on t1
    SubPlan 1  (slice0)
-     ->  Result
-           ->  Append
+     ->  Append
+           ->  Result
+                 Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Seq Scan on t2
+                                   Filter: (0 = b)
+           ->  Result
+                 Filter: (0 = "outer".?column?)
                  ->  Result
-                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
-                       ->  Materialize
-                             ->  Gather Motion 3:1  (slice2; segments: 3)
-                                   ->  Seq Scan on t2
-                                         Filter: (0 = b)
-                 ->  Result
-                       Filter: (0 = "outer".?column?)
                        ->  Result
-                             ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(17 rows)
 ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -473,62 +472,66 @@ explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a 
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
-            <dxl:TestExpr/>
+          <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+            <dxl:TestExpr>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:TestExpr>
             <dxl:ParamList>
               <dxl:Param ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ParamList>
-            <dxl:Result>
+            <dxl:Append IsTarget="false" IsZapped="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000311" Rows="2.000000"
                         Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Append IsTarget="false" IsZapped="false">
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000311"
-                          Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000265"
+                          Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="10" Alias="b">
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:Result>
+                <dxl:Filter>
+                  <dxl:Or>
+                    <dxl:Comparison ComparisonOperator="="
+                            OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="="
+                            OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Or>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
+                <dxl:Materialize Eager="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000265"
-                            Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000166"
+                            Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="a">
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="10" Alias="b">
                       <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Or>
-                      <dxl:Comparison ComparisonOperator="="
-                              OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="="
-                              OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:Or>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Materialize Eager="true">
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000166"
+                      <dxl:Cost StartupCost="0" TotalCost="431.000158"
                               Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
@@ -540,9 +543,10 @@ explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a 
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000158"
+                        <dxl:Cost StartupCost="0" TotalCost="431.000069"
                                 Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
@@ -554,107 +558,85 @@ explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a 
                                   TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000069"
-                                  Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="9" Alias="a">
-                            <dxl:Ident ColId="9" ColName="a"
-                                    TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="10" Alias="b">
-                            <dxl:Ident ColId="10" ColName="b"
-                                    TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="="
-                                  OperatorMdid="0.96.1.0">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                            <dxl:Ident ColId="10" ColName="b"
-                                    TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:TableDescriptor Mdid="6.482898.1.0" TableName="t2">
-                          <dxl:Columns>
-                            <dxl:Column ColId="9" Attno="1" ColName="a"
-                                    TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="10" Attno="2" ColName="b"
-                                    TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="11" Attno="-1" ColName="ctid"
-                                    TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="12" Attno="-3" ColName="xmin"
-                                    TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="13" Attno="-4" ColName="cmin"
-                                    TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="14" Attno="-5" ColName="xmax"
-                                    TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="15" Attno="-6" ColName="cmax"
-                                    TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid"
-                                    TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="17" Attno="-8"
-                                    ColName="gp_segment_id" TypeMdid="0.23.1.0"
-                                    ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:GatherMotion>
-                  </dxl:Materialize>
-                </dxl:Result>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="="
+                                OperatorMdid="0.96.1.0">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                          <dxl:Ident ColId="10" ColName="b"
+                                  TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="6.482898.1.0" TableName="t2">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="a"
+                                  TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="10" Attno="2" ColName="b"
+                                  TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid"
+                                  TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin"
+                                  TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin"
+                                  TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax"
+                                  TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax"
+                                  TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid"
+                                  TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="17" Attno="-8"
+                                  ColName="gp_segment_id" TypeMdid="0.23.1.0"
+                                  ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Materialize>
+              </dxl:Result>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="19" Alias="?column?">
+                    <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                    <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:OneTimeFilter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000038"
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005"
                             Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="19" Alias="?column?">
-                      <dxl:Ident ColId="19" ColName="?column?"
-                              TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="="
-                            OperatorMdid="0.96.1.0">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                      <dxl:Ident ColId="19" ColName="?column?"
-                              TypeMdid="0.23.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
+                  <dxl:Filter/>
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000005"
-                              Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001"
+                              Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:ProjElem ColId="18" Alias="">
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001"
-                                Rows="1.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="18" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
                   </dxl:Result>
                 </dxl:Result>
-              </dxl:Append>
-            </dxl:Result>
+              </dxl:Result>
+            </dxl:Append>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3625,16 +3625,17 @@ CTranslatorExprToDXL::PdxlnCorrelatedNLJoin(
 	COperator::EOperatorId op_id = pexpr->Pop()->Eopid();
 	CDXLNode *pdxlnCond = NULL;
 
-	// Create a subplan with a Boolean from the inner child if we have a Const True as a join condition.
-	// One scenario for this is when IN sublinks contain a projection from the outer table only such as:
-	// select * from foo where foo.a in (select foo.b from bar);
-	// If bar is a very small table, ORCA generates a CorrelatedInLeftSemiNLJoin with a Const true join filter
-	// and condition foo.a = foo.b is added as a filter on the table scan of foo. If bar is a large table,
-	// ORCA generates a plan with CorrelatedInnerNLJoin with a Const true join filter and a LIMIT over the
-	// scan of bar. The same foo.a = foo.b condition is also added as a filter on the table scan of foo.
+	// Create a subplan with a Boolean from the inner child if we have a Const
+	// True as a join condition. One scenario for this is when sublink contain a
+	// projection from the outer table such as:
+	// select * from foo where 10 > (select bar.b from bar where foo.b = bar.b);
+	// If bar is a very small table, ORCA generates a CorrelatedInnerNLJoin with
+	// a Const true join filter and condition 10 > bar.b is added as a filter
+	// to the scan of bar.
+	// For the other cases function BuildSubplans generates another sublink type
+	// for correct type of join condition.
 	if (CUtils::FScalarConstTrue(pexprScalar) &&
-		(COperator::EopPhysicalCorrelatedInnerNLJoin == op_id ||
-		 COperator::EopPhysicalCorrelatedInLeftSemiNLJoin == op_id))
+		COperator::EopPhysicalCorrelatedInnerNLJoin == op_id)
 	{
 		// translate relational inner child expression
 		CDXLNode *pdxlnInnerChild =

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -572,27 +572,26 @@ insert into t2 values(0,0);
 insert into t2 values(3,3);
 set optimizer_donot_enforce_subplans = on;
 explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
-                                QUERY PLAN                                
---------------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on t1
    SubPlan 1  (slice0)
-     ->  Result
-           ->  Append
+     ->  Append
+           ->  Result
+                 Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Seq Scan on t2
+                                   Filter: (0 = b)
+           ->  Result
+                 Filter: (0 = "outer".?column?)
                  ->  Result
-                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
-                       ->  Materialize
-                             ->  Gather Motion 3:1  (slice2; segments: 3)
-                                   ->  Seq Scan on t2
-                                         Filter: (0 = b)
-                 ->  Result
-                       Filter: (0 = "outer".?column?)
                        ->  Result
-                             ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(17 rows)
 
 select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b union all select 1);
  a | b 
@@ -602,26 +601,25 @@ select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b u
 (2 rows)
 
 explain (costs off) select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on t1
    SubPlan 1  (slice0)
-     ->  Result
-           ->  GroupAggregate
-                 Group Key: t2.b
-                 ->  Sort
-                       Sort Key: t2.b
-                       ->  Result
-                             Filter: ((t2.a = 0) OR (t2.b = t1.b))
-                             ->  Materialize
-                                   ->  Gather Motion 3:1  (slice2; segments: 3)
-                                         ->  Seq Scan on t2
-                                               Filter: (0 = b)
+     ->  GroupAggregate
+           Group Key: t2.b
+           ->  Sort
+                 Sort Key: t2.b
+                 ->  Result
+                       Filter: ((t2.a = 0) OR (t2.b = t1.b))
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on t2
+                                         Filter: (0 = b)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 select * from t1 where 0 in (select t2.b from t2 where t2.a = 0 or t2.b = t1.b group by 1);
  a | b 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1190,6 +1190,10 @@ select * from t1 where
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
+-- start_matchsubs
+-- m/[ ]*\+$/
+-- s/[ ]*\+$/ \+/
+-- end_matchsubs
 -- Output DXL plan without unimportant properties.
 select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '        <', '<');
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
@@ -1219,3 +1223,33 @@ select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pre
 ERROR:  could not stat file "minidumps/pretty.xml": No such file or directory
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;
+-- Test case for subquery, which returns more than one rows
+create table table1 as
+    select * from (values (1, 0), (1, 0)) v(a, b) distributed by (a);
+create table table2 as
+    select * from (values (0, 10), (0, 10)) v(a, b) distributed by (a);
+explain (costs off)
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on table1
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Filter: ((table2.a = 0) OR (table1.b = table2.b))
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on table2
+(10 rows)
+
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+ a | b 
+---+---
+ 1 | 0
+ 1 | 0
+(2 rows)
+
+drop table table1, table2;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1263,6 +1263,10 @@ select * from t1 where
 
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
+-- start_matchsubs
+-- m/[ ]*\+$/
+-- s/[ ]*\+$/ \+/
+-- end_matchsubs
 -- Output DXL plan without unimportant properties.
 -- start_ignore
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
@@ -1672,8 +1676,8 @@ reset optimizer_trace_fallback;
 \! sed -i 's/dxl://' $MASTER_DATA_DIRECTORY/minidumps/pretty.xml
 -- end_ignore
 select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
-                                                                    replace                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  replace                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------
  {"<Plan Id=\"0\" SpaceSize=\"0\">                                                                                                             +
    <Result>                                                                                                                                    +
        <ProjList>                                                                                                                              +
@@ -1682,150 +1686,143 @@ select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pre
            </ProjElem>                                                                                                                         +
        </ProjList>                                                                                                                             +
        <Filter>                                                                                                                                +
-           <SubPlan SubPlanType=\"ScalarSubPlan\">                                                                                             +
-               <TestExpr/>                                                                                                                     +
+           <SubPlan SubPlanType=\"AnySubPlan\">                                                                                                +
+               <TestExpr>                                                                                                                      +
+                   <ConstValue/>                                                                                                               +
+               </TestExpr>                                                                                                                     +
                <ParamList>                                                                                                                     +
                    <Param ColId=\"0\" ColName=\"i1\"/>                                                                                         +
                </ParamList>                                                                                                                    +
                <Result>                                                                                                                        +
                    <ProjList>                                                                                                                  +
-                       <ProjElem Alias=\"ColRef_0038\" ColId=\"38\">                                                                           +
-                           <ConstValue/>                                                                                                       +
+                       <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                              +
+                           <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                          +
                        </ProjElem>                                                                                                             +
                    </ProjList>                                                                                                                 +
-                   <Filter/>                                                                                                                   +
+                   <Filter>                                                                                                                    +
+                       <Comparison ComparisonOperator=\"=\">                                                                                   +
+                           <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                                                                       +
+                           <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                          +
+                       </Comparison>                                                                                                           +
+                   </Filter>                                                                                                                   +
                    <OneTimeFilter/>                                                                                                            +
                    <Result>                                                                                                                    +
                        <ProjList>                                                                                                              +
                            <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                          +
-                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                      +
+                               <Comparison ComparisonOperator=\"=\">                                                                           +
+                                   <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
+                                   <ConstValue/>                                                                                               +
+                               </Comparison>                                                                                                   +
                            </ProjElem>                                                                                                         +
-                       </ProjList>                                                                                                             +
-                       <Filter>                                                                                                                +
-                           <Comparison ComparisonOperator=\"=\">                                                                               +
-                               <Ident ColId=\"29\" ColName=\"ColRef_0029\"/>                                                                   +
-                               <Ident ColId=\"16\" ColName=\"?column?\"/>                                                                      +
-                           </Comparison>                                                                                                       +
-                       </Filter>                                                                                                               +
-                       <OneTimeFilter/>                                                                                                        +
-                       <Result>                                                                                                                +
-                           <ProjList>                                                                                                          +
-                               <ProjElem Alias=\"?column?\" ColId=\"16\">                                                                      +
-                                   <Comparison ComparisonOperator=\"=\">                                                                       +
-                                       <Ident ColId=\"8\" ColName=\"i3\"/>                                                                     +
-                                       <ConstValue/>                                                                                           +
-                                   </Comparison>                                                                                               +
-                               </ProjElem>                                                                                                     +
-                               <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                                                   +
-                                   <SubPlan SubPlanType=\"AnySubPlan\">                                                                        +
-                                       <TestExpr>                                                                                              +
-                                           <Comparison ComparisonOperator=\"=\">                                                               +
-                                               <Ident ColId=\"0\" ColName=\"i1\"/>                                                             +
+                           <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                                                       +
+                               <SubPlan SubPlanType=\"AnySubPlan\">                                                                            +
+                                   <TestExpr>                                                                                                  +
+                                       <Comparison ComparisonOperator=\"=\">                                                                   +
+                                           <Ident ColId=\"0\" ColName=\"i1\"/>                                                                 +
+                                           <Ident ColId=\"17\" ColName=\"i2\"/>                                                                +
+                                       </Comparison>                                                                                           +
+                                   </TestExpr>                                                                                                 +
+                                   <ParamList/>                                                                                                +
+                                   <Result>                                                                                                    +
+                                       <ProjList>                                                                                              +
+                                           <ProjElem Alias=\"i2\" ColId=\"17\">                                                                +
                                                <Ident ColId=\"17\" ColName=\"i2\"/>                                                            +
-                                           </Comparison>                                                                                       +
-                                       </TestExpr>                                                                                             +
-                                       <ParamList/>                                                                                            +
+                                           </ProjElem>                                                                                         +
+                                       </ProjList>                                                                                             +
+                                       <Filter/>                                                                                               +
+                                       <OneTimeFilter/>                                                                                        +
                                        <Result>                                                                                                +
                                            <ProjList>                                                                                          +
+                                               <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                                   +
+                                                   <ConstValue/>                                                                               +
+                                               </ProjElem>                                                                                     +
                                                <ProjElem Alias=\"i2\" ColId=\"17\">                                                            +
                                                    <Ident ColId=\"17\" ColName=\"i2\"/>                                                        +
                                                </ProjElem>                                                                                     +
                                            </ProjList>                                                                                         +
                                            <Filter/>                                                                                           +
                                            <OneTimeFilter/>                                                                                    +
-                                           <Result>                                                                                            +
+                                           <Materialize Eager=\"true\">                                                                        +
                                                <ProjList>                                                                                      +
-                                                   <ProjElem Alias=\"ColRef_0029\" ColId=\"29\">                                               +
-                                                       <ConstValue/>                                                                           +
-                                                   </ProjElem>                                                                                 +
                                                    <ProjElem Alias=\"i2\" ColId=\"17\">                                                        +
                                                        <Ident ColId=\"17\" ColName=\"i2\"/>                                                    +
                                                    </ProjElem>                                                                                 +
                                                </ProjList>                                                                                     +
                                                <Filter/>                                                                                       +
-                                               <OneTimeFilter/>                                                                                +
-                                               <Materialize Eager=\"true\">                                                                    +
+                                               <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                    +
                                                    <ProjList>                                                                                  +
                                                        <ProjElem Alias=\"i2\" ColId=\"17\">                                                    +
                                                            <Ident ColId=\"17\" ColName=\"i2\"/>                                                +
                                                        </ProjElem>                                                                             +
                                                    </ProjList>                                                                                 +
                                                    <Filter/>                                                                                   +
-                                                   <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                +
+                                                   <SortingColumnList/>                                                                        +
+                                                   <TableScan>                                                                                 +
                                                        <ProjList>                                                                              +
                                                            <ProjElem Alias=\"i2\" ColId=\"17\">                                                +
                                                                <Ident ColId=\"17\" ColName=\"i2\"/>                                            +
                                                            </ProjElem>                                                                         +
                                                        </ProjList>                                                                             +
                                                        <Filter/>                                                                               +
-                                                       <SortingColumnList/>                                                                    +
-                                                       <TableScan>                                                                             +
-                                                           <ProjList>                                                                          +
-                                                               <ProjElem Alias=\"i2\" ColId=\"17\">                                            +
-                                                                   <Ident ColId=\"17\" ColName=\"i2\"/>                                        +
-                                                               </ProjElem>                                                                     +
-                                                           </ProjList>                                                                         +
-                                                           <Filter/>                                                                           +
-                                                           <TableDescriptor>                                                                   +
-                                                               <Columns>                                                                       +
-                                                                   <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>            +
-                                                                   <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>         +
-                                                                   <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>         +
-                                                                   <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>         +
-                                                                   <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>         +
-                                                                   <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>         +
-                                                                   <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>     +
-                                                                   <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>+
-                                                               </Columns>                                                                      +
-                                                           </TableDescriptor>                                                                  +
-                                                       </TableScan>                                                                            +
-                                                   </GatherMotion>                                                                             +
-                                               </Materialize>                                                                                  +
-                                           </Result>                                                                                           +
+                                                       <TableDescriptor>                                                                       +
+                                                           <Columns>                                                                           +
+                                                               <Column Attno=\"1\" ColId=\"17\" ColName=\"i2\" ColWidth=\"4\"/>                +
+                                                               <Column Attno=\"-1\" ColId=\"18\" ColName=\"ctid\" ColWidth=\"6\"/>             +
+                                                               <Column Attno=\"-3\" ColId=\"19\" ColName=\"xmin\" ColWidth=\"4\"/>             +
+                                                               <Column Attno=\"-4\" ColId=\"20\" ColName=\"cmin\" ColWidth=\"4\"/>             +
+                                                               <Column Attno=\"-5\" ColId=\"21\" ColName=\"xmax\" ColWidth=\"4\"/>             +
+                                                               <Column Attno=\"-6\" ColId=\"22\" ColName=\"cmax\" ColWidth=\"4\"/>             +
+                                                               <Column Attno=\"-7\" ColId=\"23\" ColName=\"tableoid\" ColWidth=\"4\"/>         +
+                                                               <Column Attno=\"-8\" ColId=\"24\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>    +
+                                                           </Columns>                                                                          +
+                                                       </TableDescriptor>                                                                      +
+                                                   </TableScan>                                                                                +
+                                               </GatherMotion>                                                                                 +
+                                           </Materialize>                                                                                      +
                                        </Result>                                                                                               +
-                                   </SubPlan>                                                                                                  +
+                                   </Result>                                                                                                   +
+                               </SubPlan>                                                                                                      +
+                           </ProjElem>                                                                                                         +
+                       </ProjList>                                                                                                             +
+                       <Filter/>                                                                                                               +
+                       <OneTimeFilter/>                                                                                                        +
+                       <Materialize Eager=\"true\">                                                                                            +
+                           <ProjList>                                                                                                          +
+                               <ProjElem Alias=\"i3\" ColId=\"8\">                                                                             +
+                                   <Ident ColId=\"8\" ColName=\"i3\"/>                                                                         +
                                </ProjElem>                                                                                                     +
                            </ProjList>                                                                                                         +
                            <Filter/>                                                                                                           +
-                           <OneTimeFilter/>                                                                                                    +
-                           <Materialize Eager=\"true\">                                                                                        +
+                           <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                        +
                                <ProjList>                                                                                                      +
                                    <ProjElem Alias=\"i3\" ColId=\"8\">                                                                         +
                                        <Ident ColId=\"8\" ColName=\"i3\"/>                                                                     +
                                    </ProjElem>                                                                                                 +
                                </ProjList>                                                                                                     +
                                <Filter/>                                                                                                       +
-                               <GatherMotion InputSegments=\"0,1,2\" OutputSegments=\"-1\">                                                    +
+                               <SortingColumnList/>                                                                                            +
+                               <TableScan>                                                                                                     +
                                    <ProjList>                                                                                                  +
                                        <ProjElem Alias=\"i3\" ColId=\"8\">                                                                     +
                                            <Ident ColId=\"8\" ColName=\"i3\"/>                                                                 +
                                        </ProjElem>                                                                                             +
                                    </ProjList>                                                                                                 +
                                    <Filter/>                                                                                                   +
-                                   <SortingColumnList/>                                                                                        +
-                                   <TableScan>                                                                                                 +
-                                       <ProjList>                                                                                              +
-                                           <ProjElem Alias=\"i3\" ColId=\"8\">                                                                 +
-                                               <Ident ColId=\"8\" ColName=\"i3\"/>                                                             +
-                                           </ProjElem>                                                                                         +
-                                       </ProjList>                                                                                             +
-                                       <Filter/>                                                                                               +
-                                       <TableDescriptor>                                                                                       +
-                                           <Columns>                                                                                           +
-                                               <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                 +
-                                               <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                              +
-                                               <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                             +
-                                               <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                             +
-                                               <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                             +
-                                               <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                             +
-                                               <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                         +
-                                               <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                    +
-                                           </Columns>                                                                                          +
-                                       </TableDescriptor>                                                                                      +
-                                   </TableScan>                                                                                                +
-                               </GatherMotion>                                                                                                 +
-                           </Materialize>                                                                                                      +
-                       </Result>                                                                                                               +
+                                   <TableDescriptor>                                                                                           +
+                                       <Columns>                                                                                               +
+                                           <Column Attno=\"1\" ColId=\"8\" ColName=\"i3\" ColWidth=\"4\"/>                                     +
+                                           <Column Attno=\"-1\" ColId=\"9\" ColName=\"ctid\" ColWidth=\"6\"/>                                  +
+                                           <Column Attno=\"-3\" ColId=\"10\" ColName=\"xmin\" ColWidth=\"4\"/>                                 +
+                                           <Column Attno=\"-4\" ColId=\"11\" ColName=\"cmin\" ColWidth=\"4\"/>                                 +
+                                           <Column Attno=\"-5\" ColId=\"12\" ColName=\"xmax\" ColWidth=\"4\"/>                                 +
+                                           <Column Attno=\"-6\" ColId=\"13\" ColName=\"cmax\" ColWidth=\"4\"/>                                 +
+                                           <Column Attno=\"-7\" ColId=\"14\" ColName=\"tableoid\" ColWidth=\"4\"/>                             +
+                                           <Column Attno=\"-8\" ColId=\"15\" ColName=\"gp_segment_id\" ColWidth=\"4\"/>                        +
+                                       </Columns>                                                                                              +
+                                   </TableDescriptor>                                                                                          +
+                               </TableScan>                                                                                                    +
+                           </GatherMotion>                                                                                                     +
+                       </Materialize>                                                                                                          +
                    </Result>                                                                                                                   +
                </Result>                                                                                                                       +
            </SubPlan>                                                                                                                          +
@@ -1881,3 +1878,35 @@ select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pre
 
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;
+-- Test case for subquery, which returns more than one rows
+create table table1 as
+    select * from (values (1, 0), (1, 0)) v(a, b) distributed by (a);
+create table table2 as
+    select * from (values (0, 10), (0, 10)) v(a, b) distributed by (a);
+explain (costs off)
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Result
+   Filter: (SubPlan 1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on table1
+   SubPlan 1  (slice0)
+     ->  Result
+           Filter: ((table2.a = 0) OR (table1.b = table2.b))
+           ->  Materialize
+                 ->  Gather Motion 3:1  (slice2; segments: 3)
+                       ->  Seq Scan on table2
+                             Filter: (10 = b)
+(12 rows)
+
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+ a | b 
+---+---
+ 1 | 0
+ 1 | 0
+(2 rows)
+
+drop table table1, table2;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -642,6 +642,11 @@ select * from t1 where
 reset optimizer_minidump;
 reset optimizer_trace_fallback;
 
+-- start_matchsubs
+-- m/[ ]*\+$/
+-- s/[ ]*\+$/ \+/
+-- end_matchsubs
+
 -- Output DXL plan without unimportant properties.
 -- start_ignore
 \! mv $MASTER_DATA_DIRECTORY/minidumps/*.mdp $MASTER_DATA_DIRECTORY/minidumps/dump.mdp
@@ -701,3 +706,23 @@ reset optimizer_trace_fallback;
 select replace ((xpath ('.//Plan', xmlparse(document pg_read_file('minidumps/pretty.xml'))))::text, '          <', '<');
 \! rm -rf $MASTER_DATA_DIRECTORY/minidumps
 drop table t1,t2,t3;
+
+-- Test case for subquery, which returns more than one rows
+-- start_ignore
+drop table if exists table1, table2;
+-- end_ignore
+
+create table table1 as
+    select * from (values (1, 0), (1, 0)) v(a, b) distributed by (a);
+
+create table table2 as
+    select * from (values (0, 10), (0, 10)) v(a, b) distributed by (a);
+
+explain (costs off)
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+
+select * from table1 where 10 in
+    (select b from table2 where table2.a = 0 or table1.b = table2.b);
+
+drop table table1, table2;


### PR DESCRIPTION
Add check for scalar subplan in ORCA's translator Expr to DXL

ORCA may generate scalar subplan, which returns boolean as a result. Such result
must contain only one row. If there are more than one row in the result, it will
cause to error. Any other type of subplans may return more than one rows.
Subplan is scalar just for CorrelatedInnerNLJoin as join type. Other joins are
used for the other types of subplans. If subplan is not scalar, ORCA will
generate correct subplan type using the BuildSubplans function.

(cherry picked from commit 2c4a5ec985084e56637e53963ebeda6a38de2302)

Patch was modified to adopt test's output to 6X. Also ORCA's minidump
CorrelatedInSubqueryWithUnionAll.mdp for the CSubqueryTest unittest was updated.
Matchsubs are needed to ignore spaces at the beginning of lines for ORCA's
minidumps and matchsubs allow to see only the significant changes of the plan.