### PR TITLE
Fix compilation in src/include/commands/vacuum.h

### DIFF
--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -18,6 +18,7 @@
 #include "catalog/pg_class.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_type.h"
+#include "fmgr.h"
 #include "nodes/parsenodes.h"
 #include "storage/buf.h"
 #include "storage/lock.h"


### PR DESCRIPTION
Fix compilation in src/include/commands/vacuum.h

Commit 6a04d34 removed the include utils/array.h (which included
src/include/fmgr.h) from src/include/utils/acl.h (which was included in
src/include/catalog/objectaddress.h, which was included in
src/include/catalog/pg_type.h, which was included in
src/include/commands/vacuum.h), but an earlier commit by baa7653 added
gp_acquire_sample_rows to src/include/commands/vacuum.h, which requires
PG_FUNCTION_ARGS to be defined in src/include/fmgr.h, so we need to add the
necessary include.