### PR TITLE
Fix explain_format test [8X]

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,47 +1,50 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
--- ignore variable JIT gucs which can be shown when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
+-- Tests EXPLAIN format output
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -50,244 +53,210 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=3577.00..11272.25 rows=77900 width=84)
-   ->  Hash Left Join  (cost=3577.00..9714.25 rows=25967 width=84)
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                             explain_filter                                             
+--------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+   ->  Hash Left Join  (cost=N.N..N.N rows=N width=N)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=2361.00..7427.12 rows=25967 width=48)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=2361.00..5869.12 rows=25967 width=48)
+               ->  Hash Left Join  (cost=N.N..N.N rows=N width=N)
                      Hash Cond: (boxes.apple_id = apples.id)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2437.00 rows=25967 width=12)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..879.00 rows=25967 width=12)
-                     ->  Hash  (cost=1111.00..1111.00 rows=33334 width=36)
-                           ->  Seq Scan on apples  (cost=0.00..1111.00 rows=33334 width=36)
-         ->  Hash  (cost=596.00..596.00 rows=16534 width=36)
-               ->  Seq Scan on box_locations  (cost=0.00..596.00 rows=16534 width=36)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N)
+                     ->  Hash  (cost=N.N..N.N rows=N width=N)
+                           ->  Seq Scan on apples  (cost=N.N..N.N rows=N width=N)
+         ->  Hash  (cost=N.N..N.N rows=N width=N)
+               ->  Seq Scan on box_locations  (cost=N.N..N.N rows=N width=N)
  Optimizer: Postgres query optimizer
 (15 rows)
 
--- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                                QUERY PLAN                                                                 
------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=812.00..3838.66 rows=77900 width=84) (actual time=13.602..13.602 rows=0 loops=1)
-   ->  Hash Left Join  (cost=812.00..2799.99 rows=25967 width=84) (actual time=0.000..13.242 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                                explain_filter                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+   ->  Hash Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
          Hash Cond: (boxes.location_id = box_locations.id)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=406.00..2066.16 rows=25967 width=48) (actual time=0.000..12.303 rows=0 loops=1)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                Hash Key: boxes.location_id
-               ->  Hash Left Join  (cost=406.00..1546.83 rows=25967 width=48) (actual time=0.000..12.138 rows=0 loops=1)
+               ->  Hash Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                      Hash Cond: (boxes.apple_id = apples.id)
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..813.00 rows=25967 width=12) (actual time=0.000..0.005 rows=0 loops=1)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                            Hash Key: boxes.apple_id
-                           ->  Seq Scan on boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.007 rows=0 loops=1)
-                     ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=9.989..9.989 rows=33462 loops=1)
-                           Buckets: 131072  Batches: 1  Memory Usage: 2201kB
-                           ->  Seq Scan on apples  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.024..3.215 rows=33462 loops=1)
-         ->  Hash  (cost=199.33..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
-               Buckets: 131072  Batches: 1  Memory Usage: 1024kB
-               ->  Seq Scan on box_locations  (cost=0.00..199.33 rows=16533 width=36) (actual time=0.000..0.010 rows=0 loops=1)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                     ->  Hash  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                           Buckets: N  Batches: N  Memory Usage: NkB
+                           ->  Seq Scan on apples  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+         ->  Hash  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+               Buckets: N  Batches: N  Memory Usage: NkB
+               ->  Seq Scan on box_locations  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
  Optimizer: Postgres query optimizer
- Planning Time: 0.893 ms
-   (slice0)    Executor memory: 64K bytes.
-   (slice1)    Executor memory: 1051K bytes avg x 3 workers, 1051K bytes max (seg0).  Work_mem: 1024K bytes max.
-   (slice2)    Executor memory: 2364K bytes avg x 3 workers, 2364K bytes max (seg0).  Work_mem: 2201K bytes max.
-   (slice3)    Executor memory: 41K bytes avg x 3 workers, 44K bytes max (seg1).
- Memory used:  128000kB
- Execution Time: 29.877 ms
+ Planning Time: N.N ms
+   (sliceN)    Executor memory: NK bytes.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+ Memory used:  NkB
+ Execution Time: N.N ms
 (24 rows)
 
--- explain_processing_on
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
 -- and its position depends on the longest line. If the width changes, all
 -- lines need to be adjusted for the moved end-of-line-marker.
 \a
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 3577.00
-    Total Cost: 11272.25
-    Plan Rows: 77900
-    Plan Width: 84
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Plans: 
       - Node Type: "Hash Join"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 3577.00
-        Total Cost: 9714.25
-        Plan Rows: 77900
-        Plan Width: 84
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Inner Unique: true
         Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 2361.00
-            Total Cost: 7427.12
-            Plan Rows: 77900
-            Plan Width: 48
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Hash Key: "boxes.location_id"
             Plans: 
               - Node Type: "Hash Join"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 2361.00
-                Total Cost: 5869.12
-                Plan Rows: 77900
-                Plan Width: 48
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
                 Inner Unique: true
                 Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 2437.00
-                    Plan Rows: 77900
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Hash Key: "boxes.apple_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 879.00
-                        Plan Rows: 77900
-                        Plan Width: 12
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
                   - Node Type: "Hash"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 1111.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 2
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "apples"
                         Alias: "apples"
-                        Startup Cost: 0.00
-                        Total Cost: 1111.00
-                        Plan Rows: 100000
-                        Plan Width: 36
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
           - Node Type: "Hash"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 596.00
-            Total Cost: 596.00
-            Plan Rows: 49600
-            Plan Width: 36
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Plans: 
               - Node Type: "Seq Scan"
                 Parent Relationship: "Outer"
-                Slice: 1
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Relation Name: "box_locations"
                 Alias: "box_locations"
-                Startup Cost: 0.00
-                Total Cost: 596.00
-                Plan Rows: 49600
-                Plan Width: 36
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
   Optimizer: "Postgres query optimizer"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 1332.33
-    Plan Rows: 77900
-    Plan Width: 12
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -295,45 +264,41 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: 0.00
-        Total Cost: 293.67
-        Plan Rows: 25967
-        Plan Width: 12
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Postgres query optimizer"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
+    cpu_index_tuple_cost: "N.N"
     optimizer: "off"
-    random_page_cost: "1"
+    random_page_cost: "N"
 (1 row)
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: #
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: ###.##
-    Total Cost: ###.##
-    Plan Rows: #####
-    Plan Width: ##
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -341,308 +306,276 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: #
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: ###.##
-        Total Cost: ###.##
-        Plan Rows: #####
-        Plan Width: ##
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Postgres query optimizer"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
     optimizer: "off"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 3577.00
-    Total Cost: 11272.25
-    Plan Rows: 77900
-    Plan Width: 84
-    Actual Startup Time: 70.104
-    Actual Total Time: 70.104
-    Actual Rows: 0
-    Actual Loops: 1
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
+    Actual Startup Time: N.N
+    Actual Total Time: N.N
+    Actual Rows: N
+    Actual Loops: N
     Plans: 
       - Node Type: "Hash Join"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 3577.00
-        Total Cost: 9714.25
-        Plan Rows: 77900
-        Plan Width: 84
-        Actual Startup Time: 0.000
-        Actual Total Time: 0.000
-        Actual Rows: 0
-        Actual Loops: 0
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
+        Actual Startup Time: N.N
+        Actual Total Time: N.N
+        Actual Rows: N
+        Actual Loops: N
         Inner Unique: true
         Hash Cond: "(boxes.location_id = box_locations.id)"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 2361.00
-            Total Cost: 7427.12
-            Plan Rows: 77900
-            Plan Width: 48
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Hash Key: "boxes.location_id"
             Plans: 
               - Node Type: "Hash Join"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 2361.00
-                Total Cost: 5869.12
-                Plan Rows: 77900
-                Plan Width: 48
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
                 Inner Unique: true
                 Hash Cond: "(boxes.apple_id = apples.id)"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 2437.00
-                    Plan Rows: 77900
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Hash Key: "boxes.apple_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 879.00
-                        Plan Rows: 77900
-                        Plan Width: 12
-                        Actual Startup Time: 0.000
-                        Actual Total Time: 0.000
-                        Actual Rows: 0
-                        Actual Loops: 0
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
                   - Node Type: "Hash"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 1111.00
-                    Total Cost: 1111.00
-                    Plan Rows: 100000
-                    Plan Width: 36
-                    Actual Startup Time: 58.354
-                    Actual Total Time: 58.354
-                    Actual Rows: 33462
-                    Actual Loops: 1
-                    Hash Buckets: 131072
-                    Original Hash Buckets: 131072
-                    Hash Batches: 1
-                    Original Hash Batches: 1
-                    Peak Memory Usage: 2332
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
+                    Hash Buckets: N
+                    Original Hash Buckets: N
+                    Hash Batches: N
+                    Original Hash Batches: N
+                    Peak Memory Usage: N
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 2
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "apples"
                         Alias: "apples"
-                        Startup Cost: 0.00
-                        Total Cost: 1111.00
-                        Plan Rows: 100000
-                        Plan Width: 36
-                        Actual Startup Time: 0.088
-                        Actual Total Time: 14.932
-                        Actual Rows: 33462
-                        Actual Loops: 1
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
           - Node Type: "Hash"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 596.00
-            Total Cost: 596.00
-            Plan Rows: 49600
-            Plan Width: 36
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
-            Hash Buckets: 131072
-            Original Hash Buckets: 131072
-            Hash Batches: 1
-            Original Hash Batches: 1
-            Peak Memory Usage: 1024
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
+            Hash Buckets: N
+            Original Hash Buckets: N
+            Hash Batches: N
+            Original Hash Batches: N
+            Peak Memory Usage: N
             Plans: 
               - Node Type: "Seq Scan"
                 Parent Relationship: "Outer"
-                Slice: 1
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Relation Name: "box_locations"
                 Alias: "box_locations"
-                Startup Cost: 0.00
-                Total Cost: 596.00
-                Plan Rows: 49600
-                Plan Width: 36
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
   Optimizer: "Postgres query optimizer"
-  Planning Time: 5.148
+  Planning Time: N.N
   Triggers: 
   Slice statistics: 
-    - Slice: 0
-      Executor Memory: 130048
-    - Slice: 1
+    - Slice: N
+      Executor Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 1129528
-        Workers: 3
-        Maximum Memory Used: 1129528
-      Work Maximum Memory: 1048576
-    - Slice: 2
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+      Work Maximum Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 2213776
-        Workers: 3
-        Maximum Memory Used: 2213776
-      Work Maximum Memory: 2119360
-    - Slice: 3
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+      Work Maximum Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 60624
-        Workers: 3
-        Maximum Memory Used: 60624
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
   Statement statistics: 
-    Memory used: 128000
-  Execution Time: 72.942
+    Memory used: N
+  Execution Time: N.N
 (1 row)
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- end_matchsubs
---- Check explain analyze sort infomation in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 width=12) (actual time=0.380..0.380 rows=0 loops=1)
+--- Check explain analyze sort information in verbose mode
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12) (actual time=0.000..0.069 rows=0 loops=1)
+  ->  Sort  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
-        Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
-        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.010 rows=0 loops=1)
+        Sort Method:  quicksort  Memory: NkB  Max Memory: NkB  Avg Memory: NkB (N segments)
+        Executor Memory: NkB  Segments: N  Max: NkB (segment N)
+        work_mem: NkB  Segments: N  Max: NkB (segment N)  Workfile: (N spilling)
+        ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: Postgres query optimizer
-Settings: cpu_index_tuple_cost = '0.1', optimizer = 'off', random_page_cost = '1'
-Planning Time: 0.397 ms
-  (slice0)    Executor memory: 40K bytes.
-  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
-Memory used:  128000kB
-Execution Time: 0.782 ms
+Settings: cpu_index_tuple_cost = 'N.N', optimizer = 'off', random_page_cost = 'N'
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+Memory used:  NkB
+Execution Time: N.N ms
 (18 rows)
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.
 --
 -- This should be enough for those format. The only difference between JSON,
 -- XML, and YAML is in the formatting, after all.
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Function Scan",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Function Name": "generate_series",
-      "Alias": "generate_series"
-    },
-    "Optimizer": "Postgres query optimizer"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter_to_json
+[{"Plan": {"Alias": "generate_series", "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Function Scan", "Function Name": "generate_series", "Parallel Aware": false}, "Optimizer": "Postgres query optimizer"}]
 (1 row)
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-<explain xmlns="http://www.postgresql.org/2009/explain">
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter
+<explain xmlns="http://www.postgresql.org/N/explain">
   <Query>
     <Plan>
       <Node-Type>Function Scan</Node-Type>
-      <Slice>0</Slice>
-      <Segments>0</Segments>
+      <Slice>N</Slice>
+      <Segments>N</Segments>
       <Gang-Type>unallocated</Gang-Type>
       <Parallel-Aware>false</Parallel-Aware>
       <Function-Name>generate_series</Function-Name>
@@ -657,45 +590,11 @@ QUERY PLAN
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 1,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 1,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Plans": [
-        {
-          "Node Type": "Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 1,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "jsonexplaintest_1_prt_2",
-          "Alias": "jsonexplaintest_1_prt_2",
-          "Filter": "(i = 2)"
-        }
-      ]
-    },
-    "Optimizer": "Postgres query optimizer"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "jsonexplaintest_1_prt_2", "Slice": 0, "Filter": "(i = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Relation Name": "jsonexplaintest_1_prt_2", "Parallel Aware": false, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Parallel Aware": false}, "Optimizer": "Postgres query optimizer"}]
 (1 row)
--- explain_processing_on
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -706,198 +605,40 @@ SET gp_explain_jit = on;
 -- ORCA GUCs to enable JIT
 set optimizer_jit to on;
 set optimizer_jit_above_cost to 1;
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=35.50..35.67 rows=10 width=4)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4)
-        ->  Limit  (cost=35.50..35.61 rows=10 width=4)
-              ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4)
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+        ->  Limit  (cost=N.N..N.N rows=N width=N)
+              ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N)
 Optimizer: Postgres query optimizer
 JIT:
-  Functions: 2
+  Functions: N
   Options: Inlining false, Optimization false, Expressions true, Deforming true
 (8 rows)
--- explain_processing_on
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=35.50..35.67 rows=10 width=4) (actual time=13.199..13.310 rows=10 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (actual time=11.848..11.890 rows=10 loops=1)
-        ->  Limit  (cost=35.50..35.61 rows=10 width=4) (actual time=0.861..0.971 rows=10 loops=1)
-              ->  Seq Scan on jit_explain_output  (cost=0.00..355.00 rows=32100 width=4) (actual time=0.029..0.070 rows=10 loops=1)
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+              ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Postgres query optimizer
-Planning Time: 0.158 ms
-  (slice0)    Executor memory: 37K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
 JIT:
   Options: Inlining false, Optimization false, Expressions true, Deforming true.
-  (slice0): Functions: 2.00. Timing: 1.381 ms total.
-  (slice1): Functions: 1.00 avg x 3 workers, 1.00 max (seg0). Timing: 0.830 ms avg x 3 workers, 0.854 ms max (seg1).
-Execution Time: 24.023 ms
+  (sliceN): Functions: N.N. Timing: N.N ms total.
+  (sliceN): Functions: N.N avg x N workers, N.N max (segN). Timing: N.N ms avg x N workers, N.N ms max (segN).
+Execution Time: N.N ms
 (14 rows)
--- explain_processing_on
 -- Check explain analyze json format output with jit enable
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Limit",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Startup Cost": 35.50,
-      "Total Cost": 35.67,
-      "Plan Rows": 10,
-      "Plan Width": 4,
-      "Actual Startup Time": 1.378,
-      "Actual Total Time": 1.576,
-      "Actual Rows": 10,
-      "Actual Loops": 1,
-      "Plans": [
-        {
-          "Node Type": "Gather Motion",
-          "Senders": 3,
-          "Receivers": 1,
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Startup Cost": 35.50,
-          "Total Cost": 36.01,
-          "Plan Rows": 30,
-          "Plan Width": 4,
-          "Actual Startup Time": 0.815,
-          "Actual Total Time": 0.889,
-          "Actual Rows": 10,
-          "Actual Loops": 1,
-          "Plans": [
-            {
-              "Node Type": "Limit",
-              "Parent Relationship": "Outer",
-              "Slice": 1,
-              "Segments": 3,
-              "Gang Type": "primary reader",
-              "Parallel Aware": false,
-              "Startup Cost": 35.50,
-              "Total Cost": 35.61,
-              "Plan Rows": 10,
-              "Plan Width": 4,
-              "Actual Startup Time": 0.711,
-              "Actual Total Time": 0.870,
-              "Actual Rows": 10,
-              "Actual Loops": 1,
-              "Plans": [
-                {
-                  "Node Type": "Seq Scan",
-                  "Parent Relationship": "Outer",
-                  "Slice": 1,
-                  "Segments": 3,
-                  "Gang Type": "primary reader",
-                  "Parallel Aware": false,
-                  "Relation Name": "jit_explain_output",
-                  "Alias": "jit_explain_output",
-                  "Startup Cost": 0.00,
-                  "Total Cost": 355.00,
-                  "Plan Rows": 32100,
-                  "Plan Width": 4,
-                  "Actual Startup Time": 0.025,
-                  "Actual Total Time": 0.099,
-                  "Actual Rows": 10,
-                  "Actual Loops": 1
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "Optimizer": "Postgres query optimizer",
-    "Planning Time": 0.244,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 37800
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36760,
-          "Workers": 3,
-          "Maximum Memory Used": 36760
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "JIT": {
-        "Options": {
-          "Inlining": false,
-          "Optimization": false,
-          "Expressions": true,
-          "Deforming": true
-        },
-        "slice": {
-          "slice": 0,
-          "functions": 2.00,
-          "Timing": 0.001
-        },
-        "slice": {
-          "slice": 1,
-          "Functions": {
-            "avg": 1.00,
-            "nworker": 3,
-            "max": 1.00,
-            "segid": 0
-          },
-          "Timing": {
-            "avg": 0.531,
-            "nworker": 3,
-            "max": 0.686,
-            "segid": 0
-          }
-        }
-    },
-    "Execution Time": 2.889
-  }
-]
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter_to_json
+[{"JIT": {"slice": {"slice": 0, "Timing": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}, "Functions": {"avg": 0.0, "max": 0.0, "segid": 0, "nworker": 0}}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "Postgres query optimizer", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
--- explain_processing_on
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,47 +1,50 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
--- ignore variable JIT gucs which can be shown when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
+-- Tests EXPLAIN format output
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -50,226 +53,192 @@ CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), locat
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36)
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                explain_filter                                                
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+   ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                Hash Key: boxes.apple_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24)
+               ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
                            Hash Key: boxes.location_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12)
-                     ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..6.00 rows=1 width=12)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N)
+                     ->  Index Scan using box_locations_pkey on box_locations  (cost=N.N..N.N rows=N width=N)
                            Index Cond: (id = boxes.location_id)
-         ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12)
+         ->  Index Scan using apples_pkey on apples  (cost=N.N..N.N rows=N width=N)
                Index Cond: (id = boxes.apple_id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
--- explain_processing_on
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-                                                            QUERY PLAN                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..449.00 rows=3 width=36) (actual time=1.912..1.912 rows=0 loops=1)
-   ->  Nested Loop Left Join  (cost=0.00..449.00 rows=1 width=36) (actual time=0.000..1.443 rows=0 loops=1)
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+                                                                explain_filter                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+   ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
          Join Filter: true
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..437.00 rows=1 width=24) (actual time=0.000..1.440 rows=0 loops=1)
+         ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                Hash Key: boxes.apple_id
-               ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=24) (actual time=0.000..0.677 rows=0 loops=1)
+               ->  Nested Loop Left Join  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                      Join Filter: true
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.673 rows=0 loops=1)
+                     ->  Redistribute Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
                            Hash Key: boxes.location_id
-                           ->  Seq Scan on boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.021 rows=0 loops=1)
-                     ->  Index Scan using box_locations_pkey on box_locations  (cost=0.00..6.00 rows=1 width=12) (never executed)
+                           ->  Seq Scan on boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+                     ->  Index Scan using box_locations_pkey on box_locations  (cost=N.N..N.N rows=N width=N) (never executed)
                            Index Cond: (id = boxes.location_id)
-         ->  Index Scan using apples_pkey on apples  (cost=0.00..12.00 rows=1 width=12) (never executed)
+         ->  Index Scan using apples_pkey on apples  (cost=N.N..N.N rows=N width=N) (never executed)
                Index Cond: (id = boxes.apple_id)
  Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 40.380 ms
-   (slice0)    Executor memory: 56K bytes.
-   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg0).
-   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice3)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).
- Memory used:  256000kB
- Execution Time: 19.964 ms
+ Planning Time: N.N ms
+   (sliceN)    Executor memory: NK bytes.
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+   (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+ Memory used:  NkB
+ Execution Time: N.N ms
 (22 rows)
 
--- explain_processing_on
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
 -- and its position depends on the longest line. If the width changes, all
 -- lines need to be adjusted for the moved end-of-line-marker.
 \a
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 449.00
-    Plan Rows: 3
-    Plan Width: 36
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Plans: 
       - Node Type: "Nested Loop"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 0.00
-        Total Cost: 449.00
-        Plan Rows: 1
-        Plan Width: 36
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Inner Unique: false
         Join Filter: "true"
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 0.00
-            Total Cost: 437.00
-            Plan Rows: 1
-            Plan Width: 24
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Hash Key: "boxes.apple_id"
             Plans: 
               - Node Type: "Nested Loop"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 0.00
-                Total Cost: 437.00
-                Plan Rows: 1
-                Plan Width: 24
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
                 Inner Unique: false
                 Join Filter: "true"
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 431.00
-                    Plan Rows: 1
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Hash Key: "boxes.location_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 431.00
-                        Plan Rows: 1
-                        Plan Width: 12
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
                   - Node Type: "Index Scan"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
                     Scan Direction: "Forward"
                     Index Name: "box_locations_pkey"
                     Relation Name: "box_locations"
                     Alias: "box_locations"
-                    Startup Cost: 0.00
-                    Total Cost: 6.00
-                    Plan Rows: 1
-                    Plan Width: 12
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
                     Index Cond: "(id = boxes.location_id)"
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
             Scan Direction: "Forward"
             Index Name: "apples_pkey"
             Relation Name: "apples"
             Alias: "apples"
-            Startup Cost: 0.00
-            Total Cost: 12.00
-            Plan Rows: 1
-            Plan Width: 12
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
             Index Cond: "(id = boxes.apple_id)"
   Optimizer: "Pivotal Optimizer (GPORCA)"
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 431.00
-    Plan Rows: 1
-    Plan Width: 12
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -277,44 +246,40 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: 0.00
-        Total Cost: 431.00
-        Plan Rows: 1
-        Plan Width: 12
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Pivotal Optimizer (GPORCA)"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
 (1 row)
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
-QUERY PLAN
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: #
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: ###.##
-    Total Cost: ###.##
-    Plan Rows: #####
-    Plan Width: ##
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
     Output: 
       - "id"
       - "apple_id"
@@ -322,275 +287,243 @@ QUERY PLAN
     Plans: 
       - Node Type: "Seq Scan"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: #
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Relation Name: "boxes"
         Schema: "public"
         Alias: "boxes"
-        Startup Cost: ###.##
-        Total Cost: ###.##
-        Plan Rows: #####
-        Plan Width: ##
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
         Output: 
           - "id"
           - "apple_id"
           - "location_id"
   Optimizer: "Pivotal Optimizer (GPORCA)"
   Settings: 
-    cpu_index_tuple_cost: "0.1"
-    random_page_cost: "1"
+    cpu_index_tuple_cost: "N.N"
+    random_page_cost: "N"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
-QUERY PLAN
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+explain_filter
 - Plan: 
     Node Type: "Gather Motion"
-    Senders: 3
-    Receivers: 1
-    Slice: 1
-    Segments: 3
+    Senders: N
+    Receivers: N
+    Slice: N
+    Segments: N
     Gang Type: "primary reader"
     Parallel Aware: false
-    Startup Cost: 0.00
-    Total Cost: 449.00
-    Plan Rows: 3
-    Plan Width: 36
-    Actual Startup Time: 15.617
-    Actual Total Time: 15.617
-    Actual Rows: 0
-    Actual Loops: 1
+    Startup Cost: N.N
+    Total Cost: N.N
+    Plan Rows: N
+    Plan Width: N
+    Actual Startup Time: N.N
+    Actual Total Time: N.N
+    Actual Rows: N
+    Actual Loops: N
     Plans: 
       - Node Type: "Nested Loop"
         Parent Relationship: "Outer"
-        Slice: 1
-        Segments: 3
+        Slice: N
+        Segments: N
         Gang Type: "primary reader"
         Parallel Aware: false
         Join Type: "Left"
-        Startup Cost: 0.00
-        Total Cost: 449.00
-        Plan Rows: 1
-        Plan Width: 36
-        Actual Startup Time: 0.000
-        Actual Total Time: 0.000
-        Actual Rows: 0
-        Actual Loops: 0
+        Startup Cost: N.N
+        Total Cost: N.N
+        Plan Rows: N
+        Plan Width: N
+        Actual Startup Time: N.N
+        Actual Total Time: N.N
+        Actual Rows: N
+        Actual Loops: N
         Inner Unique: false
         Join Filter: "true"
-        Rows Removed by Join Filter: 0
+        Rows Removed by Join Filter: N
         Plans: 
           - Node Type: "Redistribute Motion"
-            Senders: 3
-            Receivers: 3
+            Senders: N
+            Receivers: N
             Parent Relationship: "Outer"
-            Slice: 2
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
-            Startup Cost: 0.00
-            Total Cost: 437.00
-            Plan Rows: 1
-            Plan Width: 24
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Hash Key: "boxes.apple_id"
             Plans: 
               - Node Type: "Nested Loop"
                 Parent Relationship: "Outer"
-                Slice: 2
-                Segments: 3
+                Slice: N
+                Segments: N
                 Gang Type: "primary reader"
                 Parallel Aware: false
                 Join Type: "Left"
-                Startup Cost: 0.00
-                Total Cost: 437.00
-                Plan Rows: 1
-                Plan Width: 24
-                Actual Startup Time: 0.000
-                Actual Total Time: 0.000
-                Actual Rows: 0
-                Actual Loops: 0
+                Startup Cost: N.N
+                Total Cost: N.N
+                Plan Rows: N
+                Plan Width: N
+                Actual Startup Time: N.N
+                Actual Total Time: N.N
+                Actual Rows: N
+                Actual Loops: N
                 Inner Unique: false
                 Join Filter: "true"
-                Rows Removed by Join Filter: 0
+                Rows Removed by Join Filter: N
                 Plans: 
                   - Node Type: "Redistribute Motion"
-                    Senders: 3
-                    Receivers: 3
+                    Senders: N
+                    Receivers: N
                     Parent Relationship: "Outer"
-                    Slice: 3
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
-                    Startup Cost: 0.00
-                    Total Cost: 431.00
-                    Plan Rows: 1
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Hash Key: "boxes.location_id"
                     Plans: 
                       - Node Type: "Seq Scan"
                         Parent Relationship: "Outer"
-                        Slice: 3
-                        Segments: 3
+                        Slice: N
+                        Segments: N
                         Gang Type: "primary reader"
                         Parallel Aware: false
                         Relation Name: "boxes"
                         Alias: "boxes"
-                        Startup Cost: 0.00
-                        Total Cost: 431.00
-                        Plan Rows: 1
-                        Plan Width: 12
-                        Actual Startup Time: 0.000
-                        Actual Total Time: 0.000
-                        Actual Rows: 0
-                        Actual Loops: 0
+                        Startup Cost: N.N
+                        Total Cost: N.N
+                        Plan Rows: N
+                        Plan Width: N
+                        Actual Startup Time: N.N
+                        Actual Total Time: N.N
+                        Actual Rows: N
+                        Actual Loops: N
                   - Node Type: "Index Scan"
                     Parent Relationship: "Inner"
-                    Slice: 2
-                    Segments: 3
+                    Slice: N
+                    Segments: N
                     Gang Type: "primary reader"
                     Parallel Aware: false
                     Scan Direction: "Forward"
                     Index Name: "box_locations_pkey"
                     Relation Name: "box_locations"
                     Alias: "box_locations"
-                    Startup Cost: 0.00
-                    Total Cost: 6.00
-                    Plan Rows: 1
-                    Plan Width: 12
-                    Actual Startup Time: 0.000
-                    Actual Total Time: 0.000
-                    Actual Rows: 0
-                    Actual Loops: 0
+                    Startup Cost: N.N
+                    Total Cost: N.N
+                    Plan Rows: N
+                    Plan Width: N
+                    Actual Startup Time: N.N
+                    Actual Total Time: N.N
+                    Actual Rows: N
+                    Actual Loops: N
                     Index Cond: "(id = boxes.location_id)"
-                    Rows Removed by Index Recheck: 0
+                    Rows Removed by Index Recheck: N
           - Node Type: "Index Scan"
             Parent Relationship: "Inner"
-            Slice: 1
-            Segments: 3
+            Slice: N
+            Segments: N
             Gang Type: "primary reader"
             Parallel Aware: false
             Scan Direction: "Forward"
             Index Name: "apples_pkey"
             Relation Name: "apples"
             Alias: "apples"
-            Startup Cost: 0.00
-            Total Cost: 12.00
-            Plan Rows: 1
-            Plan Width: 12
-            Actual Startup Time: 0.000
-            Actual Total Time: 0.000
-            Actual Rows: 0
-            Actual Loops: 0
+            Startup Cost: N.N
+            Total Cost: N.N
+            Plan Rows: N
+            Plan Width: N
+            Actual Startup Time: N.N
+            Actual Total Time: N.N
+            Actual Rows: N
+            Actual Loops: N
             Index Cond: "(id = boxes.apple_id)"
-            Rows Removed by Index Recheck: 0
+            Rows Removed by Index Recheck: N
   Optimizer: "Pivotal Optimizer (GPORCA)"
-  Planning Time: 14.827
+  Planning Time: N.N
   Triggers: 
   Slice statistics: 
-    - Slice: 0
-      Executor Memory: 195920
-    - Slice: 1
+    - Slice: N
+      Executor Memory: N
+    - Slice: N
       Executor Memory: 
-        Average: 97488
-        Workers: 3
-        Maximum Memory Used: 97488
-    - Slice: 2
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+    - Slice: N
       Executor Memory: 
-        Average: 97488
-        Workers: 3
-        Maximum Memory Used: 97488
-    - Slice: 3
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
+    - Slice: N
       Executor Memory: 
-        Average: 60624
-        Workers: 3
-        Maximum Memory Used: 60624
+        Average: N
+        Workers: N
+        Maximum Memory Used: N
   Statement statistics: 
-    Memory used: 128000
-  Execution Time: 3.332
+    Memory used: N
+  Execution Time: N.N
 (1 row)
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- end_matchsubs
---- Check explain analyze sort infomation in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
-QUERY PLAN
-Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (actual time=0.388..0.388 rows=0 loops=1)
+--- Check explain analyze sort information in verbose mode
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
+explain_filter
+Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
   Output: id, apple_id, location_id
   Merge Key: apple_id
-  ->  Sort  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.072 rows=0 loops=1)
+  ->  Sort  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
         Output: id, apple_id, location_id
         Sort Key: boxes.apple_id
-        Sort Method:  quicksort  Memory: 75kB  Max Memory: 25kB  Avg Memory: 25kB (3 segments)
-        Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-        work_mem: 177kB  Segments: 3  Max: 59kB (segment 0)  Workfile: (0 spilling)
-        ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (actual time=0.000..0.014 rows=0 loops=1)
+        Sort Method:  quicksort  Memory: NkB  Max Memory: NkB  Avg Memory: NkB (N segments)
+        Executor Memory: NkB  Segments: N  Max: NkB (segment N)
+        work_mem: NkB  Segments: N  Max: NkB (segment N)  Workfile: (N spilling)
+        ->  Seq Scan on public.boxes  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
               Output: id, apple_id, location_id
 Optimizer: Pivotal Optimizer (GPORCA)
-Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
-Planning Time: 4.622 ms
-  (slice0)    Executor memory: 40K bytes.
-  (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
-Memory used:  128000kB
-Execution Time: 0.846 ms
+Settings: cpu_index_tuple_cost = 'N.N', random_page_cost = 'N'
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).  Work_mem: NK bytes max.
+Memory used:  NkB
+Execution Time: N.N ms
 (18 rows)
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.
 --
 -- This should be enough for those format. The only difference between JSON,
 -- XML, and YAML is in the formatting, after all.
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Function Scan",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Function Name": "generate_series",
-      "Alias": "generate_series"
-    },
-    "Optimizer": "Pivotal Optimizer (GPORCA)"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter_to_json
+[{"Plan": {"Alias": "generate_series", "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Function Scan", "Function Name": "generate_series", "Parallel Aware": false}, "Optimizer": "Pivotal Optimizer (GPORCA)"}]
 (1 row)
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
-QUERY PLAN
-<explain xmlns="http://www.postgresql.org/2009/explain">
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
+explain_filter
+<explain xmlns="http://www.postgresql.org/N/explain">
   <Query>
     <Plan>
       <Node-Type>Function Scan</Node-Type>
-      <Slice>0</Slice>
-      <Segments>0</Segments>
+      <Slice>N</Slice>
+      <Segments>N</Segments>
       <Gang-Type>unallocated</Gang-Type>
       <Parallel-Aware>false</Parallel-Aware>
       <Function-Name>generate_series</Function-Name>
@@ -605,46 +538,11 @@ QUERY PLAN
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Gather Motion",
-      "Senders": 1,
-      "Receivers": 1,
-      "Slice": 1,
-      "Segments": 1,
-      "Gang Type": "primary reader",
-      "Parallel Aware": false,
-      "Plans": [
-        {
-          "Node Type": "Dynamic Seq Scan",
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 1,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Relation Name": "jsonexplaintest",
-          "Alias": "jsonexplaintest",
-          "Number of partitions to scan": 1,
-          "Filter": "(i = 2)"
-        }
-      ]
-    },
-    "Optimizer": "Pivotal Optimizer (GPORCA)"
-  }
-]
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
+explain_filter_to_json
+[{"Plan": {"Plans": [{"Alias": "jsonexplaintest", "Slice": 0, "Filter": "(i = 0)", "Segments": 0, "Gang Type": "primary reader", "Node Type": "Dynamic Seq Scan", "Relation Name": "jsonexplaintest", "Parallel Aware": false, "Parent Relationship": "Outer", "Number of partitions to scan": 0}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Receivers": 0, "Parallel Aware": false}, "Optimizer": "Pivotal Optimizer (GPORCA)"}]
 (1 row)
--- explain_processing_on
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -655,162 +553,37 @@ SET gp_explain_jit = on;
 -- ORCA GUCs to enable JIT
 set optimizer_jit to on;
 set optimizer_jit_above_cost to 1;
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=0.00..431.00 rows=1 width=4)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-        ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4)
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N)
+        ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N)
 Optimizer: Pivotal Optimizer (GPORCA)
 JIT:
-  Functions: 2
+  Functions: N
   Options: Inlining false, Optimization false, Expressions true, Deforming true
 (7 rows)
--- explain_processing_on
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=1.103..1.107 rows=10 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.013..0.014 rows=10 loops=1)
-        ->  Seq Scan on jit_explain_output  (cost=0.00..431.00 rows=1 width=4) (actual time=0.025..0.030 rows=38 loops=1)
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter
+Limit  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+  ->  Gather Motion N:N  (sliceN; segments: N)  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
+        ->  Seq Scan on jit_explain_output  (cost=N.N..N.N rows=N width=N) (actual time=N.N..N.N rows=N loops=N)
 Optimizer: Pivotal Optimizer (GPORCA)
-Planning Time: 5.824 ms
-  (slice0)    Executor memory: 37K bytes.
-  (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
-Memory used:  128000kB
+Planning Time: N.N ms
+  (sliceN)    Executor memory: NK bytes.
+  (sliceN)    Executor memory: NK bytes avg x N workers, NK bytes max (segN).
+Memory used:  NkB
 JIT:
   Options: Inlining false, Optimization false, Expressions true, Deforming true.
-  (slice0): Functions: 2.00. Timing: 1.137 ms total.
-Execution Time: 1.597 ms
+  (sliceN): Functions: N.N. Timing: N.N ms total.
+Execution Time: N.N ms
 (12 rows)
--- explain_processing_on
 -- Check explain analyze json format output with jit enable
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
-QUERY PLAN
-[
-  {
-    "Plan": {
-      "Node Type": "Limit",
-      "Slice": 0,
-      "Segments": 0,
-      "Gang Type": "unallocated",
-      "Parallel Aware": false,
-      "Startup Cost": 0.00,
-      "Total Cost": 431.00,
-      "Plan Rows": 1,
-      "Plan Width": 4,
-      "Actual Startup Time": 0.611,
-      "Actual Total Time": 0.615,
-      "Actual Rows": 10,
-      "Actual Loops": 1,
-      "Plans": [
-        {
-          "Node Type": "Gather Motion",
-          "Senders": 3,
-          "Receivers": 1,
-          "Parent Relationship": "Outer",
-          "Slice": 1,
-          "Segments": 3,
-          "Gang Type": "primary reader",
-          "Parallel Aware": false,
-          "Startup Cost": 0.00,
-          "Total Cost": 431.00,
-          "Plan Rows": 1,
-          "Plan Width": 4,
-          "Actual Startup Time": 0.014,
-          "Actual Total Time": 0.015,
-          "Actual Rows": 10,
-          "Actual Loops": 1,
-          "Plans": [
-            {
-              "Node Type": "Seq Scan",
-              "Parent Relationship": "Outer",
-              "Slice": 1,
-              "Segments": 3,
-              "Gang Type": "primary reader",
-              "Parallel Aware": false,
-              "Relation Name": "jit_explain_output",
-              "Alias": "jit_explain_output",
-              "Startup Cost": 0.00,
-              "Total Cost": 431.00,
-              "Plan Rows": 1,
-              "Plan Width": 4,
-              "Actual Startup Time": 0.024,
-              "Actual Total Time": 0.028,
-              "Actual Rows": 38,
-              "Actual Loops": 1
-            }
-          ]
-        }
-      ]
-    },
-    "Optimizer": "Pivotal Optimizer (GPORCA)",
-    "Planning Time": 5.884,
-    "Triggers": [
-    ],
-    "Slice statistics": [
-      {
-        "Slice": 0,
-        "Executor Memory": 37144
-      },
-      {
-        "Slice": 1,
-        "Executor Memory": {
-          "Average": 36104,
-          "Workers": 3,
-          "Maximum Memory Used": 36104
-        }
-      }
-    ],
-    "Statement statistics": {
-      "Memory used": 128000
-    },
-    "JIT": {
-        "Options": {
-          "Inlining": false,
-          "Optimization": false,
-          "Expressions": true,
-          "Deforming": true
-        },
-        "slice": {
-          "slice": 0,
-          "functions": 2.00,
-          "Timing": 0.001
-        }
-    },
-    "Execution Time": 1.221
-  }
-]
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
+explain_filter_to_json
+[{"JIT": {"slice": {"slice": 0, "Timing": 0.0, "functions": 0.0}, "Options": {"Inlining": false, "Deforming": true, "Expressions": true, "Optimization": false}}, "Plan": {"Plans": [{"Plans": [{"Alias": "jit_explain_output", "Slice": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Seq Scan", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Relation Name": "jit_explain_output", "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Senders": 0, "Segments": 0, "Gang Type": "primary reader", "Node Type": "Gather Motion", "Plan Rows": 0, "Receivers": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0, "Parent Relationship": "Outer"}], "Slice": 0, "Segments": 0, "Gang Type": "unallocated", "Node Type": "Limit", "Plan Rows": 0, "Plan Width": 0, "Total Cost": 0.0, "Actual Rows": 0, "Actual Loops": 0, "Startup Cost": 0.0, "Parallel Aware": false, "Actual Total Time": 0.0, "Actual Startup Time": 0.0}, "Triggers": [], "Optimizer": "Pivotal Optimizer (GPORCA)", "Planning Time": 0.0, "Execution Time": 0.0, "Slice statistics": [{"Slice": 0, "Executor Memory": 0}, {"Slice": 0, "Executor Memory": {"Average": 0, "Workers": 0, "Maximum Memory Used": 0}}], "Statement statistics": {"Memory used": 0}}]
 (1 row)
--- explain_processing_on
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,47 +1,52 @@
--- start_matchsubs
--- m/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/
--- s/\(actual time=\d+\.\d+..\d+\.\d+ rows=\d+ loops=\d+\)/(actual time=##.###..##.### rows=# loops=#)/
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes\./
--- s/Executor memory: (\d+)\w bytes\./Executor memory: (#####)K bytes./
--- m/\(slice\d+\)    Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./
--- s/Executor memory: (\d+)\w bytes avg x \d+ workers, \d+\w bytes max \(seg\d+\)\./Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#)./
--- m/Work_mem: \d+\w bytes max\./
--- s/Work_mem: \d+\w bytes max\. */Work_mem: ###K bytes max./
--- m/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/
--- s/Memory: \d+kB  Max Memory: \d+kB  Peak Memory: \d+kB  Avg Memory: \d+kB \(3 segments\)/Memory: ###kB  Max Memory: ###kB  Peak Memory: ###kB  Avg Memory: ###kB \(3 segments\)/
--- m/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/
--- s/work_mem: \d+kB  Segments: 3  Max: \d+kB \(segment \d+\)  Workfile: \(0 spilling\)/work_mem: ###kB  Segments: 3  Max: ###kB \(segment ##\)  Workfile: \(0 spilling\)/
--- m/Execution Time: \d+\.\d+ ms/
--- s/Execution Time: \d+\.\d+ ms/Execution Time: ##.### ms/
--- m/Planning Time: \d+\.\d+ ms/
--- s/Planning Time: \d+\.\d+ ms/Planning Time: ##.### ms/
--- m/cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+/
--- s/\(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)/(cost=##.###..##.### rows=### width=###)/
--- m/Memory used:  \d+\w?B/
--- s/Memory used:  \d+\w?B/Memory used: ###B/
--- m/Memory Usage: \d+\w?B/
--- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
--- m/Peak Memory Usage: \d+/
--- s/Peak Memory Usage: \d+/Peak Memory Usage: ###/
--- m/Buckets: \d+/
--- s/Buckets: \d+/Buckets: ###/
--- m/Batches: \d+/
--- s/Batches: \d+/Batches: ###/
--- m/^Settings:.*/
--- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- m/^Settings:.*/
--- s/,?\s*optimizer\w*\s*=\s*'off'//g
--- end_matchsubs
--- ignore variable JIT gucs which can be shown when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- m/\s*optimizer:\s*"off"/
--- m/^\s+optimizer_jit\w*:/
--- end_matchignore
+-- Tests EXPLAIN format output
+
+-- To produce stable regression test output, it's usually necessary to
+-- ignore details such as exact costs or row counts.  These filter
+-- functions replace changeable output details with fixed strings.
+create function explain_filter(text) returns setof text
+language plpgsql as
+$$
+declare
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        ln := regexp_replace(ln, '\m\d+K', 'NK', 'g');
+        -- Replace slice and segment numbers with 'N'
+        ln := regexp_replace(ln, '\mslice\d+', 'sliceN', 'g');
+        ln := regexp_replace(ln, '\mseg\d+', 'segN', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        return next ln;
+    end loop;
+end;
+$$;
+-- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
+create function explain_filter_to_json(text) returns jsonb
+language plpgsql as
+$$
+declare
+    data text := '';
+    ln text;
+begin
+    for ln in execute $1
+    loop
+        -- Replace any numeric word with just '0'
+        ln := regexp_replace(ln, '\m\d+\M', '0', 'g');
+        data := data || ln;
+    end loop;
+    return data::jsonb;
+end;
+$$;
+
 -- DEFAULT syntax
 CREATE TABLE apples(id int PRIMARY KEY, type text);
 INSERT INTO apples(id) SELECT generate_series(1, 100000);
@@ -49,14 +54,10 @@ CREATE TABLE box_locations(id int PRIMARY KEY, address text);
 CREATE TABLE boxes(id int PRIMARY KEY, apple_id int REFERENCES apples(id), location_id int REFERENCES box_locations(id));
 
 --- Check Explain Text format output
--- explain_processing_off
-EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
--- explain_processing_on
+select explain_filter('EXPLAIN SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 
 --- Check Explain Analyze Text output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
--- explain_processing_on
+select explain_filter('EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 
 -- Unaligned output format is better for the YAML / XML / JSON outputs.
 -- In aligned format, you have end-of-line markers at the end of each line,
@@ -65,67 +66,23 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 \a
 
 -- YAML Required replaces for costs and time changes
--- start_matchsubs
--- m/ Loops: \d+/
--- s/ Loops: \d+/ Loops: #/
--- m/ Cost: \d+\.\d+/
--- s/ Cost: \d+\.\d+/ Cost: ###.##/
--- m/ Rows: \d+/
--- s/ Rows: \d+/ Rows: #####/
--- m/ Plan Width: \d+/
--- s/ Plan Width: \d+/ Plan Width: ##/
--- m/ Time: \d+\.\d+/
--- s/ Time: \d+\.\d+/ Time: ##.###/
--- m/Execution Time: \d+\.\d+/
--- s/Execution Time: \d+\.\d+/Execution Time: ##.###/
--- m/Segments: \d+$/
--- s/Segments: \d+$/Segments: #/
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+",?/Pivotal Optimizer \(GPORCA\)"/
--- m/ Memory: \d+$/
--- s/ Memory: \d+$/ Memory: ###/
--- m/Maximum Memory Used: \d+/
--- s/Maximum Memory Used: \d+/Maximum Memory Used: ###/
--- m/Workers: \d+/
--- s/Workers: \d+/Workers: ##/
--- m/Average: \d+/
--- s/Average: \d+/Average: ##/
--- m/Total memory used across slices: \d+/
--- s/Total memory used across slices: \d+\s*/Total memory used across slices: ###/
--- m/Memory used: \d+/
--- s/Memory used: \d+/Memory used: ###/
--- end_matchsubs
+
 -- Check Explain YAML output
-EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
+select explain_filter('EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
-EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
--- ignore variable JIT gucs which can be showed when SETTINGS=ON
--- start_matchignore
--- m/^\s+jit\w*:/
--- end_matchignore
-EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;');
+
+select explain_filter('EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;');
 
 --- Check Explain Analyze YAML output that include the slices information
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 
--- start_matchsubs
--- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
--- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
--- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
--- start_matchsubs
--- m/^Settings:.*/
--- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
--- m/^Settings:.*/
--- s/^Settings:[,\s]*/Settings: /
--- end_matchsubs
---- Check explain analyze sort infomation in verbose mode
-EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
+select explain_filter('EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;');
+
+--- Check explain analyze sort information in verbose mode
+select explain_filter('EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;');
 RESET random_page_cost;
 RESET cpu_index_tuple_cost;
--- explain_processing_on
 
 --
 -- Test a simple case with JSON and XML output, too.
@@ -134,31 +91,16 @@ RESET cpu_index_tuple_cost;
 -- XML, and YAML is in the formatting, after all.
 
 -- Check JSON format
---
--- start_matchsubs
--- m/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/
--- s/Pivotal Optimizer \(GPORCA\) version \d+\.\d+\.\d+/Pivotal Optimizer \(GPORCA\)/
--- end_matchsubs
--- explain_processing_off
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM generate_series(1, 10);');
 
-EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);
+select explain_filter('EXPLAIN (FORMAT XML, COSTS OFF) SELECT * FROM generate_series(1, 10);');
 
 -- Test for an old bug in printing Sequence nodes in JSON/XML format
 -- (https://github.com/greenplum-db/gpdb/issues/9410)
 CREATE TABLE jsonexplaintest (i int4) PARTITION BY RANGE (i) (START(1) END(3) EVERY(1));
-EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;
-
--- explain_processing_on
+select explain_filter_to_json('EXPLAIN (FORMAT JSON, COSTS OFF) SELECT * FROM jsonexplaintest WHERE i = 2;');
 
 -- Check Explain Text format output with jit enable
---
--- start_matchsubs
--- m/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./
--- s/\(slice\d+\): Functions: \d+\.\d+\. Timing: \d+\.\d+ ms total\./\(slice###\): Functions: ##.###. Timing: ##.### ms total\./
--- m/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./
--- s/\(slice\d+\): Functions: \d+\.\d+ avg x \d+ workers, \d+\.\d+ max \(seg\d+\)\. Timing: \d+\.\d+ ms avg x \d+ workers, \d+\.\d+ ms max \(seg\d+\)\./\(slice###\): Functions: ##.### avg x ### workers, ##.### max \(seg###\)\. Timing: ##.### ms avg x ### workers, ##.### ms max \(seg###\)\./
--- end_matchsubs
 CREATE TABLE jit_explain_output(c1 int);
 INSERT INTO jit_explain_output SELECT generate_series(1,100);
 
@@ -170,47 +112,13 @@ SET gp_explain_jit = on;
 set optimizer_jit to on;
 set optimizer_jit_above_cost to 1;
 
--- explain_processing_off
-EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+select explain_filter('EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;');
 
--- Check explain anlyze text format output with jit enable 
--- explain_processing_off
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+-- Check explain anlyze text format output with jit enable
+select explain_filter('EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;');
 
 -- Check explain analyze json format output with jit enable
-
--- start_matchsubs
--- m/\"Actual Startup Time\": \d+\.\d+/
--- s/\"Actual Startup Time\": \d+\.\d+/\"Actual Startup Time\": ###/
--- m/\"Actual Total Time\": \d+\.\d+/
--- s/\"Actual Total Time\": \d+\.\d+/\"Actual Total Time\": ###/
--- m/\"Planning Time\": \d+\.\d+/
--- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
--- m/\"Execution Time\": \d+\.\d+/
--- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
--- m/\"slice\": \d+/
--- s/\"slice\": \d+/"slice": ###/
--- m/\"functions\": \d+\.\d+/
--- s/\"functions\": \d+\.\d+/\"functions\": ###/
--- m/\"Timing\": \d+\.\d+/
--- s/\"Timing\": \d+\.\d+/\"Timing": ###/
--- m/\"avg\": \d+\.\d+/
--- s/\"avg\": \d+\.\d+/\"avg\": ###/
--- m/\"nworker\": \d+/
--- s/\"nworker\": \d+/\"nworker\": ###/
--- m/\"max\": \d+\.\d+/
--- s/\"max\": \d+\.\d+/\"max\": ###/
--- m/\"segid\": \d+/
--- s/\"segid\": \d+/\"segid\": ###/
--- m/\"Memory used\": \d+/
--- s/\"Memory used\": \d+/\"Memory used\": ###/
--- end_matchsubs
-
--- explain_processing_off
-EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
--- explain_processing_on
+select explain_filter_to_json('EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;');
 
 RESET jit;
 RESET jit_above_cost;


### PR DESCRIPTION
This commit borrows two test helper functions from PG13 1001368 that replace changeable output details in the EXPLAIN output. As a result, remove the complex matchsubs in the explain_format.sql regression test. This results in stable test output across planner/orca and assert/non-assert builds.

Differences from the original patch:
- Only changes for existing tests are taken.
- The output has been adapted for the current explain format.

(cherry picked from commit ecc8344c428622bd7b0d0943ba5de03f1b678915)

---
Absolute values in explain are unstable, especially during sync. Therefore, it is better to solve the problem more reliably.

Do not squash to preserve authorship.