### PR TITLE
Fix conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302504211
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201909071
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+#define CATALOG_VERSION_NO	302505161
 
 #endif


### PR DESCRIPTION
Fix conflicts in src/include/catalog/catversion.h

Commit ca70bda updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.