### PR TITLE
Fix conflicts in src/include/storage/proc.h

### DIFF
--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -397,14 +397,10 @@ extern PGPROC *AuxiliaryPidGetProc(int pid);
 extern void BecomeLockGroupLeader(void);
 extern bool BecomeLockGroupMember(PGPROC *leader, int pid);
 
-<<<<<<< HEAD
 extern int ResProcSleep(LOCKMODE lockmode, LOCALLOCK *locallock, void *incrementSet);
 
 extern void ResLockWaitCancel(void);
 extern bool ProcCanSetMppSessionId(void);
 extern void ProcNewMppSessionId(int *newSessionId);
 
-#endif							/* PROC_H */
-=======
 #endif							/* _PROC_H_ */
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8


### PR DESCRIPTION
Fix conflicts in src/include/storage/proc.h

Commit 8548ddc renamed PROC_H to _PROC_H_ at the end of the file, while earlier
commit 6b0e52b had already added several function declarations before that
point.