### PR TITLE
Fix conflicts in heaptoast.h, heapam.c, heaptoast.c and rewriteheap.c

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2804,11 +2804,11 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 	 * into the relation; instup is the caller's original untoasted data.
 	 */
 	if (need_toast)
-		tup = heap_toast_insert_or_update_memtup(relation, instup, NULL,
-												 aoInsertDesc->mt_bind,
-												 aoInsertDesc->toast_tuple_target,
-												 false,	/* errtbl is never AO */
-												 0);
+		tup = mem_toast_insert_or_update(relation, instup, NULL,
+										 aoInsertDesc->mt_bind,
+										 aoInsertDesc->toast_tuple_target,
+										 false,	/* errtbl is never AO */
+										 0);
 	else
 		tup = instup;
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2804,11 +2804,11 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 	 * into the relation; instup is the caller's original untoasted data.
 	 */
 	if (need_toast)
-		tup = toast_insert_or_update_memtup(relation, instup,
-											NULL, aoInsertDesc->mt_bind,
-											aoInsertDesc->toast_tuple_target,
-											false,	/* errtbl is never AO */
-											0);
+		tup = heap_toast_insert_or_update_memtup(relation, instup, NULL,
+												 aoInsertDesc->mt_bind,
+												 aoInsertDesc->toast_tuple_target,
+												 false,	/* errtbl is never AO */
+												 0);
 	else
 		tup = instup;
 

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2159,13 +2159,9 @@ heap_prepare_insert(Relation relation, HeapTuple tup, TransactionId xid,
 		return tup;
 	}
 	else if (HeapTupleHasExternal(tup) || tup->t_len > TOAST_TUPLE_THRESHOLD)
-<<<<<<< HEAD
-		return toast_insert_or_update(relation, tup, NULL,
-									  TOAST_TUPLE_TARGET, isFrozen,
-									  options);
-=======
-		return heap_toast_insert_or_update(relation, tup, NULL, options);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+		return heap_toast_insert_or_update(relation, tup, NULL,
+										   TOAST_TUPLE_TARGET, isFrozen,
+										   options);
 	else
 		return tup;
 }
@@ -3610,12 +3606,9 @@ l2:
 		if (need_toast)
 		{
 			/* Note we always use WAL and FSM during updates */
-<<<<<<< HEAD
-			heaptup = toast_insert_or_update(relation, newtup, &oldtup,
-											 TOAST_TUPLE_TARGET, false, 0);
-=======
-			heaptup = heap_toast_insert_or_update(relation, newtup, &oldtup, 0);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+			heaptup = heap_toast_insert_or_update(relation, newtup, &oldtup,
+												  TOAST_TUPLE_TARGET, false,
+												  0);
 			newtupsize = MAXALIGN(heaptup->t_len);
 		}
 		else

--- a/src/backend/access/heap/heaptoast.c
+++ b/src/backend/access/heap/heaptoast.c
@@ -104,7 +104,7 @@ compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool hasnull, Dat
 
 
 static void *
-heap_toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
+toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 							   MemTupleBinding *pbind, int toast_tuple_target,
 							   bool isFrozen, int options, bool ismemtuple)
 {
@@ -392,32 +392,31 @@ heap_toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 
 HeapTuple
 heap_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
-					   int toast_tuple_target,
-					   bool isFrozen, int options)
+						    int toast_tuple_target, bool isFrozen, int options)
 {
-	return (HeapTuple) heap_toast_insert_or_update_generic(rel,
-														   (void *) newtup,
-														   (void *) oldtup,
-														   NULL,
-														   toast_tuple_target,
-														   isFrozen,
-														   options,
-														   false);
+	return (HeapTuple) toast_insert_or_update_generic(rel,
+													  (void *) newtup,
+													  (void *) oldtup,
+													  NULL,
+													  toast_tuple_target,
+													  isFrozen,
+													  options,
+													  false);
 }
 
 MemTuple
-heap_toast_insert_or_update_memtup(Relation rel, MemTuple newtup, MemTuple oldtup,
-					   MemTupleBinding *pbind, int toast_tuple_target,
-					   bool isFrozen, int options)
+mem_toast_insert_or_update(Relation rel, MemTuple newtup, MemTuple oldtup,
+						   MemTupleBinding *pbind, int toast_tuple_target,
+						   bool isFrozen, int options)
 {
-	return (MemTuple) heap_toast_insert_or_update_generic(rel,
-														  (void *) newtup,
-														  (void *) oldtup,
-														  pbind,
-														  toast_tuple_target,
-														  isFrozen,
-														  options,
-														  true);
+	return (MemTuple) toast_insert_or_update_generic(rel,
+													 (void *) newtup,
+													 (void *) oldtup,
+													 pbind,
+													 toast_tuple_target,
+													 isFrozen,
+													 options,
+													 true);
 }
 
 /* ----------

--- a/src/backend/access/heap/heaptoast.c
+++ b/src/backend/access/heap/heaptoast.c
@@ -90,14 +90,8 @@ heap_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
  * from the pre-8.1 API of this routine.
  * ----------
  */
-<<<<<<< HEAD
 static int
 compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool hasnull, Datum *d, bool *isnull)
-=======
-HeapTuple
-heap_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
-							int options)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 {
 	if(pbind)
 	{
@@ -110,7 +104,7 @@ heap_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 
 
 static void *
-toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
+heap_toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 							   MemTupleBinding *pbind, int toast_tuple_target,
 							   bool isFrozen, int options, bool ismemtuple)
 {
@@ -397,33 +391,33 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 }
 
 HeapTuple
-toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
+heap_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 					   int toast_tuple_target,
 					   bool isFrozen, int options)
 {
-	return (HeapTuple) toast_insert_or_update_generic(rel,
-													  (void *) newtup,
-													  (void *) oldtup,
-													  NULL,
-													  toast_tuple_target,
-													  isFrozen,
-													  options,
-													  false);
+	return (HeapTuple) heap_toast_insert_or_update_generic(rel,
+														   (void *) newtup,
+														   (void *) oldtup,
+														   NULL,
+														   toast_tuple_target,
+														   isFrozen,
+														   options,
+														   false);
 }
 
 MemTuple
-toast_insert_or_update_memtup(Relation rel, MemTuple newtup, MemTuple oldtup,
+heap_toast_insert_or_update_memtup(Relation rel, MemTuple newtup, MemTuple oldtup,
 					   MemTupleBinding *pbind, int toast_tuple_target,
 					   bool isFrozen, int options)
 {
-	return (MemTuple) toast_insert_or_update_generic(rel,
-													 (void *) newtup,
-													 (void *) oldtup,
-													 pbind,
-													 toast_tuple_target,
-													 isFrozen,
-													 options,
-													 true);
+	return (MemTuple) heap_toast_insert_or_update_generic(rel,
+														  (void *) newtup,
+														  (void *) oldtup,
+														  pbind,
+														  toast_tuple_target,
+														  isFrozen,
+														  options,
+														  true);
 }
 
 /* ----------

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -664,15 +664,9 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 		 */
 		options |= HEAP_INSERT_NO_LOGICAL;
 
-<<<<<<< HEAD
-		heaptup = toast_insert_or_update(state->rs_new_rel, tup, NULL,
-										 TOAST_TUPLE_TARGET,
-										 false,
-										 options);
-=======
 		heaptup = heap_toast_insert_or_update(state->rs_new_rel, tup, NULL,
+											  TOAST_TUPLE_TARGET, false,
 											  options);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 	}
 	else
 		heaptup = tup;

--- a/src/backend/cdb/motion/tupser.c
+++ b/src/backend/cdb/motion/tupser.c
@@ -444,7 +444,7 @@ SerializeTuple(TupleTableSlot *slot, SerTupInfo *pSerInfo, struct directTranspor
 						memcpy(values, slot->tts_values, tupdesc->natts * sizeof(Datum));
 					}
 					Assert(&values[i] != &slot->tts_values[i]);
-					values[i] = PointerGetDatum(heap_tuple_fetch_attr((struct varlena *)
+					values[i] = PointerGetDatum(detoast_external_attr((struct varlena *)
 																DatumGetPointer(val)));
 				}
 			}

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1054,7 +1054,7 @@ datumstreamwrite_lob(DatumStreamWrite * acc,
 	 */
 	if (VARATT_IS_EXTERNAL(DatumGetPointer(d)))
 	{
-		d = PointerGetDatum(heap_tuple_fetch_attr(
+		d = PointerGetDatum(detoast_external_attr(
 								(struct varlena *) DatumGetPointer(d)));
 	}
 

--- a/src/include/access/heaptoast.h
+++ b/src/include/access/heaptoast.h
@@ -111,10 +111,11 @@ extern HeapTuple heap_toast_insert_or_update(Relation rel,
 										int toast_tuple_target,
 										bool isFrozen, int options);
 
-extern MemTuple heap_toast_insert_or_update_memtup(Relation rel,
-											  MemTuple newtup, MemTuple oldtup,
-											  MemTupleBinding *pbind, int toast_tuple_target,
-											  bool isFrozen, int options);
+extern MemTuple mem_toast_insert_or_update(Relation rel, MemTuple newtup,
+										   MemTuple oldtup,
+										   MemTupleBinding *pbind,
+										   int toast_tuple_target,
+										   bool isFrozen, int options);
 
 /* ----------
  * heap_toast_delete -

--- a/src/include/access/heaptoast.h
+++ b/src/include/access/heaptoast.h
@@ -106,20 +106,15 @@
  *	toasted data to be inserted frozen as well.
  * ----------
  */
-<<<<<<< HEAD
-extern HeapTuple toast_insert_or_update(Relation rel,
+extern HeapTuple heap_toast_insert_or_update(Relation rel,
 										HeapTuple newtup, HeapTuple oldtup,
 										int toast_tuple_target,
 										bool isFrozen, int options);
 
-extern MemTuple toast_insert_or_update_memtup(Relation rel,
+extern MemTuple heap_toast_insert_or_update_memtup(Relation rel,
 											  MemTuple newtup, MemTuple oldtup,
 											  MemTupleBinding *pbind, int toast_tuple_target,
 											  bool isFrozen, int options);
-=======
-extern HeapTuple heap_toast_insert_or_update(Relation rel, HeapTuple newtup,
-											 HeapTuple oldtup, int options);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 /* ----------
  * heap_toast_delete -

--- a/src/include/access/heaptoast.h
+++ b/src/include/access/heaptoast.h
@@ -106,10 +106,10 @@
  *	toasted data to be inserted frozen as well.
  * ----------
  */
-extern HeapTuple heap_toast_insert_or_update(Relation rel,
-										HeapTuple newtup, HeapTuple oldtup,
-										int toast_tuple_target,
-										bool isFrozen, int options);
+extern HeapTuple heap_toast_insert_or_update(Relation rel, HeapTuple newtup,
+											 HeapTuple oldtup,
+											 int toast_tuple_target,
+											 bool isFrozen, int options);
 
 extern MemTuple mem_toast_insert_or_update(Relation rel, MemTuple newtup,
 										   MemTuple oldtup,


### PR DESCRIPTION
Fix conflicts in heaptoast.h, heapam.c, heaptoast.c and rewriteheap.c

1) Commit 2e8b6bf renamed the function toast_insert_or_update to
heap_toast_insert_or_update, while earlier commit c02f93d had already added a
definition of a new function toast_insert_or_update_memtup after it.

2) Commit 2e8b6bf renamed the function heap_tuple_fetch_attr to
detoast_external_attr, we need to do the same in GPDB-specific functions/files.