### PR TITLE
Fix conflicts in src/pl/plpgsql/src/expected/plpgsql_trap.out

### DIFF
--- a/src/pl/plpgsql/src/expected/plpgsql_trap.out
+++ b/src/pl/plpgsql/src/expected/plpgsql_trap.out
@@ -186,21 +186,11 @@ NOTICE:  should see this only if -100 fits in smallint
 --
 -- test foreign key error trapping
 --
-<<<<<<< HEAD
-create temp table master(f1 int primary key);
-create temp table slave(f1 int references master deferrable);
-insert into master values(1);
-insert into slave values(1);
-insert into slave values(2);	-- fails
-=======
 create temp table root(f1 int primary key);
 create temp table leaf(f1 int references root deferrable);
 insert into root values(1);
 insert into leaf values(1);
 insert into leaf values(2);	-- fails
-ERROR:  insert or update on table "leaf" violates foreign key constraint "leaf_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "root".
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 create function trap_foreign_key(int) returns int as $$
 begin
 	begin	-- start a subtransaction
@@ -245,11 +235,6 @@ begin;
 
   savepoint x;
     set constraints all immediate; -- fails
-<<<<<<< HEAD
-=======
-ERROR:  insert or update on table "leaf" violates foreign key constraint "leaf_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "root".
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
   rollback to x;
   select trap_foreign_key_2();  -- detects FK violation
  trap_foreign_key_2 
@@ -258,10 +243,5 @@ DETAIL:  Key (f1)=(2) is not present in table "root".
 (1 row)
 
 commit;				-- still fails
-<<<<<<< HEAD
-=======
-ERROR:  insert or update on table "leaf" violates foreign key constraint "leaf_f1_fkey"
-DETAIL:  Key (f1)=(2) is not present in table "root".
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 drop function trap_foreign_key(int);
 drop function trap_foreign_key_2();


### PR DESCRIPTION
Fix conflicts in src/pl/plpgsql/src/expected/plpgsql_trap.out

Commit 3f0f991 changed the word master to root and the word slave to leaf in
the src/pl/plpgsql/src/sql/plpgsql_trap.sql test, while the GPDB does not
support FOREIGN KEY and therefore does not return an error in case of integrity
violation.