### PR TITLE
Fix conflicts in src/backend/executor/nodeHash.c

### DIFF
--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -184,15 +184,10 @@ MultiExecPrivateHash(HashState *node)
 			break;
 
 		/* We have to compute the hash value */
-<<<<<<< HEAD
-		econtext->ecxt_innertuple = slot;
+		econtext->ecxt_outertuple = slot;
 		bool hashkeys_null = false;
 
 		if (ExecHashGetHashValue(node, hashtable, econtext, hashkeys,
-=======
-		econtext->ecxt_outertuple = slot;
-		if (ExecHashGetHashValue(hashtable, econtext, hashkeys,
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 								 false, hashtable->keepNulls,
 								 &hashvalue, &hashkeys_null))
 		{
@@ -322,13 +317,8 @@ MultiExecParallelHash(HashState *node)
 				slot = ExecProcNode(outerNode);
 				if (TupIsNull(slot))
 					break;
-<<<<<<< HEAD
-				econtext->ecxt_innertuple = slot;
-				if (ExecHashGetHashValue(node, hashtable, econtext, hashkeys,
-=======
 				econtext->ecxt_outertuple = slot;
-				if (ExecHashGetHashValue(hashtable, econtext, hashkeys,
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+				if (ExecHashGetHashValue(node, hashtable, econtext, hashkeys,
 										 false, hashtable->keepNulls,
 										 &hashvalue, &hashkeys_null))
 					ExecParallelHashTableInsert(hashtable, slot, hashvalue);


### PR DESCRIPTION
Fix conflicts in src/backend/executor/nodeHash.c

Commit 2abd7ae changed the ecxt_innertuple field to ecxt_outertuple in the
MultiExecPrivateHash and MultiExecParallelHash functions, while an earlier
commit 6b0e52b added hashState and hashkeys_null arguments to the
ExecHashGetHashValue function.