### PR TITLE
ADBDEV-7552: Fix stable function inlining

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -75,6 +75,7 @@ typedef struct
 	bool		recurse_queries; /* recurse into query structures */
 	bool		recurse_sublink_testexpr; /* recurse into sublink test expressions */
 	Size        max_size; /* max constant binary size in bytes, 0: no restrictions */
+	char		prodataaccess;
 } eval_const_expressions_context;
 
 typedef struct
@@ -2358,6 +2359,7 @@ fold_constants(PlannerInfo *root, Query *q, ParamListInfo boundParams, Size max_
 	context.max_size = max_size;
 	
 	context.eval_stable_functions = should_eval_stable_functions(root);
+	context.prodataaccess = PRODATAACCESS_NONE;
 
 	return (Query *) query_or_expression_tree_mutator
 						(
@@ -2493,6 +2495,7 @@ eval_const_expressions(PlannerInfo *root, Node *node)
 	context.recurse_sublink_testexpr = true;
 	context.max_size = 0;
 	context.eval_stable_functions = should_eval_stable_functions(root);
+	context.prodataaccess = PRODATAACCESS_NONE;
 
 	saved_oid_assignments = SaveOidAssignments();
 	result = eval_const_expressions_mutator(node, &context);
@@ -2533,6 +2536,7 @@ estimate_expression_value(PlannerInfo *root, Node *node)
 	context.recurse_sublink_testexpr = true;
 	context.max_size = 0;
 	context.eval_stable_functions = false;
+	context.prodataaccess = PRODATAACCESS_NONE;
 
 	return eval_const_expressions_mutator(node, &context);
 }
@@ -4269,12 +4273,20 @@ simplify_function(Oid funcid, Oid result_type, int32 result_typmod,
 	 */
 	if (process_args)
 	{
+		bool		isnull;
+		char		prodataaccess = context->prodataaccess;
+
+		context->prodataaccess = DatumGetChar(SysCacheGetAttr(
+			PROCOID, func_tuple, Anum_pg_proc_prodataaccess, &isnull));
+
 		args = expand_function_arguments(args, result_type, func_tuple);
 		args = (List *) expression_tree_mutator((Node *) args,
 												eval_const_expressions_mutator,
 												(void *) context);
 		/* Argument processing done, give it back to the caller */
 		*args_p = args;
+
+		context->prodataaccess = prodataaccess;
 	}
 
 	/* Now attempt simplification of the function call proper. */
@@ -4667,6 +4679,16 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 		 /* okay */ ;
 	else if (context->eval_stable_functions && funcform->provolatile == PROVOLATILE_STABLE)
 	{
+		bool		isnull;
+		char		prodataaccess = DatumGetChar(SysCacheGetAttr(
+			PROCOID, func_tuple, Anum_pg_proc_prodataaccess, &isnull));
+
+		if ((prodataaccess == PRODATAACCESS_NONE ||
+			 prodataaccess == PRODATAACCESS_CONTAINS) &&
+			(context->prodataaccess == PRODATAACCESS_NONE ||
+			 context->prodataaccess == PRODATAACCESS_CONTAINS))
+			return NULL;
+
 		/* okay, but we cannot reuse this plan */
 		context->root->glob->oneoffPlan = true;
 	}

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4683,10 +4683,8 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 		char		prodataaccess = DatumGetChar(SysCacheGetAttr(
 			PROCOID, func_tuple, Anum_pg_proc_prodataaccess, &isnull));
 
-		if ((prodataaccess == PRODATAACCESS_NONE ||
-			 prodataaccess == PRODATAACCESS_CONTAINS) &&
-			(context->prodataaccess == PRODATAACCESS_NONE ||
-			 context->prodataaccess == PRODATAACCESS_CONTAINS))
+		if (prodataaccess == PRODATAACCESS_NONE &&
+			context->prodataaccess == PRODATAACCESS_NONE)
 			return NULL;
 
 		/* okay, but we cannot reuse this plan */

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4683,8 +4683,10 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 		char		prodataaccess = DatumGetChar(SysCacheGetAttr(
 			PROCOID, func_tuple, Anum_pg_proc_prodataaccess, &isnull));
 
-		if (prodataaccess == PRODATAACCESS_NONE &&
-			context->prodataaccess == PRODATAACCESS_NONE)
+		if ((prodataaccess == PRODATAACCESS_NONE ||
+			 prodataaccess == PRODATAACCESS_CONTAINS) &&
+			(context->prodataaccess == PRODATAACCESS_NONE ||
+			 context->prodataaccess == PRODATAACCESS_CONTAINS))
 			return NULL;
 
 		/* okay, but we cannot reuse this plan */

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -819,17 +819,17 @@ reset optimizer;
 --
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database()) as x from (values(1),(2)) v(y)) ss;
+    (select (select now()) as x from (values(1),(2)) v(y)) ss;
               QUERY PLAN              
 --------------------------------------
  Values Scan on "*VALUES*"
    Output: $0, $1
    InitPlan 1 (returns $0)
      ->  Result
-           Output: 'regression'::name
+           Output: now()
    InitPlan 2 (returns $1)
      ->  Result
-           Output: 'regression'::name
+           Output: now()
  Optimizer: Postgres query optimizer
 (9 rows)
 
@@ -850,18 +850,18 @@ explain (verbose, costs off)
 
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database() where y=y) as x from (values(1),(2)) v(y)) ss;
+    (select (select now() where y=y) as x from (values(1),(2)) v(y)) ss;
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Values Scan on "*VALUES*"
    Output: (SubPlan 1), (SubPlan 2)
    SubPlan 1
      ->  Result
-           Output: 'regression'::name
+           Output: now()
            One-Time Filter: ("*VALUES*".column1 = "*VALUES*".column1)
    SubPlan 2
      ->  Result
-           Output: 'regression'::name
+           Output: now()
            One-Time Filter: ("*VALUES*".column1 = "*VALUES*".column1)
  Optimizer: Postgres query optimizer
 (11 rows)
@@ -1291,14 +1291,14 @@ select * from x where f1 = 1;
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() from subselect_tbl) ss)
+with x as (select * from (select f1, now() from subselect_tbl) ss)
 select * from x where f1 = 1;
                       QUERY PLAN                      
 ------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   Output: subselect_tbl.f1, ('regression'::name)
+   Output: subselect_tbl.f1, (now())
    ->  Seq Scan on public.subselect_tbl
-         Output: subselect_tbl.f1, 'regression'::name
+         Output: subselect_tbl.f1, now()
          Filter: (subselect_tbl.f1 = 1)
  Optimizer: Postgres query optimizer
  Settings: gp_cte_sharing=on
@@ -1370,7 +1370,7 @@ select * from x where f1 = 1;
 
 -- Multiply-referenced CTEs are inlined only when requested
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
@@ -1392,33 +1392,33 @@ select * from x, x x2 where x.n = x2.n;
                      ->  Shared Scan (share slice:id 3:0)
                            Output: share0_ref1.f1, share0_ref1.n
                            ->  Seq Scan on public.subselect_tbl
-                                 Output: subselect_tbl.f1, 'regression'::name
+                                 Output: subselect_tbl.f1, now()
  Optimizer: Postgres query optimizer
  Settings: gp_cte_sharing=on
 (21 rows)
 
 explain (verbose, costs off)
-with x as not materialized (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as not materialized (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: subselect_tbl.f1, ('regression'::name), subselect_tbl_1.f1, ('regression'::name)
+   Output: subselect_tbl.f1, (now()), subselect_tbl_1.f1, (now())
    ->  Hash Join
-         Output: subselect_tbl.f1, ('regression'::name), subselect_tbl_1.f1, ('regression'::name)
-         Hash Cond: (('regression'::name) = ('regression'::name))
+         Output: subselect_tbl.f1, (now()), subselect_tbl_1.f1, (now())
+         Hash Cond: ((now()) = (now()))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Output: subselect_tbl.f1, ('regression'::name)
-               Hash Key: ('regression'::name)
+               Output: subselect_tbl.f1, (now())
+               Hash Key: (now())
                ->  Seq Scan on public.subselect_tbl
-                     Output: subselect_tbl.f1, 'regression'::name
+                     Output: subselect_tbl.f1, now()
          ->  Hash
-               Output: subselect_tbl_1.f1, ('regression'::name)
+               Output: subselect_tbl_1.f1, (now())
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Output: subselect_tbl_1.f1, ('regression'::name)
-                     Hash Key: ('regression'::name)
+                     Output: subselect_tbl_1.f1, (now())
+                     Hash Key: (now())
                      ->  Seq Scan on public.subselect_tbl subselect_tbl_1
-                           Output: subselect_tbl_1.f1, 'regression'::name
+                           Output: subselect_tbl_1.f1, now()
  Optimizer: Postgres query optimizer
  Settings: gp_cte_sharing=on
 (19 rows)

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1113,12 +1113,12 @@ explain (verbose, costs off)
 select * from
   (select 9 as x, unnest(array[1,2,3,11,12,13]) as u) ss
   where tattle(x, 8);
-NOTICE:  x = 9, y = 8
                      QUERY PLAN                     
 ----------------------------------------------------
  ProjectSet
    Output: 9, unnest('{1,2,3,11,12,13}'::integer[])
    ->  Result
+         One-Time Filter: tattle(9, 8)
 (4 rows)
 
 select * from

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -845,20 +845,18 @@ reset optimizer;
 --
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database()) as x from (values(1),(2)) v(y)) ss;
-              QUERY PLAN              
---------------------------------------
- Values Scan on "*VALUES*"
-   Output: $0, $1
-   InitPlan 1 (returns $0)
-     ->  Result
-           Output: 'regression'::name
-   InitPlan 2 (returns $1)
-     ->  Result
-           Output: 'regression'::name
- Optimizer: Postgres query optimizer
- Settings: optimizer=on
-(9 rows)
+    (select (select now()) as x from (values(1),(2)) v(y)) ss;
+              QUERY PLAN               
+---------------------------------------
+ Nested Loop Left Join
+   Output: (now()), (now())
+   Join Filter: true
+   ->  Values Scan on "Values"
+         Output: column1
+   ->  Result
+         Output: now()
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -877,22 +875,18 @@ explain (verbose, costs off)
 
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database() where y=y) as x from (values(1),(2)) v(y)) ss;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Values Scan on "*VALUES*"
-   Output: (SubPlan 1), (SubPlan 2)
-   SubPlan 1
-     ->  Result
-           Output: 'regression'::name
-           One-Time Filter: ("*VALUES*".column1 = "*VALUES*".column1)
-   SubPlan 2
-     ->  Result
-           Output: 'regression'::name
-           One-Time Filter: ("*VALUES*".column1 = "*VALUES*".column1)
- Optimizer: Postgres query optimizer
- Settings: optimizer=on
-(9 rows)
+    (select (select now() where y=y) as x from (values(1),(2)) v(y)) ss;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop Left Join
+   Output: (now()), (now())
+   Join Filter: ("Values".column1 = "Values".column1)
+   ->  Values Scan on "Values"
+         Output: column1
+   ->  Result
+         Output: now()
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -1321,17 +1315,17 @@ select * from x where f1 = 1;
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() from subselect_tbl) ss)
+with x as (select * from (select f1, now() from subselect_tbl) ss)
 select * from x where f1 = 1;
                       QUERY PLAN                      
 ------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   Output: subselect_tbl.f1, ('regression'::name)
+   Output: f1, (now())
    ->  Seq Scan on public.subselect_tbl
-         Output: subselect_tbl.f1, 'regression'::name
+         Output: f1, now()
          Filter: (subselect_tbl.f1 = 1)
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: gp_cte_sharing = 'on'
 (7 rows)
 
 -- Volatile functions prevent inlining
@@ -1410,58 +1404,68 @@ select * from x where f1 = 1;
 
 -- Multiply-referenced CTEs are inlined only when requested
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: share0_ref2.f1, share0_ref2.n, share0_ref1.f1, share0_ref1.n
-   ->  Hash Join
-         Output: share0_ref2.f1, share0_ref2.n, share0_ref1.f1, share0_ref1.n
-         Hash Cond: (share0_ref2.n = share0_ref1.n)
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Output: share0_ref2.f1, share0_ref2.n
-               Hash Key: share0_ref2.n
-               ->  Shared Scan (share slice:id 2:0)
-                     Output: share0_ref2.f1, share0_ref2.n
-         ->  Hash
+   Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+   ->  Sequence
+         Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+         ->  Shared Scan (share slice:id 1:0)
                Output: share0_ref1.f1, share0_ref1.n
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Output: share0_ref1.f1, share0_ref1.n
-                     Hash Key: share0_ref1.n
-                     ->  Shared Scan (share slice:id 3:0)
-                           Output: share0_ref1.f1, share0_ref1.n
-                           ->  Seq Scan on public.subselect_tbl
-                                 Output: subselect_tbl.f1, 'regression'::name
- Optimizer: Postgres query optimizer
- Settings: gp_cte_sharing=on, optimizer=on
-(21 rows)
+               ->  Seq Scan on public.subselect_tbl
+                     Output: subselect_tbl.f1, now()
+         ->  Hash Join
+               Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+               Hash Cond: (share0_ref3.n = share0_ref2.n)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: share0_ref3.f1, share0_ref3.n
+                     Hash Key: share0_ref3.n
+                     ->  Shared Scan (share slice:id 2:0)
+                           Output: share0_ref3.f1, share0_ref3.n
+               ->  Hash
+                     Output: share0_ref2.f1, share0_ref2.n
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: share0_ref2.f1, share0_ref2.n
+                           Hash Key: share0_ref2.n
+                           ->  Shared Scan (share slice:id 3:0)
+                                 Output: share0_ref2.f1, share0_ref2.n
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: gp_cte_sharing = 'on'
+(25 rows)
 
 explain (verbose, costs off)
-with x as not materialized (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as not materialized (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: subselect_tbl.f1, ('regression'::name), subselect_tbl_1.f1, ('regression'::name)
-   ->  Hash Join
-         Output: subselect_tbl.f1, ('regression'::name), subselect_tbl_1.f1, ('regression'::name)
-         Hash Cond: (('regression'::name) = ('regression'::name))
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Output: subselect_tbl.f1, ('regression'::name)
-               Hash Key: ('regression'::name)
+   Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+   ->  Sequence
+         Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+         ->  Shared Scan (share slice:id 1:0)
+               Output: share0_ref1.f1, share0_ref1.n
                ->  Seq Scan on public.subselect_tbl
-                     Output: subselect_tbl.f1, 'regression'::name
-         ->  Hash
-               Output: subselect_tbl_1.f1, ('regression'::name)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Output: subselect_tbl_1.f1, ('regression'::name)
-                     Hash Key: ('regression'::name)
-                     ->  Seq Scan on public.subselect_tbl subselect_tbl_1
-                           Output: subselect_tbl_1.f1, 'regression'::name
- Optimizer: Postgres query optimizer
- Settings: gp_cte_sharing=on, optimizer=on
-(19 rows)
+                     Output: subselect_tbl.f1, now()
+         ->  Hash Join
+               Output: share0_ref3.f1, share0_ref3.n, share0_ref2.f1, share0_ref2.n
+               Hash Cond: (share0_ref3.n = share0_ref2.n)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: share0_ref3.f1, share0_ref3.n
+                     Hash Key: share0_ref3.n
+                     ->  Shared Scan (share slice:id 2:0)
+                           Output: share0_ref3.f1, share0_ref3.n
+               ->  Hash
+                     Output: share0_ref2.f1, share0_ref2.n
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Output: share0_ref2.f1, share0_ref2.n
+                           Hash Key: share0_ref2.n
+                           ->  Shared Scan (share slice:id 3:0)
+                                 Output: share0_ref2.f1, share0_ref2.n
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: gp_cte_sharing = 'on'
+(25 rows)
 
 -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs
 explain (verbose, costs off)

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -493,13 +493,13 @@ reset optimizer;
 --
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database()) as x from (values(1),(2)) v(y)) ss;
+    (select (select now()) as x from (values(1),(2)) v(y)) ss;
 explain (verbose, costs off)
   select x, x from
     (select (select random()) as x from (values(1),(2)) v(y)) ss;
 explain (verbose, costs off)
   select x, x from
-    (select (select current_database() where y=y) as x from (values(1),(2)) v(y)) ss;
+    (select (select now() where y=y) as x from (values(1),(2)) v(y)) ss;
 explain (verbose, costs off)
   select x, x from
     (select (select random() where y=y) as x from (values(1),(2)) v(y)) ss;
@@ -704,7 +704,7 @@ select * from x where f1 = 1;
 
 -- Stable functions are safe to inline
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() from subselect_tbl) ss)
+with x as (select * from (select f1, now() from subselect_tbl) ss)
 select * from x where f1 = 1;
 
 
@@ -734,11 +734,11 @@ select * from x where f1 = 1;
 
 -- Multiply-referenced CTEs are inlined only when requested
 explain (verbose, costs off)
-with x as (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
 
 explain (verbose, costs off)
-with x as not materialized (select * from (select f1, current_database() as n from subselect_tbl) ss)
+with x as not materialized (select * from (select f1, now() as n from subselect_tbl) ss)
 select * from x, x x2 where x.n = x2.n;
 
 -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs


### PR DESCRIPTION
Fix stable function inlining

Commit 7266d09 renamed inline_set_returning_functions to
preprocess_function_rtes and added a call to eval_const_expressions to apply
const-simplification, while the earlier GPDB-specific commit 4cf4743 had
already added similar behavior for stable functions. However, in the case of
explicitly specifying the function's return type as columns, using both
approaches together results in an error, because the GPDB-specific code tries
to call the function without specifying the return type.

SELECT * FROM json_populate_record(null::record, '{"x": 776}') AS (x int, y int);
ERROR:  could not determine row type for result of json_populate_record

The patch uses a GPDB-specific addition of prodataaccess by specifying the type
of SQL statements for a function. Stable functions that read or modify data
must be precomputed (but only once, which is controlled by the oneoffPlan
parameter setting), otherwise the segment will try to access all the data,
which is impossible.

Checking the parent function type is needed for cases like in the test:

SELECT * FROM func1_read_int_sql_stb(func2_nosql_stb(5)), foo order by 1,2,3;

Commits b97ee66 and 608b167 added new tests to
src/test/regress/sql/subselect.sql with the now function, and commits 1617960
and 19cd1cf replaced the now function with the current_database function. To
avoid new conflicts during sync, this patch returns the now function to the
tests.

Commit 72daabc added new tests to src/test/regress/sql/subselect.sql, while the
stable tattle function was in the One-Time Filter and did not issue
notifications when planning a query, but only when executing, and commit
19cd1cf removed the One-Time Filter and added notifications when planning. To
avoid new conflicts during sync, this patch again adds the One-Time Filter and
removes notifications when planning.

Ticket: ADBDEV-7552