### PR TITLE
Fix conflicts in src/include/common/hashfn.h and src/common/hashfn.c

### DIFF
--- a/src/common/hashfn.c
+++ b/src/common/hashfn.c
@@ -158,13 +158,8 @@
  * by using the final values of both b and c.  b is perhaps a little less
  * well mixed than c, however.
  */
-<<<<<<< HEAD:src/common/hashfn.c
 uint32
 hash_bytes(const unsigned char *k, int keylen)
-=======
-Datum
-hash_any(const unsigned char *k, int keylen)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8:src/backend/utils/hash/hashfn.c
 {
 	uint32		a,
 				b,
@@ -389,14 +384,8 @@ hash_any(const unsigned char *k, int keylen)
  *
  * Returns a uint64 value.  Otherwise similar to hash_bytes.
  */
-<<<<<<< HEAD:src/common/hashfn.c
 uint64
 hash_bytes_extended(const unsigned char *k, int keylen, uint64 seed)
-=======
-Datum
-hash_any_extended(const unsigned char *k, int keylen,
-				  uint64 seed)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8:src/backend/utils/hash/hashfn.c
 {
 	uint32		a,
 				b,

--- a/src/include/common/hashfn.h
+++ b/src/include/common/hashfn.h
@@ -20,7 +20,6 @@
 	(((v) >> 31) & UINT64CONST(0x100000001)))
 
 
-<<<<<<< HEAD:src/include/common/hashfn.h
 extern uint32 hash_bytes(const unsigned char *k, int keylen);
 extern uint64 hash_bytes_extended(const unsigned char *k,
 								  int keylen, uint64 seed);
@@ -59,13 +58,6 @@ extern uint32 uint32_hash(const void *key, Size keysize);
 extern uint32 int32_hash(const void *key, Size keysize);
 
 #define oid_hash uint32_hash	/* Remove me eventually */
-=======
-extern Datum hash_any(const unsigned char *k, int keylen);
-extern Datum hash_any_extended(const unsigned char *k,
-							   int keylen, uint64 seed);
-extern Datum hash_uint32(uint32 k);
-extern Datum hash_uint32_extended(uint32 k, uint64 seed);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8:src/include/utils/hashutils.h
 
 /*
  * Combine two 32-bit hash values, resulting in another hash value, with


### PR DESCRIPTION
Fix conflicts in src/include/common/hashfn.h and src/common/hashfn.c

Commit 232720b removed the register qualifier, while earlier commit 9b6de72 had
already refactored the declarations into inline functions.