### PR TITLE
Fix compilation of files depending on fmgr.h

### DIFF
--- a/src/include/access/aosegfiles.h
+++ b/src/include/access/aosegfiles.h
@@ -17,6 +17,7 @@
 #define AOSEGFILES_H
 
 #include "catalog/pg_appendonly.h"
+#include "fmgr.h"
 #include "utils/rel.h"
 #include "utils/snapshot.h"
 

--- a/src/include/access/formatter.h
+++ b/src/include/access/formatter.h
@@ -18,6 +18,7 @@
 
 #include "access/htup.h"
 #include "access/tupdesc.h"
+#include "fmgr.h"
 #include "lib/stringinfo.h"
 #include "mb/pg_wchar.h"
 #include "nodes/nodes.h"

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -20,6 +20,7 @@
 
 #include "catalog/genbki.h"
 #include "catalog/pg_attribute_encoding_d.h"
+#include "fmgr.h"
 #include "utils/rel.h"
 
 /* ----------------

--- a/src/include/cdb/cdbhash.h
+++ b/src/include/cdb/cdbhash.h
@@ -15,6 +15,7 @@
 #ifndef CDBHASH_H
 #define CDBHASH_H
 
+#include "fmgr.h"
 #include "utils/rel.h"
 
 /* GUC */


### PR DESCRIPTION
Fix compilation of files depending on fmgr.h

1) Commit fb3b098 removed the fmgr.h include from src/include/utils/rel.h,
while earlier commit 6b0e52b added declaration of get_funcs_for_compression to
catalog/pg_attribute_encoding.h, which depends on PGFunction type definition,
so we need to add this include.

2) Commit fb3b098 removed the fmgr.h include from src/include/utils/rel.h,
while earlier commit 857d4d4 added declarations of get_ao_distribution and
get_ao_compression_ratio to src/include/access/aosegfiles.h, which depend on
PG_FUNCTION_ARGS definition, so we need to add this include.

3) Commit fb3b098 removed the fmgr.h include from src/include/utils/rel.h,
while earlier commit 242783a added a new hashfuncs field to struct CdbHash in
src/include/cdb/cdbhash.h that depends on the FmgrInfo type definition, so we
need to add the specified include.

4) Commit fb3b098 removed the fmgr.h include from src/include/utils/rel.h,
while earlier commit 6b0e52b added the fmt_conversion_proc field of type
FmgrInfo to the FormatterData structure, so we need to add this include.