### PR TITLE
Fix tests in src/test/regress/expected/subselect_optimizer.out

### DIFF
--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -790,6 +790,31 @@ select * from outer_text where (f1, f2) not in (select * from inner_text);
 (2 rows)
 
 --
+-- Another test case for cross-type hashed subplans: comparison of
+-- inner-side values must be done with appropriate operator
+--
+explain (verbose, costs off)
+select 'foo'::text in (select 'bar'::name union all select 'bar'::name);
+             QUERY PLAN              
+-------------------------------------
+ Result
+   Output: (hashed SubPlan 1)
+   SubPlan 1
+     ->  Append
+           ->  Result
+                 Output: 'bar'::name
+           ->  Result
+                 Output: 'bar'::name
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select 'foo'::text in (select 'bar'::name union all select 'bar'::name);
+ ?column? 
+----------
+ f
+(1 row)
+
+--
 -- Test case for premature memory release during hashing of subplan output
 --
 select '1'::text in (select '1'::name union all select '1'::name);


### PR DESCRIPTION
Fix tests in src/test/regress/expected/subselect_optimizer.out

Commit 4766dce added new tests to src/test/regress/sql/subselect.sql, we need
to add their output to the ORCA planner.