### PR TITLE
Fix tests in src/test/regress/expected/inherit_optimizer.out

### DIFF
--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -739,6 +739,16 @@ select * from d;
  32 | one | two | three
 (1 row)
 
+-- The above verified that we can change the type of a multiply-inherited
+-- column; but we should reject that if any definition was inherited from
+-- an unrelated parent.
+create temp table parent1(f1 int, f2 int);
+create temp table parent2(f1 int, f3 bigint);
+create temp table childtab(f4 int) inherits(parent1, parent2);
+NOTICE:  merging multiple inherited definitions of column "f1"
+alter table parent1 alter column f1 type bigint;  -- fail, conflict w/parent2
+ERROR:  cannot alter inherited column "f1" of relation "childtab"
+alter table parent1 alter column f2 type bigint;  -- ok
 -- Test non-inheritable parent constraints
 create table p1(ff1 int);
 alter table p1 add constraint p1chk check (ff1 > 0) no inherit;


### PR DESCRIPTION
Fix tests in src/test/regress/expected/inherit_optimizer.out

Commit 4d4c66a added new tests, whose patch prevents altering inherited column
types unless all parent tables have consistently changed the type, allowing
exceptions only when columns originate from a single common ancestor. We need to
add the output to optimizer tests.
