### PR TITLE
Fix conflicts in src/test/regress/expected/join.out

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -803,7 +803,7 @@ preprocess_function_rtes(PlannerInfo *root)
 
 			/* Apply const-simplification */
 			rte->functions = (List *)
-				eval_const_expressions(root, (Node *) rte->functions);
+				eval_const_expressions_not_eval(root, (Node *) rte->functions);
 
 			/* Check safety of expansion, and expand if possible */
 			funcquery = inline_set_returning_function(root, rte);

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2474,8 +2474,9 @@ transform_array_Const_to_ArrayExpr(Const *c)
  * converted to positional notation.  The executor won't handle either.
  *--------------------
  */
-Node *
-eval_const_expressions(PlannerInfo *root, Node *node)
+static Node *
+eval_const_expressions_internal(PlannerInfo *root, Node *node,
+								bool eval_stable_functions)
 {
 	eval_const_expressions_context context;
 	Node                          *result;
@@ -2492,13 +2493,26 @@ eval_const_expressions(PlannerInfo *root, Node *node)
 	context.recurse_queries = false; /* do not recurse into query structures */
 	context.recurse_sublink_testexpr = true;
 	context.max_size = 0;
-	context.eval_stable_functions = should_eval_stable_functions(root);
+	context.eval_stable_functions = eval_stable_functions;
 
 	saved_oid_assignments = SaveOidAssignments();
 	result = eval_const_expressions_mutator(node, &context);
 	RestoreOidAssignments(saved_oid_assignments);
 
 	return result;
+}
+
+Node *
+eval_const_expressions(PlannerInfo *root, Node *node)
+{
+	return eval_const_expressions_internal(root, node,
+										   should_eval_stable_functions(root));
+}
+
+Node *
+eval_const_expressions_not_eval(PlannerInfo *root, Node *node)
+{
+	return eval_const_expressions_internal(root, node, false);
 }
 
 /*--------------------

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -134,6 +134,7 @@ extern bool contain_volatile_functions(Node *clause);
 extern bool contain_volatile_functions_not_nextval(Node *clause);
 
 extern Node *eval_const_expressions(PlannerInfo *root, Node *node);
+extern Node *eval_const_expressions_not_eval(PlannerInfo *root, Node *node);
 
 extern Node *estimate_expression_value(PlannerInfo *root, Node *node);
 

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3168,51 +3168,39 @@ select * from
   tenk1 join int4_tbl on f1 = twothousand,
   q1, q2
 where q1 = thousand or q2 = thousand;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
-<<<<<<< HEAD
-               ->  Function Scan on q2
-               ->  Nested Loop
-                     ->  Function Scan on q1
-                     ->  Bitmap Heap Scan on tenk1
-                           Recheck Cond: ((q1.q1 = thousand) OR (q2.q2 = thousand))
-                           ->  BitmapOr
-                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: (thousand = q1.q1)
-                                 ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                       Index Cond: (thousand = q2.q2)
-         ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on q2
+               ->  Materialize
+                     ->  Nested Loop
+                           ->  Materialize
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                       ->  Seq Scan on q1
+                           ->  Bitmap Heap Scan on tenk1
+                                 Recheck Cond: ((q1.q1 = thousand) OR (q2.q2 = thousand))
+                                 ->  BitmapOr
+                                       ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                             Index Cond: (thousand = q1.q1)
+                                       ->  Bitmap Index Scan on tenk1_thous_tenthous
+                                             Index Cond: (thousand = q2.q2)
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Postgres query optimizer
-(18 rows)
-=======
-               ->  Seq Scan on q1
-               ->  Seq Scan on q2
-         ->  Bitmap Heap Scan on tenk1
-               Recheck Cond: ((q1.q1 = thousand) OR (q2.q2 = thousand))
-               ->  BitmapOr
-                     ->  Bitmap Index Scan on tenk1_thous_tenthous
-                           Index Cond: (thousand = q1.q1)
-                     ->  Bitmap Index Scan on tenk1_thous_tenthous
-                           Index Cond: (thousand = q2.q2)
-   ->  Hash
-         ->  Seq Scan on int4_tbl
-(15 rows)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+(22 rows)
 
 explain (costs off)
 select * from
   tenk1 join int4_tbl on f1 = twothousand,
   q1, q2
 where thousand = (q1 + q2);
-<<<<<<< HEAD
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.thousand = (q1.q1 + q2.q2))
@@ -3223,28 +3211,14 @@ where thousand = (q1 + q2);
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)
                            ->  Seq Scan on int4_tbl
          ->  Hash
-               ->  Nested Loop
-                     ->  Function Scan on q1
-                     ->  Function Scan on q2
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                     ->  Nested Loop
+                           ->  Seq Scan on q1
+                           ->  Materialize
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                       ->  Seq Scan on q2
  Optimizer: Postgres query optimizer
-(14 rows)
-=======
-                          QUERY PLAN                          
---------------------------------------------------------------
- Hash Join
-   Hash Cond: (tenk1.twothousand = int4_tbl.f1)
-   ->  Nested Loop
-         ->  Nested Loop
-               ->  Seq Scan on q1
-               ->  Seq Scan on q2
-         ->  Bitmap Heap Scan on tenk1
-               Recheck Cond: (thousand = (q1.q1 + q2.q2))
-               ->  Bitmap Index Scan on tenk1_thous_tenthous
-                     Index Cond: (thousand = (q1.q1 + q2.q2))
-   ->  Hash
-         ->  Seq Scan on int4_tbl
-(12 rows)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
+(17 rows)
 
 --
 -- test ability to generate a suitable plan for a star-schema query
@@ -3409,83 +3383,108 @@ $$ begin return i; end; $$ language plpgsql immutable;
 explain (costs off)
 select unique1 from tenk1, (select * from f_immutable_int4(1) x) x
 where x = unique1;
-                  QUERY PLAN                  
-----------------------------------------------
- Index Only Scan using tenk1_unique1 on tenk1
-   Index Cond: (unique1 = 1)
-(2 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Only Scan using tenk1_unique1 on tenk1
+         Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
 
 explain (verbose, costs off)
 select unique1, x.*
 from tenk1, (select *, random() from f_immutable_int4(1) x) x
 where x = unique1;
-                        QUERY PLAN                         
------------------------------------------------------------
- Nested Loop
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: tenk1.unique1, (1), (random())
-   ->  Result
-         Output: 1, random()
-   ->  Index Only Scan using tenk1_unique1 on public.tenk1
-         Output: tenk1.unique1
-         Index Cond: (tenk1.unique1 = (1))
-(7 rows)
+   ->  Hash Join
+         Output: tenk1.unique1, (1), (random())
+         Hash Cond: (tenk1.unique1 = (1))
+         ->  Seq Scan on public.tenk1
+               Output: tenk1.unique1, tenk1.unique2, tenk1.two, tenk1.four, tenk1.ten, tenk1.twenty, tenk1.hundred, tenk1.thousand, tenk1.twothousand, tenk1.fivethous, tenk1.tenthous, tenk1.odd, tenk1.even, tenk1.stringu1, tenk1.stringu2, tenk1.string4
+         ->  Hash
+               Output: (1), (random())
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                     Output: (1), (random())
+                     Hash Key: (1)
+                     ->  Result
+                           Output: 1, random()
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(16 rows)
 
 explain (costs off)
 select unique1 from tenk1, f_immutable_int4(1) x where x = unique1;
-                  QUERY PLAN                  
-----------------------------------------------
- Index Only Scan using tenk1_unique1 on tenk1
-   Index Cond: (unique1 = 1)
-(2 rows)
-
-explain (costs off)
-select unique1 from tenk1, lateral f_immutable_int4(1) x where x = unique1;
-                  QUERY PLAN                  
-----------------------------------------------
- Index Only Scan using tenk1_unique1 on tenk1
-   Index Cond: (unique1 = 1)
-(2 rows)
-
-explain (costs off)
-select unique1, x from tenk1 join f_immutable_int4(1) x on unique1 = x;
-                  QUERY PLAN                  
-----------------------------------------------
- Index Only Scan using tenk1_unique1 on tenk1
-   Index Cond: (unique1 = 1)
-(2 rows)
-
-explain (costs off)
-select unique1, x from tenk1 left join f_immutable_int4(1) x on unique1 = x;
                      QUERY PLAN                     
 ----------------------------------------------------
- Nested Loop Left Join
-   Join Filter: (tenk1.unique1 = 1)
-   ->  Index Only Scan using tenk1_unique1 on tenk1
-   ->  Materialize
-         ->  Result
-(5 rows)
-
-explain (costs off)
-select unique1, x from tenk1 right join f_immutable_int4(1) x on unique1 = x;
-                     QUERY PLAN                     
-----------------------------------------------------
- Nested Loop Left Join
-   ->  Result
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Index Only Scan using tenk1_unique1 on tenk1
          Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
 (4 rows)
 
 explain (costs off)
-select unique1, x from tenk1 full join f_immutable_int4(1) x on unique1 = x;
+select unique1 from tenk1, lateral f_immutable_int4(1) x where x = unique1;
                      QUERY PLAN                     
 ----------------------------------------------------
- Merge Full Join
-   Merge Cond: (tenk1.unique1 = (1))
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Index Only Scan using tenk1_unique1 on tenk1
-   ->  Sort
-         Sort Key: (1)
-         ->  Result
-(6 rows)
+         Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off)
+select unique1, x from tenk1 join f_immutable_int4(1) x on unique1 = x;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Only Scan using tenk1_unique1 on tenk1
+         Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off)
+select unique1, x from tenk1 left join f_immutable_int4(1) x on unique1 = x;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Join
+         Join Filter: (tenk1.unique1 = 1)
+         ->  Seq Scan on tenk1
+         ->  Materialize
+               ->  Result
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain (costs off)
+select unique1, x from tenk1 right join f_immutable_int4(1) x on unique1 = x;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Result
+   ->  Materialize
+         ->  Gather Motion 1:1  (slice1; segments: 1)
+               ->  Index Only Scan using tenk1_unique1 on tenk1
+                     Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+explain (costs off)
+select unique1, x from tenk1 full join f_immutable_int4(1) x on unique1 = x;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Full Join
+         Hash Cond: (tenk1.unique1 = (1))
+         ->  Seq Scan on tenk1
+         ->  Hash
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)
+                     Hash Key: (1)
+                     ->  Result
+ Optimizer: Postgres query optimizer
+(9 rows)
 
 -- check that pullup of a const function allows further const-folding
 explain (costs off)
@@ -3509,18 +3508,24 @@ from nt3 as nt3
     ) as ss2
     on ss2.id = nt3.nt2_id
 where nt3.id = 1 and ss2.b3;
-                  QUERY PLAN                  
-----------------------------------------------
- Nested Loop Left Join
-   Filter: ((nt2.b1 OR ((0) = 42)))
-   ->  Index Scan using nt3_pkey on nt3
-         Index Cond: (id = 1)
-   ->  Nested Loop Left Join
-         Join Filter: (0 = nt2.nt1_id)
-         ->  Index Scan using nt2_pkey on nt2
-               Index Cond: (id = nt3.nt2_id)
-         ->  Result
-(9 rows)
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Right Join
+         Hash Cond: (nt2.id = nt3.nt2_id)
+         Filter: ((nt2.b1 OR ((0) = 42)))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: 1
+               ->  Nested Loop Left Join
+                     Join Filter: (0 = nt2.nt1_id)
+                     ->  Index Scan using nt2_pkey on nt2
+                     ->  Materialize
+                           ->  Result
+         ->  Hash
+               ->  Seq Scan on nt3
+                     Filter: (id = 1)
+ Optimizer: Postgres query optimizer
+(15 rows)
 
 drop function f_immutable_int4(int);
 --

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3535,12 +3535,18 @@ create function mki4(int) returns int4_tbl as
 $$select row($1)::int4_tbl$$ language sql;
 explain (verbose, costs off)
 select * from mki8(1,2);
-             QUERY PLAN             
-------------------------------------
- Function Scan on mki8
-   Output: q1, q2
-   Function Call: '(1,2)'::int8_tbl
-(3 rows)
+                    QUERY PLAN                    
+--------------------------------------------------
+ Subquery Scan on sirvf_sq
+   Output: (sirvf_sq.mki8).q1, (sirvf_sq.mki8).q2
+   ->  Result
+         Output: $0
+         InitPlan 1 (returns $0)
+           ->  Result
+                 Output: '(1,2)'::int8_tbl
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(9 rows)
 
 select * from mki8(1,2);
  q1 | q2 
@@ -3550,12 +3556,18 @@ select * from mki8(1,2);
 
 explain (verbose, costs off)
 select * from mki4(42);
-            QUERY PLAN             
------------------------------------
- Function Scan on mki4
-   Output: f1
-   Function Call: '(42)'::int4_tbl
-(3 rows)
+                QUERY PLAN                
+------------------------------------------
+ Subquery Scan on sirvf_sq
+   Output: (sirvf_sq.mki4).f1
+   ->  Result
+         Output: $0
+         InitPlan 1 (returns $0)
+           ->  Result
+                 Output: '(42)'::int4_tbl
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off'
+(9 rows)
 
 select * from mki4(42);
  f1 

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3234,60 +3234,66 @@ select * from int4_tbl a full join int4_tbl b on false;
 --
 -- test for ability to use a cartesian join when necessary
 --
+create temp table q1 as select 1 as q1;
+create temp table q2 as select 0 as q2;
+analyze q1;
+analyze q2;
 explain (costs off)
 select * from
   tenk1 join int4_tbl on f1 = twothousand,
-  int4(sin(1)) q1,
-  int4(sin(0)) q2
+  q1, q2
 where q1 = thousand or q2 = thousand;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
                Join Filter: true
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Result
-                     ->  Result
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Nested Loop
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on q1
+                           ->  Seq Scan on q2
                ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: ((thousand = (1)) OR (thousand = (0)))
+                     Recheck Cond: ((thousand = q1.q1) OR (thousand = q2.q2))
                      ->  BitmapOr
                            ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                 Index Cond: (thousand = (1))
+                                 Index Cond: (thousand = q1.q1)
                            ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                 Index Cond: (thousand = (0))
+                                 Index Cond: (thousand = q2.q2)
          ->  Hash
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(22 rows)
 
 explain (costs off)
 select * from
   tenk1 join int4_tbl on f1 = twothousand,
-  int4(sin(1)) q1,
-  int4(sin(0)) q2
+  q1, q2
 where thousand = (q1 + q2);
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Join
          Hash Cond: (tenk1.twothousand = int4_tbl.f1)
          ->  Nested Loop
                Join Filter: true
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Result
-                     ->  Result
-               ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: (thousand = ((1) + (0)))
-         ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Nested Loop
+                           Join Filter: true
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on q1
+                           ->  Seq Scan on q2
+               ->  Index Scan using tenk1_thous_tenthous on tenk1
+                     Index Cond: (thousand = (q1.q1 + q2.q2))
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(17 rows)
 
 --
 -- test ability to generate a suitable plan for a star-schema query
@@ -3472,6 +3478,181 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
       11 | WFAAAA   |       3 | LKIAAA
 (1 row)
 
+--
+-- test inlining of immutable functions
+--
+create function f_immutable_int4(i integer) returns integer as
+$$ begin return i; end; $$ language plpgsql immutable;
+-- check optimization of function scan with join
+explain (costs off)
+select unique1 from tenk1, (select * from f_immutable_int4(1) x) x
+where x = unique1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Result
+               Filter: ((1) = 1)
+               ->  Result
+         ->  Index Only Scan using tenk1_unique1 on tenk1
+               Index Cond: ((unique1 = (1)) AND (unique1 = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain (verbose, costs off)
+select unique1, x.*
+from tenk1, (select *, random() from f_immutable_int4(1) x) x
+where x = unique1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: unique1, (1), (random())
+   ->  Nested Loop
+         Output: unique1, (1), (random())
+         Join Filter: true
+         ->  Broadcast Motion 1:3  (slice2)
+               Output: (1), (random())
+               ->  Result
+                     Output: (1), random()
+                     Filter: ((1) = 1)
+                     ->  Result
+                           Output: 1
+         ->  Index Only Scan using tenk1_unique1 on public.tenk1
+               Output: unique1
+               Index Cond: ((tenk1.unique1 = (1)) AND (tenk1.unique1 = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+explain (costs off)
+select unique1 from tenk1, f_immutable_int4(1) x where x = unique1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Result
+               Filter: ((1) = 1)
+               ->  Result
+         ->  Index Only Scan using tenk1_unique1 on tenk1
+               Index Cond: ((unique1 = (1)) AND (unique1 = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain (costs off)
+select unique1 from tenk1, lateral f_immutable_int4(1) x where x = unique1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Index Only Scan using tenk1_unique1 on tenk1
+         Index Cond: (unique1 = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off)
+select unique1, x from tenk1 join f_immutable_int4(1) x on unique1 = x;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop
+         Join Filter: true
+         ->  Result
+               Filter: ((1) = 1)
+               ->  Result
+         ->  Index Only Scan using tenk1_unique1 on tenk1
+               Index Cond: ((unique1 = (1)) AND (unique1 = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+explain (costs off)
+select unique1, x from tenk1 left join f_immutable_int4(1) x on unique1 = x;
+                   QUERY PLAN                   
+------------------------------------------------
+ Hash Left Join
+   Hash Cond: (unique1 = (1))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on tenk1
+   ->  Hash
+         ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+explain (costs off)
+select unique1, x from tenk1 right join f_immutable_int4(1) x on unique1 = x;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Hash Right Join
+   Hash Cond: (unique1 = (1))
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Index Only Scan using tenk1_unique1 on tenk1
+               Index Cond: (unique1 = 1)
+   ->  Hash
+         ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+explain (costs off)
+select unique1, x from tenk1 full join f_immutable_int4(1) x on unique1 = x;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Merge Full Join
+         Merge Cond: (unique1 = (1))
+         ->  Sort
+               Sort Key: unique1
+               ->  Seq Scan on tenk1
+         ->  Sort
+               Sort Key: (1)
+               ->  Result
+                     ->  Result
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+-- check that pullup of a const function allows further const-folding
+explain (costs off)
+select unique1 from tenk1, f_immutable_int4(1) x where x = 42;
+              QUERY PLAN               
+---------------------------------------
+ Result
+   One-Time Filter: false
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+-- test inlining of immutable functions with PlaceHolderVars
+explain (costs off)
+select nt3.id
+from nt3 as nt3
+  left join
+    (select nt2.*, (nt2.b1 or i4 = 42) AS b3
+     from nt2 as nt2
+       left join
+         f_immutable_int4(0) i4
+         on i4 = nt2.nt1_id
+    ) as ss2
+    on ss2.id = nt3.nt2_id
+where nt3.id = 1 and ss2.b3;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (nt2.id = nt3.nt2_id)
+         ->  Redistribute Motion 1:3  (slice2)
+               ->  Result
+                     Filter: (nt2.b1 OR ((0) = 42))
+                     ->  Hash Left Join
+                           Hash Cond: (nt2.nt1_id = (0))
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 ->  Seq Scan on nt2
+                           ->  Hash
+                                 ->  Result
+         ->  Hash
+               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                     ->  Index Scan using nt3_pkey on nt3
+                           Index Cond: (id = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
+
+drop function f_immutable_int4(int);
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3653,6 +3653,45 @@ where nt3.id = 1 and ss2.b3;
 (17 rows)
 
 drop function f_immutable_int4(int);
+-- test inlining when function returns composite
+create function mki8(bigint, bigint) returns int8_tbl as
+$$select row($1,$2)::int8_tbl$$ language sql;
+create function mki4(int) returns int4_tbl as
+$$select row($1)::int4_tbl$$ language sql;
+explain (verbose, costs off)
+select * from mki8(1,2);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki8
+   Output: q1, q2
+   Function Call: '(1,2)'::int8_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki8(1,2);
+ q1 | q2 
+----+----
+  1 |  2
+(1 row)
+
+explain (verbose, costs off)
+select * from mki4(42);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki4
+   Output: f1
+   Function Call: '(42)'::int4_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki4(42);
+ f1 
+----
+ 42
+(1 row)
+
+drop function mki8(bigint, bigint);
+drop function mki4(int);
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)

--- a/src/test/regress/expected/json.out
+++ b/src/test/regress/expected/json.out
@@ -387,13 +387,6 @@ SELECT row_to_json(row((select array_agg(x) as d from generate_series(5,10) x)),
 analyze rows;
 select attname, to_json(histogram_bounds) histogram_bounds
 from pg_stats
-<<<<<<< HEAD
-where attname = 'tmplname' and tablename = 'pg_pltemplate';
-                                                histogram_bounds                                                
-----------------------------------------------------------------------------------------------------------------
- ["pljava","pljavau","plperl","plperlu","plpgsql","plpython2u","plpython3u","plpythonu","plr","pltcl","pltclu"]
-(1 row)
-=======
 where tablename = 'rows' and
       schemaname = pg_my_temp_schema()::regnamespace::text
 order by 1;
@@ -402,7 +395,6 @@ order by 1;
  x       | [1,2,3]
  y       | ["txt1","txt2","txt3"]
 (2 rows)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 -- to_json, timestamps
 select to_json(timestamp '2014-05-28 12:22:35.614298');

--- a/src/test/regress/expected/jsonb.out
+++ b/src/test/regress/expected/jsonb.out
@@ -286,13 +286,6 @@ FROM generate_series(1,3) AS x;
 analyze rows;
 select attname, to_jsonb(histogram_bounds) histogram_bounds
 from pg_stats
-<<<<<<< HEAD
-where attname = 'tmplname' and tablename = 'pg_pltemplate';
-                                                     histogram_bounds                                                     
---------------------------------------------------------------------------------------------------------------------------
- ["pljava", "pljavau", "plperl", "plperlu", "plpgsql", "plpython2u", "plpython3u", "plpythonu", "plr", "pltcl", "pltclu"]
-(1 row)
-=======
 where tablename = 'rows' and
       schemaname = pg_my_temp_schema()::regnamespace::text
 order by 1;
@@ -301,7 +294,6 @@ order by 1;
  x       | [1, 2, 3]
  y       | ["txt1", "txt2", "txt3"]
 (2 rows)
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 
 -- to_jsonb, timestamps
 select to_jsonb(timestamp '2014-05-28 12:22:35.614298');


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected join.out, json.out and jsonb.out

1) Commit 7266d09 changed in src/test/regress/expected/join.out, in the plan,
Function Scan to Seq Scan, while this plan was already changed in accordance
with the GPDB specification.

2) Commit 7266d09 added new tests to the src/test/regress/sql/join.sql file, we
need to adapt their output for GPDB and add them for ORCA.

3) Commit bbd9366 simplified tests in src/test/regress/sql/json.sql and
src/test/regress/sql/jsonb.sql, while earlier commit 19cd1cf added pljava,
pljavau and plr to the output in the same places.

4) Commit 525ebe7 added new tests to src/test/regress/sql/join.sql, we need to
adapt their output for GPDB and add them to ORCA.

5) Commit 7266d09 renamed inline_set_returning_functions to
preprocess_function_rtes and added a call to eval_const_expressions to apply
const-simplification, while the earlier GPDB-specific commit 4cf4743 had
already added similar behavior for stable functions. However, in the case of
explicitly specifying the function's return type as columns, using both
approaches together results in an error, because the GPDB-specific code tries
to call the function without specifying the return type. So in this case,
eval_const_expressions is called with eval_stable_functions set to false.