### PR TITLE
Fix conflicts in src/backend/utils/adt/network.c

### DIFF
--- a/src/backend/utils/adt/network.c
+++ b/src/backend/utils/adt/network.c
@@ -26,11 +26,7 @@
 #include "nodes/supportnodes.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
-<<<<<<< HEAD
-=======
 #include "utils/guc.h"
-#include "utils/hashutils.h"
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 #include "utils/inet.h"
 #include "utils/lsyscache.h"
 #include "utils/sortsupport.h"


### PR DESCRIPTION
Fix conflicts in src/backend/utils/adt/network.c

Commit 71dcd74 added include utils/guc.h, while earlier commit af38498 added
include utils/hashutils.h in the same place, and commit 5d3dc2e replaced it
with include common/hashfn.h.