### PR TITLE
Fix conflicts in src/backend/commands/vacuum.c

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -493,7 +493,6 @@ vacuum(List *relations, VacuumParams *params,
 					 */
 					CommandCounterIncrement();
 				}
-<<<<<<< HEAD
 
 #ifdef FAULT_INJECTOR
 				if (IsAutoVacuumWorkerProcess())
@@ -503,8 +502,6 @@ vacuum(List *relations, VacuumParams *params,
 						"", vrel->relation->relname);
 				}
 #endif
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 			}
 		}
 	}


### PR DESCRIPTION
Fix conflicts in src/backend/commands/vacuum.c

Commit cabe0f2 added a call to the CommandCounterIncrement function at the very
end of the try block in the vacuum function, while the earlier commit 259cb9e
added a fault injector to the same place.