### PR TITLE
Fix conflicts in src/test/regress/expected/select_parallel.out

### DIFF
--- a/src/test/regress/expected/select_parallel.out
+++ b/src/test/regress/expected/select_parallel.out
@@ -107,22 +107,6 @@ where relname like '__star' order by relname;
  f_star  |        1 |        16
 (6 rows)
 
-<<<<<<< HEAD
-select relname, vacuum_count, analyze_count, autovacuum_count, autoanalyze_count
-from pg_stat_all_tables
-where relname like '__star' order by relname;
- relname | vacuum_count | analyze_count | autovacuum_count | autoanalyze_count 
----------+--------------+---------------+------------------+-------------------
- a_star  |            0 |             1 |                0 |                 0
- b_star  |            0 |             1 |                0 |                 0
- c_star  |            0 |             1 |                0 |                 0
- d_star  |            0 |             1 |                0 |                 0
- e_star  |            0 |             1 |                0 |                 0
- f_star  |            0 |             1 |                0 |                 0
-(6 rows)
-
-=======
->>>>>>> eb57bd9c1d83a20eaff559a53b2f584dcd0668a8
 -- Disable Parallel Append
 alter table a_star reset (parallel_workers);
 alter table b_star reset (parallel_workers);

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -107,19 +107,6 @@ where relname like '__star' order by relname;
  f_star  |        1 |        16
 (6 rows)
 
-select relname, vacuum_count, analyze_count, autovacuum_count, autoanalyze_count
-from pg_stat_all_tables
-where relname like '__star' order by relname;
- relname | vacuum_count | analyze_count | autovacuum_count | autoanalyze_count 
----------+--------------+---------------+------------------+-------------------
- a_star  |            0 |             1 |                0 |                 0
- b_star  |            0 |             1 |                0 |                 0
- c_star  |            0 |             1 |                0 |                 0
- d_star  |            0 |             1 |                0 |                 0
- e_star  |            0 |             1 |                0 |                 0
- f_star  |            0 |             1 |                0 |                 0
-(6 rows)
-
 -- Disable Parallel Append
 alter table a_star reset (parallel_workers);
 alter table b_star reset (parallel_workers);


### PR DESCRIPTION
Fix conflicts in src/test/regress/expected/select_parallel.out

Commit b43f7c1 deleted a test from the src/test/regress/sql/select_parallel.sql
file, we need to remove the output for the GPDB, as well as delete the output
for the ORCA planner.