### PR TITLE
Fix conflicts in src/include/access/xlogreader.h

### DIFF
--- a/src/include/access/xlogreader.h
+++ b/src/include/access/xlogreader.h
@@ -225,20 +225,13 @@ extern struct XLogRecord *XLogReadRecord(XLogReaderState *state,
 extern bool XLogReaderValidatePageHeader(XLogReaderState *state,
 										 XLogRecPtr recptr, char *phdr);
 
-<<<<<<< HEAD
 /* Validate a page */
 extern bool XLogReaderValidatePageHeader(XLogReaderState *state,
 					XLogRecPtr recptr, char *phdr);
 
-/* Invalidate read state */
-extern void XLogReaderInvalReadState(XLogReaderState *state);
-
 /* In GPDB, this is needed in the backend, too, for WAL replication tests. */
 /* #ifdef FRONTEND */
 #if 1
-=======
-#ifdef FRONTEND
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 extern XLogRecPtr XLogFindNextRecord(XLogReaderState *state, XLogRecPtr RecPtr);
 #endif							/* FRONTEND */
 /* Functions for decoding an XLogRecord */


### PR DESCRIPTION
Fix conflicts in src/include/access/xlogreader.h

Commit 25dcc9d removed the declaration of the XLogReaderInvalReadState
function, while an earlier commit by db8d375 changed ifdef FRONTEND to if 1
near that location.