### PR TITLE
Fix conflicts in pg_upgrade.h and pg_upgrade.c

### DIFF
--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -132,21 +132,12 @@ main(int argc, char **argv)
 	check_cluster_compatibility(live_check);
 
 	/* Set mask based on PGDATA permissions */
-<<<<<<< HEAD
 	if (!is_skip_target_check())
 	{
 		if (!GetDataDirectoryCreatePerm(new_cluster.pgdata))
-		{
-			pg_log(PG_FATAL, "could not read permissions of directory \"%s\": %s\n",
+			pg_fatal("could not read permissions of directory \"%s\": %s\n",
 					 new_cluster.pgdata, strerror(errno));
-			exit(1);
-		}
 	}
-=======
-	if (!GetDataDirectoryCreatePerm(new_cluster.pgdata))
-		pg_fatal("could not read permissions of directory \"%s\": %s\n",
-				 new_cluster.pgdata, strerror(errno));
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	umask(pg_mode_mask);
 

--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -562,20 +562,7 @@ void		old_9_6_check_for_unknown_data_type_usage(ClusterInfo *cluster);
 void		old_9_6_invalidate_hash_indexes(ClusterInfo *cluster,
 											bool check_mode);
 
-<<<<<<< HEAD
-/* version_old_8_3.c */
-
-void		old_8_3_check_for_name_data_type_usage(ClusterInfo *cluster);
-void		old_8_3_check_for_tsquery_usage(ClusterInfo *cluster);
-void		old_8_3_check_ltree_usage(ClusterInfo *cluster);
-void		old_8_3_rebuild_tsvector_tables(ClusterInfo *cluster, bool check_mode);
-void		old_8_3_invalidate_hash_gin_indexes(ClusterInfo *cluster, bool check_mode);
-void old_8_3_invalidate_bpchar_pattern_ops_indexes(ClusterInfo *cluster,
-											  bool check_mode);
-char	   *old_8_3_create_sequence_script(ClusterInfo *cluster);
-=======
 void		old_11_check_for_sql_identifier_data_type_usage(ClusterInfo *cluster);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 /* parallel.c */
 void		parallel_exec_prog(const char *log_file, const char *opt_log_file,


### PR DESCRIPTION
Fix conflicts in pg_upgrade.h and pg_upgrade.c

1) Commit 0ccfc28 added a new function
old_11_check_for_sql_identifier_data_type_usage, while earlier commit 8f0f312
removed functions old_8_3_*, but forgot to remove their declarations.

2) Commit 3b5d372 replaced pg_log and exit in function main with pg_fatal,
while earlier commit e99317c added an additional check is_skip_target_check in
the same place.