### PR TITLE
Fix conflicts in src/backend/commands/trigger.c

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -3392,17 +3392,13 @@ GetTupleForTrigger(EState *estate,
 {
 	Relation	relation = relinfo->ri_RelationDesc;
 
-<<<<<<< HEAD
 	/* these should be rejected when you try to create such triggers, but let's check */
 	if (RelationIsAppendOptimized(relation))
 		elog(ERROR, "UPDATE and DELETE triggers are not supported on append-only tables");
 
 	Assert(RelationIsHeap(relation));
 
-	if (newSlot != NULL)
-=======
 	if (epqslot != NULL)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 	{
 		TM_Result	test;
 		TM_FailureData tmfd;


### PR DESCRIPTION
Fix conflicts in src/backend/commands/trigger.c

Commit d986d4e renamed the GetTupleForTrigger function's newSlot argument to
epqslot, while earlier commits 740f304 and 958a672 added GPDB-specific logic
before that.