### PR TITLE
Fix explain_format test [8X]

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -1,4 +1,21 @@
 -- Tests EXPLAIN format output
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- start_matchsubs
+-- m/^Settings:.*/
+-- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- end_matchsubs
+-- ignore variable JIT gucs which can be shown when SETTINGS=ON
+-- start_matchignore
+-- m/^\s+jit\w*:/
+-- m/\s*optimizer:\s*"off"/
+-- m/^\s+optimizer_jit\w*:/
+-- end_matchignore
 -- To produce stable regression test output, it's usually necessary to
 -- ignore details such as exact costs or row counts.  These filter
 -- functions replace changeable output details with fixed strings.

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -1,4 +1,21 @@
 -- Tests EXPLAIN format output
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- start_matchsubs
+-- m/^Settings:.*/
+-- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- end_matchsubs
+-- ignore variable JIT gucs which can be shown when SETTINGS=ON
+-- start_matchignore
+-- m/^\s+jit\w*:/
+-- m/\s*optimizer:\s*"off"/
+-- m/^\s+optimizer_jit\w*:/
+-- end_matchignore
 -- To produce stable regression test output, it's usually necessary to
 -- ignore details such as exact costs or row counts.  These filter
 -- functions replace changeable output details with fixed strings.

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -1,5 +1,24 @@
 -- Tests EXPLAIN format output
 
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
+-- start_matchsubs
+-- m/^Settings:.*/
+-- s/,?\s*optimizer_jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
+-- m/^Settings:.*/
+-- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
+-- end_matchsubs
+
+-- ignore variable JIT gucs which can be shown when SETTINGS=ON
+-- start_matchignore
+-- m/^\s+jit\w*:/
+-- m/\s*optimizer:\s*"off"/
+-- m/^\s+optimizer_jit\w*:/
+-- end_matchignore
+
 -- To produce stable regression test output, it's usually necessary to
 -- ignore details such as exact costs or row counts.  These filter
 -- functions replace changeable output details with fixed strings.


### PR DESCRIPTION
Ignore variable JIT gucs in explain_format output

---

The previous patch 3ec6a32208eefb183d23a5e2eb1dd075452b61a0 did not cover the case with jit enabled.
Do not squash to preserve authorship.