### PR TITLE
Fix conflicts in memnodes.h, aset.c and generation.c

### DIFF
--- a/src/backend/utils/mmgr/aset.c
+++ b/src/backend/utils/mmgr/aset.c
@@ -557,7 +557,6 @@ AllocSetContextCreateInternal(MemoryContext parent,
 								parent,
 								name);
 
-<<<<<<< HEAD
 			if (parent)
 				set->accountingParent = ((AllocSet) parent)->accountingParent;
 			else
@@ -566,8 +565,6 @@ AllocSetContextCreateInternal(MemoryContext parent,
 			set->currentAllocated = 0;
 			set->peakAllocated = 0;
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 			((MemoryContext) set)->mem_allocated =
 				set->keeper->endptr - ((char *) set);
 
@@ -663,7 +660,6 @@ AllocSetContextCreateInternal(MemoryContext parent,
 						parent,
 						name);
 
-<<<<<<< HEAD
 	if (parent)
 		set->accountingParent = ((AllocSet) parent)->accountingParent;
 	else
@@ -672,8 +668,6 @@ AllocSetContextCreateInternal(MemoryContext parent,
 	set->currentAllocated = 0;
 	set->peakAllocated = 0;
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 	((MemoryContext) set)->mem_allocated = firstBlockSize;
 
 	return (MemoryContext) set;
@@ -696,12 +690,8 @@ AllocSetReset(MemoryContext context)
 {
 	AllocSet	set = (AllocSet) context;
 	AllocBlock	block;
-<<<<<<< HEAD
-	Size		keepersize PG_USED_FOR_ASSERTS_ONLY = set->keeper->endptr - ((char *) set);
-=======
 	Size		keepersize PG_USED_FOR_ASSERTS_ONLY
 		= set->keeper->endptr - ((char *) set);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	AssertArg(AllocSetIsValid(set));
 
@@ -775,12 +765,8 @@ AllocSetDelete(MemoryContext context, MemoryContext parent)
 {
 	AllocSet	set = (AllocSet) context;
 	AllocBlock	block = set->blocks;
-<<<<<<< HEAD
-	Size		keepersize PG_USED_FOR_ASSERTS_ONLY = set->keeper->endptr - ((char *) set);
-=======
 	Size		keepersize PG_USED_FOR_ASSERTS_ONLY
 		= set->keeper->endptr - ((char *) set);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	AssertArg(AllocSetIsValid(set));
 
@@ -1365,16 +1351,10 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 		chksize = MAXALIGN(chksize);
 
 		/* Do the realloc */
-<<<<<<< HEAD
+		blksize = chksize + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ;
 		oldblksize = UserPtr_GetUserPtrSize(block);
-		blksize = chksize + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ;
-		block = (AllocBlock) gp_realloc(block, blksize);
-=======
-		blksize = chksize + ALLOC_BLOCKHDRSZ + ALLOC_CHUNKHDRSZ;
-		oldblksize = block->endptr - ((char *)block);
 
-		block = (AllocBlock) realloc(block, blksize);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+		block = (AllocBlock) gp_realloc(block, blksize);
 		if (block == NULL)
 		{
 			/* Disallow external access to private part of chunk header. */
@@ -1382,13 +1362,9 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 			return NULL;
 		}
 
-<<<<<<< HEAD
-		context->mem_allocated += blksize - oldblksize;
-=======
 		/* updated separately, not to underflow when (oldblksize > blksize) */
 		context->mem_allocated -= oldblksize;
 		context->mem_allocated += blksize;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 		block->freeptr = block->endptr = ((char *) block) + blksize;
 
@@ -1443,14 +1419,11 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 		/* Disallow external access to private part of chunk header. */
 		VALGRIND_MAKE_MEM_NOACCESS(chunk, ALLOCCHUNK_PRIVATE_LEN);
 
-<<<<<<< HEAD
 		if (chksize > oldsize)
 			MEMORY_ACCOUNT_INC_ALLOCATED(set, chksize - oldsize);
 		else
 			MEMORY_ACCOUNT_DEC_ALLOCATED(set, oldsize - chksize);
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		return pointer;
 	}
 
@@ -1501,14 +1474,11 @@ AllocSetRealloc(MemoryContext context, void *pointer, Size size)
 		/* Disallow external access to private part of chunk header. */
 		VALGRIND_MAKE_MEM_NOACCESS(chunk, ALLOCCHUNK_PRIVATE_LEN);
 
-<<<<<<< HEAD
 		/*
 		 * no need to update memory accounting summaries, since chunk->size
 		 * didn't change
 		 */
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		return pointer;
 	}
 	else
@@ -1785,11 +1755,7 @@ AllocSetCheck(MemoryContext context)
 	const char *name = set->header.name;
 	AllocBlock	prevblock;
 	AllocBlock	block;
-<<<<<<< HEAD
-	int64		total_allocated = 0;
-=======
 	Size		total_allocated = 0;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	for (prevblock = NULL, block = set->blocks;
 		 block != NULL;

--- a/src/backend/utils/mmgr/generation.c
+++ b/src/backend/utils/mmgr/generation.c
@@ -753,11 +753,7 @@ GenerationCheck(MemoryContext context)
 	GenerationContext *gen = (GenerationContext *) context;
 	const char *name = context->name;
 	dlist_iter	iter;
-<<<<<<< HEAD
-	int64		total_allocated = 0;
-=======
 	Size		total_allocated = 0;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	/* walk all blocks in this context */
 	dlist_foreach(iter, &gen->blocks)

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -85,11 +85,7 @@ typedef struct MemoryContextData
 	/* these two fields are placed here to minimize alignment wastage: */
 	bool		isReset;		/* T = no space alloced since last reset */
 	bool		allowInCritSection; /* allow palloc in critical section */
-<<<<<<< HEAD
-	int64		mem_allocated;	/* track memory allocated for this context */
-=======
 	Size		mem_allocated;	/* track memory allocated for this context */
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 	const MemoryContextMethods *methods;	/* virtual function table */
 	MemoryContext parent;		/* NULL if no parent (toplevel context) */
 	MemoryContext firstchild;	/* head of linked list of children */


### PR DESCRIPTION
Fix conflicts in memnodes.h, aset.c and generation.c

1) Commit 5dd7fc1 added a new mem_allocated field of type int64 to the
MemoryContextData structure, while earlier commit 19cd1cf had already done
this. Then commit f2369bc changed the type of the mem_allocated field in the
MemoryContextData structure from int64 to Size, and conflicts arose.

2) Commit 5dd7fc1 added the calculation of the new mem_allocated field to the
AllocSetRealloc function, while earlier commit 19cd1cf had already done this.
Then commit f2369bc changed the calculation of the mem_allocated field in the
AllocSetRealloc function, and conflicts arose.

3) Commit 5dd7fc1 added declaration of new local variable total_allocated to
AllocSetCheck and GenerationCheck functions, while earlier commit 19cd1cf had
already done this. Then commit f2369bc changed the type of local variable
total_allocated from int64 to Size in AllocSetCheck and GenerationCheck
functions, and conflicts arose.

4) Commit 5dd7fc1 added calculation of new field mem_allocated to
AllocSetContextCreateInternal function, while earlier commit 19cd1cf had
already done this, but before this place added other calculations.

5) Commit fa2fe04 added marking PG_USED_FOR_ASSERTS_ONLY to AllocSetReset and
AllocSetDelete functions, while earlier commit 31a35cd had already done this,
but with different formatting.

6) Commit 5dd7fc1 added a new local variable oldblksize and its calculation to
the AllocSetRealloc function, while the earlier commit 19cd1cf had already done
this, but in a different way, taking into account the GPDB specifics.

7) Commit c477f3e moved the piece of code with the condition oldsize >= size
lower in the AllocSetRealloc function, while the earlier commit b0cff1c had
already done this.