### PR TITLE
Fix conflicts in src/bin/pg_rewind/Makefile

### DIFF
--- a/src/bin/pg_rewind/Makefile
+++ b/src/bin/pg_rewind/Makefile
@@ -16,11 +16,7 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
 override CPPFLAGS := -I$(libpq_srcdir) -DFRONTEND $(CPPFLAGS)
-<<<<<<< HEAD
-LDFLAGS_INTERNAL += $(libpq_pgport) -L$(top_builddir)/src/fe_utils -lpgfeutils
-=======
 LDFLAGS_INTERNAL += -L$(top_builddir)/src/fe_utils -lpgfeutils $(libpq_pgport)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 OBJS	= pg_rewind.o parsexlog.o xlogreader.o datapagemap.o timeline.o \
 	fetch.o file_ops.o copy_fetch.o libpq_fetch.o filemap.o \


### PR DESCRIPTION
Fix conflicts in src/bin/pg_rewind/Makefile

Commit 927474c added options to the LDFLAGS_INTERNAL variable, while earlier
commit 19cd1cf had already done so, and then commit 5daf682 moved the
libpq_pgport argument to the end of the line.