### PR TITLE
Fix conflicts in eval-plan-qual.spec and eval-plan-qual.out

### DIFF
--- a/src/test/isolation/expected/eval-plan-qual.out
+++ b/src/test/isolation/expected/eval-plan-qual.out
@@ -259,19 +259,11 @@ checking       1050
 savings        600            
 
 starting permutation: wnested2 c1 c2 read
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -301,17 +293,10 @@ step wxext1: UPDATE accounts_ext SET balance = balance - 200 WHERE accountid = '
 balance        
 
 400            
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -325,17 +310,6 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 400 > numeric 200.0: t
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 400 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 400 > numeric 200.0: t
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 400 > numeric 200.0: t
 s2: NOTICE:  upid: text checking = text checking: t
@@ -345,7 +319,6 @@ s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 400 > numeric 200.0: t
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;
@@ -367,17 +340,10 @@ step wxext1: UPDATE accounts_ext SET balance = balance - 200 WHERE accountid = '
 balance        
 
 400            
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -391,19 +357,11 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 400 > numeric 200.0: t
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 200 > numeric 200.0: f
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 400 > numeric 200.0: t
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 200 > numeric 200.0: f
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;
@@ -429,17 +387,10 @@ step wxext1: UPDATE accounts_ext SET balance = balance - 200 WHERE accountid = '
 balance        
 
 200            
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -453,17 +404,10 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 200 > numeric 200.0: f
-s2: WARNING:  lock_id: text savings = text checking: f
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 200 > numeric 200.0: f
 s2: NOTICE:  lock_id: text savings = text checking: f
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;
@@ -485,17 +429,10 @@ step wxext1: UPDATE accounts_ext SET balance = balance - 200 WHERE accountid = '
 balance        
 
 200            
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -509,17 +446,10 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 200 > numeric 200.0: f
-s2: WARNING:  lock_id: text savings = text checking: f
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 200 > numeric 200.0: f
 s2: NOTICE:  lock_id: text savings = text checking: f
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;
@@ -534,17 +464,10 @@ balance
 
 400            
 step tocds1: UPDATE accounts SET accountid = 'cds' WHERE accountid = 'checking';
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -558,13 +481,8 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  upid: text cds = text checking: f
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  upid: text cds = text checking: f
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;
@@ -579,17 +497,10 @@ balance
 
 400            
 step tocdsext1: UPDATE accounts_ext SET accountid = 'cds' WHERE accountid = 'checking';
-<<<<<<< HEAD
-s2: WARNING:  upid: text checking = text checking: t
-s2: WARNING:  up: numeric 600 > numeric 200.0: t
-s2: WARNING:  lock_id: text checking = text checking: t
-s2: WARNING:  lock_bal: numeric 600 > numeric 200.0: t
-=======
 s2: NOTICE:  upid: text checking = text checking: t
 s2: NOTICE:  up: numeric 600 > numeric 200.0: t
 s2: NOTICE:  lock_id: text checking = text checking: t
 s2: NOTICE:  lock_bal: numeric 600 > numeric 200.0: t
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: 
     UPDATE accounts SET balance = balance - 1200
     WHERE noisy_oper('upid', accountid, '=', 'checking')
@@ -603,15 +514,9 @@ step wnested2:
     );
  <waiting ...>
 step c1: COMMIT;
-<<<<<<< HEAD
-s2: WARNING:  lock_id: text cds = text checking: f
-s2: WARNING:  lock_id: text savings = text checking: f
-s2: WARNING:  upid: text savings = text checking: f
-=======
 s2: NOTICE:  lock_id: text cds = text checking: f
 s2: NOTICE:  lock_id: text savings = text checking: f
 s2: NOTICE:  upid: text savings = text checking: f
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 step wnested2: <... completed>
 step c2: COMMIT;
 step read: SELECT * FROM accounts ORDER BY accountid;

--- a/src/test/isolation/specs/eval-plan-qual.spec
+++ b/src/test/isolation/specs/eval-plan-qual.spec
@@ -49,11 +49,7 @@ setup
   r bool;
   BEGIN
   EXECUTE format('SELECT $1 %s $2', p_op) INTO r USING p_a, p_b;
-<<<<<<< HEAD
-  RAISE WARNING '%: % % % % %: %', p_comment, pg_typeof(p_a), p_a, p_op, pg_typeof(p_b), p_b, r;
-=======
   RAISE NOTICE '%: % % % % %: %', p_comment, pg_typeof(p_a), p_a, p_op, pg_typeof(p_b), p_b, r;
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
   RETURN r;
   END;$$;
 }


### PR DESCRIPTION
Fix conflicts in eval-plan-qual.spec and eval-plan-qual.out

Commit 27cc7cd added a new function noisy_oper to the test
src/test/isolation/specs/eval-plan-qual.spec that issues a notification, while
the earlier commit 675ac58 already did this but issued a warning, and commit
675ac58 disabled this test altogether.