### PR TITLE
Fix conflicts in configure, configure.in and src/include/pg_config.h.in

### DIFF
--- a/configure
+++ b/configure
@@ -17427,11 +17427,7 @@ fi
 LIBS_including_readline="$LIBS"
 LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
 
-<<<<<<< HEAD
-for ac_func in backtrace_symbols cbrt clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit mbstowcs_l memmove poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink setproctitle setproctitle_fast setsid shm_open strchrnul strsignal symlink sync_file_range uselocale utime utimes wcstombs_l
-=======
-for ac_func in cbrt clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit mbstowcs_l memset_s memmove poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink setproctitle setproctitle_fast setsid shm_open strchrnul strsignal symlink sync_file_range uselocale utime utimes wcstombs_l
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+for ac_func in backtrace_symbols cbrt clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit mbstowcs_l memset_s memmove poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink setproctitle setproctitle_fast setsid shm_open strchrnul strsignal symlink sync_file_range uselocale utime utimes wcstombs_l
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -21187,99 +21183,6 @@ $as_echo_n "checking for XMLLINT... " >&6; }
 $as_echo "$XMLLINT" >&6; }
 fi
 
-<<<<<<< HEAD
-=======
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DocBook XML V4.5" >&5
-$as_echo_n "checking for DocBook XML V4.5... " >&6; }
-if ${pgac_cv_check_docbook+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat >conftest.xml <<EOF
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<book>
- <title>test</title>
- <chapter>
-  <title>random</title>
-   <sect1>
-    <title>testsect</title>
-    <para>text</para>
-  </sect1>
- </chapter>
-</book>
-EOF
-
-pgac_cv_check_docbook=no
-
-if test -n "$XMLLINT"; then
-  $XMLLINT --noout --valid conftest.xml 1>&5 2>&1
-  if test $? -eq 0; then
-    pgac_cv_check_docbook=yes
-  fi
-fi
-rm -f conftest.xml
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_check_docbook" >&5
-$as_echo "$pgac_cv_check_docbook" >&6; }
-
-have_docbook=$pgac_cv_check_docbook
-
-
-if test -z "$DBTOEPUB"; then
-  for ac_prog in dbtoepub
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_DBTOEPUB+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $DBTOEPUB in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_DBTOEPUB="$DBTOEPUB" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_DBTOEPUB="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-DBTOEPUB=$ac_cv_path_DBTOEPUB
-if test -n "$DBTOEPUB"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DBTOEPUB" >&5
-$as_echo "$DBTOEPUB" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$DBTOEPUB" && break
-done
-
-else
-  # Report the value of DBTOEPUB in configure's output in all cases.
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for DBTOEPUB" >&5
-$as_echo_n "checking for DBTOEPUB... " >&6; }
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DBTOEPUB" >&5
-$as_echo "$DBTOEPUB" >&6; }
-fi
-
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 if test -z "$XSLTPROC"; then
   for ac_prog in xsltproc
 do

--- a/configure.in
+++ b/configure.in
@@ -2634,13 +2634,7 @@ fi
 #
 # Check for documentation-building tools
 #
-<<<<<<< HEAD
 PGAC_PATH_PROGS(XMLLINT, xmllint)
-=======
-PGAC_PATH_XMLLINT
-PGAC_CHECK_DOCBOOK(4.5)
-PGAC_PATH_PROGS(DBTOEPUB, dbtoepub)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 PGAC_PATH_PROGS(XSLTPROC, xsltproc)
 PGAC_PATH_PROGS(FOP, fop)
 PGAC_PATH_PROGS(DBTOEPUB, dbtoepub)

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -151,15 +151,9 @@
 /* Define to 1 if you have the `CRYPTO_lock' function. */
 #undef HAVE_CRYPTO_LOCK
 
-<<<<<<< HEAD
-/* Define to 1 if you have the <crypt.h> header file. */
-#undef HAVE_CRYPT_H
-
 /* define if the compiler supports basic C++14 syntax */
 #undef HAVE_CXX14
 
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 /* Define to 1 if you have the declaration of `fdatasync', and to 0 if you
    don't. */
 #undef HAVE_DECL_FDATASYNC
@@ -229,16 +223,14 @@
 /* Define to 1 if you have the <editline/readline.h> header file. */
 #undef HAVE_EDITLINE_READLINE_H
 
-<<<<<<< HEAD
 /* Define to 1 if you have the <event.h> header file. */
 #undef HAVE_EVENT_H
 
 /* Define to 1 if you have the <execinfo.h> header file. */
 #undef HAVE_EXECINFO_H
-=======
+
 /* Define to 1 if you have the `explicit_bzero' function. */
 #undef HAVE_EXPLICIT_BZERO
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 /* Define to 1 if you have the `fdatasync' function. */
 #undef HAVE_FDATASYNC


### PR DESCRIPTION
Fix conflicts in configure, configure.in and src/include/pg_config.h.in

1) Commit 74a308c added memset_s to the list, while earlier commit 19cd1cf had
already added backtrace_symbols to the same list.

2) Commit 416c75c updated the DocBook version, while earlier commit 424050a had
removed DocBook from the config altogether.

3) Commit 74a308c added HAVE_EXPLICIT_BZERO, while earlier commits d2d1982 and
0527e4a had already added HAVE_EVENT_H and HAVE_EXECINFO_H to the same place.

4) Commit c45643d removed HAVE_CRYPT and HAVE_CRYPT_H, while earlier commit
b371e59 added HAVE_CXX14 in the same place.