### PR TITLE
Fix conflicts in src/include/access/table.h

### DIFF
--- a/contrib/indexscan/indexscan.c
+++ b/contrib/indexscan/indexscan.c
@@ -211,7 +211,7 @@ readindex(PG_FUNCTION_ARGS)
 	if (!irel)
 		irel = index_open(info->ireloid, NoLock);
 	if (!hrel && info->hreloid != InvalidOid)
-		hrel = heap_open(info->hreloid, NoLock);
+		hrel = table_open(info->hreloid, NoLock);
 
 	while (info->blkno < info->num_pages)
 	{
@@ -261,14 +261,14 @@ readindex(PG_FUNCTION_ARGS)
 		result = HeapTupleGetDatum(tuple);
 
 		if (hrel != NULL)
-			heap_close(hrel, NoLock);
+			table_close(hrel, NoLock);
 		index_close(irel, NoLock);
 
 		SRF_RETURN_NEXT(funcctx, result);
 	}
 
 	if (hrel != NULL)
-		heap_close(hrel, AccessShareLock);
+		table_close(hrel, AccessShareLock);
 	index_close(irel, AccessShareLock);
 	SRF_RETURN_DONE(funcctx);
 }

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -86,7 +86,7 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();
 
-	segrel = heap_open(segrelid, RowExclusiveLock);
+	segrel = table_open(segrelid, RowExclusiveLock);
 
 	values[Anum_pg_aocs_segno - 1] = Int32GetDatum(segno);
 	values[Anum_pg_aocs_vpinfo - 1] = PointerGetDatum(vpinfo);
@@ -118,7 +118,7 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid
 		ReleaseBuffer(buf);
 
 	heap_freetuple(segtup);
-	heap_close(segrel, RowExclusiveLock);
+	table_close(segrel, RowExclusiveLock);
 
 	pfree(vpinfo);
 	pfree(nulls);
@@ -163,7 +163,7 @@ GetAOCSFileSegInfo(Relation prel,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
 
-	segrel = heap_open(segrelid, AccessShareLock);
+	segrel = table_open(segrelid, AccessShareLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/* Scan aoseg relation for tuple. */
@@ -197,7 +197,7 @@ GetAOCSFileSegInfo(Relation prel,
 	{
 		/* This segment file does not have an entry. */
 		systable_endscan(scan);
-		heap_close(segrel, AccessShareLock);
+		table_close(segrel, AccessShareLock);
 
 		if (locked)
 			ereport(ERROR,
@@ -255,7 +255,7 @@ GetAOCSFileSegInfo(Relation prel,
 
 	heap_freetuple(fssegtup);
 	systable_endscan(scan);
-	heap_close(segrel, AccessShareLock);
+	table_close(segrel, AccessShareLock);
 
 	return seginfo;
 }
@@ -293,7 +293,7 @@ GetAllAOCSFileSegInfo(Relation prel,
 												   appendOnlyMetaDataSnapshot,
 												   totalseg);
 
-	heap_close(pg_aocsseg_rel, AccessShareLock);
+	table_close(pg_aocsseg_rel, AccessShareLock);
 
 	return results;
 }
@@ -512,7 +512,7 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
-	segrel = heap_open(segrelid, RowExclusiveLock);
+	segrel = table_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/*
@@ -605,7 +605,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
-	segrel = heap_open(segrelid, RowExclusiveLock);
+	segrel = table_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/*
@@ -696,7 +696,7 @@ UpdateAOCSFileSegInfo(AOCSInsertDesc idesc)
 	int			i;
 	AOCSVPInfo *vpinfo = create_aocs_vpinfo(nvp);
 
-	segrel = heap_open(idesc->segrelid, RowExclusiveLock);
+	segrel = table_open(idesc->segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/*
@@ -835,7 +835,7 @@ UpdateAOCSFileSegInfo(AOCSInsertDesc idesc)
 	pfree(vpinfo);
 
 	systable_endscan(scan);
-	heap_close(segrel, RowExclusiveLock);
+	table_close(segrel, RowExclusiveLock);
 }
 
 /*
@@ -894,7 +894,7 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
                               NULL,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
-	segrel = heap_open(segrelid, RowExclusiveLock);
+	segrel = table_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/*
@@ -988,7 +988,7 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
 	 * AccessExclusive lock on the AOCS relation OID.
 	 */
 	systable_endscan(scan);
-	heap_close(segrel, NoLock);
+	table_close(segrel, NoLock);
 }
 
 void
@@ -1014,7 +1014,7 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
 
-	segrel = heap_open(segrelid, RowExclusiveLock);
+	segrel = table_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
 	/*
@@ -1080,7 +1080,7 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
 	heap_freetuple(newtup);
 
 	systable_endscan(scan);
-	heap_close(segrel, RowExclusiveLock);
+	table_close(segrel, RowExclusiveLock);
 }
 
 extern Datum aocsvpinfo_decode(PG_FUNCTION_ARGS);
@@ -1186,7 +1186,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 
 		context->aocsRelOid = aocsRelOid;
 
-		aocsRel = heap_open(aocsRelOid, AccessShareLock);
+		aocsRel = table_open(aocsRelOid, AccessShareLock);
 		if (!RelationIsAoCols(aocsRel))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -1201,7 +1201,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
                                   appendOnlyMetaDataSnapshot,
                                   &segrelid, NULL, NULL,
                                   NULL, NULL);
-		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
+		pg_aocsseg_rel = table_open(segrelid, AccessShareLock);
 
 		context->aocsSegfileArray = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
 																		 aocsRel->rd_rel->relnatts,
@@ -1210,8 +1210,8 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 																		 appendOnlyMetaDataSnapshot,
 																		 &context->totalAocsSegFiles);
 
-		heap_close(pg_aocsseg_rel, AccessShareLock);
-		heap_close(aocsRel, AccessShareLock);
+		table_close(pg_aocsseg_rel, AccessShareLock);
+		table_close(aocsRel, AccessShareLock);
 
 		/* Iteration positions. */
 		context->segfileArrayIndex = 0;
@@ -1396,10 +1396,10 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 
 		context->aocsRelOid = aocsRelOid;
 
-		aocsRel = heap_open(aocsRelOid, AccessShareLock);
+		aocsRel = table_open(aocsRelOid, AccessShareLock);
 		if (!RelationIsAoCols(aocsRel))
 		{
-			heap_close(aocsRel, AccessShareLock);
+			table_close(aocsRel, AccessShareLock);
 			ereport(ERROR,
 			        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				        errmsg("'%s' is not an append-only columnar relation",
@@ -1415,7 +1415,7 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
                                   &segrelid, NULL, NULL,
                                   NULL, NULL);
 
-		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
+		pg_aocsseg_rel = table_open(segrelid, AccessShareLock);
 
 		context->aocsSegfileArray = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
 																		 RelationGetNumberOfAttributes(aocsRel),
@@ -1424,8 +1424,8 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 																		 SnapshotAny, //Get ALL tuples from pg_aocsseg_ % including aborted and in - progress ones.
 																		 & context->totalAocsSegFiles);
 
-		heap_close(pg_aocsseg_rel, AccessShareLock);
-		heap_close(aocsRel, AccessShareLock);
+		table_close(pg_aocsseg_rel, AccessShareLock);
+		table_close(aocsRel, AccessShareLock);
 
 		/* Iteration positions. */
 		context->segfileArrayIndex = 0;
@@ -1542,7 +1542,7 @@ aocol_compression_ratio_internal(Relation parentrel)
 	/*
 	 * open the aoseg relation
 	 */
-	aosegrel = heap_open(segrelid, AccessShareLock);
+	aosegrel = table_open(segrelid, AccessShareLock);
 
 	/*
 	 * assemble our query string.
@@ -1562,7 +1562,7 @@ aocol_compression_ratio_internal(Relation parentrel)
 						 get_namespace_name(RelationGetNamespace(aosegrel)),
 						 RelationGetRelationName(aosegrel));
 
-	heap_close(aosegrel, AccessShareLock);
+	table_close(aosegrel, AccessShareLock);
 
 	PG_TRY();
 	{

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -110,7 +110,7 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 
 	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
 
-	pg_aoseg_rel = heap_open(segrelid, RowExclusiveLock);
+	pg_aoseg_rel = table_open(segrelid, RowExclusiveLock);
 
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 	natts = pg_aoseg_dsc->natts;

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -541,7 +541,7 @@ AppendOptimizedCollectDeadSegments(Relation aorel)
 	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
 							  &segrelid, NULL, NULL, NULL, NULL);
 	
-	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
+	pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	aoscan = systable_beginscan(pg_aoseg_rel, InvalidOid, false, appendOnlyMetaDataSnapshot, 0, NULL);
@@ -626,7 +626,7 @@ AppendOptimizedCollectDeadSegments(Relation aorel)
 	}
 	systable_endscan(aoscan);
 
-	heap_close(pg_aoseg_rel, AccessShareLock);
+	table_close(pg_aoseg_rel, AccessShareLock);
 
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
@@ -701,7 +701,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
 							  &segrelid, NULL, NULL, NULL, NULL);
 
-	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
+	pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	aoscan = systable_beginscan(pg_aoseg_rel, InvalidOid, false, appendOnlyMetaDataSnapshot, 0, NULL);
@@ -757,7 +757,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	}
 	systable_endscan(aoscan);
 	UnlockRelationForExtension(aorel, ExclusiveLock);
-	heap_close(pg_aoseg_rel, AccessShareLock);
+	table_close(pg_aoseg_rel, AccessShareLock);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 }
 

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -210,7 +210,7 @@ AppendOnlyBlockDirectory_Init_forSearch(
 	Assert(OidIsValid(blkdirrelid));
 
 	blockDirectory->blkdirRel =
-		heap_open(blkdirrelid, AccessShareLock);
+		table_open(blkdirrelid, AccessShareLock);
 
 	Assert(OidIsValid(blkdiridxid));
 
@@ -277,7 +277,7 @@ AppendOnlyBlockDirectory_Init_forUniqueChecks(
 	blockDirectory->numColumnGroups = numColumnGroups;
 	blockDirectory->proj = NULL;
 
-	blockDirectory->blkdirRel = heap_open(blkdirrelid, AccessShareLock);
+	blockDirectory->blkdirRel = table_open(blkdirrelid, AccessShareLock);
 	blockDirectory->blkdirIdx = index_open(blkdiridxid, AccessShareLock);
 
 	init_internal(blockDirectory);
@@ -333,7 +333,7 @@ AppendOnlyBlockDirectory_Init_forInsert(
 	Assert(OidIsValid(blkdirrelid));
 
 	blockDirectory->blkdirRel =
-		heap_open(blkdirrelid, RowExclusiveLock);
+		table_open(blkdirrelid, RowExclusiveLock);
 
 	Assert(OidIsValid(blkdiridxid));
 
@@ -409,7 +409,7 @@ AppendOnlyBlockDirectory_Init_addCol(
 	 * segment.
 	 */
 	blockDirectory->blkdirRel =
-		heap_open(blkdirrelid, RowExclusiveLock);
+		table_open(blkdirrelid, RowExclusiveLock);
 
 	Assert(OidIsValid(blkdiridxid));
 
@@ -1498,7 +1498,7 @@ AppendOnlyBlockDirectory_End_forInsert(
 					  blockDirectory->isAOCol)));
 
 	index_close(blockDirectory->blkdirIdx, RowExclusiveLock);
-	heap_close(blockDirectory->blkdirRel, RowExclusiveLock);
+	table_close(blockDirectory->blkdirRel, RowExclusiveLock);
 	CatalogCloseIndexes(blockDirectory->indinfo);
 
 	MemoryContextDelete(blockDirectory->memoryContext);
@@ -1521,7 +1521,7 @@ AppendOnlyBlockDirectory_End_forSearch(
 
 	if (blockDirectory->blkdirIdx)
 		index_close(blockDirectory->blkdirIdx, AccessShareLock);
-	heap_close(blockDirectory->blkdirRel, AccessShareLock);
+	table_close(blockDirectory->blkdirRel, AccessShareLock);
 
 	MemoryContextDelete(blockDirectory->memoryContext);
 }
@@ -1568,7 +1568,7 @@ AppendOnlyBlockDirectory_End_addCol(
 	 * of alter-table transaction.
 	 */
 	index_close(blockDirectory->blkdirIdx, NoLock);
-	heap_close(blockDirectory->blkdirRel, NoLock);
+	table_close(blockDirectory->blkdirRel, NoLock);
 	CatalogCloseIndexes(blockDirectory->indinfo);
 
 	MemoryContextDelete(blockDirectory->memoryContext);
@@ -1593,7 +1593,7 @@ AppendOnlyBlockDirectory_End_forUniqueChecks(AppendOnlyBlockDirectory *blockDire
 							blockDirectory->blkdirIdx->rd_id)));
 
 	index_close(blockDirectory->blkdirIdx, AccessShareLock);
-	heap_close(blockDirectory->blkdirRel, AccessShareLock);
+	table_close(blockDirectory->blkdirRel, AccessShareLock);
 
 	MemoryContextDelete(blockDirectory->memoryContext);
 }

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -24,7 +24,7 @@
 #include "access/appendonlytid.h"		/* AOTupleId_MaxRowNum  */
 #include "access/appendonlywriter.h"
 #include "access/aocssegfiles.h"		/* AOCS */
-#include "access/heapam.h"				/* heap_open */
+#include "access/heapam.h"				/* table_open */
 #include "access/transam.h"
 #include "access/xact.h"
 #include "catalog/indexing.h"
@@ -267,7 +267,7 @@ LockSegnoForWrite(Relation rel, int segno)
 
 	UnlockRelationForExtension(rel, ExclusiveLock);
 
-	heap_close(pg_aoseg_rel, AccessShareLock);
+	table_close(pg_aoseg_rel, AccessShareLock);
 
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
@@ -452,7 +452,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	 * Now pick a segment that is not in use, and is not over the allowed
 	 * size threshold (90% full).
 	 */
-	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
+	pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
 
 	/*
@@ -609,7 +609,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 				(errmsg("Segno chosen for append-only relation \"%s\" is %d",
 						RelationGetRelationName(rel), chosen_segno)));
 
-	heap_close(pg_aoseg_rel, AccessShareLock);
+	table_close(pg_aoseg_rel, AccessShareLock);
 
 	return chosen_segno;
 }

--- a/src/backend/access/bitmap/bitmapattutil.c
+++ b/src/backend/access/bitmap/bitmapattutil.c
@@ -118,7 +118,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		Assert(OidIsValid(idxid));
 		*lovIndexOid = idxid;
 
-		lovHeap = heap_open(heapid, AccessExclusiveLock);
+		lovHeap = table_open(heapid, AccessExclusiveLock);
 		lovIndex = index_open(idxid, AccessExclusiveLock);
 
 		RelationSetNewRelfilenode(lovHeap, lovHeap->rd_rel->relpersistence);
@@ -153,7 +153,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 		_bt_relbuf(lovIndex, btree_metabuf);
 
 		index_close(lovIndex, NoLock);
-		heap_close(lovHeap, NoLock);
+		table_close(lovHeap, NoLock);
 
 		return;
 	}
@@ -195,7 +195,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 	CommandCounterIncrement();
 
 	/* ShareLock is not really needed here, but take it anyway */
-	lov_heap_rel = heap_open(heapid, ShareLock);
+	lov_heap_rel = table_open(heapid, ShareLock);
 
 	objAddr.classId = RelationRelationId;
 	objAddr.objectId = heapid;
@@ -264,7 +264,7 @@ _bitmap_create_lov_heapandindex(Relation rel,
 						 NULL);
 	*lovIndexOid = idxid;
 
-	heap_close(lov_heap_rel, NoLock);
+	table_close(lov_heap_rel, NoLock);
 }
 
 /*
@@ -310,7 +310,7 @@ _bitmap_open_lov_heapandindex(Relation rel pg_attribute_unused(), BMMetaPage met
 							  Relation *lovHeapP, Relation *lovIndexP,
 							  LOCKMODE lockMode)
 {
-	*lovHeapP = heap_open(metapage->bm_lov_heapId, lockMode);
+	*lovHeapP = table_open(metapage->bm_lov_heapId, lockMode);
 	*lovIndexP = index_open(metapage->bm_lov_indexId, lockMode);
 }
 
@@ -356,7 +356,7 @@ void
 _bitmap_close_lov_heapandindex(Relation lovHeap, Relation lovIndex,
 							   LOCKMODE lockMode)
 {
-	heap_close(lovHeap, lockMode);
+	table_close(lovHeap, lockMode);
 	index_close(lovIndex, lockMode);
 }
 

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -134,7 +134,7 @@ GetExtTableEntryIfExists(Oid relid)
 	if (!HeapTupleIsValid(fttuple))
 	{
 		systable_endscan(ftscan);
-		heap_close(pg_foreign_table_rel, RowExclusiveLock);
+		table_close(pg_foreign_table_rel, RowExclusiveLock);
 
 		return NULL;
 	}

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -4880,7 +4880,7 @@ pg_extprotocol_aclmask(Oid ptcOid, Oid roleid,
     if (superuser_arg(roleid))
         return mask;
 
-    rel = heap_open(ExtprotocolRelationId, AccessShareLock);
+    rel = table_open(ExtprotocolRelationId, AccessShareLock);
 
     ScanKeyInit(&scankey, Anum_pg_extprotocol_oid,
                 BTEqualStrategyNumber, F_OIDEQ,
@@ -4930,7 +4930,7 @@ pg_extprotocol_aclmask(Oid ptcOid, Oid roleid,
 
     /* Finish up scan and close pg_extprotocol catalog. */
     systable_endscan(sscan);
-    heap_close(rel, AccessShareLock);
+    table_close(rel, AccessShareLock);
 
     return result;
 }
@@ -6569,8 +6569,8 @@ CopyRelationAcls(Oid srcId, Oid destId)
 	CatCList   *attlist;
 	int			i;
 
-	pg_class_rel = heap_open(RelationRelationId, RowExclusiveLock);
-	pg_attribute_rel = heap_open(AttributeRelationId, RowExclusiveLock);
+	pg_class_rel = table_open(RelationRelationId, RowExclusiveLock);
+	pg_attribute_rel = table_open(AttributeRelationId, RowExclusiveLock);
 
 	/* Look up the ACL on the source relation. */
 	srcTuple = SearchSysCache1(RELOID, ObjectIdGetDatum(srcId));
@@ -6697,8 +6697,8 @@ CopyRelationAcls(Oid srcId, Oid destId)
 
 	ReleaseSysCache(srcTuple);
 	ReleaseSysCache(destTuple);
-	heap_close(pg_class_rel, RowExclusiveLock);
-	heap_close(pg_attribute_rel, RowExclusiveLock);
+	table_close(pg_class_rel, RowExclusiveLock);
+	table_close(pg_attribute_rel, RowExclusiveLock);
 
 	/* Make these updates visible */
 	CommandCounterIncrement();

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -2894,7 +2894,7 @@ checkDependencies(const ObjectAddresses *objects,
 	 * We save some cycles by opening pg_depend just once and passing the
 	 * Relation pointer down to all the recursive deletion steps.
 	 */
-	depRel = heap_open(DependRelationId, RowExclusiveLock);
+	depRel = table_open(DependRelationId, RowExclusiveLock);
 
 	targetObjects = new_object_addresses();
 
@@ -2968,7 +2968,7 @@ checkDependencies(const ObjectAddresses *objects,
 	/* And clean up */
 	free_object_addresses(targetObjects);
 
-	heap_close(depRel, RowExclusiveLock);
+	table_close(depRel, RowExclusiveLock);
 }
 
 /*

--- a/src/backend/catalog/gp_fastsequence.c
+++ b/src/backend/catalog/gp_fastsequence.c
@@ -274,7 +274,7 @@ int64 ReadLastSequence(Oid objid, int64 objmod)
 	HeapTuple tuple;
 	int64 lastSequence;
 
-	gp_fastsequence_rel = heap_open(FastSequenceRelationId, AccessShareLock);
+	gp_fastsequence_rel = table_open(FastSequenceRelationId, AccessShareLock);
 	tupleDesc = RelationGetDescr(gp_fastsequence_rel);
 
 	/*
@@ -324,7 +324,7 @@ int64 ReadLastSequence(Oid objid, int64 objmod)
 	 * is an insert operation has acquired a lock first on segment and is
 	 * trying to acquire a lock on the Master. Deadlock!
 	 */
-	heap_close(gp_fastsequence_rel, AccessShareLock);
+	table_close(gp_fastsequence_rel, AccessShareLock);
 
 	return lastSequence;
 }

--- a/src/backend/catalog/gp_segment_config.c
+++ b/src/backend/catalog/gp_segment_config.c
@@ -24,7 +24,7 @@ gp_segment_config_has_mirrors()
 	SysScanDesc scan;
 	HeapTuple tuple;
 
-	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+	rel = table_open(GpSegmentConfigRelationId, AccessShareLock);
 
 	/*
 	 * SELECT dbid FROM gp_segment_configuration
@@ -46,7 +46,7 @@ gp_segment_config_has_mirrors()
 	mirrors_exist = HeapTupleIsValid(tuple);
 
 	systable_endscan(scan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return mirrors_exist;
 }

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -947,7 +947,7 @@ void MetaTrackUpdObject(Oid		classid,
 		ii++;
 	}
 	systable_endscan(desc);
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 
 	/* add it if it didn't already exist */
 	if (!ii)

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -48,7 +48,7 @@ add_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum attoptions)
 	
 	Assert(attnum != InvalidAttrNumber);
 
-	rel = heap_open(AttributeEncodingRelationId, RowExclusiveLock);
+	rel = table_open(AttributeEncodingRelationId, RowExclusiveLock);
 
 	MemSet(nulls, 0, sizeof(nulls));
 	values[Anum_pg_attribute_encoding_attrelid - 1] = ObjectIdGetDatum(relid);
@@ -62,7 +62,7 @@ add_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum attoptions)
 
 	heap_freetuple(tuple);
 
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }
 
 static void
@@ -81,7 +81,7 @@ update_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum newattoption
 	MemSet(nulls, false, sizeof(nulls));
 	MemSet(repl, false, sizeof(repl));
 
-	rel = heap_open(AttributeEncodingRelationId, RowExclusiveLock);
+	rel = table_open(AttributeEncodingRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&skey[0],
 				Anum_pg_attribute_encoding_attrelid,
@@ -108,7 +108,7 @@ update_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum newattoption
 	heap_freetuple(newtup);
 
 	systable_endscan(scan);
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }
 /*
  * Get the set of functions implementing a compression algorithm.
@@ -148,7 +148,7 @@ get_rel_attoptions(Oid relid, AttrNumber max_attno)
 	SysScanDesc scan;
 	HeapTuple		tuple;
 	Datum		   *dats;
-	Relation 		pgae = heap_open(AttributeEncodingRelationId,
+	Relation 		pgae = table_open(AttributeEncodingRelationId,
 									 AccessShareLock);
 
 	/* used for attbyval and len below */
@@ -184,7 +184,7 @@ get_rel_attoptions(Oid relid, AttrNumber max_attno)
 
 	systable_endscan(scan);
 
-	heap_close(pgae, AccessShareLock);
+	table_close(pgae, AccessShareLock);
 
 	return dats;
 
@@ -378,7 +378,7 @@ RemoveAttributeEncodingsByRelid(Oid relid)
 	SysScanDesc scan;
 	HeapTuple	tup;
 
-	rel = heap_open(AttributeEncodingRelationId, RowExclusiveLock);
+	rel = table_open(AttributeEncodingRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&skey,
 				Anum_pg_attribute_encoding_attrelid,
@@ -393,5 +393,5 @@ RemoveAttributeEncodingsByRelid(Oid relid)
 
 	systable_endscan(scan);
 
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }

--- a/src/backend/catalog/pg_collation.c
+++ b/src/backend/catalog/pg_collation.c
@@ -154,7 +154,7 @@ CollationCreate(const char *collname, Oid collnamespace,
 			checkMembershipInCurrentExtension(&myself);
 
 			/* OK to skip */
-			heap_close(rel, NoLock);
+			table_close(rel, NoLock);
 			ereport(NOTICE,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
 					 errmsg("collation \"%s\" already exists, skipping",

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -1354,7 +1354,7 @@ ConstraintGetPrimaryKeyOf(Oid relid, AttrNumber attno, Oid *pkrelid, AttrNumber 
 	ScanKeyData skey;
 	HeapTuple	tup;
 
-	conDesc = heap_open(ConstraintRelationId, AccessShareLock);
+	conDesc = table_open(ConstraintRelationId, AccessShareLock);
 
 	found = false;
 
@@ -1416,7 +1416,7 @@ ConstraintGetPrimaryKeyOf(Oid relid, AttrNumber attno, Oid *pkrelid, AttrNumber 
 	}
 
 	systable_endscan(conscan);
-	heap_close(conDesc, AccessShareLock);
+	table_close(conDesc, AccessShareLock);
 
 	return found;
 }

--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -586,7 +586,7 @@ ProcedureCreate(const char *procedureName,
 			SysScanDesc scan;
 			HeapTuple   depTup;
 
-			depRel = heap_open(DependRelationId, AccessShareLock);
+			depRel = table_open(DependRelationId, AccessShareLock);
 
 			/*
 			 * This is equivalent to:
@@ -618,7 +618,7 @@ ProcedureCreate(const char *procedureName,
 			}
 			systable_endscan(scan);
 
-			heap_close(depRel, AccessShareLock);
+			table_close(depRel, AccessShareLock);
 		}
 
 		/*

--- a/src/backend/catalog/pg_proc_callback.c
+++ b/src/backend/catalog/pg_proc_callback.c
@@ -52,7 +52,7 @@ deleteProcCallbacks(Oid profnoid)
 	 *
 	 * DELETE FROM pg_proc_callback WHERE profnoid = :1
 	 */
-	rel = heap_open(ProcCallbackRelationId, RowExclusiveLock);
+	rel = table_open(ProcCallbackRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&skey,
 				Anum_pg_proc_callback_profnoid,
@@ -66,7 +66,7 @@ deleteProcCallbacks(Oid profnoid)
 
 	systable_endscan(scan);
 
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }
 
 
@@ -134,7 +134,7 @@ lookupProcCallback(Oid profnoid, char promethod)
 	Assert(OidIsValid(profnoid));
 
 	/* open pg_proc_callback */
-	rel = heap_open(ProcCallbackRelationId, AccessShareLock);
+	rel = table_open(ProcCallbackRelationId, AccessShareLock);
 
 	/* Lookup (profnoid, promethod) from index */
 	/* (profnoid, promethod) is guaranteed unique by the index */
@@ -164,7 +164,7 @@ lookupProcCallback(Oid profnoid, char promethod)
 		result = InvalidOid;
 
 	systable_endscan(scan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return result;
 }

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -91,7 +91,7 @@ get_type_encoding(TypeName *typname)
 
 	typid = typenameTypeId(NULL, typname);
 
-	rel = heap_open(TypeEncodingRelationId, AccessShareLock);
+	rel = table_open(TypeEncodingRelationId, AccessShareLock);
 
 	/* SELECT typoptions FROM pg_type_encoding where typid = :1 */
 	ScanKeyInit(&scankey,
@@ -119,7 +119,7 @@ get_type_encoding(TypeName *typname)
 	}
 
 	systable_endscan(sscan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return out;
 }
@@ -135,7 +135,7 @@ remove_type_encoding(Oid typid)
 	SysScanDesc 	sscan;
 	HeapTuple 	tuple;
 
-	rel = heap_open(TypeEncodingRelationId, RowExclusiveLock);
+	rel = table_open(TypeEncodingRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&scankey,
 				Anum_pg_type_encoding_typid,
@@ -150,7 +150,7 @@ remove_type_encoding(Oid typid)
 	}
 	systable_endscan(sscan);
 
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 }
 
 /*
@@ -166,7 +166,7 @@ update_type_encoding(Oid typid, Datum typoptions)
 	HeapTuple	tup;
 
 	/* SELECT * FROM pg_type_encoding WHERE typid = :1 FOR UPDATE */
-	pgtypeenc = heap_open(TypeEncodingRelationId, RowExclusiveLock);
+	pgtypeenc = table_open(TypeEncodingRelationId, RowExclusiveLock);
 	ScanKeyInit(&scankey, Anum_pg_type_encoding_typid,
 				BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(typid));
@@ -199,7 +199,7 @@ update_type_encoding(Oid typid, Datum typoptions)
 		add_type_encoding(typid, typoptions);
 	}	
 	systable_endscan(scan);
-	heap_close(pgtypeenc, NoLock);
+	table_close(pgtypeenc, NoLock);
 
 }
 

--- a/src/backend/cdb/cdbutil.c
+++ b/src/backend/cdb/cdbutil.c
@@ -1531,7 +1531,7 @@ dbid_get_dbinfo(int16 dbid)
 	if (!IS_QUERY_DISPATCHER())
 		elog(ERROR, "dbid_get_dbinfo() executed on execution segment");
 
-	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+	rel = table_open(GpSegmentConfigRelationId, AccessShareLock);
 
 	/* SELECT * FROM gp_segment_configuration WHERE dbid = :1 */
 	ScanKeyInit(&scankey,
@@ -1630,7 +1630,7 @@ dbid_get_dbinfo(int16 dbid)
 	}
 
 	systable_endscan(scan);
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 
 	return i;
 }
@@ -1658,7 +1658,7 @@ contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRo
 	if (!IS_QUERY_DISPATCHER())
 		elog(ERROR, "contentid_get_dbid() executed on execution segment");
 
-	rel = heap_open(GpSegmentConfigRelationId, AccessShareLock);
+	rel = table_open(GpSegmentConfigRelationId, AccessShareLock);
 
 	/* XXX XXX: CHECK THIS  XXX jic 2011/12/09 */
 	if (getPreferredRoleNotCurrentRole)
@@ -1707,7 +1707,7 @@ contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRo
 
 	/* no need to hold the lock, it's a catalog */
 	systable_endscan(scan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return dbid;
 }

--- a/src/backend/commands/analyzeutils.c
+++ b/src/backend/commands/analyzeutils.c
@@ -1067,7 +1067,7 @@ fetch_leaf_attnum(Oid leafRelid, const char* attname)
 	Form_pg_attribute attForm;
 	AttrNumber	result = InvalidAttrNumber;
 
-	rel = heap_open(AttributeRelationId, AccessShareLock);
+	rel = table_open(AttributeRelationId, AccessShareLock);
 
 	ScanKeyInit(&skey[0],
 				Anum_pg_attribute_attrelid,
@@ -1089,7 +1089,7 @@ fetch_leaf_attnum(Oid leafRelid, const char* attname)
 	}
 
 	systable_endscan(sscan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return result;
 }
@@ -1133,7 +1133,7 @@ fetch_leaf_att_stats(Oid leafRelid, AttrNumber leafAttNum)
 	}
 
 	systable_endscan(sscan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return tuple;
 }

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -183,7 +183,7 @@ cdb_sync_indcheckxmin_with_segments(Oid indexRelationId)
 		HeapTuple	indexTuple;
 		Form_pg_index indexForm;
 
-		pg_index = heap_open(IndexRelationId, RowExclusiveLock);
+		pg_index = table_open(IndexRelationId, RowExclusiveLock);
 
 		indexTuple = SearchSysCacheCopy1(INDEXRELID, ObjectIdGetDatum(indexRelationId));
 		if (!HeapTupleIsValid(indexTuple))
@@ -197,7 +197,7 @@ cdb_sync_indcheckxmin_with_segments(Oid indexRelationId)
 		}
 
 		heap_freetuple(indexTuple);
-		heap_close(pg_index, RowExclusiveLock);
+		table_close(pg_index, RowExclusiveLock);
 	}
 }
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -551,7 +551,7 @@ transientrel_init(QueryDesc *queryDesc)
 	matviewOid = RangeVarGetRelidExtended(refreshClause->relation,
 										  lockmode, 0,
 										  RangeVarCallbackOwnsTable, NULL);
-	matviewRel = heap_open(matviewOid, NoLock);
+	matviewRel = table_open(matviewOid, NoLock);
 
 	/*
 	 * Tentatively mark the matview as populated or not (this will roll back
@@ -583,7 +583,7 @@ transientrel_init(QueryDesc *queryDesc)
 	queryDesc->dest = CreateTransientRelDestReceiver(OIDNewHeap, matviewOid, concurrent,
 													 relpersistence, refreshClause->skipData);
 
-	heap_close(matviewRel, NoLock);
+	table_close(matviewRel, NoLock);
 }
 
 /*

--- a/src/backend/commands/queue.c
+++ b/src/backend/commands/queue.c
@@ -310,7 +310,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		{
 			bWithout = true;
 
-			rel = heap_open(ResourceTypeRelationId, RowExclusiveLock);
+			rel = table_open(ResourceTypeRelationId, RowExclusiveLock);
 			tupdesc = RelationGetDescr(rel);
 
 			goto L_loop_cont;
@@ -440,7 +440,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 	}
 
 	if (bWithout)
-		heap_close(rel, RowExclusiveLock); /* close pg_resourcetype */
+		table_close(rel, RowExclusiveLock); /* close pg_resourcetype */
 
 	if (bCreate)
 	{
@@ -451,7 +451,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		 * corresponding match in dupcheck -- if no entry then add the
 		 * one to the WITH list (elems) with the default. 
 		 */
-		rel = heap_open(ResourceTypeRelationId, RowExclusiveLock);
+		rel = table_open(ResourceTypeRelationId, RowExclusiveLock);
 		tupdesc = RelationGetDescr(rel);
 
 		/* Note: key is empty - scan entire table */
@@ -508,12 +508,12 @@ AlterResqueueCapabilityEntry(Oid queueid,
 		} /* end while heaptuple is valid */
 		systable_endscan(sscan);
 
-		heap_close(rel, RowExclusiveLock); /* close pg_resourcetype */
+		table_close(rel, RowExclusiveLock); /* close pg_resourcetype */
 	} /* end if bCreate */
 
 	/* insert/update valid entries in pg_resqueuecapability */
 
-	rel = heap_open(ResQueueCapabilityRelationId, RowExclusiveLock);
+	rel = table_open(ResQueueCapabilityRelationId, RowExclusiveLock);
 
 	foreach(lc, elems)
 	{
@@ -633,7 +633,7 @@ AlterResqueueCapabilityEntry(Oid queueid,
 
 	} /* end foreach elem */
 
-	heap_close(rel, RowExclusiveLock);
+	table_close(rel, RowExclusiveLock);
 } /* end AlterResqueueCapabilityEntry */
 
 /* MPP-6923: */				  
@@ -650,7 +650,7 @@ GetResqueueCapabilityEntry(Oid  queueid)
 	Assert(IsTransactionState());
 
 	/* SELECT * FROM pg_resqueuecapability WHERE resqueueid = :1 */
-	rel = heap_open(ResQueueCapabilityRelationId, AccessShareLock);
+	rel = table_open(ResQueueCapabilityRelationId, AccessShareLock);
 
 	tupdesc = RelationGetDescr(rel);
 
@@ -691,7 +691,7 @@ GetResqueueCapabilityEntry(Oid  queueid)
 	}
 	systable_endscan(sscan);
 
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 	
 	return (elems);
 } /* end GetResqueueCapabilityEntry */
@@ -864,7 +864,7 @@ CreateQueue(CreateQueueStmt *stmt)
 	 * Check the pg_resqueue relation to be certain the queue doesn't already
 	 * exist. 
 	 */
-	pg_resqueue_rel = heap_open(ResQueueRelationId, RowExclusiveLock);
+	pg_resqueue_rel = table_open(ResQueueRelationId, RowExclusiveLock);
 	pg_resqueue_dsc = RelationGetDescr(pg_resqueue_rel);
 
 	/**
@@ -872,7 +872,7 @@ CreateQueue(CreateQueueStmt *stmt)
 	 * this catalog table later.
 	 */
 	Relation resqueueCapabilityRel = 
-			heap_open(ResQueueCapabilityRelationId, RowExclusiveLock);
+			table_open(ResQueueCapabilityRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&scankey,
 				Anum_pg_resqueue_rsqname,
@@ -984,8 +984,8 @@ CreateQueue(CreateQueueStmt *stmt)
 				);
 	}
 
-	heap_close(resqueueCapabilityRel, NoLock);
-	heap_close(pg_resqueue_rel, NoLock);
+	table_close(resqueueCapabilityRel, NoLock);
+	table_close(pg_resqueue_rel, NoLock);
 }
 
 
@@ -1226,12 +1226,12 @@ AlterQueue(AlterQueueStmt *stmt)
 	 * Check the pg_resqueue relation to be certain the queue already
 	 * exists. 
 	 */
-	pg_resqueue_rel = heap_open(ResQueueRelationId, RowExclusiveLock);
+	pg_resqueue_rel = table_open(ResQueueRelationId, RowExclusiveLock);
 
 	/**
 	 * Get database locks in anticipation that we'll need to access this catalog table later.
 	 */
-	Relation resqueueCapabilityRel = heap_open(ResQueueCapabilityRelationId, RowExclusiveLock);
+	Relation resqueueCapabilityRel = table_open(ResQueueCapabilityRelationId, RowExclusiveLock);
 	pg_resqueue_dsc = RelationGetDescr(pg_resqueue_rel);
 
 	ScanKeyInit(&scankey,
@@ -1388,7 +1388,7 @@ AlterQueue(AlterQueueStmt *stmt)
 		}
 	}
 
-	heap_close(resqueueCapabilityRel, NoLock);
+	table_close(resqueueCapabilityRel, NoLock);
 
 	/* MPP-6929, MPP-7583: metadata tracking */
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -1405,7 +1405,7 @@ AlterQueue(AlterQueueStmt *stmt)
 						   "ALTER", alter_subtype
 				);
 	}
-	heap_close(pg_resqueue_rel, NoLock);
+	table_close(pg_resqueue_rel, NoLock);
 }
 
 
@@ -1436,12 +1436,12 @@ DropQueue(DropQueueStmt *stmt)
 	 * Check the pg_resqueue relation to be certain the queue already
 	 * exists. 
 	 */
-	pg_resqueue_rel = heap_open(ResQueueRelationId, RowExclusiveLock);
+	pg_resqueue_rel = table_open(ResQueueRelationId, RowExclusiveLock);
 	
 	/**
 	 * Get database locks in anticipation that we'll need to access this catalog table later.
 	 */
-	Relation resqueueCapabilityRel = heap_open(ResQueueCapabilityRelationId, RowExclusiveLock);
+	Relation resqueueCapabilityRel = table_open(ResQueueCapabilityRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&scankey,
 				Anum_pg_resqueue_rsqname,
@@ -1467,7 +1467,7 @@ DropQueue(DropQueueStmt *stmt)
 	/*
 	 * Check to see if any roles are in this queue.
 	 */
-	Relation authIdRel = heap_open(AuthIdRelationId, RowExclusiveLock);
+	Relation authIdRel = table_open(AuthIdRelationId, RowExclusiveLock);
 	ScanKeyInit(&authid_scankey,
 				Anum_pg_authid_rolresqueue,
 				BTEqualStrategyNumber, F_OIDEQ,
@@ -1490,7 +1490,7 @@ DropQueue(DropQueueStmt *stmt)
 						stmt->queue)));
 
 	systable_endscan(authid_scan);
-	heap_close(authIdRel, RowExclusiveLock);
+	table_close(authIdRel, RowExclusiveLock);
 
 	/*
 	 * Delete the queue from the catalog.
@@ -1559,9 +1559,9 @@ DropQueue(DropQueueStmt *stmt)
 	systable_endscan(sscan);
 
 
-	heap_close(resqueueCapabilityRel, NoLock);
+	table_close(resqueueCapabilityRel, NoLock);
 
-	heap_close(pg_resqueue_rel, NoLock);
+	table_close(pg_resqueue_rel, NoLock);
 }
 
 Oid
@@ -1573,7 +1573,7 @@ get_resqueue_oid(const char *queuename, bool missing_ok)
 	HeapTuple	tuple;
 	Oid			oid;
 
-	rel = heap_open(ResQueueRelationId, AccessShareLock);
+	rel = table_open(ResQueueRelationId, AccessShareLock);
 	ScanKeyInit(&scankey, Anum_pg_resqueue_rsqname,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				CStringGetDatum(queuename));
@@ -1587,7 +1587,7 @@ get_resqueue_oid(const char *queuename, bool missing_ok)
 		oid = InvalidOid;
 
 	systable_endscan(scan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	if (!OidIsValid(oid) && !missing_ok)
 		ereport(ERROR,

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -289,7 +289,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	 * Check the pg_resgroup relation to be certain the resource group already
 	 * exists.
 	 */
-	pg_resgroup_rel = heap_open(ResGroupRelationId, RowExclusiveLock);
+	pg_resgroup_rel = table_open(ResGroupRelationId, RowExclusiveLock);
 
 	ScanKeyInit(&scankey,
 				Anum_pg_resgroup_rsgname,
@@ -341,7 +341,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	 */
 	simple_heap_delete(pg_resgroup_rel, &tuple->t_self);
 	systable_endscan(sscan);
-	heap_close(pg_resgroup_rel, NoLock);
+	table_close(pg_resgroup_rel, NoLock);
 
 	/* drop the extended attributes for this resource group */
 	deleteResgroupCapabilities(groupid);
@@ -438,7 +438,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	 * AccessExclusiveLock is not compatible with any other lock.
 	 * ExclusiveLock and AccessShareLock are compatible.
 	 */
-	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,
+	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId,
 										  ExclusiveLock);
 
 	/* Load current resource group capabilities */
@@ -505,7 +505,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 									  groupid, limitType, value, "");
 	}
 
-	heap_close(pg_resgroupcapability_rel, NoLock);
+	table_close(pg_resgroupcapability_rel, NoLock);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -764,7 +764,7 @@ ResGroupCheckForRole(Oid groupId)
 	Relation pg_resgroupcapability_rel;
 	ResGroupCaps caps;
 
-	pg_resgroupcapability_rel = heap_open(ResGroupCapabilityRelationId,
+	pg_resgroupcapability_rel = table_open(ResGroupCapabilityRelationId,
 										  AccessShareLock);
 
 	/* Load current resource group capabilities */
@@ -775,7 +775,7 @@ ResGroupCheckForRole(Oid groupId)
 				 errmsg("you cannot assign a role to this resource group"),
 				 errdetail("The memory_auditor property for this group is not the default.")));
 
-	heap_close(pg_resgroupcapability_rel, AccessShareLock);
+	table_close(pg_resgroupcapability_rel, AccessShareLock);
 }
 
 /*
@@ -1461,7 +1461,7 @@ deleteResgroupCapabilities(Oid groupid)
 	ScanKeyData	 scankey;
 	SysScanDesc	 sscan;
 
-	resgroup_capability_rel = heap_open(ResGroupCapabilityRelationId,
+	resgroup_capability_rel = table_open(ResGroupCapabilityRelationId,
 										RowExclusiveLock);
 
 	ScanKeyInit(&scankey,
@@ -1478,7 +1478,7 @@ deleteResgroupCapabilities(Oid groupid)
 
 	systable_endscan(sscan);
 
-	heap_close(resgroup_capability_rel, NoLock);
+	table_close(resgroup_capability_rel, NoLock);
 }
 
 /*
@@ -1491,7 +1491,7 @@ checkAuthIdForDrop(Oid groupId)
 	ScanKeyData	 authidScankey;
 	SysScanDesc	 authidScan;
 
-	authIdRel = heap_open(AuthIdRelationId, RowExclusiveLock);
+	authIdRel = table_open(AuthIdRelationId, RowExclusiveLock);
 	ScanKeyInit(&authidScankey,
 				Anum_pg_authid_rolresgroup,
 				BTEqualStrategyNumber, F_OIDEQ,
@@ -1506,7 +1506,7 @@ checkAuthIdForDrop(Oid groupId)
 				 errmsg("resource group is used by at least one role")));
 
 	systable_endscan(authidScan);
-	heap_close(authIdRel, RowExclusiveLock);
+	table_close(authIdRel, RowExclusiveLock);
 }
 /*
  * Convert a C str to a integer value.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1053,12 +1053,12 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		 * We use a RowExclusiveLock but hold it till end of transaction so
 		 * that two DDL operations will not deadlock between QEs
 		 */
-		pg_class_desc = heap_open(RelationRelationId, RowExclusiveLock);
-		pg_type_desc = heap_open(TypeRelationId, RowExclusiveLock);
+		pg_class_desc = table_open(RelationRelationId, RowExclusiveLock);
+		pg_type_desc = table_open(TypeRelationId, RowExclusiveLock);
 
 		LockRelationOid(DependRelationId, RowExclusiveLock);
 
-		heap_close(pg_class_desc, NoLock);  /* gonna update, so don't unlock */
+		table_close(pg_class_desc, NoLock);  /* gonna update, so don't unlock */
 
 		stmt->relKind = relkind;
 
@@ -1069,7 +1069,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		stmt->relation->schemaname = get_namespace_name(namespaceId);
 		MemoryContextSwitchTo(oldContext);
 
-		heap_close(pg_type_desc, NoLock);
+		table_close(pg_type_desc, NoLock);
 	}
 	else if (Gp_role == GP_ROLE_EXECUTE)
 	{
@@ -1763,7 +1763,7 @@ relid_set_new_relfilenode(Oid relid)
 
 		rel = relation_open(relid, AccessExclusiveLock);
 		RelationSetNewRelfilenode(rel, rel->rd_rel->relpersistence);
-		heap_close(rel, NoLock);
+		table_close(rel, NoLock);
 	}
 }
 
@@ -5611,7 +5611,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("cannot rewrite temporary tables of other sessions")));
 		}
-		heap_close(OldHeap, NoLock);
+		table_close(OldHeap, NoLock);
 
 		/*
 		 * GPDB_12_MERGE_FIXME: This is a AM specific optimization, currently
@@ -6114,7 +6114,7 @@ ATAocsWriteNewColumns(AlteredTableInfo *tab)
 		newval->exprstate = ExecPrepareExpr((Expr *) newval->expr, estate);
 	}
 
-	rel = heap_open(tab->relid, NoLock);
+	rel = table_open(tab->relid, NoLock);
 	Assert(RelationIsAoCols(rel));
 
 	/*
@@ -6232,7 +6232,7 @@ ATAocsWriteNewColumns(AlteredTableInfo *tab)
 
 
 	FreeExecutorState(estate);
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 	UnregisterSnapshot(snapshot);
 }
 
@@ -7653,13 +7653,13 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			foreach (lc, all_inheritors)
 			{
 				Oid r = lfirst_oid(lc);
-				Relation rel = heap_open(r, NoLock);
+				Relation rel = table_open(r, NoLock);
 				AlteredTableInfo *childtab;
 				childtab = ATGetQueueEntry(wqueue, rel);
 
 				if (RelationIsAoCols(rel))
 					childtab->rewrite |= AT_REWRITE_NEW_COLUMNS_ONLY_AOCS;
-				heap_close(rel, NoLock);
+				table_close(rel, NoLock);
 			}
 		}
 	}
@@ -12018,9 +12018,9 @@ ATExecDropConstraint(Relation rel, const char *constrName,
 			Relation	frel;
 
 			/* Must match lock taken by RemoveTriggerById: */
-			frel = heap_open(con->confrelid, AccessExclusiveLock);
+			frel = table_open(con->confrelid, AccessExclusiveLock);
 			CheckTableNotInUse(frel, "ALTER TABLE");
-			heap_close(frel, NoLock);
+			table_close(frel, NoLock);
 		}
 
 		/*

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -328,16 +328,16 @@ IndexScan_GetColumnMapping(Oid oldOid, Oid newOid)
 
 	AttrNumber	  *attMap;
 
-	Relation oldRel = heap_open(oldOid, AccessShareLock);
-	Relation newRel = heap_open(newOid, AccessShareLock);
+	Relation oldRel = table_open(oldOid, AccessShareLock);
+	Relation newRel = table_open(newOid, AccessShareLock);
 
 	TupleDesc oldTupDesc = oldRel->rd_att;
 	TupleDesc newTupDesc = newRel->rd_att;
 
 	attMap = convert_tuples_by_name_map_if_req(oldTupDesc, newTupDesc);
 
-	heap_close(oldRel, AccessShareLock);
-	heap_close(newRel, AccessShareLock);
+	table_close(oldRel, AccessShareLock);
+	table_close(newRel, AccessShareLock);
 
 	return attMap;
 }

--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -3871,7 +3871,7 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 
 	ReleaseSysCache(roleTup);
 	/* Walk pg_auth_time_constraint for entries belonging to this user. */
-	reltimeconstr = heap_open(AuthTimeConstraintRelationId, AccessShareLock);
+	reltimeconstr = table_open(AuthTimeConstraintRelationId, AccessShareLock);
 
 	ScanKeyInit(&entry[0],
 				Anum_pg_auth_time_constraint_authid,
@@ -3930,7 +3930,7 @@ check_auth_time_constraints_internal(char *rolname, TimestampTz timestamp)
 
 	/* Clean up. */
 	systable_endscan(scan);
-	heap_close(reltimeconstr, AccessShareLock);
+	table_close(reltimeconstr, AccessShareLock);
 
 	/* Time constraints shouldn't be added to superuser roles */
 	if (found && isRoleSuperuser)

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -694,7 +694,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		totaltuples += childtuples;
 
 		if (childrel != rel)
-			heap_close(childrel, NoLock);
+			table_close(childrel, NoLock);
 	}
 	return totaltuples;
 }

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -300,7 +300,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	 * CDB: Acquire ExclusiveLock if it is a distributed relation and we are
 	 * doing UPDATE or DELETE activity or `insert on conflict do update`.
 	 *
-	 * We should use heap_openrv instead of parserOpenTable for inserts because
+	 * We should use table_openrv instead of parserOpenTable for inserts because
 	 * parserOpenTable upgrades the lock to Exclusive mode for distributed
 	 * tables.
 	 *
@@ -312,7 +312,7 @@ setTargetTable(ParseState *pstate, RangeVar *relation,
 	if (pstate->p_is_insert && !pstate->p_is_on_conflict_update)
 	{
 		setup_parser_errposition_callback(&pcbstate, pstate, relation->location);
-		pstate->p_target_relation = heap_openrv(relation, RowExclusiveLock);
+		pstate->p_target_relation = table_openrv(relation, RowExclusiveLock);
 		cancel_parser_errposition_callback(&pcbstate);
 	}
 	else

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1311,7 +1311,7 @@ addRangeTableEntry(ParseState *pstate,
 					(errmsg("Upgrade the lockmode to ExclusiveLock on table(%s) and ingore the wait policy.",
 					 RelationGetRelationName(rel))));
 
-		heap_close(rel, NoLock);
+		table_close(rel, NoLock);
 
 	}
 	else

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2343,7 +2343,7 @@ transformDistributedBy(ParseState *pstate,
 			GpPolicy   *parentPolicy;
 			Relation	parentrel;
 
-			parentrel = heap_openrv(parent, AccessShareLock);
+			parentrel = table_openrv(parent, AccessShareLock);
 			parentPolicy = parentrel->rd_cdbpolicy;
 
 			if (parentrel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
@@ -2396,12 +2396,12 @@ transformDistributedBy(ParseState *pstate,
 							 errmsg("table has parent, setting distribution columns to match parent table")));
 
 				distributedBy = make_distributedby_for_rel(parentrel);
-				heap_close(parentrel, AccessShareLock);
+				table_close(parentrel, AccessShareLock);
 
 				distributedBy->numsegments = numsegments;
 				return distributedBy;
 			}
-			heap_close(parentrel, AccessShareLock);
+			table_close(parentrel, AccessShareLock);
 		}
 	}
 
@@ -2552,7 +2552,7 @@ transformDistributedBy(ParseState *pstate,
 				int			count;
 
 				Assert(IsA(inh, RangeVar));
-				rel = heap_openrv(inh, AccessShareLock);
+				rel = table_openrv(inh, AccessShareLock);
 				/* check user requested inheritance from valid relkind */
 				if (rel->rd_rel->relkind != RELKIND_RELATION &&
 					rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
@@ -2591,7 +2591,7 @@ transformDistributedBy(ParseState *pstate,
 						break;
 					}
 				}
-				heap_close(rel, NoLock);
+				table_close(rel, NoLock);
 
 				if (distrkeys != NIL)
 					break;
@@ -2683,7 +2683,7 @@ transformDistributedBy(ParseState *pstate,
 					int			count;
 
 					Assert(IsA(inh, RangeVar));
-					rel = heap_openrv(inh, AccessShareLock);
+					rel = table_openrv(inh, AccessShareLock);
 					/* check user requested inheritance from valid relkind */
 					if (rel->rd_rel->relkind != RELKIND_RELATION &&
 						rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
@@ -2706,7 +2706,7 @@ transformDistributedBy(ParseState *pstate,
 							break;
 						}
 					}
-					heap_close(rel, NoLock);
+					table_close(rel, NoLock);
 					if (found)
 						elog(DEBUG1, "DISTRIBUTED BY clause refers to columns of inherited table");
 

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -173,7 +173,7 @@ AcquireRewriteLocks(Query *parsetree,
 				 * AccessShareLock.
 				 *
 				 * CDB: The proper lock mode depends on whether the relation is
-				 * local or distributed, which is discovered by heap_open().
+				 * local or distributed, which is discovered by table_open().
 				 * To handle this we make use of CdbOpenRelation().
 				 * 
 				 * For update should hold ExclusiveLock, see the discussion on

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4164,7 +4164,7 @@ get_comparison_operator(Oid oidLeft, Oid oidRight, CmpType cmpt)
 			return InvalidOid;
 	}
 
-	pg_amop = heap_open(AccessMethodOperatorRelationId, AccessShareLock);
+	pg_amop = table_open(AccessMethodOperatorRelationId, AccessShareLock);
 
 	/*
 	 * SELECT * FROM pg_amop
@@ -4201,7 +4201,7 @@ get_comparison_operator(Oid oidLeft, Oid oidRight, CmpType cmpt)
 	}
 
 	systable_endscan(sscan);
-	heap_close(pg_amop, AccessShareLock);
+	table_close(pg_amop, AccessShareLock);
 
 	return result;
 }
@@ -4226,7 +4226,7 @@ has_subclass_slow(Oid relationId)
 		return false;
 	}
 
-	rel = heap_open(InheritsRelationId, AccessShareLock);
+	rel = table_open(InheritsRelationId, AccessShareLock);
 
 	ScanKeyInit(&scankey, Anum_pg_inherits_inhparent,
 				BTEqualStrategyNumber, F_OIDEQ,
@@ -4240,7 +4240,7 @@ has_subclass_slow(Oid relationId)
 
 	systable_endscan(sscan);
 
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return result;
 }

--- a/src/backend/utils/gp/segadmin.c
+++ b/src/backend/utils/gp/segadmin.c
@@ -134,7 +134,7 @@ get_availableDbId()
 								   HASH_ELEM | HASH_FUNCTION);
 
 	/* scan GpSegmentConfigRelationId */
-	Relation	rel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	Relation	rel = table_open(GpSegmentConfigRelationId, AccessExclusiveLock);
 	HeapTuple	tuple;
 	SysScanDesc sscan;
 
@@ -147,7 +147,7 @@ get_availableDbId()
 	}
 	systable_endscan(sscan);
 
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 
 	/* search for available dbid */
 	for (int32 dbid = 1;; dbid++)
@@ -172,7 +172,7 @@ get_availableDbId()
 static int16
 get_maxcontentid()
 {
-	Relation	rel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	Relation	rel = table_open(GpSegmentConfigRelationId, AccessExclusiveLock);
 	int16		contentid = 0;
 	HeapTuple	tuple;
 	SysScanDesc sscan;
@@ -184,7 +184,7 @@ get_maxcontentid()
 						((Form_gp_segment_configuration) GETSTRUCT(tuple))->content);
 	}
 	systable_endscan(sscan);
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 
 	return contentid;
 }
@@ -582,7 +582,7 @@ gp_remove_segment_mirror(PG_FUNCTION_ARGS)
 	mirroring_sanity_check(MASTER_ONLY | SUPERUSER, "gp_remove_segment_mirror");
 
 	/* avoid races */
-	rel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	rel = table_open(GpSegmentConfigRelationId, AccessExclusiveLock);
 
 	pridbid = contentid_get_dbid(contentid, GP_SEGMENT_CONFIGURATION_ROLE_PRIMARY, false /* false == current, not
 								   * preferred, role */ );
@@ -600,7 +600,7 @@ gp_remove_segment_mirror(PG_FUNCTION_ARGS)
 
 	remove_segment(pridbid, mirdbid);
 
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 
 	PG_RETURN_BOOL(true);
 }
@@ -647,7 +647,7 @@ gp_add_master_standby(PG_FUNCTION_ARGS)
 		elog(ERROR, "only a single master standby may be defined");
 
 	/* Lock exclusively to avoid concurrent changes */
-	gprel = heap_open(GpSegmentConfigRelationId, AccessExclusiveLock);
+	gprel = table_open(GpSegmentConfigRelationId, AccessExclusiveLock);
 
 	maxdbid = get_maxdbid();
 
@@ -679,7 +679,7 @@ gp_add_master_standby(PG_FUNCTION_ARGS)
 
 	add_segment_config_entry(config);
 	
-	heap_close(gprel, NoLock);
+	table_close(gprel, NoLock);
 
 	PG_RETURN_INT16(config->dbid);
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -568,7 +568,7 @@ initCgroup(void)
 /*
  * Load the resource groups in shared memory. Note this
  * can only be done after enough setup has been done. This uses
- * heap_open etc which in turn requires shared memory to be set up.
+ * table_open etc which in turn requires shared memory to be set up.
  */
 void
 InitResGroups(void)

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -184,7 +184,7 @@ InitResPortalIncrementHash(void)
 /*
  * InitResQueues -- initialize the resource queues in shared memory. Note this
  * can only be done after enough setup has been done. This uses
- * heap_open etc which in turn requires shared memory to be set up.
+ * table_open etc which in turn requires shared memory to be set up.
  */
 
 void 
@@ -206,7 +206,7 @@ InitResQueues(void)
 	 * first.
 	 */
 	/* XXX XXX: should this be rowexclusive ? */
-	Relation relResqueue = heap_open(ResQueueRelationId, AccessShareLock);
+	Relation relResqueue = table_open(ResQueueRelationId, AccessShareLock);
 	LockRelationOid(ResQueueCapabilityRelationId, RowExclusiveLock);
 	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
@@ -215,7 +215,7 @@ InitResQueues(void)
 		/* Hash table has already been loaded */
 		LWLockRelease(ResQueueLock);
 		UnlockRelationOid(ResQueueCapabilityRelationId, RowExclusiveLock);
-		heap_close(relResqueue, AccessShareLock);
+		table_close(relResqueue, AccessShareLock);
 		return;
 	}
 
@@ -253,7 +253,7 @@ InitResQueues(void)
 	systable_endscan(sscan);
 	LWLockRelease(ResQueueLock);
 	UnlockRelationOid(ResQueueCapabilityRelationId, RowExclusiveLock);
-	heap_close(relResqueue, AccessShareLock);
+	table_close(relResqueue, AccessShareLock);
 
 	if (!queuesok)
 		ereport(PANIC,
@@ -933,7 +933,7 @@ GetResQueueIdForName(char	*name)
 	HeapTuple	tuple;
 	Oid			queueid;
 
-	rel = heap_open(ResQueueRelationId, AccessShareLock);
+	rel = table_open(ResQueueRelationId, AccessShareLock);
 
 	/* SELECT oid FROM pg_resqueue WHERE rsqname = :1 */
 	ScanKeyInit(&scankey,
@@ -950,7 +950,7 @@ GetResQueueIdForName(char	*name)
 		queueid = InvalidOid;
 
 	systable_endscan(scan);
-	heap_close(rel, AccessShareLock);
+	table_close(rel, AccessShareLock);
 
 	return queueid;
 }

--- a/src/include/access/table.h
+++ b/src/include/access/table.h
@@ -26,22 +26,9 @@ extern Relation table_openrv_extended(const RangeVar *relation,
 extern Relation try_table_open(Oid relationId, LOCKMODE lockmode, bool noWait);
 extern void table_close(Relation relation, LOCKMODE lockmode);
 
-<<<<<<< HEAD
 /* CDB */
 extern Relation CdbOpenTable(Oid relid, LOCKMODE reqmode, bool *lockUpgraded);
 extern Relation CdbTryOpenTable(Oid relid, LOCKMODE reqmode,
 								bool *lockUpgraded);
 
-/*
- * heap_ used to be the prefix for these routines, and a lot of code will just
- * continue to work without adaptions after the introduction of pluggable
- * storage, therefore just map these names.
- */
-#define heap_open(r, l)					table_open(r, l)
-#define heap_openrv(r, l)				table_openrv(r, l)
-#define heap_openrv_extended(r, l, m)	table_openrv_extended(r, l, m)
-#define heap_close(r, l)				table_close(r, l)
-
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 #endif							/* TABLE_H */

--- a/src/test/isolation2/isolation2_regress.c
+++ b/src/test/isolation2/isolation2_regress.c
@@ -88,7 +88,7 @@ setAOFormatVersion(PG_FUNCTION_ARGS)
 	systable_endscan(scan);
 
 	/* Done. Clean up. */
-	heap_close(aosegrel, RowExclusiveLock);
+	table_close(aosegrel, RowExclusiveLock);
 
 	pfree(replace);
 	pfree(isnull);


### PR DESCRIPTION
Fix conflicts in src/include/access/table.h

1) Commit f25968c removed heap_open/close macros in src/include/access/table.h,
while earlier commit 19cd1cf already added definition of GPDB-specific
functions before this place.

2) Commit e0c4ec0 replaced usage of heap_open/close functions with usage of
table_open/close functions, now, after removing corresponding macros, we also
need to change usage in remaining GPDB-specific files/functions.