### PR TITLE
Fix conflicts in isolationtester.h, isolationtester.c and specparse.y

### DIFF
--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -379,17 +379,6 @@ run_testspec(TestSpec *testspec)
 		run_named_permutations(testspec);
 	else
 		run_all_permutations(testspec);
-
-	/*
-	 * Verify that all steps have been used, complaining about anything
-	 * defined but not used.
-	 */
-	for (i = 0; i < testspec->nallsteps; i++)
-	{
-		if (!testspec->allsteps[i]->used)
-			fprintf(stderr, "unused step name: %s\n",
-					testspec->allsteps[i]->name);
-	}
 }
 
 /*

--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -373,8 +373,6 @@ static int *piles;
 static void
 run_testspec(TestSpec *testspec)
 {
-	int			i;
-
 	if (testspec->permutations)
 		run_named_permutations(testspec);
 	else

--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -502,11 +502,7 @@ run_permutation(TestSpec *testspec, int nsteps, PermutationStep **steps)
 
 	printf("\nstarting permutation:");
 	for (i = 0; i < nsteps; i++)
-	{
-		/* Track the permutation as in-use */
-		steps[i]->used = true;
 		printf(" %s", steps[i]->name);
-	}
 	printf("\n");
 
 	/* Perform setup */

--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -44,7 +44,6 @@ typedef struct IsoConnInfo
 static IsoConnInfo *conns = NULL;
 static int	nconns = 0;
 
-<<<<<<< HEAD
 /* Flag indicating some new NOTICE has arrived */
 static bool any_new_notice = false;
 
@@ -53,8 +52,6 @@ static int64 max_step_wait = 300 * USECS_PER_SEC;
 
 
 static void check_testspec(TestSpec *testspec);
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 static void run_testspec(TestSpec *testspec);
 static void run_all_permutations(TestSpec *testspec);
 static void run_all_permutations_recurse(TestSpec *testspec, int nsteps,
@@ -144,40 +141,8 @@ main(int argc, char **argv)
 	spec_yyparse();
 	testspec = &parseresult;
 
-<<<<<<< HEAD
 	/* Perform post-parse checking, and fill in linking fields */
 	check_testspec(testspec);
-=======
-	/* Create a lookup table of all steps. */
-	nallsteps = 0;
-	for (i = 0; i < testspec->nsessions; i++)
-		nallsteps += testspec->sessions[i]->nsteps;
-
-	allsteps = pg_malloc(nallsteps * sizeof(Step *));
-
-	n = 0;
-	for (i = 0; i < testspec->nsessions; i++)
-	{
-		for (j = 0; j < testspec->sessions[i]->nsteps; j++)
-			allsteps[n++] = testspec->sessions[i]->steps[j];
-	}
-
-	qsort(allsteps, nallsteps, sizeof(Step *), &step_qsort_cmp);
-	testspec->nallsteps = nallsteps;
-	testspec->allsteps = allsteps;
-
-	/* Verify that all step names are unique */
-	for (i = 1; i < testspec->nallsteps; i++)
-	{
-		if (strcmp(testspec->allsteps[i - 1]->name,
-				   testspec->allsteps[i]->name) == 0)
-		{
-			fprintf(stderr, "duplicate step name: %s\n",
-					testspec->allsteps[i]->name);
-			exit(1);
-		}
-	}
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	printf("Parsed test spec with %d sessions\n", testspec->nsessions);
 
@@ -546,12 +511,7 @@ run_permutation(TestSpec *testspec, int nsteps, PermutationStep **steps)
 	int			nwaiting = 0;
 	PermutationStep **waiting;
 
-<<<<<<< HEAD
 	waiting = pg_malloc(sizeof(PermutationStep *) * testspec->nsessions);
-=======
-	waiting = pg_malloc(sizeof(Step *) * testspec->nsessions);
-	errorstep = pg_malloc(sizeof(Step *) * testspec->nsessions);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	printf("\nstarting permutation:");
 	for (i = 0; i < nsteps; i++)

--- a/src/test/isolation/isolationtester.h
+++ b/src/test/isolation/isolationtester.h
@@ -32,11 +32,6 @@ typedef struct
 
 struct Step
 {
-<<<<<<< HEAD
-=======
-	int			session;
-	bool		used;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	char	   *name;
 	char	   *sql;
 	/* These fields are filled by check_testspec(): */

--- a/src/test/isolation/specparse.y
+++ b/src/test/isolation/specparse.y
@@ -151,13 +151,8 @@ step:
 				$$ = pg_malloc(sizeof(Step));
 				$$->name = $2;
 				$$->sql = $3;
-<<<<<<< HEAD
 				$$->session = -1; /* until filled */
 				$$->used = false;
-=======
-				$$->used = false;
-				$$->errormsg = NULL;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 			}
 		;
 


### PR DESCRIPTION
Fix conflicts in isolationtester.h, isolationtester.c and specparse.y

1) Commit 989d23b added a new field used to the Step structure, while the
earlier commit bbdc17b had already moved this and the session field to the end
of the structure.

2) Commit 9903338 removed the global variable dry_run, while the earlier commit
5165315 added a new global variable max_step_wait before this place.

3) Commit bbdc17b moved some code from the main function to a new function
check_testspec, and also changed the memory allocation at the beginning of the
run_permutation function.

4) Commit 989d23b added initialization of the new used field, while the earlier
commit bbdc17b added initialization of the session field before that and
removed the initialization of the errormsg field.

5) Commit 989d23b added a loop to the run_testspec function, while an earlier
commit bbdc17b had already removed it.

6) Commit 989d23b added a used field setting to the run_permutation function,
while an earlier commit bbdc17b had already removed it.