### PR TITLE
ADBDEV-7484 Disable bitcode generation

### DIFF
--- a/gpcontrib/gp_debug_numsegments/Makefile
+++ b/gpcontrib/gp_debug_numsegments/Makefile
@@ -8,6 +8,9 @@ PG_CPPFLAGS = -I$(libpq_srcdir)
 
 REGRESS = default_numsegments reset_numsegments
 
+# Avoid building LLVM Bitcode for gp_debug_numsegments module.
+with_llvm = no
+
 ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)

--- a/gpcontrib/gp_distribution_policy/Makefile
+++ b/gpcontrib/gp_distribution_policy/Makefile
@@ -8,6 +8,9 @@ PG_CPPFLAGS = -I$(libpq_srcdir)
 
 REGRESS = gp_distribution_policy
 
+# Avoid building LLVM Bitcode for gp_distribution_policy module.
+with_llvm = no
+
 ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)

--- a/gpcontrib/gp_exttable_fdw/Makefile
+++ b/gpcontrib/gp_exttable_fdw/Makefile
@@ -4,6 +4,9 @@ OBJS = gp_exttable_fdw.o extaccess.o option.o
 SHLIB_LINK_INTERNAL = $(libpq)
 #SHLIB_LINK += -lcurl
 
+# Avoid building LLVM Bitcode for gp_exttable_fdw module.
+with_llvm = no
+
 EXTENSION = gp_exttable_fdw
 DATA = gp_exttable_fdw--1.0.sql
 

--- a/gpcontrib/gp_inject_fault/Makefile
+++ b/gpcontrib/gp_inject_fault/Makefile
@@ -4,6 +4,9 @@ OBJS = gp_inject_fault.o
 EXTENSION = gp_inject_fault
 DATA = gp_inject_fault--1.0.sql
 
+# Avoid building LLVM Bitcode for gp_inject_fault module.
+with_llvm = no
+
 REGRESS = inject_fault_test
 
 PG_CPPFLAGS = -I$(libpq_srcdir)

--- a/gpcontrib/gp_internal_tools/Makefile
+++ b/gpcontrib/gp_internal_tools/Makefile
@@ -4,6 +4,9 @@ DATA       = gp_internal_tools--1.0.0.sql
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 
+# Avoid building LLVM Bitcode for gp_internal_tools module.
+with_llvm = no
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/gp_legacy_string_agg/Makefile
+++ b/gpcontrib/gp_legacy_string_agg/Makefile
@@ -20,6 +20,9 @@ DATA = gp_legacy_string_agg--1.0.0.sql
 REGRESS = gp_legacy_string_agg_tests
 PG_CPPFLAGS = -I$(libpq_srcdir)
 
+# Avoid building LLVM Bitcode for gp_legacy_string_agg module.
+with_llvm = no
+
 ifdef USE_PGXS
 	PG_CONFIG = pg_config
 	PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/gp_replica_check/Makefile
+++ b/gpcontrib/gp_replica_check/Makefile
@@ -3,6 +3,9 @@ DATA = gp_replica_check--0.0.1.sql
 MODULES = gp_replica_check
 SCRIPTS = gp_replica_check.py
 
+# Avoid building LLVM Bitcode for gp_replica_check module.
+with_llvm = no
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/gp_sparse_vector/Makefile
+++ b/gpcontrib/gp_sparse_vector/Makefile
@@ -5,6 +5,9 @@ endif
 
 override CFLAGS+=-std=gnu99
 
+# Avoid building LLVM Bitcode for gp_sparse_vector module.
+with_llvm = no
+
 MODULE_big = gp_svec
 EXTENSION = gp_sparse_vector
 DATA = gp_sparse_vector--1.0.1.sql gp_sparse_vector--1.0.0--1.0.1.sql

--- a/gpcontrib/gp_toolkit/Makefile
+++ b/gpcontrib/gp_toolkit/Makefile
@@ -9,6 +9,9 @@ else
 OBJS = resgroup-dummy.o gp_partition_maint.o
 endif
 
+# Avoid building LLVM Bitcode for gp_toolkit module.
+with_llvm = no
+
 REGRESS = resource_manager_restore_to_none gp_toolkit resource_manager_switch_to_queue gp_toolkit_resqueue gp_toolkit_ao_funcs gp_partition_maint
 EXTRA_REGRESS_OPTS = --init-file=$(top_builddir)/src/test/regress/init_file
 

--- a/gpcontrib/orafce/Makefile
+++ b/gpcontrib/orafce/Makefile
@@ -92,6 +92,9 @@ REGRESS = orafce\
 REGRESS_OPTS = --schedule=parallel_schedule --encoding=utf8
 REGRESS_OPTS += --init-file=init_file
 
+# Avoid building LLVM Bitcode for orafce module.
+with_llvm = no
+
 # override CFLAGS += -Wextra -Wimplicit-fallthrough=0
 
 ifdef NO_PGXS

--- a/gpcontrib/pg_hint_plan/Makefile
+++ b/gpcontrib/pg_hint_plan/Makefile
@@ -28,6 +28,9 @@ EXTRA_CLEAN = sql/ut-fdw.sql expected/ut-fdw.out RPMS
 
 PG_CPPFLAGS += -I$(top_srcdir)/src/pl/plpgsql/src/
 
+# Avoid building LLVM Bitcode for pg_hint_plan module.
+with_llvm = no
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/zstd/Makefile
+++ b/gpcontrib/zstd/Makefile
@@ -5,6 +5,9 @@ OBJS = zstd_compression.o
 
 REGRESS = zstd_column_compression compression_zstd zstd_abort_leak AOCO_zstd AORO_zstd
 
+# Avoid building LLVM Bitcode for zstd module.
+with_llvm = no
+
 ifdef USE_PGXS
   PGXS := $(shell pg_config --pgxs)
   include $(PGXS)


### PR DESCRIPTION
Disable bitcode generation.

This PR disables LLVM bitcode (.bc) generation for Greenplum extensions that do
not benefit from JIT inlining. Most extensions rely on GPDB core functions and
macros that make them non-inlinable, rendering bitcode unnecessary.

Why: 
No measurable performance benefit

Extensions call interposable symbols from core, preventing inlining

Reduces build time and simplifies artifacts
