### PR TITLE
Fix conflicts in execnodes.h, plannodes.h, copyfuncs.c, outfuncs.c, readfuncs.c, createplan.c and setrefs.c

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1158,8 +1158,10 @@ _copyHashJoin(const HashJoin *from)
 	 * copy remainder of node
 	 */
 	COPY_NODE_FIELD(hashclauses);
-<<<<<<< HEAD
 	COPY_NODE_FIELD(hashqualclauses);
+	COPY_NODE_FIELD(hashoperators);
+	COPY_NODE_FIELD(hashcollations);
+	COPY_NODE_FIELD(hashkeys);
 
 	return newnode;
 }
@@ -1179,11 +1181,6 @@ _copyShareInputScan(const ShareInputScan *from)
 	COPY_SCALAR_FIELD(producer_slice_id);
 	COPY_SCALAR_FIELD(this_slice_id);
 	COPY_SCALAR_FIELD(nconsumers);
-=======
-	COPY_NODE_FIELD(hashoperators);
-	COPY_NODE_FIELD(hashcollations);
-	COPY_NODE_FIELD(hashkeys);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1023,13 +1023,10 @@ _outHashJoin(StringInfo str, const HashJoin *node)
 	_outJoinPlanInfo(str, (const Join *) node);
 
 	WRITE_NODE_FIELD(hashclauses);
-<<<<<<< HEAD
 	WRITE_NODE_FIELD(hashqualclauses);
-=======
 	WRITE_NODE_FIELD(hashoperators);
 	WRITE_NODE_FIELD(hashcollations);
 	WRITE_NODE_FIELD(hashkeys);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 }
 
 static void
@@ -1173,12 +1170,9 @@ _outHash(StringInfo str, const Hash *node)
 	WRITE_NODE_TYPE("HASH");
 
 	_outPlanInfo(str, (const Plan *) node);
-<<<<<<< HEAD
-	WRITE_BOOL_FIELD(rescannable);          /*CDB*/
-=======
 
+	WRITE_BOOL_FIELD(rescannable);          /*CDB*/
 	WRITE_NODE_FIELD(hashkeys);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	WRITE_OID_FIELD(skewTable);
 	WRITE_INT_FIELD(skewColumn);
 	WRITE_BOOL_FIELD(skewInherit);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3161,13 +3161,10 @@ _readHashJoin(void)
 	ReadCommonJoin(&local_node->join);
 
 	READ_NODE_FIELD(hashclauses);
-<<<<<<< HEAD
 	READ_NODE_FIELD(hashqualclauses);
-=======
 	READ_NODE_FIELD(hashoperators);
 	READ_NODE_FIELD(hashcollations);
 	READ_NODE_FIELD(hashkeys);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	READ_DONE();
 }
@@ -3363,11 +3360,8 @@ _readHash(void)
 
 	ReadCommonPlan(&local_node->plan);
 
-<<<<<<< HEAD
     READ_BOOL_FIELD(rescannable);           /*CDB*/
-=======
 	READ_NODE_FIELD(hashkeys);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	READ_OID_FIELD(skewTable);
 	READ_INT_FIELD(skewColumn);
 	READ_BOOL_FIELD(skewInherit);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -256,17 +256,11 @@ static NestLoop *make_nestloop(List *tlist,
 							   JoinType jointype, bool inner_unique);
 static HashJoin *make_hashjoin(List *tlist,
 							   List *joinclauses, List *otherclauses,
-<<<<<<< HEAD
-							   List *hashclauses, Plan *lefttree,
-							   Plan *righttree, JoinType jointype,
-							   bool inner_unique);
-=======
 							   List *hashclauses,
 							   List *hashoperators, List *hashcollations,
 							   List *hashkeys,
 							   Plan *lefttree, Plan *righttree,
 							   JoinType jointype, bool inner_unique);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 static Hash *make_hash(Plan *lefttree,
 					   List *hashkeys,
 					   Oid skewTable,
@@ -5412,13 +5406,10 @@ create_hashjoin_plan(PlannerInfo *root,
 	Oid			skewTable = InvalidOid;
 	AttrNumber	skewColumn = InvalidAttrNumber;
 	bool		skewInherit = false;
-<<<<<<< HEAD
+	ListCell   *lc;
 	bool		partition_selectors_created;
 
 	push_partition_selector_candidate_for_join(root, &best_path->jpath);
-=======
-	ListCell   *lc;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	/*
 	 * HashJoin can project, so we don't have to demand exact tlists from the
@@ -6705,13 +6696,10 @@ make_hashjoin(List *tlist,
 	plan->lefttree = lefttree;
 	plan->righttree = righttree;
 	node->hashclauses = hashclauses;
-<<<<<<< HEAD
 	node->hashqualclauses = NIL;
-=======
 	node->hashoperators = hashoperators;
 	node->hashcollations = hashcollations;
 	node->hashkeys = hashkeys;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	node->join.jointype = jointype;
 	node->join.inner_unique = inner_unique;
 	node->join.joinqual = joinclauses;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -2126,14 +2126,12 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 										(Index) 0,
 										rtoffset);
 
-<<<<<<< HEAD
 		hj->hashqualclauses = fix_join_expr(root,
 											hj->hashqualclauses,
 											outer_itlist,
 											inner_itlist,
 											(Index) 0,
 											rtoffset);
-=======
 		/*
 		 * HashJoin's hashkeys are used to look for matching tuples from its
 		 * outer plan (not the Hash node!) in the hashtable.
@@ -2143,7 +2141,6 @@ set_join_references(PlannerInfo *root, Join *join, int rtoffset)
 											   outer_itlist,
 											   OUTER_VAR,
 											   rtoffset);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	}
 
 	/*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2736,13 +2736,9 @@ typedef struct HashState
 	PlanState	ps;				/* its first field is NodeTag */
 	HashJoinTable hashtable;	/* hash table for the hashjoin */
 	List	   *hashkeys;		/* list of ExprState nodes */
-<<<<<<< HEAD
 	bool		hs_keepnull;	/* Keep nulls */
 	bool		hs_quit_if_hashkeys_null;	/* quit building hash table if hashkeys are all null */
 	bool		hs_hashkeys_null;	/* found an instance wherein hashkeys are all null */
-	/* hashkeys is same as parent's hj_InnerHashKeys */
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	SharedHashInfo *shared_info;	/* one entry per worker */
 	HashInstrumentation *hinstrument;	/* this worker's entry */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1090,9 +1090,7 @@ typedef struct HashJoin
 {
 	Join		join;
 	List	   *hashclauses;
-<<<<<<< HEAD
 	List	   *hashqualclauses;
-=======
 	List	   *hashoperators;
 	List	   *hashcollations;
 
@@ -1101,7 +1099,6 @@ typedef struct HashJoin
 	 * perform lookups in the hashtable over the inner plan.
 	 */
 	List	   *hashkeys;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 } HashJoin;
 
 #define SHARE_ID_NOT_SHARED (-1)
@@ -1353,16 +1350,13 @@ typedef struct GatherMerge
 typedef struct Hash
 {
 	Plan		plan;
-<<<<<<< HEAD
 	bool		rescannable;            /* CDB: true => save rows for rescan */
-=======
 
 	/*
 	 * List of expressions to be hashed for tuples from Hash's outer plan,
 	 * needed to put them into the hashtable.
 	 */
 	List	   *hashkeys;		/* hash keys for the hashjoin condition */
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	Oid			skewTable;		/* outer join key's table OID, or InvalidOid */
 	AttrNumber	skewColumn;		/* outer join key's column #, or zero */
 	bool		skewInherit;	/* is outer join rel an inheritance tree? */


### PR DESCRIPTION
Fix conflicts in execnodes.h, plannodes.h, copyfuncs.c, outfuncs.c, readfuncs.c, createplan.c and setrefs.c

1) Commit 2abd7ae removed a comment in the HashState structure, while earlier
commit 6b0e52b had already added several fields before this comment.

2) Commit 2abd7ae added several new fields to the HashJoin structure, while
earlier commit 6b0e52b had already added a new field hashqualclauses in the
same place.

3) Commit 2abd7ae added a new field hashkeys to the Hash structure, while
earlier commit 6b0e52b had already added a field rescannable before this place.

4) Commit 2abd7ae added copying of hashoperators, hashcollations and hashkeys
to the _copyHashJoin function, while earlier commit 6b0e52b added a new
_copyShareInputScan function near there.

5) Commit 2abd7ae added a hashoperators, hashcollations, and hashkeys entry to
_outHashJoin and _readHashJoin, with an earlier commit 6b0e52b adding a
hashqualclauses entry near that location.

6) Commit 2abd7ae added a hashkeys entry to _outHash and _readHash, with an
earlier commit 6b0e52b adding a rescannable entry near that location.

7) Commit 2abd7ae added new arguments hashoperators, hashcollations, and
hashkeys to make_hashjoin, while earlier commit 6d02e98 removed the
hashqualclauses argument.

8) Commit 2abd7ae added a new local variable lc to create_hashjoin_plan, while
earlier commit 19cd1cf added a new local variable partition_selectors_created
and a call to push_partition_selector_candidate_for_join in the same place.

9) Commit 2abd7ae added hashkeys setting to set_join_references function, while
earlier commit 6b0e52b added hashqualclauses setting to the same place.