### PR TITLE
Fix conflicts in src/backend/access/transam/twophase.c

### DIFF
--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -1416,15 +1416,11 @@ ParsePrepareRecord(uint8 info, char *xlrec, xl_xact_parsed_prepare *parsed)
  * twophase files and ReadTwoPhaseFile should be used instead.
  *
  * Note clearly that this function can access WAL during normal operation,
-<<<<<<< HEAD
  * similarly to the way WALSender or Logical Decoding would do.  While
  * accessing WAL, read_local_xlog_page() may change ThisTimeLineID,
  * particularly if this routine is called for the end-of-recovery checkpoint
  * in the checkpointer itself, so save the current timeline number value
  * and restore it once done.
-=======
- * similarly to the way WALSender or Logical Decoding would do.
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
  */
 static void
 XlogReadTwoPhaseData(XLogRecPtr lsn, char **buf, int *len)


### PR DESCRIPTION
Fix conflicts in src/backend/access/transam/twophase.c

Commit 99569b2 had an unfixed conflict at the end of the comment before the
XlogReadTwoPhaseData function.