### PR TITLE
Fix conflicts in src/backend/executor/tstoreReceiver.c

### DIFF
--- a/src/backend/executor/tstoreReceiver.c
+++ b/src/backend/executor/tstoreReceiver.c
@@ -20,12 +20,8 @@
 
 #include "postgres.h"
 
-<<<<<<< HEAD
 #include "access/heapam.h"
-#include "access/tuptoaster.h"
-=======
 #include "access/detoast.h"
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 #include "executor/tstoreReceiver.h"
 
 


### PR DESCRIPTION
Fix conflicts in src/backend/executor/tstoreReceiver.c

Commit 8b94dab changed the include access/tuptoaster.h to access/detoast.h,
while earlier commit 6b0e52b added an include access/heapam.h before that.