### PR TITLE
Fix conflicts in contrib/pageinspect/Makefile and pageinspect--1.7--1…

### DIFF
--- a/contrib/pageinspect/Makefile
+++ b/contrib/pageinspect/Makefile
@@ -5,11 +5,7 @@ OBJS		= rawpage.o heapfuncs.o bmfuncs.o btreefuncs.o fsmfuncs.o \
 		  brinfuncs.o ginfuncs.o hashfuncs.o $(WIN32RES)
 
 EXTENSION = pageinspect
-<<<<<<< HEAD
 DATA = pageinspect--1.7--1.8.sql pageinspect--1.6--1.7.sql \
-=======
-DATA =  pageinspect--1.7--1.8.sql pageinspect--1.6--1.7.sql \
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 	pageinspect--1.5.sql pageinspect--1.5--1.6.sql \
 	pageinspect--1.4--1.5.sql pageinspect--1.3--1.4.sql \
 	pageinspect--1.2--1.3.sql pageinspect--1.1--1.2.sql \

--- a/contrib/pageinspect/pageinspect--1.7--1.8.sql
+++ b/contrib/pageinspect/pageinspect--1.7--1.8.sql
@@ -4,7 +4,6 @@
 \echo Use "ALTER EXTENSION pageinspect UPDATE TO '1.8'" to load this file. \quit
 
 --
-<<<<<<< HEAD
 -- bm_metap()
 --
 CREATE FUNCTION bm_metap(IN relname text,
@@ -67,7 +66,7 @@ CREATE FUNCTION bm_bitmap_page_items(IN page bytea,
     RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'bm_bitmap_page_items_bytea'
     LANGUAGE C STRICT PARALLEL SAFE;
-=======
+
 -- heap_tuple_infomask_flags()
 --
 CREATE FUNCTION heap_tuple_infomask_flags(
@@ -77,4 +76,3 @@ CREATE FUNCTION heap_tuple_infomask_flags(
 RETURNS text[]
 AS 'MODULE_PATHNAME', 'heap_tuple_infomask_flags'
 LANGUAGE C STRICT PARALLEL SAFE;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8


### PR DESCRIPTION
Fix conflicts in contrib/pageinspect/Makefile and pageinspect--1.7--1.8.sql

Commit ddbd5d8 updated the pageinspect module to version 1.8, while the earlier
commit 6896b2e had already done so, but in the new file
contrib/pageinspect/pageinspect--1.7--1.8.sql both commits added different
functions, so we need to preserve the changes of both commits.