### PR TITLE
Fix conflicts in configure

### DIFF
--- a/configure
+++ b/configure
@@ -16266,7 +16266,6 @@ if test x"$pgac_cv_computed_goto" = xyes ; then
 $as_echo "#define HAVE_COMPUTED_GOTO 1" >>confdefs.h
 
 fi
-<<<<<<< HEAD
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_frame_address" >&5
 $as_echo_n "checking for __builtin_frame_address... " >&6; }
 if ${pgac_cv__builtin_frame_address+:} false; then :
@@ -16298,43 +16297,7 @@ if test x"$pgac_cv__builtin_frame_address" = xyes ; then
 $as_echo "#define HAVE__BUILTIN_FRAME_ADDRESS 1" >>confdefs.h
 
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether struct tm is in sys/time.h or time.h" >&5
-$as_echo_n "checking whether struct tm is in sys/time.h or time.h... " >&6; }
-if ${ac_cv_struct_tm+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <sys/types.h>
-#include <time.h>
 
-int
-main ()
-{
-struct tm tm;
-				     int *p = &tm.tm_sec;
-				     return !p;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_struct_tm=time.h
-else
-  ac_cv_struct_tm=sys/time.h
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_tm" >&5
-$as_echo "$ac_cv_struct_tm" >&6; }
-if test $ac_cv_struct_tm = sys/time.h; then
-
-$as_echo "#define TM_IN_SYS_TIME 1" >>confdefs.h
-
-fi
-
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 ac_fn_c_check_member "$LINENO" "struct tm" "tm_zone" "ac_cv_member_struct_tm_tm_zone" "#include <sys/types.h>
 #include <time.h>
 

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -721,16 +721,9 @@
 /* Define to 1 if you have the <termios.h> header file. */
 #undef HAVE_TERMIOS_H
 
-<<<<<<< HEAD
 /* Define to 1 if you have the <time.h> header file. */
 #undef HAVE_TIME_H
 
-/* Define to 1 if your `struct tm' has `tm_zone'. Deprecated, use
-   `HAVE_STRUCT_TM_TM_ZONE' instead. */
-#undef HAVE_TM_ZONE
-
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 /* Define to 1 if your compiler understands `typeof' or something similar. */
 #undef HAVE_TYPEOF
 


### PR DESCRIPTION
Fix conflicts in configure and src/include/pg_config.h.in

1) Commit 400d5ff simplified the timezone macro definition in configure, while
earlier commit 19cd1cf had already added another macro definition in the same
place.

2) Commit 400d5ff removed the HAVE_TM_ZONE macro from
src/include/pg_config.h.in, while earlier commit 6b0e52b had already added the
HAVE_TIME_H macro before it.