### PR TITLE
Fix conflicts in src/interfaces/ecpg/test/pg_regress_ecpg.c

### DIFF
--- a/src/interfaces/ecpg/test/pg_regress_ecpg.c
+++ b/src/interfaces/ecpg/test/pg_regress_ecpg.c
@@ -97,11 +97,7 @@ ecpg_start_test(const char *testname,
 	char		outfile_source[MAXPGPATH],
 				expectfile_source[MAXPGPATH];
 	char		cmd[MAXPGPATH * 3];
-<<<<<<< HEAD
-=======
-	char	   *testname_dash;
 	char	   *appnameenv;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 	snprintf(inprg, sizeof(inprg), "%s/%s", inputdir, testname);
 	snprintf(insource, sizeof(insource), "%s.c", testname);
@@ -150,7 +146,7 @@ ecpg_start_test(const char *testname,
 			 outfile_stdout,
 			 outfile_stderr);
 
-	appnameenv = psprintf("PGAPPNAME=ecpg/%s", testname_dash);
+	appnameenv = psprintf("PGAPPNAME=ecpg/%s", testname_dash.data);
 	putenv(appnameenv);
 
 	pid = spawn_process(cmd);
@@ -162,17 +158,9 @@ ecpg_start_test(const char *testname,
 		exit(2);
 	}
 
-<<<<<<< HEAD
-	free(testname_dash.data);
-=======
 	unsetenv("PGAPPNAME");
 	free(appnameenv);
-
-	free(testname_dash);
-	free(outfile_stdout);
-	free(outfile_stderr);
-	free(outfile_source);
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+	free(testname_dash.data);
 
 	return pid;
 }


### PR DESCRIPTION
Fix conflicts in src/interfaces/ecpg/test/pg_regress_ecpg.c

1) Commit b1907d6 added a new local variable appnameenv to the ecpg_start_test
function, while the earlier commit b4c36a1 removed the local variable
testname_dash in the same place, adding it with a different type above.

1) Commit b1907d6 added a deallocation of the new local variable appnameenv and
the old local variable testname_dash to the ecpg_start_test function, while the
earlier commit b4c36a1 already added a deallocation of the local variable
testname_dash of a different type.