### PR TITLE
Ensure that creation of an empty relfile is fsync'd at checkpoint.

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -342,6 +342,9 @@ mdcreate(SMgrRelation reln, ForkNumber forkNum, bool isRedo)
 	reln->md_fd[forkNum]->mdfd_vfd = fd;
 	reln->md_fd[forkNum]->mdfd_segno = 0;
 	reln->md_fd[forkNum]->mdfd_chain = NULL;
+
+	if (!SmgrIsTemp(reln))
+		register_dirty_segment(reln, forkNum, reln->md_fd[forkNum]);
 }
 
 /*


### PR DESCRIPTION
DRAFT
----

Do not squash.