### PR TITLE
Fix conflicts in src/include/catalog/catversion.h

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -55,12 +55,7 @@
  * catalog versions from Greenplum.
  */
 
-<<<<<<< HEAD
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302505161
-=======
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201909251
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+#define CATALOG_VERSION_NO	302506031
 
 #endif


### PR DESCRIPTION
Fix conflicts in src/include/catalog/catversion.h

Commit bffe1bd updated the catalog version after the incompatible changes, so
we should do the same for the current date - the date of the incompatible
changes.