### PR TITLE
Fix conflicts in src/include/executor/nodeAgg.h

### DIFF
--- a/src/include/executor/nodeAgg.h
+++ b/src/include/executor/nodeAgg.h
@@ -323,12 +323,7 @@ extern void hash_agg_set_limits(AggState *aggstate, double hashentrysize, uint64
 								int used_bits, Size *mem_limit,
 								uint64 *ngroups_limit, int *num_partitions);
 
-<<<<<<< HEAD
-extern Datum aggregate_dummy(PG_FUNCTION_ARGS);
-
 extern void ExecSquelchAgg(AggState *aggstate);
 extern bool ReuseHashTable(AggState *node);
 
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 #endif							/* NODEAGG_H */


### PR DESCRIPTION
Fix conflicts in src/include/executor/nodeAgg.h

Commit 0ae2dc4 removed the declaration of the aggregate_dummy function, while
earlier commit a759b72 had already added a declaration of the ReuseHashTable
function near this location.