### PR TITLE
Fix tests in src/test/regress/expected/join_hash.out

### DIFF
--- a/src/test/regress/expected/join_hash.out
+++ b/src/test/regress/expected/join_hash.out
@@ -1025,37 +1025,47 @@ WHERE
     AND (SELECT hjtest_1.b * 5) < 50
     AND (SELECT hjtest_2.c * 5) < 55
     AND hjtest_1.a <> hjtest_2.b;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Hash Join
-   Output: hjtest_1.a, hjtest_2.a, (hjtest_1.tableoid)::regclass, (hjtest_2.tableoid)::regclass
-   Hash Cond: ((hjtest_1.id = (SubPlan 1)) AND ((SubPlan 2) = (SubPlan 3)))
-   Join Filter: (hjtest_1.a <> hjtest_2.b)
-   ->  Seq Scan on public.hjtest_1
-         Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
-         Filter: ((SubPlan 4) < 50)
-         SubPlan 4
-           ->  Result
-                 Output: (hjtest_1.b * 5)
-   ->  Hash
-         Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
-         ->  Seq Scan on public.hjtest_2
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
+   ->  Hash Join
+         Output: hjtest_1.a, hjtest_2.a, (hjtest_1.tableoid)::regclass, (hjtest_2.tableoid)::regclass
+         Hash Cond: ((hjtest_1.id = (SubPlan 1)) AND ((SubPlan 2) = (SubPlan 3)))
+         Join Filter: (hjtest_1.a <> hjtest_2.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
+               Hash Key: hjtest_1.id, (SubPlan 2)
+               ->  Seq Scan on public.hjtest_1
+                     Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
+                     Filter: ((SubPlan 4) < 50)
+                     SubPlan 4
+                       ->  Result
+                             Output: (hjtest_1.b * 5)
+         ->  Hash
                Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
-               Filter: ((SubPlan 5) < 55)
-               SubPlan 5
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
+                     Hash Key: (SubPlan 1), (SubPlan 3)
+                     ->  Seq Scan on public.hjtest_2
+                           Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
+                           Filter: ((SubPlan 5) < 55)
+                           SubPlan 5
+                             ->  Result
+                                   Output: (hjtest_2.c * 5)
+               SubPlan 1
+                 ->  Result
+                       Output: 1
+                       One-Time Filter: (hjtest_2.id = 1)
+               SubPlan 3
                  ->  Result
                        Output: (hjtest_2.c * 5)
-         SubPlan 1
+         SubPlan 2
            ->  Result
-                 Output: 1
-                 One-Time Filter: (hjtest_2.id = 1)
-         SubPlan 3
-           ->  Result
-                 Output: (hjtest_2.c * 5)
-   SubPlan 2
-     ->  Result
-           Output: (hjtest_1.b * 5)
-(28 rows)
+                 Output: (hjtest_1.b * 5)
+ Optimizer: Postgres query optimizer
+ Settings: enable_sort = 'off', from_collapse_limit = '1', optimizer = 'off'
+(38 rows)
 
 SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
 FROM hjtest_1, hjtest_2
@@ -1079,37 +1089,47 @@ WHERE
     AND (SELECT hjtest_1.b * 5) < 50
     AND (SELECT hjtest_2.c * 5) < 55
     AND hjtest_1.a <> hjtest_2.b;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Hash Join
-   Output: hjtest_1.a, hjtest_2.a, (hjtest_1.tableoid)::regclass, (hjtest_2.tableoid)::regclass
-   Hash Cond: (((SubPlan 1) = hjtest_1.id) AND ((SubPlan 3) = (SubPlan 2)))
-   Join Filter: (hjtest_1.a <> hjtest_2.b)
-   ->  Seq Scan on public.hjtest_2
-         Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
-         Filter: ((SubPlan 5) < 55)
-         SubPlan 5
-           ->  Result
-                 Output: (hjtest_2.c * 5)
-   ->  Hash
-         Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
-         ->  Seq Scan on public.hjtest_1
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
+   ->  Hash Join
+         Output: hjtest_1.a, hjtest_2.a, (hjtest_1.tableoid)::regclass, (hjtest_2.tableoid)::regclass
+         Hash Cond: (((SubPlan 1) = hjtest_1.id) AND ((SubPlan 3) = (SubPlan 2)))
+         Join Filter: (hjtest_1.a <> hjtest_2.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
+               Hash Key: (SubPlan 1), (SubPlan 3)
+               ->  Seq Scan on public.hjtest_2
+                     Output: hjtest_2.a, hjtest_2.tableoid, hjtest_2.id, hjtest_2.c, hjtest_2.b
+                     Filter: ((SubPlan 5) < 55)
+                     SubPlan 5
+                       ->  Result
+                             Output: (hjtest_2.c * 5)
+         ->  Hash
                Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
-               Filter: ((SubPlan 4) < 50)
-               SubPlan 4
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
+                     Hash Key: hjtest_1.id, (SubPlan 2)
+                     ->  Seq Scan on public.hjtest_1
+                           Output: hjtest_1.a, hjtest_1.tableoid, hjtest_1.id, hjtest_1.b
+                           Filter: ((SubPlan 4) < 50)
+                           SubPlan 4
+                             ->  Result
+                                   Output: (hjtest_1.b * 5)
+               SubPlan 2
                  ->  Result
                        Output: (hjtest_1.b * 5)
-         SubPlan 2
+         SubPlan 1
            ->  Result
-                 Output: (hjtest_1.b * 5)
-   SubPlan 1
-     ->  Result
-           Output: 1
-           One-Time Filter: (hjtest_2.id = 1)
-   SubPlan 3
-     ->  Result
-           Output: (hjtest_2.c * 5)
-(28 rows)
+                 Output: 1
+                 One-Time Filter: (hjtest_2.id = 1)
+         SubPlan 3
+           ->  Result
+                 Output: (hjtest_2.c * 5)
+ Optimizer: Postgres query optimizer
+ Settings: enable_sort = 'off', from_collapse_limit = '1', optimizer = 'off'
+(38 rows)
 
 SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
 FROM hjtest_2, hjtest_1

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -1089,3 +1089,179 @@ explain (costs off) select * from join_hash_t_small, join_hash_t_big where a = b
 
 rollback to settings;
 rollback;
+-- Verify that hash key expressions reference the correct
+-- nodes. Hashjoin's hashkeys need to reference its outer plan, Hash's
+-- need to reference Hash's outer plan (which is below HashJoin's
+-- inner plan). It's not trivial to verify that the references are
+-- correct (we don't display the hashkeys themselves), but if the
+-- hashkeys contain subplan references, those will be displayed. Force
+-- subplans to appear just about everywhere.
+--
+-- Bug report:
+-- https://www.postgresql.org/message-id/CAPpHfdvGVegF_TKKRiBrSmatJL2dR9uwFCuR%2BteQ_8tEXU8mxg%40mail.gmail.com
+--
+BEGIN;
+SET LOCAL enable_sort = OFF; -- avoid mergejoins
+SET LOCAL from_collapse_limit = 1; -- allows easy changing of join order
+CREATE TABLE hjtest_1 (a text, b int, id int, c bool);
+CREATE TABLE hjtest_2 (a bool, id int, b text, c int);
+INSERT INTO hjtest_1(a, b, id, c) VALUES ('text', 2, 1, false); -- matches
+INSERT INTO hjtest_1(a, b, id, c) VALUES ('text', 1, 2, false); -- fails id join condition
+INSERT INTO hjtest_1(a, b, id, c) VALUES ('text', 20, 1, false); -- fails < 50
+INSERT INTO hjtest_1(a, b, id, c) VALUES ('text', 1, 1, false); -- fails (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+INSERT INTO hjtest_2(a, id, b, c) VALUES (true, 1, 'another', 2); -- matches
+INSERT INTO hjtest_2(a, id, b, c) VALUES (true, 3, 'another', 7); -- fails id join condition
+INSERT INTO hjtest_2(a, id, b, c) VALUES (true, 1, 'another', 90);  -- fails < 55
+INSERT INTO hjtest_2(a, id, b, c) VALUES (true, 1, 'another', 3); -- fails (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+INSERT INTO hjtest_2(a, id, b, c) VALUES (true, 1, 'text', 1); --  fails hjtest_1.a <> hjtest_2.b;
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
+FROM hjtest_1, hjtest_2
+WHERE
+    hjtest_1.id = (SELECT 1 WHERE hjtest_2.id = 1)
+    AND (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+    AND (SELECT hjtest_1.b * 5) < 50
+    AND (SELECT hjtest_2.c * 5) < 55
+    AND hjtest_1.a <> hjtest_2.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
+   ->  Hash Join
+         Output: hjtest_1.a, hjtest_2.a, hjtest_1.tableoid, hjtest_2.tableoid
+         Hash Cond: (((1) = hjtest_1.id) AND (((SubPlan 2)) = ((SubPlan 4))))
+         Join Filter: (hjtest_1.a <> hjtest_2.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), ((SubPlan 2))
+               Hash Key: (1)
+               ->  Nested Loop Left Join
+                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), (SubPlan 2)
+                     Join Filter: (hjtest_2.id = 1)
+                     ->  Seq Scan on public.hjtest_2
+                           Output: hjtest_2.a, hjtest_2.id, hjtest_2.b, hjtest_2.c, hjtest_2.tableoid
+                           Filter: (SubPlan 1)
+                           SubPlan 1
+                             ->  Result
+                                   Output: true
+                                   Filter: (((hjtest_2.c * 5)) < 55)
+                                   ->  Result
+                                         Output: (hjtest_2.c * 5)
+                     ->  Result
+                           Output: 1
+                     SubPlan 2
+                       ->  Result
+                             Output: (hjtest_2.c * 5)
+                             ->  Result
+                                   Output: true
+         ->  Hash
+               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+                     Hash Key: hjtest_1.id
+                     ->  Seq Scan on public.hjtest_1
+                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 4)
+                           Filter: (SubPlan 3)
+                           SubPlan 4
+                             ->  Result
+                                   Output: (hjtest_1.b * 5)
+                                   ->  Result
+                                         Output: true
+                           SubPlan 3
+                             ->  Result
+                                   Output: true
+                                   Filter: (((hjtest_1.b * 5)) < 50)
+                                   ->  Result
+                                         Output: (hjtest_1.b * 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_sort = 'off', from_collapse_limit = '1'
+(49 rows)
+
+SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
+FROM hjtest_1, hjtest_2
+WHERE
+    hjtest_1.id = (SELECT 1 WHERE hjtest_2.id = 1)
+    AND (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+    AND (SELECT hjtest_1.b * 5) < 50
+    AND (SELECT hjtest_2.c * 5) < 55
+    AND hjtest_1.a <> hjtest_2.b;
+  a1  | a2 |    t1    |    t2    
+------+----+----------+----------
+ text | t  | hjtest_1 | hjtest_2
+(1 row)
+
+EXPLAIN (COSTS OFF, VERBOSE)
+SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
+FROM hjtest_2, hjtest_1
+WHERE
+    hjtest_1.id = (SELECT 1 WHERE hjtest_2.id = 1)
+    AND (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+    AND (SELECT hjtest_1.b * 5) < 50
+    AND (SELECT hjtest_2.c * 5) < 55
+    AND hjtest_1.a <> hjtest_2.b;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
+   ->  Hash Join
+         Output: hjtest_1.a, hjtest_2.a, hjtest_1.tableoid, hjtest_2.tableoid
+         Hash Cond: (((1) = hjtest_1.id) AND (((SubPlan 2)) = ((SubPlan 4))))
+         Join Filter: (hjtest_1.a <> hjtest_2.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), ((SubPlan 2))
+               Hash Key: (1), ((SubPlan 2))
+               ->  Nested Loop Left Join
+                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), (SubPlan 2)
+                     Join Filter: (hjtest_2.id = 1)
+                     ->  Seq Scan on public.hjtest_2
+                           Output: hjtest_2.a, hjtest_2.id, hjtest_2.b, hjtest_2.c, hjtest_2.tableoid
+                           Filter: (SubPlan 1)
+                           SubPlan 1
+                             ->  Result
+                                   Output: true
+                                   Filter: (((hjtest_2.c * 5)) < 55)
+                                   ->  Result
+                                         Output: (hjtest_2.c * 5)
+                     ->  Result
+                           Output: 1
+                     SubPlan 2
+                       ->  Result
+                             Output: (hjtest_2.c * 5)
+                             ->  Result
+                                   Output: true
+         ->  Hash
+               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+                     Hash Key: hjtest_1.id, ((SubPlan 4))
+                     ->  Seq Scan on public.hjtest_1
+                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 4)
+                           Filter: (SubPlan 3)
+                           SubPlan 4
+                             ->  Result
+                                   Output: (hjtest_1.b * 5)
+                                   ->  Result
+                                         Output: true
+                           SubPlan 3
+                             ->  Result
+                                   Output: true
+                                   Filter: (((hjtest_1.b * 5)) < 50)
+                                   ->  Result
+                                         Output: (hjtest_1.b * 5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_sort = 'off', from_collapse_limit = '1'
+(49 rows)
+
+SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
+FROM hjtest_2, hjtest_1
+WHERE
+    hjtest_1.id = (SELECT 1 WHERE hjtest_2.id = 1)
+    AND (SELECT hjtest_1.b * 5) = (SELECT hjtest_2.c*5)
+    AND (SELECT hjtest_1.b * 5) < 50
+    AND (SELECT hjtest_2.c * 5) < 55
+    AND hjtest_1.a <> hjtest_2.b;
+  a1  | a2 |    t1    |    t2    
+------+----+----------+----------
+ text | t  | hjtest_1 | hjtest_2
+(1 row)
+
+ROLLBACK;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/join_hash.out

Commit 2abd7ae added new tests to the src/test/regress/sql/join_hash.sql file,
we need to adapt their output for the GPDB and add their output for the ORCA
planner.