### PR TITLE
Fix compilation of utils/hashutils.h include

### DIFF
--- a/src/backend/commands/async.c
+++ b/src/backend/commands/async.c
@@ -136,7 +136,6 @@
 #include "storage/sinval.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
-#include "utils/hashutils.h"
 #include "utils/memutils.h"
 #include "utils/ps_status.h"
 #include "utils/snapmgr.h"


### PR DESCRIPTION
Fix compilation of utils/hashutils.h include

Commit bb5ae8f added utils/hashutils.h include, while earlier commit 5d3dc2e
had already renamed utils/hashutils.h include to common/hashfn.h include.