### PR TITLE
ADBDEV-7542-hotfix: Hotfix for duplicate outcoming SIGINTs

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -927,9 +927,6 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 		 */
 		if (pParms->waitMode == DISPATCH_WAIT_CANCEL)
 		{
-			/* Make QE come to its sense. */
-			signalQE(dispatchResult, DISPATCH_WAIT_CANCEL);
-
 			/*
 			 * If we're cancelling the transaction due to an OOM, there
 			 * might not be enough memory to discard the result properly.


### PR DESCRIPTION
Hotfix for duplicate outcoming SIGINTs

Commit 52dbaa7 added a `signalQE()` call to query cancellations handlers. This
change caused CI to reliably trigger an already long-present race-condition,
where coordinator's SIGINT may arrive to segments after the query has been
cancelled already, causing `QueryCancelCleanup` to become true outside of
transaction. The affected segments would then proceed to ignore any errors that
may have occured on the next transaction, since the segment would confuse the
error with a cancel.

This patch removes the said function call.