### PR TITLE
Fix conflicts in src/backend/executor/execMain.c

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3818,13 +3818,8 @@ EvalPlanQualBegin(EPQState *epqstate)
 			 * by the subplan, just in case they got reset since
 			 * EvalPlanQualStart (see comments therein).
 			 */
-<<<<<<< HEAD
-			ExecSetParamPlanMulti(planstate->plan->extParam,
-								  GetPerTupleExprContext(parentestate), NULL);
-=======
 			ExecSetParamPlanMulti(rcplanstate->plan->extParam,
-								  GetPerTupleExprContext(parentestate));
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+								  GetPerTupleExprContext(parentestate), NULL);
 
 			i = list_length(parentestate->es_plannedstmt->paramExecTypes);
 


### PR DESCRIPTION
Fix conflicts in src/backend/executor/execMain.c

Commit 27cc7cd renamed the local variable planstate to rcplanstate in the
EvalPlanQualBegin function, which was used among other things when calling the
ExecSetParamPlanMulti function, while the earlier commit f2e0802 added the
ExecSetParamPlanMulti function with three arguments, rather than the two in
upstream.