### PR TITLE
Prevent bogus pullup of constant-valued functions returning composite.

### DIFF
--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -28,6 +28,7 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#include "funcapi.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
@@ -1873,6 +1874,9 @@ pull_up_constant_function(PlannerInfo *root, Node *jtnode,
 {
 	Query	   *parse = root->parse;
 	RangeTblFunction *rtf;
+	TypeFuncClass functypclass;
+	Oid			funcrettype;
+	TupleDesc	tupdesc;
 	pullup_replace_vars_context rvcontext;
 
 	/* Fail if the RTE has ORDINALITY - we don't implement that here. */
@@ -1885,6 +1889,20 @@ pull_up_constant_function(PlannerInfo *root, Node *jtnode,
 	rtf = linitial_node(RangeTblFunction, rte->functions);
 	if (!IsA(rtf->funcexpr, Const))
 		return jtnode;
+
+	/*
+	 * If the function's result is not a scalar, we punt.  In principle we
+	 * could break the composite constant value apart into per-column
+	 * constants, but for now it seems not worth the work.
+	 */
+	if (rtf->funccolcount != 1)
+		return jtnode;			/* definitely composite */
+
+	functypclass = get_expr_result_type(rtf->funcexpr,
+										&funcrettype,
+										&tupdesc);
+	if (functypclass != TYPEFUNC_SCALAR)
+		return jtnode;			/* must be a one-column composite type */
 
 	/* Create context for applying pullup_replace_vars */
 	rvcontext.root = root;

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3523,6 +3523,53 @@ where nt3.id = 1 and ss2.b3;
 (9 rows)
 
 drop function f_immutable_int4(int);
+-- test inlining when function returns composite
+create function mki8(bigint, bigint) returns int8_tbl as
+$$select row($1,$2)::int8_tbl$$ language sql;
+create function mki4(int) returns int4_tbl as
+$$select row($1)::int4_tbl$$ language sql;
+explain (verbose, costs off)
+select * from mki8(1,2);
+                    QUERY PLAN                    
+--------------------------------------------------
+ Subquery Scan on sirvf_sq
+   Output: (sirvf_sq.mki8).q1, (sirvf_sq.mki8).q2
+   ->  Result
+         Output: $0
+         InitPlan 1 (returns $0)
+           ->  Result
+                 Output: '(1,2)'::int8_tbl
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from mki8(1,2);
+ q1 | q2 
+----+----
+  1 |  2
+(1 row)
+
+explain (verbose, costs off)
+select * from mki4(42);
+                QUERY PLAN                
+------------------------------------------
+ Subquery Scan on sirvf_sq
+   Output: (sirvf_sq.mki4).f1
+   ->  Result
+         Output: $0
+         InitPlan 1 (returns $0)
+           ->  Result
+                 Output: '(42)'::int4_tbl
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select * from mki4(42);
+ f1 
+----
+ 42
+(1 row)
+
+drop function mki8(bigint, bigint);
+drop function mki4(int);
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3472,6 +3472,45 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
       11 | WFAAAA   |       3 | LKIAAA
 (1 row)
 
+-- test inlining when function returns composite
+create function mki8(bigint, bigint) returns int8_tbl as
+$$select row($1,$2)::int8_tbl$$ language sql;
+create function mki4(int) returns int4_tbl as
+$$select row($1)::int4_tbl$$ language sql;
+explain (verbose, costs off)
+select * from mki8(1,2);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki8
+   Output: q1, q2
+   Function Call: '(1,2)'::int8_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki8(1,2);
+ q1 | q2 
+----+----
+  1 |  2
+(1 row)
+
+explain (verbose, costs off)
+select * from mki4(42);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki4
+   Output: f1
+   Function Call: '(42)'::int4_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki4(42);
+ f1 
+----
+ 42
+(1 row)
+
+drop function mki8(bigint, bigint);
+drop function mki4(int);
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)

--- a/src/test/regress/sql/join.sql
+++ b/src/test/regress/sql/join.sql
@@ -1098,6 +1098,25 @@ where nt3.id = 1 and ss2.b3;
 
 drop function f_immutable_int4(int);
 
+-- test inlining when function returns composite
+
+create function mki8(bigint, bigint) returns int8_tbl as
+$$select row($1,$2)::int8_tbl$$ language sql;
+
+create function mki4(int) returns int4_tbl as
+$$select row($1)::int4_tbl$$ language sql;
+
+explain (verbose, costs off)
+select * from mki8(1,2);
+select * from mki8(1,2);
+
+explain (verbose, costs off)
+select * from mki4(42);
+select * from mki4(42);
+
+drop function mki8(bigint, bigint);
+drop function mki4(int);
+
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)


### PR DESCRIPTION
Prevent bogus pullup of constant-valued functions returning composite.

Fix an oversight in commit 7266d0997: as it stood, the code failed
when a function-in-FROM returns composite and can be simplified
to a composite constant.

For the moment, just test for composite result and abandon pullup
if we see one.  To make it actually work, we'd have to decompose
the composite constant into per-column constants; which is surely
do-able, but I'm not convinced it's worth the code space.

Per report from Raúl Marín Rodríguez.

Discussion: https://postgr.es/m/CAM6_UM4isP+buRA5sWodO_MUEgutms-KDfnkwGmryc5DGj9XuQ@mail.gmail.com
(cherry picked from commit a9ae99d0190960ce2d3dd3e5f10e7f4adc3cf203)

Changes from original commit:
New tests in src/test/regress/sql/join.sql adapted for GPDB and added to ORCA.

---
Don't squash!