### PR TITLE
Fix conflicts in memutils.h and mcxt.c

### DIFF
--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -499,7 +499,6 @@ MemoryContextIsEmpty(MemoryContext context)
 }
 
 /*
-<<<<<<< HEAD
  * MemoryContextError
  *		Report failure of a memory context operation.  Does not return.
  */
@@ -628,19 +627,10 @@ MemoryContextSetPeakSpace(MemoryContext context, Size nbytes)
  * Find the memory allocated to blocks for this memory context. If recurse is
  * true, also include children.
  */
-int64
-MemoryContextMemAllocated(MemoryContext context, bool recurse)
-{
-	int64 total = context->mem_allocated;
-=======
- * Find the memory allocated to blocks for this memory context. If recurse is
- * true, also include children.
- */
 Size
 MemoryContextMemAllocated(MemoryContext context, bool recurse)
 {
 	Size	total = context->mem_allocated;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	AssertArg(MemoryContextIsValid(context));
 

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -114,7 +114,6 @@ extern void MemoryContextSetParent(MemoryContext context,
 extern Size GetMemoryChunkSpace(void *pointer);
 extern MemoryContext MemoryContextGetParent(MemoryContext context);
 extern bool MemoryContextIsEmpty(MemoryContext context);
-<<<<<<< HEAD
 
 /* Statistics */
 extern void MemoryContextDeclareAccountingRoot(MemoryContext context);
@@ -125,10 +124,7 @@ extern Size MemoryContextSetPeakSpace(MemoryContext context, Size nbytes);
 #define MemoryContextDelete(context)    (MemoryContextDeleteImpl(context, __FILE__, PG_FUNCNAME_MACRO, __LINE__))
 extern void MemoryContextDeleteImpl(MemoryContext context, const char* sfile, const char *func, int sline);
 
-extern int64 MemoryContextMemAllocated(MemoryContext context, bool recurse);
-=======
 extern Size MemoryContextMemAllocated(MemoryContext context, bool recurse);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 extern void MemoryContextStats(MemoryContext context);
 extern void MemoryContextStatsDetail(MemoryContext context, int max_children);
 extern void MemoryContextAllowInCriticalSection(MemoryContext context,


### PR DESCRIPTION
Fix conflicts in memutils.h and mcxt.c

Commit 36425ec changed the return type of MemoryContextMemAllocated from int64
to Size, while earlier commit 6b0e52b had already added several GPDB-specific
functions before that point.