### PR TITLE
ADBDEV-7546 Fix lost executor error messages after query cancellation

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3801,6 +3801,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	{
 		ProcDiePending = false;
 		QueryCancelPending = false;		/* ProcDie trumps QueryCancel */
+		QueryCancelCleanup = false;  /* no cancel request means no error */
 		ImmediateInterruptOK = false;	/* not idle anymore */
 		ImmediateDieOK = false;		/* prevent re-entry */
 		LockErrorCleanup();
@@ -3874,6 +3875,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	if (ClientConnectionLost)
 	{
 		QueryCancelPending = false;		/* lost connection trumps QueryCancel */
+		QueryCancelCleanup = false;
 		ImmediateInterruptOK = false;	/* not idle anymore */
 		LockErrorCleanup();
 		DisableNotifyInterrupt();
@@ -3895,6 +3897,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	if (RecoveryConflictPending && DoingCommandRead)
 	{
 		QueryCancelPending = false;			/* this trumps QueryCancel */
+		QueryCancelCleanup = false;
 		ImmediateInterruptOK = false;		/* not idle anymore */
 		RecoveryConflictPending = false;
 		LockErrorCleanup();
@@ -4055,6 +4058,13 @@ ProcessInterrupts(const char* filename, int lineno)
 						break;
 				}
 			}
+		}
+		else
+		{
+			/*
+			 * Skip cleanup as far as we forget a cancel request
+			 */
+			QueryCancelCleanup = false;
 		}
 	}
 	/* If we get here, do nothing (probably, QueryCancelPending was reset) */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3801,7 +3801,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	{
 		ProcDiePending = false;
 		QueryCancelPending = false;		/* ProcDie trumps QueryCancel */
-		QueryCancelCleanup = false;  /* no cancel request means no error */
+		QueryCancelCleanup = false;		/* no cancel request means no error */
 		ImmediateInterruptOK = false;	/* not idle anymore */
 		ImmediateDieOK = false;		/* prevent re-entry */
 		LockErrorCleanup();
@@ -3875,7 +3875,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	if (ClientConnectionLost)
 	{
 		QueryCancelPending = false;		/* lost connection trumps QueryCancel */
-		QueryCancelCleanup = false;
+		QueryCancelCleanup = false;		/* no cancel request means no error */
 		ImmediateInterruptOK = false;	/* not idle anymore */
 		LockErrorCleanup();
 		DisableNotifyInterrupt();
@@ -3897,7 +3897,7 @@ ProcessInterrupts(const char* filename, int lineno)
 	if (RecoveryConflictPending && DoingCommandRead)
 	{
 		QueryCancelPending = false;			/* this trumps QueryCancel */
-		QueryCancelCleanup = false;
+		QueryCancelCleanup = false;			/* no cancel request means no error */
 		ImmediateInterruptOK = false;		/* not idle anymore */
 		RecoveryConflictPending = false;
 		LockErrorCleanup();

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -29,6 +29,7 @@ ProtocolVersion FrontendProtocol;
 
 volatile bool InterruptPending = false;
 volatile bool QueryCancelPending = false;
+/* True if the query was cancelled and cleanup shall be done, Error otherwise. */
 volatile bool QueryCancelCleanup = false;
 volatile bool QueryFinishPending = false;
 volatile bool ProcDiePending = false;


### PR DESCRIPTION
Fix lost executor error messages after query cancellation.

This patch addresses an issue where error messages from the executor are lost if
a query fails (with an error) after a cancellation has been initiated.

PostgreSQL uses two flags to manage query cancellation:

QueryCancelPending – indicates that the query should be cancelled as soon as
possible.

QueryCancelCleanup – set when the query was actually cancelled and cleanup is
expected. If QueryCancelCleanup is set, error messages should be suppressed.

In certain cases, such as in the ADCC third-party component, errors from failed
queries were not reported because QueryCancelCleanup was not properly cleared
after the cancellation path. This led to lost diagnostic information.

This fix ensures that QueryCancelCleanup is reset appropriately when an
error—not a cancellation—is detected in the executor, so that legitimate error
messages are not suppressed.
