### PR TITLE
Fix conflicts in hash.h and walsender.h

### DIFF
--- a/src/include/access/hash.h
+++ b/src/include/access/hash.h
@@ -20,11 +20,7 @@
 #include "access/amapi.h"
 #include "access/itup.h"
 #include "access/sdir.h"
-<<<<<<< HEAD
 #include "common/hashfn.h"
-#include "fmgr.h"
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 #include "lib/stringinfo.h"
 #include "storage/bufmgr.h"
 #include "storage/lockdefs.h"

--- a/src/include/replication/walsender.h
+++ b/src/include/replication/walsender.h
@@ -14,12 +14,8 @@
 
 #include <signal.h>
 
-<<<<<<< HEAD
-#include "fmgr.h"
 #include "access/xlogdefs.h"
 
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 /*
  * What to do with a snapshot in create replication slot command.
  */


### PR DESCRIPTION
Fix conflicts in hash.h and walsender.h

1) Commit fb3b098 removed the fmgr.h include from src/include/access/hash.h,
while earlier commit 5d3dc2e added the common/hashfn.h include before that
place.

2) Commit fb3b098 removed the fmgr.h include from
src/include/replication/walsender.h, while earlier commit 6b0e52b added the
access/xlogdefs.h include after that place.