### PR TITLE
Fix conflicts in src/bin/pg_upgrade/pg_upgrade.h

### DIFF
--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -212,14 +212,9 @@ typedef struct
 	/* Can't use NAMEDATALEN; not guaranteed to be same on client */
 	char	   *nspname;		/* namespace name */
 	char	   *relname;		/* relation name */
-<<<<<<< HEAD
-	Oid			reloid;			/* relation oid */
-	char		relstorage;
-	Oid			relfilenode;	/* relation relfile node */
-=======
 	Oid			reloid;			/* relation OID */
+	char		relstorage;
 	Oid			relfilenode;	/* relation file node */
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	Oid			indtable;		/* if index, OID of its table, else 0 */
 	Oid			toastheap;		/* if toast table, OID of base table, else 0 */
 	char	   *tablespace;		/* tablespace path; "" for cluster default */


### PR DESCRIPTION
Fix conflicts in src/bin/pg_upgrade/pg_upgrade.h

Commit 66bde49 changed in the RelInfo structure, for the relfilenode field, in
the comment relfile to file, while the earlier commit 9806f2b added a new
relstorage field to this structure in the same place.