### PR TITLE
Fix tests in src/test/regress/expected/join_optimizer.out

### DIFF
--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3478,45 +3478,6 @@ where t1.unique2 < 42 and t1.stringu1 > t2.stringu2;
       11 | WFAAAA   |       3 | LKIAAA
 (1 row)
 
--- test inlining when function returns composite
-create function mki8(bigint, bigint) returns int8_tbl as
-$$select row($1,$2)::int8_tbl$$ language sql;
-create function mki4(int) returns int4_tbl as
-$$select row($1)::int4_tbl$$ language sql;
-explain (verbose, costs off)
-select * from mki8(1,2);
-              QUERY PLAN               
----------------------------------------
- Function Scan on mki8
-   Output: q1, q2
-   Function Call: '(1,2)'::int8_tbl
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
-
-select * from mki8(1,2);
- q1 | q2 
-----+----
-  1 |  2
-(1 row)
-
-explain (verbose, costs off)
-select * from mki4(42);
-              QUERY PLAN               
----------------------------------------
- Function Scan on mki4
-   Output: f1
-   Function Call: '(42)'::int4_tbl
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
-
-select * from mki4(42);
- f1 
-----
- 42
-(1 row)
-
-drop function mki8(bigint, bigint);
-drop function mki4(int);
 --
 -- test inlining of immutable functions
 --
@@ -3692,6 +3653,45 @@ where nt3.id = 1 and ss2.b3;
 (17 rows)
 
 drop function f_immutable_int4(int);
+-- test inlining when function returns composite
+create function mki8(bigint, bigint) returns int8_tbl as
+$$select row($1,$2)::int8_tbl$$ language sql;
+create function mki4(int) returns int4_tbl as
+$$select row($1)::int4_tbl$$ language sql;
+explain (verbose, costs off)
+select * from mki8(1,2);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki8
+   Output: q1, q2
+   Function Call: '(1,2)'::int8_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki8(1,2);
+ q1 | q2 
+----+----
+  1 |  2
+(1 row)
+
+explain (verbose, costs off)
+select * from mki4(42);
+              QUERY PLAN               
+---------------------------------------
+ Function Scan on mki4
+   Output: f1
+   Function Call: '(42)'::int4_tbl
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from mki4(42);
+ f1 
+----
+ 42
+(1 row)
+
+drop function mki8(bigint, bigint);
+drop function mki4(int);
 --
 -- test extraction of restriction OR clauses from join OR clause
 -- (we used to only do this for indexable clauses)


### PR DESCRIPTION
Fix tests in src/test/regress/expected/join_optimizer.out

Commit ecbb378 mistakenly added new output in the wrong place, this patch fixes
that.