### PR TITLE
ADBDEV-7374: Emit an error if GUC synchronization fails in GPDB 7

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -302,6 +302,8 @@ cdbdisp_dispatchSetCommandInternal(const char *strCommand, bool cancelOnError, b
 		 "CdbDispatchSetCommand for command = '%s'",
 		 strCommand);
 
+	SIMPLE_FAULT_INJECTOR("dispatch_set_command");
+
 	/*
 	 * Dispatch a command with DF_SYNC_SET flag if we are performing a config
 	 * reload. This will allow us to distinguish between user-invoked SET and QD

--- a/src/test/isolation2/expected/sync_guc.out
+++ b/src/test/isolation2/expected/sync_guc.out
@@ -154,6 +154,10 @@ RESET
 4q: ... <quitting>
 
 -- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres\.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres\.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
 1: create temp table sync_temp_table(a int) distributed by (a);
 CREATE TABLE
 -- Cause panic on segment from another session
@@ -171,12 +175,11 @@ ERROR:  fault triggered, fault name:'create_function_fail' fault type:'panic'  (
 !\retcode gpstop -u;
 (exited with code 0)
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
+-- Query to execute GUC sync (GUC sync fails)
 1: select 1;
- ?column? 
-----------
- 1        
-(1 row)
+ERROR:  failed to synchronize GUC settings across segments
+DETAIL:  Query aborted due to GUC synchronization failure
+HINT:  Check segment logs for more details
 -- Should fail with "relation does not exist"
 1: select * from sync_temp_table;
 ERROR:  relation "sync_temp_table" does not exist

--- a/src/test/isolation2/sql/sync_guc.sql
+++ b/src/test/isolation2/sql/sync_guc.sql
@@ -71,6 +71,10 @@
 4q:
 
 -- TEST 4: make sure GUC sync failure doesn't leave broken temp tables
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres\.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres\.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
 1: create temp table sync_temp_table(a int) distributed by (a);
 -- Cause panic on segment from another session
 2: select gp_inject_fault('create_function_fail', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
@@ -80,7 +84,7 @@
 !\retcode gpconfig -c log_min_messages -v 'warning' -m 'notice';
 !\retcode gpstop -u;
 
--- Query to execute GUC sync (GUC sync fails, query succeeds)
+-- Query to execute GUC sync (GUC sync fails)
 1: select 1;
 -- Should fail with "relation does not exist"
 1: select * from sync_temp_table;

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -10,7 +10,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
--- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected \(session id = \d*\)/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
 -- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
@@ -598,6 +598,11 @@ drop table t_create_gang_time;
 -- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
 --
 
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
+
 -- start_ignore
 DROP ROLE IF EXISTS dispatch_test_user2;
 -- end_ignore
@@ -674,7 +679,30 @@ SELECT * from show_on_segments('constraint_exclusion');
 
 SELECT FROM gang_is_the_same;
 
+-- Make sure that at least one parameter from synced list has been changed
+--start_ignore
+\!gpconfig -c log_min_messages -v 'info'
+--end_ignore
+
+-- Don't fail silently if we encountered an error.
+SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--start_ignore
+\!gpstop -u
+--end_ignore
+
+-- Table is gone after an error.
 DROP TABLE gang_is_the_same;
+
+SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--start_ignore
+\!gpconfig -r log_min_messages
+\!gpstop -u
+--end_ignore
+
 RESET SESSION AUTHORIZATION;
 
 DROP FUNCTION show_on_segments(show_name text);

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -8,7 +8,7 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^ \(seg\d .*:\d+\)//
 -- m/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
--- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
+-- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected \(session id = \d*\)/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
 -- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
 -- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
@@ -1016,6 +1016,10 @@ drop table t_create_gang_time;
 -- GUCs that were changed in the configuration file of the QD should be re-sent
 -- to segments on gpstop -u, if GUC_GPDB_NEED_SYNC is present in the flags.
 --
+-- start_matchsubs
+-- m/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/
+-- s/^ERROR:  failed to synchronize GUC settings across segments \(postgres.c:\d+\)/ERROR:  failed to synchronize GUC settings across segments/
+-- end_matchsubs
 -- Use a separate user without any priveleges to catch possible context issues.
 CREATE ROLE dispatch_test_user2 NOSUPERUSER;
 SET SESSION AUTHORIZATION dispatch_test_user2;
@@ -1143,7 +1147,39 @@ SELECT FROM gang_is_the_same;
 --
 (0 rows)
 
+-- Make sure that at least one parameter from synced list has been changed
+--start_ignore
+\!gpconfig -c log_min_messages -v 'info'
+--end_ignore
+-- Don't fail silently if we encountered an error.
+SELECT gp_inject_fault('dispatch_set_command', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+--start_ignore
+\!gpstop -u
+--end_ignore
+-- Table is gone after an error.
 DROP TABLE gang_is_the_same;
+WARNING:  fault triggered, fault name:'dispatch_set_command' fault type:'error'
+WARNING:  Any temporary tables for this session have been dropped because the gang was disconnected (session id = DUMMY)
+ERROR:  failed to synchronize GUC settings across segments
+DETAIL:  Query aborted due to GUC synchronization failure
+HINT:  Check segment logs for more details
+SELECT gp_inject_fault('dispatch_set_command', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+--start_ignore
+\!gpconfig -r log_min_messages
+\!gpstop -u
+--end_ignore
 RESET SESSION AUTHORIZATION;
 DROP FUNCTION show_on_segments(show_name text);
 DROP ROLE dispatch_test_user2;


### PR DESCRIPTION
Adopt https://github.com/arenadata/gpdb/commit/d26e12a16a3cb00888c63fedd66046231ecc8fbb to GPDB 7.

Changes from original commit:
- Remove MemoryContextSwitchTo(oldcontext) in send_guc_to_QE() since
ereport(ERROR) never returns and context is already restored by the
error handling mechanism.
- Replace removal of checkForResetSession() with removal of
GpResetSessionIfNeeded() and GpDropTempTables(), because these commands
were used in GPDB 7.
- Add matchsubs rule to the sync_guc isolation2 test to make the error
output independent of line numbers in the source file.
- Add ignored blocks in dispatch test output for improved readability.
- Log if error couldn't be demoted and was rethrown in GUC sync.

Do not squash to preserve authorship.
