### PR TITLE
ADBDEV-7513: Fix memory leak from short lived accounts in Global Deadlock Detector

### DIFF
--- a/src/backend/utils/gdd/gddbackend.c
+++ b/src/backend/utils/gdd/gddbackend.c
@@ -173,6 +173,8 @@ GlobalDeadLockDetectorLoop(void)
 		/* emergency bailout if postmaster has died */
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
+
+		MemoryAccounting_Reset();
 	}
 
 	return;


### PR DESCRIPTION
Fix memory leak from short lived accounts in Global Deadlock Detector.

When using a custom planner hook, f.e. with ADCC alongside the 
Global Deadlock Detector, START_MEMORY_ACCOUNT() in the planner() function 
creates short-lived account that are never cleaned up.
These accumulate in shortLivingMemoryAccountArray, causing memory bloat.

This PR ensures that memory is properly released by explicitly cleaning the
array to prevent unbounded growth.
