### PR TITLE
Improve tuple count estimation by 'cdb_estimate_rel_size()'

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1015,6 +1015,128 @@ GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 	return result;
 }
 
+/*
+ * GetSegFilesTotalsCluster
+ *
+ * Fill the total FileSegTotals information for a specific AO table
+ * from the pg_aoseg tables on the entire cluster.
+ */
+void
+GetSegFilesTotalsCluster(Relation parentrel, FileSegTotals * totals)
+{
+	StringInfoData sqlstmt;
+	Relation	aosegrel;
+	volatile bool connected = false;
+	Oid			segrelid = InvalidOid;
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+	Assert(RelationIsAoRows(parentrel));
+
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
+
+	Assert(OidIsValid(segrelid));
+
+	Assert(totals);
+
+	aosegrel = heap_open(segrelid, AccessShareLock);
+	initStringInfo(&sqlstmt);
+	appendStringInfo(&sqlstmt,
+					 "select count(1)::int4, "
+					 "sum(eof)::int8, sum(tupcount)::int8, "
+					 "sum(varblockcount)::int8, sum(eofuncompressed)::int8 "
+					 "from gp_dist_random('%s.%s')",
+					 get_namespace_name(RelationGetNamespace(aosegrel)),
+					 RelationGetRelationName(aosegrel));
+
+	heap_close(aosegrel, AccessShareLock);
+
+	/*
+	 * Temporarily disable Orca because it's slow to start up, and it wouldn't
+	 * come up with any better plan for the simple queries that we run. Plus
+	 * this function may be called during Orca's work, and that will result in
+	 * nested Orca planning, which is not supported.
+	 */
+	bool		save_optimizer_guc_value = optimizer;
+
+	optimizer = false;
+
+	PG_TRY();
+	{
+		if (SPI_OK_CONNECT != SPI_connect())
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("unable to obtain AO relation information"),
+					 errdetail("SPI_connect failed in %s.", __func__)));
+
+		connected = true;
+
+		if ((SPI_execute(sqlstmt.data, false, 0) <= 0) ||
+			(SPI_tuptable == NULL))
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("unable to obtain AO relation information"),
+					 errdetail("SPI_execute failed in %s.", __func__)));
+		else
+		{
+			TupleDesc	tupdesc = SPI_tuptable->tupdesc;
+			SPITupleTable *tuptable = SPI_tuptable;
+			HeapTuple	tuple = tuptable->vals[0];
+			bool		isnull;
+
+			/* we expect only 1 tuple */
+			Assert(SPI_processed == 1);
+
+			Datum		datum_totalfilesegs =
+				SPI_getbinval(tuple, tupdesc, 1, &isnull);
+			Assert(!isnull);
+			totals->totalfilesegs = DatumGetInt32(datum_totalfilesegs);
+
+			Datum		datum_totalbytes =
+				SPI_getbinval(tuple, tupdesc, 2, &isnull);
+			Assert(!isnull);
+			totals->totalbytes = DatumGetInt64(datum_totalbytes);
+
+			Datum		datum_totaltuples =
+				SPI_getbinval(tuple, tupdesc, 3, &isnull);
+			Assert(!isnull);
+			totals->totaltuples = DatumGetInt64(datum_totaltuples);
+
+			Datum		datum_totalvarblocks =
+				SPI_getbinval(tuple, tupdesc, 4, &isnull);
+			Assert(!isnull);
+			totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
+
+			Datum		datum_totalbytesuncompressed =
+				SPI_getbinval(tuple, tupdesc, 5, &isnull);
+			Assert(!isnull);
+			totals->totalbytesuncompressed =
+				DatumGetInt64(datum_totalbytesuncompressed);
+		}
+
+		connected = false;
+		SPI_finish();
+	}
+
+	/* Clean up in case of error. */
+	PG_CATCH();
+	{
+		if (connected)
+			SPI_finish();
+
+		pfree(sqlstmt.data);
+
+		optimizer = save_optimizer_guc_value;
+
+		/* Carry on with error handling. */
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	pfree(sqlstmt.data);
+
+	optimizer = save_optimizer_guc_value;
+}
+
 PG_FUNCTION_INFO_V1(gp_aoseg_history);
 
 extern Datum gp_aoseg_history(PG_FUNCTION_ARGS);

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1093,22 +1093,18 @@ GetSegFilesTotalsCluster(Relation parentrel, FileSegTotals * totals)
 
 			Datum		datum_totalbytes =
 				SPI_getbinval(tuple, tupdesc, 2, &isnull);
-			Assert(!isnull);
 			totals->totalbytes = DatumGetInt64(datum_totalbytes);
 
 			Datum		datum_totaltuples =
 				SPI_getbinval(tuple, tupdesc, 3, &isnull);
-			Assert(!isnull);
 			totals->totaltuples = DatumGetInt64(datum_totaltuples);
 
 			Datum		datum_totalvarblocks =
 				SPI_getbinval(tuple, tupdesc, 4, &isnull);
-			Assert(!isnull);
 			totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
 
 			Datum		datum_totalbytesuncompressed =
 				SPI_getbinval(tuple, tupdesc, 5, &isnull);
-			Assert(!isnull);
 			totals->totalbytesuncompressed =
 				DatumGetInt64(datum_totalbytesuncompressed);
 		}

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -59,6 +59,7 @@
 
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbrelsize.h"
+#include "cdb/cdbutil.h"
 #include "catalog/pg_appendonly.h"
 #include "catalog/pg_foreign_server.h"
 #include "catalog/pg_inherits.h"
@@ -554,9 +555,14 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 	BlockNumber relpages;
 	double		reltuples;
 	BlockNumber relallvisible;
-	double		density;
     BlockNumber curpages = 0;
 	bool		use_external_table_defaults = false;
+
+	/*
+	 * Set tuples to -1 to distinguish if we had set it for AO table from
+	 * FileSegTotals, and do not calculate it in this case.
+	 */
+	*tuples = -1;
 
     /* Rel not distributed?  RelationGetNumberOfBlocks can get actual #pages. */
     if (!relOptInfo->cdbpolicy ||
@@ -601,7 +607,36 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 		 * to derive curpages, else use the default value.
 		 */
 		if (gp_enable_relsize_collection)
-			curpages = cdbRelMaxSegSize(rel) / BLCKSZ;
+		{
+			if (RelationIsAppendOptimized(rel))
+			{
+				FileSegTotals totals = {0};
+				if (RelationIsAoRows(rel))
+					GetSegFilesTotalsCluster(rel, &totals);
+				else
+					GetAOCSSegFilesTotalsCluster(rel, &totals);
+
+				curpages = totals.totalbytes / BLCKSZ;
+				*tuples = totals.totaltuples;
+
+				if (relOptInfo->cdbpolicy->ptype == POLICYTYPE_REPLICATED)
+					*tuples /= getgpsegmentCount();
+			}
+			else
+			{
+				curpages = DatumGetInt64(DirectFunctionCall2(
+															 pg_relation_size,
+									 ObjectIdGetDatum(RelationGetRelid(rel)),
+									  CStringGetTextDatum("main"))) / BLCKSZ;
+			}
+
+			/*
+			 * If the relation is replicated, we need to scale down to the
+			 * value on one segment in order to calculate row count properly.
+			 */
+			if (relOptInfo->cdbpolicy->ptype == POLICYTYPE_REPLICATED)
+				curpages /= getgpsegmentCount();
+		}
 		else
 			curpages = DEFAULT_INTERNAL_TABLE_PAGES;
 	}
@@ -620,38 +655,61 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 		relpages--;
 	}
 
-	/*
-	 * Estimate number of tuples from previous tuple density (as of last
-	 * analyze)
-	 */
-	if (relpages > 0)
-		density = reltuples / (double) relpages;
-	else if (use_external_table_defaults)
+	/* Calculate tuples only if they were not set before */
+	if (*tuples < 0)
 	{
-		/*
-		 * For an external table with no estimates stored in pg_class, use
-		 * defaults.
-		 */
-		density = DEFAULT_EXTERNAL_TABLE_TUPLES /
-			(double) DEFAULT_EXTERNAL_TABLE_PAGES;
-	}
-	else
-	{
-		/*
-		 * When we have no data because the relation was truncated, estimate
-		 * tuples per page from attribute datatypes.
-		 *
-		 * (This is the same computation as in get_relation_info()
-		 */
-		int32		tuple_width;
+		double		density;
 
-		tuple_width = get_rel_data_width(rel, attr_widths);
-		tuple_width += sizeof(HeapTupleHeaderData);
-		tuple_width += sizeof(ItemPointerData);
-		/* note: integer division is intentional here */
-		density = (BLCKSZ - SizeOfPageHeaderData) / tuple_width;
+		/*
+		 * Estimate number of tuples from previous tuple density (as of last
+		 * analyze)
+		 */
+		if (relpages > 0)
+			density = reltuples / (double) relpages;
+		else if (use_external_table_defaults)
+		{
+			/*
+			 * For an external table with no estimates stored in pg_class, use
+			 * defaults.
+			 */
+			density = DEFAULT_EXTERNAL_TABLE_TUPLES /
+				(double) DEFAULT_EXTERNAL_TABLE_PAGES;
+		}
+		else
+		{
+			/*
+			 * When we have no data because the relation was truncated,
+			 * estimate tuples per page from attribute datatypes.
+			 *
+			 * (This is the same computation as in get_relation_info()
+			 */
+			int32		tuple_width;
+
+			tuple_width = get_rel_data_width(rel, attr_widths);
+
+			if (RelationIsAoRows(rel))
+			{
+				/*
+				 * Row oriented relations store memtuples, that have a header,
+				 * plus storage is done in VarBlock, which has item-offsets
+				 * array with at 2 or 3 byte offsets. For simplicity, in our
+				 * rough estimation we consider only 2 byte offsets. Thus, we
+				 * add (2 + header size) to the tuple width.
+				 */
+				tuple_width += (offsetof(MemTupleData, PRIVATE_mt_bits) + 2);
+			}
+			else if (!RelationIsAoCols(rel))
+			{
+				/* do the adjustment for heap relations */
+				tuple_width += sizeof(HeapTupleHeaderData);
+				tuple_width += sizeof(ItemPointerData);
+			}
+
+			/* note: integer division is intentional here */
+			density = (BLCKSZ - SizeOfPageHeaderData) / tuple_width;
+		}
+		*tuples = rint(density * (double) curpages);
 	}
-	*tuples = rint(density * (double) curpages);
 
 	/*
 	 * We use relallvisible as-is, rather than scaling it up like we

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -687,28 +687,40 @@ cdb_estimate_rel_size(RelOptInfo   *relOptInfo,
 
 			tuple_width = get_rel_data_width(rel, attr_widths);
 
-			if (RelationIsAoRows(rel))
-			{
+			if (tuple_width == 0)
 				/*
-				 * Row oriented relations store memtuples, that have a header,
-				 * plus storage is done in VarBlock, which has item-offsets
-				 * array with at 2 or 3 byte offsets. For simplicity, in our
-				 * rough estimation we consider only 2 byte offsets. Thus, we
-				 * add (2 + header size) to the tuple width.
+				 * If the relation has 0 columns, set the same value for tuple
+				 * count, as we would get if we run ANALYZE on the relation.
 				 */
-				tuple_width += (offsetof(MemTupleData, PRIVATE_mt_bits) + 2);
-			}
-			else if (!RelationIsAoCols(rel))
+				*tuples = 1;
+			else
 			{
-				/* do the adjustment for heap relations */
-				tuple_width += sizeof(HeapTupleHeaderData);
-				tuple_width += sizeof(ItemPointerData);
-			}
+				if (RelationIsAoRows(rel))
+				{
+					/*
+					 * Row oriented relations store memtuples, that have a
+					 * header, plus storage is done in VarBlock, which has
+					 * item-offsets array with at 2 or 3 byte offsets. For
+					 * simplicity, in our rough estimation we consider only 2
+					 * byte offsets. Thus, we add (2 + header size) to the
+					 * tuple width.
+					 */
+					tuple_width +=
+						(offsetof(MemTupleData, PRIVATE_mt_bits) + 2);
+				}
+				else if (!RelationIsAoCols(rel))
+				{
+					/* do the adjustment for heap relations */
+					tuple_width += sizeof(HeapTupleHeaderData);
+					tuple_width += sizeof(ItemPointerData);
+				}
 
-			/* note: integer division is intentional here */
-			density = (BLCKSZ - SizeOfPageHeaderData) / tuple_width;
+				/* note: integer division is intentional here */
+				density = (BLCKSZ - SizeOfPageHeaderData) / tuple_width;
+			}
 		}
-		*tuples = rint(density * (double) curpages);
+		if (*tuples < 0)
+			*tuples = rint(density * (double) curpages);
 	}
 
 	/*

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -149,6 +149,9 @@ extern FileSegTotals *GetAOCSSSegFilesTotalsWithProj(Relation parentrel,
 													 AttrNumber *proj_atts,
 													 AttrNumber num_proj_atts);
 
+extern void GetAOCSSegFilesTotalsCluster(Relation parentrel,
+							 FileSegTotals * totals);
+
 extern void InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid);
 extern void UpdateAOCSFileSegInfo(struct AOCSInsertDescData *desc);
 extern void

--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -150,6 +150,9 @@ extern void MarkFileSegInfoAwaitingDrop(Relation parentrel, int segno);
 extern void IncrementFileSegInfoModCount(Relation parentrel, int segno);
 extern FileSegTotals *GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot);
 
+extern void GetSegFilesTotalsCluster(Relation parentrel,
+						 FileSegTotals * totals);
+
 extern void FreeAllSegFileInfo(FileSegInfo **allSegInfo,
 				   int totalSegFiles);
 

--- a/src/test/regress/expected/gp_backend_info.out
+++ b/src/test/regress/expected/gp_backend_info.out
@@ -78,6 +78,8 @@ SELECT COUNT(DISTINCT pid) = :num_primaries +1 FROM gp_backend_info();
 --
 CREATE TEMPORARY TABLE temp2();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+CREATE TEMPORARY TABLE temp3 AS SELECT 0 AS a FROM generate_series(1, 500);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 SELECT * FROM temp JOIN (SELECT * FROM temp2) temp2 ON (temp = temp2);
 --
 (0 rows)
@@ -160,9 +162,9 @@ GROUP BY content;
 --
 -- Start up a singleton reader.
 --
-SELECT * FROM temp JOIN (SELECT oid FROM pg_class) temp2 on (temp = temp2);
- oid 
------
+SELECT * FROM temp3 JOIN (SELECT oid FROM pg_class) temp2 on (temp3.a = temp2.oid);
+ a | oid 
+---+-----
 (0 rows)
 
 --start_ignore

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20508,3 +20508,98 @@ SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
 (0 rows)
 
 RESET optimizer_enable_hashjoin;
+-- Check row count estimation in case gp_enable_relsize_collection is enabled,
+-- and stats are not available.
+--
+-- Use matchsubs to check that row count estimation differs at most +/- 10% from the real value.
+--
+-- start_matchsubs
+-- m/cost=\d+\.\d+\.\.\d+\.\d+ /
+-- s/cost=\d+\.\d+\.\.\d+\.\d+ /cost=##.###..##.### /
+-- m/rows=9\d\d\d\d /
+-- s/rows=9\d\d\d\d /rows=100000 /
+-- m/rows=10\d\d\d\d /
+-- s/rows=10\d\d\d\d /rows=100000 /
+-- end_matchsubs
+set gp_enable_relsize_collection = on;
+set gp_autostats_mode = none;
+-- Check heap table.
+create table test_table
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..434.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..434.07 rows=3 width=8)
+         ->  Partial Aggregate  (cost=0.00..434.07 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..433.88 rows=100000 width=0)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Check AO table with column orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=column, COMPRESSTYPE=rle_type, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..433.05 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.05 rows=3 width=8)
+         ->  Partial Aggregate  (cost=0.00..433.05 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..432.87 rows=100000 width=0)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Check AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..433.04 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.04 rows=3 width=8)
+         ->  Partial Aggregate  (cost=0.00..433.04 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..432.86 rows=100000 width=0)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+-- Check replicated AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 100000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed replicated;
+-- explain_processing_off
+explain select count(1) from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate  (cost=1263.00..1263.01 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=1263.00..1263.01 rows=100000 width=0)
+         ->  Seq Scan on test_table  (cost=0.00..1013.00 rows=100000 width=0)
+ Optimizer: Postgres-based planner
+(4 rows)
+
+-- Check AO table with row orientation and compression and with high skew.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as
+(select generate_series(1, 150000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5)
+union all
+(select 1::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5 from generate_series(1, 150000))
+distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=3778.06..3778.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3778.00..3778.05 rows=3 width=8)
+         ->  Partial Aggregate  (cost=3778.00..3778.01 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..3028.00 rows=100000 width=0)
+ Optimizer: Postgres-based planner
+(5 rows)
+
+drop table test_table;
+reset gp_enable_relsize_collection;
+reset gp_autostats_mode;

--- a/src/test/regress/expected/qp_misc.out
+++ b/src/test/regress/expected/qp_misc.out
@@ -20600,6 +20600,86 @@ explain select count(1) from test_table;
  Optimizer: Postgres-based planner
 (5 rows)
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
 reset gp_enable_relsize_collection;
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres-based planner
+(3 rows)
+
+drop table test_table;
 reset gp_autostats_mode;

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -20516,3 +20516,99 @@ SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
 (0 rows)
 
 RESET optimizer_enable_hashjoin;
+-- Check row count estimation in case gp_enable_relsize_collection is enabled,
+-- and stats are not available.
+--
+-- Use matchsubs to check that row count estimation differs at most +/- 10% from the real value.
+--
+-- start_matchsubs
+-- m/cost=\d+\.\d+\.\.\d+\.\d+ /
+-- s/cost=\d+\.\d+\.\.\d+\.\d+ /cost=##.###..##.### /
+-- m/rows=9\d\d\d\d /
+-- s/rows=9\d\d\d\d /rows=100000 /
+-- m/rows=10\d\d\d\d /
+-- s/rows=10\d\d\d\d /rows=100000 /
+-- end_matchsubs
+set gp_enable_relsize_collection = on;
+set gp_autostats_mode = none;
+-- Check heap table.
+create table test_table
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..434.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..434.07 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..434.07 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..433.88 rows=100000 width=1)
+ Optimizer: GPORCA
+(5 rows)
+
+-- Check AO table with column orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=column, COMPRESSTYPE=rle_type, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..433.05 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.05 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..433.05 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..432.87 rows=100000 width=1)
+ Optimizer: GPORCA
+(5 rows)
+
+-- Check AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..433.04 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.04 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..433.04 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..432.86 rows=100000 width=1)
+ Optimizer: GPORCA
+(5 rows)
+
+-- Check replicated AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 100000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed replicated;
+-- explain_processing_off
+explain select count(1) from test_table;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..437.16 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..437.16 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..437.16 rows=3 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..436.60 rows=300000 width=1)
+ Optimizer: GPORCA
+(5 rows)
+
+-- Check AO table with row orientation and compression and with high skew.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as
+(select generate_series(1, 150000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5)
+union all
+(select 1::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5 from generate_series(1, 150000))
+distributed by (col_1);
+-- explain_processing_off
+explain select count(1) from test_table;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..433.05 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..433.05 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..433.05 rows=1 width=8)
+               ->  Seq Scan on test_table  (cost=0.00..432.87 rows=100000 width=1)
+ Optimizer: GPORCA
+(5 rows)
+
+drop table test_table;
+reset gp_enable_relsize_collection;
+reset gp_autostats_mode;

--- a/src/test/regress/expected/qp_misc_optimizer.out
+++ b/src/test/regress/expected/qp_misc_optimizer.out
@@ -20609,6 +20609,86 @@ explain select count(1) from test_table;
  Optimizer: GPORCA
 (5 rows)
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
 reset gp_enable_relsize_collection;
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: GPORCA
+(3 rows)
+
+drop table test_table;
 reset gp_autostats_mode;

--- a/src/test/regress/sql/gp_backend_info.sql
+++ b/src/test/regress/sql/gp_backend_info.sql
@@ -36,6 +36,7 @@ SELECT COUNT(DISTINCT pid) = :num_primaries +1 FROM gp_backend_info();
 --
 
 CREATE TEMPORARY TABLE temp2();
+CREATE TEMPORARY TABLE temp3 AS SELECT 0 AS a FROM generate_series(1, 500);
 SELECT * FROM temp JOIN (SELECT * FROM temp2) temp2 ON (temp = temp2);
 
 --start_ignore
@@ -65,7 +66,7 @@ GROUP BY content;
 -- Start up a singleton reader.
 --
 
-SELECT * FROM temp JOIN (SELECT oid FROM pg_class) temp2 on (temp = temp2);
+SELECT * FROM temp3 JOIN (SELECT oid FROM pg_class) temp2 on (temp3.a = temp2.oid);
 
 --start_ignore
 -- Debugging helper (see above).

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15614,3 +15614,69 @@ INSERT INTO tparam VALUES ('a_value');
 
 SELECT * FROM tparam t1 JOIN tparam t2 ON UPPER(t1.a) = t2.a;
 RESET optimizer_enable_hashjoin;
+
+-- Check row count estimation in case gp_enable_relsize_collection is enabled,
+-- and stats are not available.
+--
+-- Use matchsubs to check that row count estimation differs at most +/- 10% from the real value.
+--
+-- start_matchsubs
+-- m/cost=\d+\.\d+\.\.\d+\.\d+ /
+-- s/cost=\d+\.\d+\.\.\d+\.\d+ /cost=##.###..##.### /
+-- m/rows=9\d\d\d\d /
+-- s/rows=9\d\d\d\d /rows=100000 /
+-- m/rows=10\d\d\d\d /
+-- s/rows=10\d\d\d\d /rows=100000 /
+-- end_matchsubs
+set gp_enable_relsize_collection = on;
+set gp_autostats_mode = none;
+
+-- Check heap table.
+-- start_ignore
+drop table if exists test_table;
+-- end_ignore
+create table test_table
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+
+-- explain_processing_off
+explain select count(1) from test_table;
+
+-- Check AO table with column orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=column, COMPRESSTYPE=rle_type, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+
+-- explain_processing_off
+explain select count(1) from test_table;
+
+-- Check AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 300000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed by (col_1);
+
+-- explain_processing_off
+explain select count(1) from test_table;
+
+-- Check replicated AO table with row orientation and compression.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as (select generate_series(1, 100000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5) distributed replicated;
+
+-- explain_processing_off
+explain select count(1) from test_table;
+
+-- Check AO table with row orientation and compression and with high skew.
+drop table test_table;
+create table test_table with (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=zlib, COMPRESSLEVEL=2)
+as
+(select generate_series(1, 150000)::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5)
+union all
+(select 1::int as col_1, 1::int as col_2, 1::int as col_3, 1::int as col_4, 1::int as col_5 from generate_series(1, 150000))
+distributed by (col_1);
+
+-- explain_processing_off
+explain select count(1) from test_table;
+
+drop table test_table;
+reset gp_enable_relsize_collection;
+reset gp_autostats_mode;

--- a/src/test/regress/sql/qp_misc.sql
+++ b/src/test/regress/sql/qp_misc.sql
@@ -15677,6 +15677,39 @@ distributed by (col_1);
 -- explain_processing_off
 explain select count(1) from test_table;
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+-- explain_processing_off
+explain select * from test_table;
+
 reset gp_enable_relsize_collection;
+
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
 reset gp_autostats_mode;


### PR DESCRIPTION
Improve tuple count estimation by 'cdb_estimate_rel_size()'

Problem description:
The original problematic scenario from the user's perspective was following:
 - set 'gp_autostats_mode' to 'none';
 - set 'gp_enable_relsize_collection' to 'on';
 - create a table and perform explain for some simple query over the table.
The explain output showed that the row count estimation was several times
different from the actual number. The magnitude of the error depended on the
table storage type, for compressed AO tables it could be >100 times the
difference.

Root cause:
In case statistics are not available, 'cdb_estimate_rel_size()' is used to
estimate the row count for a relation. This function had a bunch of issues:
1. In case 'gp_enable_relsize_collection' is 'on', 'cdb_estimate_rel_size()'
calls 'cdbRelMaxSegSize()' to estimate relation size (and compute tuple count
from it). 'cdbRelMaxSegSize()' returns info only for 1 segment, which wasn't
taken into account. So, due to this issue the resulting number of tuples was
divided by the number of segments. Also, it didn't take into account table data
skew.
2. 'cdb_estimate_rel_size()' uses under the hood 'pg_relation_size' to retrieve
relation size, and it doesn't take into account if the relation was compressed.
So, due to this issue the resulting number of tuples for AO compressed tables
was divided by the compression ratio.
3. 'cdb_estimate_rel_size()' uses a tuple width value to calculate the row count
estimation from the relation size. Before this patch, tuple width always
considered header's size for heap tuple. But AO tables have different internal
structure, so row estimation for AO tables was affected by the wrong tuple
width.

Fix:
1. Add the new functions 'GetAOCSSegFilesTotalsCluster()' and
'GetSegFilesTotalsCluster()' to retrieve information about AO tables (size and
tuple count).
2. For heap tables use direct call to 'pg_relation_size()' instead of
'cdbRelMaxSegSize()'.
3. Adjust tuple width calculation for AO row-oriented and AO column-oriented
tables in 'cdb_estimate_rel_size()'. We still may need it if we have 'relpages'
values from 'pg_class'.

(cherry picked from commit 1f4d9b473693d91c4219a239456aa60ead0f5f7c)
and
(cherry picked from commit 0cc2bd196465af5c7190fb2f57f98f443a6a48ec)

Changes comparing to the original commits:
1. changes in 'gporca' test are no more needed (the affected test was removed);
2. function 'GetAppendOnlyEntryAuxOids()' now has different arguments comparing
to 6x, so calls to this function are updated;
3. plans in test's expected results are updated due to changes in 7x explain
output;
4. test cases were moved into 'qp_misc' test from 'qp_misc_jiras', as the later
now has matchsubs that truncate all cost output of explain completely (refer to
commit c2dbe68 for details)
5. Test 'gp_backend_info' is updated, as the patch caused change of plan for one
of the test queries in 'gp_backend_info', and the new plan was without a slice
with Entry DB Reader, causing the test to fail. So, the problematic query is
updated to use a table with some data, causing a plan with Entry DB Reader.

-------------------

WILL BE SQUASHED, as the second commit is a fix for the first one