### PR TITLE
Fix conflicts in src/backend/catalog/dependency.c

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -2261,14 +2261,6 @@ find_expr_references_walker(Node *node,
 							   context->addrs);
 		}
 
-<<<<<<< HEAD
-		/* query_tree_walker ignores ORDER BY etc, but we need those opers */
-		find_expr_references_walker((Node *) query->sortClause, context);
-		find_expr_references_walker((Node *) query->groupClause, context);
-		find_expr_references_walker((Node *) query->distinctClause, context);
-
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		/* Examine substructure of query */
 		context->rtables = lcons(query->rtable, context->rtables);
 		result = query_tree_walker(query,


### PR DESCRIPTION
Fix conflicts in src/backend/catalog/dependency.c

Commit b7a1c55 removed four calls to find_expr_references_walker from the
function find_expr_references_walker, while earlier commit 9511304 added three
of these calls, and commit 95b07bc added another, but it apparently got lost
when importing the GPDB code.