### PR TITLE
Fix errors on planning queries with zero column AO tables

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1045,32 +1045,20 @@ GetSegFilesTotalsCluster(Relation parentrel, FileSegTotals * totals)
 
 			Datum		datum_totalbytes =
 				SPI_getbinval(tuple, tupdesc, 2, &isnull);
-			if (isnull)
-				totals->totalbytes = 0;
-			else
-				totals->totalbytes = DatumGetInt64(datum_totalbytes);
+			totals->totalbytes = DatumGetInt64(datum_totalbytes);
 
 			Datum		datum_totaltuples =
 				SPI_getbinval(tuple, tupdesc, 3, &isnull);
-			if (isnull)
-				totals->totaltuples = 0;
-			else
-				totals->totaltuples = DatumGetInt64(datum_totaltuples);
+			totals->totaltuples = DatumGetInt64(datum_totaltuples);
 
 			Datum		datum_totalvarblocks =
 				SPI_getbinval(tuple, tupdesc, 4, &isnull);
-			if (isnull)
-				totals->totalvarblocks = 0;
-			else
-				totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
+			totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
 
 			Datum		datum_totalbytesuncompressed =
 				SPI_getbinval(tuple, tupdesc, 5, &isnull);
-			if (isnull)
-				totals->totalbytesuncompressed = 0;
-			else
-				totals->totalbytesuncompressed =
-					DatumGetInt64(datum_totalbytesuncompressed);
+			totals->totalbytesuncompressed =
+				DatumGetInt64(datum_totalbytesuncompressed);
 		}
 
 		connected = false;

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1045,24 +1045,32 @@ GetSegFilesTotalsCluster(Relation parentrel, FileSegTotals * totals)
 
 			Datum		datum_totalbytes =
 				SPI_getbinval(tuple, tupdesc, 2, &isnull);
-			Assert(!isnull);
-			totals->totalbytes = DatumGetInt64(datum_totalbytes);
+			if (isnull)
+				totals->totalbytes = 0;
+			else
+				totals->totalbytes = DatumGetInt64(datum_totalbytes);
 
 			Datum		datum_totaltuples =
 				SPI_getbinval(tuple, tupdesc, 3, &isnull);
-			Assert(!isnull);
-			totals->totaltuples = DatumGetInt64(datum_totaltuples);
+			if (isnull)
+				totals->totaltuples = 0;
+			else
+				totals->totaltuples = DatumGetInt64(datum_totaltuples);
 
 			Datum		datum_totalvarblocks =
 				SPI_getbinval(tuple, tupdesc, 4, &isnull);
-			Assert(!isnull);
-			totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
+			if (isnull)
+				totals->totalvarblocks = 0;
+			else
+				totals->totalvarblocks = DatumGetInt64(datum_totalvarblocks);
 
 			Datum		datum_totalbytesuncompressed =
 				SPI_getbinval(tuple, tupdesc, 5, &isnull);
-			Assert(!isnull);
-			totals->totalbytesuncompressed =
-				DatumGetInt64(datum_totalbytesuncompressed);
+			if (isnull)
+				totals->totalbytesuncompressed = 0;
+			else
+				totals->totalbytesuncompressed =
+					DatumGetInt64(datum_totalbytesuncompressed);
 		}
 
 		connected = false;

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -4687,8 +4687,88 @@ explain select count(1) from test_table;
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
 reset gp_enable_relsize_collection;
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=0)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table test_table;
 reset gp_autostats_mode;
 -- start_ignore
 drop schema qp_misc_jiras cascade;

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4687,8 +4687,88 @@ explain select count(1) from test_table;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
 reset gp_enable_relsize_collection;
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
+-- explain_processing_off
+explain select * from test_table;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..430.00 rows=1 width=1)
+   ->  Seq Scan on test_table  (cost=0.00..430.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+drop table test_table;
 reset gp_autostats_mode;
 -- start_ignore
 drop schema qp_misc_jiras cascade;

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -2691,8 +2691,41 @@ distributed by (col_1);
 -- explain_processing_off
 explain select count(1) from test_table;
 
+-- Check 0 column tables
 drop table test_table;
+create table test_table();
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+-- explain_processing_off
+explain select * from test_table;
+
 reset gp_enable_relsize_collection;
+
+-- Check 0 column tables with default gp_enable_relsize_collection
+drop table test_table;
+create table test_table();
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=row);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
+create table test_table() with (APPENDONLY=true, ORIENTATION=column);
+-- explain_processing_off
+explain select * from test_table;
+
+drop table test_table;
 reset gp_autostats_mode;
 
 -- start_ignore


### PR DESCRIPTION
Fix errors on planning queries with zero column AO tables

Problem description:
1. Planning a query with an AO column-oriented table with 0 columns caused an
error "floating-point exception", if Postgres planner was used.
2. Planning a query with an AO row-oriented table with 0 columns with GUC
'gp_enable_relsize_collection' enabled caused a failed assertion in function
'GetSegFilesTotalsCluster()'.

Both issues are a side effect of the commit
1f4d9b473693d91c4219a239456aa60ead0f5f7c.

Root cause:
1. The "floating-point exception" was caused by a division by zero when
calculating row count, because data width is zero when there are no columns in
a relation. The issue didn't occur for heap or row-oriented tables because data
width for them is adjusted by additional header sizes.
2. The assertions in 'GetSegFilesTotalsCluster()' were wrong, as actually the
SPI result of the query, used in the function, can return NULL values if there 
are no columns in a relation.

Fix:
1. Do the calculation for the tuple count only if the data width is not 0;
otherwise just set the tuple count to 1.
2. Remove assertions in 'GetSegFilesTotalsCluster()' where actually NULLs can
be returned.


------
Note: better to review the delta with "hide whitespaces" setting.