### PR TITLE
Fix conflicts in reloptions.h and reloptions.c

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -755,14 +755,9 @@ add_int_reloption(bits32 kinds, const char *name, const char *desc, int default_
  *		Add a new float reloption
  */
 void
-<<<<<<< HEAD
 add_real_reloption(bits32 kinds, const char *name, const char *desc,
 				   double default_val, double min_val, double max_val,
 				   LOCKMODE lockmode)
-=======
-add_real_reloption(bits32 kinds, const char *name, const char *desc, double default_val,
-				   double min_val, double max_val, LOCKMODE lockmode)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 {
 	relopt_real *newoption;
 
@@ -813,14 +808,9 @@ add_enum_reloption(bits32 kinds, const char *name, const char *desc,
  * the validation.
  */
 void
-<<<<<<< HEAD
 add_string_reloption(bits32 kinds, const char *name, const char *desc,
 					 const char *default_val, validate_string_relopt validator,
 					 LOCKMODE lockmode)
-=======
-add_string_reloption(bits32 kinds, const char *name, const char *desc, const char *default_val,
-					 validate_string_relopt validator, LOCKMODE lockmode)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 {
 	relopt_string *newoption;
 

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -755,9 +755,8 @@ add_int_reloption(bits32 kinds, const char *name, const char *desc, int default_
  *		Add a new float reloption
  */
 void
-add_real_reloption(bits32 kinds, const char *name, const char *desc,
-				   double default_val, double min_val, double max_val,
-				   LOCKMODE lockmode)
+add_real_reloption(bits32 kinds, const char *name, const char *desc, double default_val,
+				   double min_val, double max_val, LOCKMODE lockmode)
 {
 	relopt_real *newoption;
 
@@ -808,9 +807,8 @@ add_enum_reloption(bits32 kinds, const char *name, const char *desc,
  * the validation.
  */
 void
-add_string_reloption(bits32 kinds, const char *name, const char *desc,
-					 const char *default_val, validate_string_relopt validator,
-					 LOCKMODE lockmode)
+add_string_reloption(bits32 kinds, const char *name, const char *desc, const char *default_val,
+					 validate_string_relopt validator, LOCKMODE lockmode)
 {
 	relopt_string *newoption;
 

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -297,16 +297,11 @@ extern void add_int_reloption(bits32 kinds, const char *name, const char *desc,
 							  int default_val, int min_val, int max_val,
 							  LOCKMODE lockmode);
 extern void add_real_reloption(bits32 kinds, const char *name, const char *desc,
-<<<<<<< HEAD
-							   double default_val, double min_val,double max_val,
-							   LOCKMODE lockmode);
-=======
 							   double default_val, double min_val, double max_val,
 							   LOCKMODE lockmode);
 extern void add_enum_reloption(bits32 kinds, const char *name, const char *desc,
 							   relopt_enum_elt_def *members, int default_val,
 							   const char *detailmsg, LOCKMODE lockmode);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 extern void add_string_reloption(bits32 kinds, const char *name, const char *desc,
 								 const char *default_val, validate_string_relopt validator,
 								 LOCKMODE lockmode);


### PR DESCRIPTION
Fix conflicts in reloptions.h and reloptions.c

1) Commit 773df88 added a new function add_enum_reloption to
src/include/access/reloptions.h, while an earlier commit d3e0a65 for some
reason removed the space between the arguments double min_val and double
max_val in the previous definition of the function add_real_reloption.

2) Commit 69f9410 added a new argument LOCKMODE lockmode to the functions
add_real_reloption and add_string_reloption, while an earlier commit d3e0a65
had already done this, but with different formatting.