### PR TITLE
Optimization for regression test qp_dml_joins

### DIFF
--- a/src/test/regress/expected/qp_dml_joins.out
+++ b/src/test/regress/expected/qp_dml_joins.out
@@ -208,7 +208,7 @@ CREATE TABLE dml_heap_pt_r (
 	d numeric)
 DISTRIBUTED BY (a)
 partition by range(b) (
-	start(1) end(301) every(10));
+	start(1) end(301) every(20));
 CREATE TABLE dml_heap_pt_s (
 	a int ,
 	b int,
@@ -216,7 +216,7 @@ CREATE TABLE dml_heap_pt_s (
 	d numeric)
 DISTRIBUTED BY (b)
 partition by range(a) (
-	start(1) end(101) every(10),
+	start(1) end(101) every(20),
 	default partition def);
 CREATE TABLE dml_heap_pt_p (
 	a int ,

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -208,7 +208,7 @@ CREATE TABLE dml_heap_pt_r (
 	d numeric)
 DISTRIBUTED BY (a)
 partition by range(b) (
-	start(1) end(301) every(10));
+	start(1) end(301) every(20));
 CREATE TABLE dml_heap_pt_s (
 	a int ,
 	b int,
@@ -216,7 +216,7 @@ CREATE TABLE dml_heap_pt_s (
 	d numeric)
 DISTRIBUTED BY (b)
 partition by range(a) (
-	start(1) end(101) every(10),
+	start(1) end(101) every(20),
 	default partition def);
 CREATE TABLE dml_heap_pt_p (
 	a int ,

--- a/src/test/regress/sql/qp_dml_joins.sql
+++ b/src/test/regress/sql/qp_dml_joins.sql
@@ -249,7 +249,7 @@ CREATE TABLE dml_heap_pt_r (
 	d numeric)
 DISTRIBUTED BY (a)
 partition by range(b) (
-	start(1) end(301) every(10));
+	start(1) end(301) every(20));
 
 CREATE TABLE dml_heap_pt_s (
 	a int ,
@@ -258,7 +258,7 @@ CREATE TABLE dml_heap_pt_s (
 	d numeric)
 DISTRIBUTED BY (b)
 partition by range(a) (
-	start(1) end(101) every(10),
+	start(1) end(101) every(20),
 	default partition def);
 
 CREATE TABLE dml_heap_pt_p (


### PR DESCRIPTION
Optimization for regression test qp_dml_joins

Test qp_dml_joins contains two partitioned tables (dml_heap_pt_s,
dml_heap_pt_r), which are used for different DML operations. One of such
operation is UPDATE, which contains join of these tables and contains subquery
in WHERE, which also contains join of these tables. And all joins are built at
fields, which are distributed keys for these tables. It means, that optimizer
can not apply filter to exclude some partitions from the plan. As the result,
plan contains 3091 nodes, which are processed by 364 forks. Each fork uses
400-600Mb RAM. It lead to use almost 11Gb RAM at the peak of plan's execution.

CI sends SIGKILL to the process with max of used RAM. Next, the qp_dml_joins
test fails. QD's log contains message "server process (PID 65211) was terminated
by signal 9: Killed".

This patch just decrease count of partitions for these tables. As the result,
plan contains 961 nodes, count of processes is 229. Time of test running
decreases: from ~320 to ~210 seconds.
