### PR TITLE
Fix compilation in src/backend/executor/nodeMotion.c

### DIFF
--- a/src/backend/executor/nodeMotion.c
+++ b/src/backend/executor/nodeMotion.c
@@ -675,7 +675,7 @@ ExecInitMotion(Motion *node, EState *estate, int eflags)
 	 * but there are no slice tables in the new EState and we can not AssignGangs
 	 * on the QE. In this case, we raise an error.
 	 */
-	if (estate->es_epqTupleSlot)
+	if (estate->es_epq_active)
 		ereport(ERROR,
 				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 				 errmsg("EvalPlanQual can not handle subPlan with Motion node")));


### PR DESCRIPTION
Fix compilation in src/backend/executor/nodeMotion.c

Commit 27cc7cd changed the es_epqTupleSlot field in the EState structure to
es_epq_active, we need to change it in the GPDB specific code of the
ExecInitMotion function.