### PR TITLE
Fix conflicts in src/backend/executor/execScan.c

### DIFF
--- a/src/backend/executor/execScan.c
+++ b/src/backend/executor/execScan.c
@@ -41,14 +41,10 @@ ExecScanFetch(ScanState *node,
 
 	CHECK_FOR_INTERRUPTS();
 
-<<<<<<< HEAD
 	if (QueryFinishPending)
 		return NULL;
 
-	if (estate->es_epqTupleSlot != NULL)
-=======
 	if (estate->es_epq_active != NULL)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	{
 		EPQState   *epqstate = estate->es_epq_active;
 


### PR DESCRIPTION
Fix conflicts in src/backend/executor/execScan.c

Commit 27cc7cd changed the es_epqTupleSlot field in the EState structure to
es_epq_active, while the earlier commit 19cd1cf added a QueryFinishPending
check to the beginning of the ExecScanFetch function.