### PR TITLE
Process XLOG_PENDING_DELETE record on mirror

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10788,8 +10788,7 @@ xlog_redo(XLogRecPtr beginLoc __attribute__((unused)), XLogRecPtr lsn __attribut
 	}
 	else if (info == XLOG_PENDING_DELETE)
 	{
-		if (IsCrashRecoveryOnly())
-			PdlRedoXLogRecord(record);
+		PdlRedoXLogRecord(record);
 	}
 }
 


### PR DESCRIPTION
Process XLOG_PENDING_DELETE record on mirror

Problem description:
After following scenario:
1. primary segment started a transaction;
2. primary segment created a relation;
3. primary segment did a checkpoint;
4. mirror created a restartpoint by timeout;
5. both primary and mirror crashed and, then, recovered;

primary has removed the orphaned file, but mirror didn't.

Root cause:
On step 5, mirror started replaying WAL from the restartpoint, so it didn't meet
the XLOG_SMGR_CREATE_PDL record (which was at the moment of table creation,
before the restartpoint). The information about the table's relfilenode is also
stored in the XLOG_PENDING_DELETE WAL record. But the mirror skipped the
processing of the XLOG_PENDING_DELETE record.

Fix:
Enable processing of the XLOG_PENDING_DELETE record by the mirror. This record
is created on each checkpoint, so if the mirror starts from a restartpoint, it
will be one of the first records to replay. Mirror will obtain the relfilenode
information from this record and will remove the orphaned file. 