### PR TITLE
Fix conflicts in src/backend/storage/smgr/smgr.c

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -397,16 +397,8 @@ smgrcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo)
  *		Given a RelFileNode, cause the underlying disk file for the
  *		AO segment to be created.
  *
-<<<<<<< HEAD
  *		If isRedo is true, it is okay for the underlying file to exist
  *		already because we are in a WAL replay sequence.
-=======
- *		All forks of the relation are removed from the store.  This should
- *		not be used during transactional operations, since it can't be undone.
- *
- *		If isRedo is true, it is okay for the underlying file(s) to be gone
- *		already.
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
  */
 void
 smgrcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
@@ -494,60 +486,6 @@ smgrdounlinkall(SMgrRelation *rels, int nrels, bool isRedo)
 
 	pfree(rnodes);
 }
-
-<<<<<<< HEAD
-/*
- *	smgrdounlinkfork() -- Immediately unlink one fork of a relation.
- *
- *		The specified fork of the relation is removed from the store.  This
- *		should not be used during transactional operations, since it can't be
- *		undone.
- *
- *		If isRedo is true, it is okay for the underlying file to be gone
- *		already.
- */
-void
-smgrdounlinkfork(SMgrRelation reln, ForkNumber forknum, bool isRedo)
-{
-	RelFileNodeBackend rnode = reln->smgr_rnode;
-
-	/* Close the fork at smgr level */
-	(*reln->storageManager).smgr_close(reln, forknum);
-
-	/*
-	 * Get rid of any remaining buffers for the fork.  bufmgr will just drop
-	 * them without bothering to write the contents.
-	 */
-	DropRelFileNodeBuffers(rnode, forknum, 0);
-
-	/*
-	 * It'd be nice to tell the stats collector to forget it immediately, too.
-	 * But we can't because we don't know the OID (and in cases involving
-	 * relfilenode swaps, it's not always clear which table OID to forget,
-	 * anyway).
-	 */
-
-	/*
-	 * Send a shared-inval message to force other backends to close any
-	 * dangling smgr references they may have for this rel.  We should do this
-	 * before starting the actual unlinking, in case we fail partway through
-	 * that step.  Note that the sinval message will eventually come back to
-	 * this backend, too, and thereby provide a backstop that we closed our
-	 * own smgr rel.
-	 */
-	CacheInvalidateSmgr(rnode);
-
-	/*
-	 * Delete the physical file(s).
-	 *
-	 * Note: smgr_unlink must treat deletion failure as a WARNING, not an
-	 * ERROR, because we've already decided to commit or abort the current
-	 * xact.
-	 */
-	(*reln->storageManager).smgr_unlink(rnode, forknum, isRedo);
-}
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 /*
  *	smgrextend() -- Add a new block to a file.
@@ -672,19 +610,10 @@ smgrtruncate(SMgrRelation reln, ForkNumber *forknum, int nforks, BlockNumber *nb
 	 */
 	CacheInvalidateSmgr(reln->smgr_rnode);
 
-<<<<<<< HEAD
-	/*
-	 * Do the truncation.
-	 */
-	(*reln->storageManager).smgr_truncate(reln, forknum, nblocks);
-
-	if (file_truncate_hook)
-		(*file_truncate_hook)(reln->smgr_rnode);
-=======
 	/* Do the truncation */
 	for (i = 0; i < nforks; i++)
 	{
-		smgrsw[reln->smgr_which].smgr_truncate(reln, forknum[i], nblocks[i]);
+		(*reln->storageManager).smgr_truncate(reln, forknum[i], nblocks[i]);
 
 		/*
 		 * We might as well update the local smgr_fsm_nblocks and
@@ -699,7 +628,9 @@ smgrtruncate(SMgrRelation reln, ForkNumber *forknum, int nforks, BlockNumber *nb
 		if (forknum[i] == VISIBILITYMAP_FORKNUM)
 			reln->smgr_vm_nblocks = nblocks[i];
 	}
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+
+	if (file_truncate_hook)
+		(*file_truncate_hook)(reln->smgr_rnode);
 }
 
 /*


### PR DESCRIPTION
Fix conflicts in src/backend/storage/smgr/smgr.c

1) During the merge, comments were mistakenly added to the GPDB-specific
smgrcreate_ao function

2) Commit 33a94ba removed the unused smgrdounlinkfork function, while the
earlier commit b354832 changed the storage manager in it.

3) Commit 6d05086 added a fork loop to the smgrtruncate function, while the
earlier commit a9f594f added a call to the diskquota hook in the same place,
and the commit b354832 changed the storage manager in the same place.