### PR TITLE
Fix conflicts in be-secure-gssapi.c and sfe-secure-gssapi.c

### DIFF
--- a/src/backend/libpq/be-secure-gssapi.c
+++ b/src/backend/libpq/be-secure-gssapi.c
@@ -122,13 +122,10 @@ be_gssapi_write(Port *port, void *ptr, size_t len)
 	 */
 	while (bytes_to_encrypt || PqGSSSendLength)
 	{
-<<<<<<< HEAD
-=======
 		OM_uint32	major,
 					minor;
 		gss_buffer_desc input,
 					output;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		int			conf_state = 0;
 		uint32		netlen;
 
@@ -196,11 +193,7 @@ be_gssapi_write(Port *port, void *ptr, size_t len)
 		output.length = 0;
 
 		/* Create the next encrypted packet */
-<<<<<<< HEAD
 		major = gss_wrap(&minor, gctx, 1, GSS_C_QOP_DEFAULT,
-=======
-		major = gss_wrap(&minor, gss->ctx, 1, GSS_C_QOP_DEFAULT,
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 						 &input, &conf_state, &output);
 		if (major != GSS_S_COMPLETE)
 			pg_GSS_error_be(FATAL, gettext_noop("GSSAPI wrap error"), major, minor);
@@ -258,12 +251,7 @@ be_gssapi_read(Port *port, void *ptr, size_t len)
 				output;
 	ssize_t		ret;
 	size_t		bytes_returned = 0;
-<<<<<<< HEAD
 	gss_ctx_id_t gctx = port->gss->ctx;
-=======
-	int			conf_state = 0;
-	pg_gssinfo *gss = port->gss;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	/*
 	 * The plan here is to read one incoming encrypted packet into
@@ -375,11 +363,7 @@ be_gssapi_read(Port *port, void *ptr, size_t len)
 		output.length = 0;
 		input.value = PqGSSRecvBuffer + sizeof(uint32);
 
-<<<<<<< HEAD
 		major = gss_unwrap(&minor, gctx, &input, &output, &conf_state, NULL);
-=======
-		major = gss_unwrap(&minor, gss->ctx, &input, &output, &conf_state, NULL);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		if (major != GSS_S_COMPLETE)
 			pg_GSS_error_be(FATAL, gettext_noop("GSSAPI unwrap error"),
 						 major, minor);
@@ -564,11 +548,7 @@ secure_open_gssapi(Port *port)
 									   NULL, NULL);
 		if (GSS_ERROR(major))
 		{
-<<<<<<< HEAD
 			pg_GSS_error_be(ERROR, gettext_noop("could not accept GSSAPI security context"),
-=======
-			pg_GSS_error(ERROR, gettext_noop("could not accept GSSAPI security context"),
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 						 major, minor);
 			gss_release_buffer(&minor, &output);
 			return -1;

--- a/src/backend/libpq/be-secure-gssapi.c
+++ b/src/backend/libpq/be-secure-gssapi.c
@@ -122,10 +122,6 @@ be_gssapi_write(Port *port, void *ptr, size_t len)
 	 */
 	while (bytes_to_encrypt || PqGSSSendLength)
 	{
-		OM_uint32	major,
-					minor;
-		gss_buffer_desc input,
-					output;
 		int			conf_state = 0;
 		uint32		netlen;
 

--- a/src/interfaces/libpq/fe-secure-gssapi.c
+++ b/src/interfaces/libpq/fe-secure-gssapi.c
@@ -197,16 +197,11 @@ pg_GSS_write(PGconn *conn, const void *ptr, size_t len)
 		output.value = NULL;
 		output.length = 0;
 
-<<<<<<< HEAD
 		/*
 		 * Create the next encrypted packet.  Any failure here is considered a
 		 * hard failure, so we return -1 even if bytes_sent > 0.
 		 */
 		major = gss_wrap(&minor, gctx, 1, GSS_C_QOP_DEFAULT,
-=======
-		/* Create the next encrypted packet */
-		major = gss_wrap(&minor, conn->gctx, 1, GSS_C_QOP_DEFAULT,
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 						 &input, &conf_state, &output);
 		if (major != GSS_S_COMPLETE)
 		{
@@ -214,19 +209,12 @@ pg_GSS_write(PGconn *conn, const void *ptr, size_t len)
 			errno = EIO;		/* for lack of a better idea */
 			goto cleanup;
 		}
-<<<<<<< HEAD
 
 		if (conf_state == 0)
 		{
 			printfPQExpBuffer(&conn->errorMessage,
 							  libpq_gettext("outgoing GSSAPI message would not use confidentiality\n"));
 			errno = EIO;		/* for lack of a better idea */
-=======
-		else if (conf_state == 0)
-		{
-			printfPQExpBuffer(&conn->errorMessage,
-							  libpq_gettext("outgoing GSSAPI message would not use confidentiality\n"));
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 			goto cleanup;
 		}
 
@@ -236,10 +224,7 @@ pg_GSS_write(PGconn *conn, const void *ptr, size_t len)
 							  libpq_gettext("client tried to send oversize GSSAPI packet (%zu > %zu)\n"),
 							  (size_t) output.length,
 							  PQ_GSS_SEND_BUFFER_SIZE - sizeof(uint32));
-<<<<<<< HEAD
 			errno = EIO;		/* for lack of a better idea */
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 			goto cleanup;
 		}
 
@@ -376,13 +361,8 @@ pg_GSS_read(PGconn *conn, void *ptr, size_t len)
 							  libpq_gettext("oversize GSSAPI packet sent by the server (%zu > %zu)\n"),
 							  (size_t) input.length,
 							  PQ_GSS_RECV_BUFFER_SIZE - sizeof(uint32));
-<<<<<<< HEAD
 			errno = EIO;		/* for lack of a better idea */
 			return -1;
-=======
-			ret = -1;
-			goto cleanup;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		}
 
 		/*
@@ -414,11 +394,7 @@ pg_GSS_read(PGconn *conn, void *ptr, size_t len)
 		output.length = 0;
 		input.value = PqGSSRecvBuffer + sizeof(uint32);
 
-<<<<<<< HEAD
 		major = gss_unwrap(&minor, gctx, &input, &output, &conf_state, NULL);
-=======
-		major = gss_unwrap(&minor, conn->gctx, &input, &output, &conf_state, NULL);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		if (major != GSS_S_COMPLETE)
 		{
 			pg_GSS_error(libpq_gettext("GSSAPI unwrap error"), conn,
@@ -427,12 +403,8 @@ pg_GSS_read(PGconn *conn, void *ptr, size_t len)
 			errno = EIO;		/* for lack of a better idea */
 			goto cleanup;
 		}
-<<<<<<< HEAD
 
 		if (conf_state == 0)
-=======
-		else if (conf_state == 0)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		{
 			printfPQExpBuffer(&conn->errorMessage,
 							  libpq_gettext("incoming GSSAPI message did not use confidentiality\n"));


### PR DESCRIPTION
Fix conflicts in be-secure-gssapi.c and sfe-secure-gssapi.c

Commit e1c8743 improved error messages in GSSAPI, while earlier commit 2cdfd4c
already did it, and commit 42d0473 improved the GSSAPI encryption mechanism,
and commit 536fd6b renamed the pg_GSS_error function to pg_GSS_error_be.