### PR TITLE
Fix conflicts in src/test/regress/.gitignore

### DIFF
--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -6,7 +6,6 @@
 /results/
 /log/
 
-<<<<<<< HEAD
 # Configure-generated files
 /GPTest.pm
 
@@ -31,10 +30,7 @@ regression.out
 
 stdin
 stdout
-=======
-# Note: regreesion.* are only left behind on a failure; that's why they're not ignored
-=======
+
 # Note: regression.* are only left behind on a failure; that's why they're not ignored
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 #/regression.diffs
 #/regression.out


### PR DESCRIPTION
Fix conflicts in src/test/regress/.gitignore

Commit 66bde49 changed the word regreesion to regression in
src/test/regress/.gitignore, while earlier commits 25a9039, bf020bf, e0e8f47,
05a2e92 and 908280a had already added several lines to this file before this
point.