### PR TITLE
Fix convert_tuples_by_name_map_if_req compilation

### DIFF
--- a/src/backend/executor/nodeDynamicBitmapHeapscan.c
+++ b/src/backend/executor/nodeDynamicBitmapHeapscan.c
@@ -158,7 +158,7 @@ initNextTableToScan(DynamicBitmapHeapScanState *node)
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
 	 */
-	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc, "unused msg");
+	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc);
 	table_close(lastScannedRel, AccessShareLock);
 
 	/* If attribute remapping is not necessary, then do not change the varattno */

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -334,7 +334,7 @@ IndexScan_GetColumnMapping(Oid oldOid, Oid newOid)
 	TupleDesc oldTupDesc = oldRel->rd_att;
 	TupleDesc newTupDesc = newRel->rd_att;
 
-	attMap = convert_tuples_by_name_map_if_req(oldTupDesc, newTupDesc, "unused msg");
+	attMap = convert_tuples_by_name_map_if_req(oldTupDesc, newTupDesc);
 
 	heap_close(oldRel, AccessShareLock);
 	heap_close(newRel, AccessShareLock);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -144,7 +144,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
 	 */
-	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc, "unused msg");
+	attMap = convert_tuples_by_name_map_if_req(partTupDesc, lastTupDesc);
 	table_close(lastScannedRel, AccessShareLock);
 
 	/* If attribute remapping is not necessary, then do not change the varattno */


### PR DESCRIPTION
Fix convert_tuples_by_name_map_if_req compilation

Commit fe66125 removed the msg argument from convert_tuples_by_name_map_if_req,
so we need to remove it when calling this function in GPDB specific code.