### PR TITLE
ADBDEV-7460: Prevent use after free in flatten_join_alias_var_optimizer function

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5701,35 +5701,40 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NIL != targetList)
 	{
 		queryNew->targetList = (List *) flatten_join_alias_vars(queryNew, (Node *) targetList);
-		list_free(targetList);
+		if (targetList != queryNew->targetList)
+			list_free(targetList);
 	}
 
 	List * returningList = queryNew->returningList;
 	if (NIL != returningList)
 	{
 		queryNew->returningList = (List *) flatten_join_alias_vars(queryNew, (Node *) returningList);
-		list_free(returningList);
+		if (returningList != queryNew->returningList)
+			list_free(returningList);
 	}
 
 	Node *havingQual = queryNew->havingQual;
 	if (NULL != havingQual)
 	{
 		queryNew->havingQual = flatten_join_alias_vars(queryNew, havingQual);
-		pfree(havingQual);
+		if (havingQual != queryNew->havingQual)
+			pfree(havingQual);
 	}
 
 	List *scatterClause = queryNew->scatterClause;
 	if (NIL != scatterClause)
 	{
 		queryNew->scatterClause = (List *) flatten_join_alias_vars(queryNew, (Node *) scatterClause);
-		list_free(scatterClause);
+		if (scatterClause != queryNew->scatterClause)
+			list_free(scatterClause);
 	}
 
 	Node *limitOffset = queryNew->limitOffset;
 	if (NULL != limitOffset)
 	{
 		queryNew->limitOffset = flatten_join_alias_vars(queryNew, limitOffset);
-		pfree(limitOffset);
+		if (limitOffset != queryNew->limitOffset)
+			pfree(limitOffset);
 	}
 
 	List *windowClause = queryNew->windowClause;
@@ -5756,7 +5761,8 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NULL != limitCount)
 	{
 		queryNew->limitCount = flatten_join_alias_vars(queryNew, limitCount);
-		pfree(limitCount);
+		if (limitCount != queryNew->limitCount)
+			pfree(limitCount);
 	}
 
     return queryNew;

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -1002,8 +1002,6 @@ explain (costs off)
 
 select v.c, (select count(*) from gstest2 group by () having v.c)
   from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
  c | count 
 ---+-------
  f |      
@@ -1013,24 +1011,21 @@ DETAIL:  Falling back to Postgres-based planner because GPORCA does not support 
 explain (costs off)
   select v.c, (select count(*) from gstest2 group by () having v.c)
     from (values (false),(true)) v(c) order by v.c;
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Sort
-   Sort Key: "*VALUES*".column1
-   ->  Values Scan on "*VALUES*"
-         SubPlan 1
-           ->  Aggregate
-                 Group Key: ()
-                 Filter: "*VALUES*".column1
-                 ->  Result
-                       One-Time Filter: "*VALUES*".column1
-                       ->  Materialize
-                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                   ->  Seq Scan on gstest2
- Optimizer: Postgres query optimizer
-(13 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Result
+   ->  Sort
+         Sort Key: "Values".column1
+         ->  Nested Loop Left Join
+               Join Filter: "Values".column1
+               ->  Values Scan on "Values"
+               ->  Materialize
+                     ->  Finalize Aggregate
+                           ->  Gather Motion 3:1  (slice1; segments: 3)
+                                 ->  Partial Aggregate
+                                       ->  Seq Scan on gstest2
+ Optimizer: GPORCA
+(12 rows)
 
 -- HAVING with GROUPING queries
 select ten, grouping(ten) from onek

--- a/src/test/regress/expected/orca_groupingsets_fallbacks.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks.out
@@ -78,14 +78,6 @@ select d from gstest2 group by grouping sets ((a,b), (a));
  1
 (4 rows)
 
--- Orca falls back due to HAVING clause with outer references
-select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
- c | count 
----+-------
- f |      
- t |     4
-(2 rows)
-
 -- Orca falls back due to grouping function with multiple arguments
 select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
  a | b  | grouping | sum  | count | max 

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -84,16 +84,6 @@ select d from gstest2 group by grouping sets ((a,b), (a));
  1
 (4 rows)
 
--- Orca falls back due to HAVING clause with outer references
-select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
-INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
-DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: {TARGETENTRY :expr {VAR :varno 1 :varattno 2 :vartype 20 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 2 :location -1} :resno 1 :resname count :ressortgroupref 0 :resorigtbl 0 :resorigcol 0 :resjunk false}
- c | count 
----+-------
- f |      
- t |     4
-(2 rows)
-
 -- Orca falls back due to grouping function with multiple arguments
 select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner

--- a/src/test/regress/sql/orca_groupingsets_fallbacks.sql
+++ b/src/test/regress/sql/orca_groupingsets_fallbacks.sql
@@ -34,9 +34,6 @@ insert into gstest2 values (1, 1, 1, 1, 1);
 insert into gstest2 values (2, 2, 2, 2, 1);
 select d from gstest2 group by grouping sets ((a,b), (a));
 
--- Orca falls back due to HAVING clause with outer references
-select v.c, (select count(*) from gstest1 group by () having v.c) from (values (false),(true)) v(c);
-
 -- Orca falls back due to grouping function with multiple arguments
 select a, b, grouping(a,b), sum(v), count(*), max(v) from gstest1 group by rollup (a,b);
 -- Orca falls back due to grouping function with outer references


### PR DESCRIPTION
This patch prevents several use after free bugs present in
flatten_join_alias_var_optimizer. Specifically, the function uses
flatten_join_alias_vars function multiple times, and assumes that the
original node can be freed immediately after. This is not always the case
since under some circumstances flatten_join_alias_vars does not modify its
input and simply passes it through without copying. This patch adds conditions
to check if the original node can safely be freed, preventing use after free.

This prevents ORCA falling back to Postgres planner in some cases, in
particular a query with HAVING previously tested in
orca_groupingsets_fallbacks. After this patch we can remove it since it no
longer falls back to Postgres.

Co-authored-by: Georgy Shelkovy \<g.shelkovy@arenadata.io\>

---

Note: groupingsets and orca_groupingsets_fallbacks tests are affected by this patch. The test outputs were changed to the state they should have after #1589 is merged, so they will be failing until it is.