### PR TITLE
Fix conflicts in src/backend/utils/adt/jsonb_util.c

### DIFF
--- a/src/backend/utils/adt/jsonb_util.c
+++ b/src/backend/utils/adt/jsonb_util.c
@@ -14,18 +14,12 @@
 #include "postgres.h"
 
 #include "catalog/pg_collation.h"
-<<<<<<< HEAD
+#include "catalog/pg_type.h"
 #include "common/hashfn.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
-=======
-#include "catalog/pg_type.h"
-#include "miscadmin.h"
-#include "utils/builtins.h"
 #include "utils/datetime.h"
-#include "utils/hashutils.h"
 #include "utils/jsonapi.h"
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 #include "utils/jsonb.h"
 #include "utils/memutils.h"
 #include "utils/varlena.h"


### PR DESCRIPTION
Fix conflicts in src/backend/utils/adt/jsonb_util.c

Commit 6dda292 added new includes to src/backend/utils/adt/jsonb_util.c, while
earlier commit 5d3dc2e had already renamed the utils/hashutils.h include to
common/hashfn.h in the same place.