### PR TITLE
Fix compilation in src/backend/nodes/outfast.c

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -39,6 +39,7 @@
 #include "utils/datum.h"
 #include "catalog/heap.h"
 #include "cdb/cdbgang.h"
+#include "utils/expandeddatum.h"
 #include "utils/workfile_mgr.h"
 #include "parser/parsetree.h"
 


### PR DESCRIPTION
Fix compilation in src/backend/nodes/outfast.c

Commit 6a04d34 removed include utils/array.h (which included
src/include/utils/expandeddatum.h) from src/include/utils/acl.h (which was
included in src/include/catalog/objectaddress.h, which was included in
src/include/catalog/heap.h, which was included in src/backend/nodes/outfast.c),
while earlier commit 8ae22d1 used functions DatumGetEOHP, EOH_get_flat_size,
EOH_flatten_into, which are declared in src/include/utils/expandeddatum.h, so
we need to add the necessary include.