### PR TITLE
Fix conflicts in pg_basebackup.c and recovery_gen.c

### DIFF
--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1729,12 +1729,9 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 
 	if (basetablespace && writerecoveryconf)
 		WriteRecoveryConfig(conn, basedir, recoveryconfcontents);
-<<<<<<< HEAD
 
 	if (basetablespace)
 		WriteInternalConfFile();
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	/*
 	 * No data is synced here, everything is done for all tablespaces at the
@@ -1742,7 +1739,6 @@ ReceiveAndUnpackTarFile(PGconn *conn, PGresult *res, int rownum)
 	 */
 }
 
-<<<<<<< HEAD
 static void
 add_to_exclude_list(PQExpBufferData *buf, const char *exclude)
 {
@@ -1816,8 +1812,6 @@ build_exclude_list(void)
 
 	return buf.data;
 }
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 static void
 BaseBackup(void)

--- a/src/fe_utils/recovery_gen.c
+++ b/src/fe_utils/recovery_gen.c
@@ -16,11 +16,8 @@
 
 static char *escape_quotes(const char *src);
 
-<<<<<<< HEAD
 #define GP_WALRECEIVER_APPNAME "gp_walreceiver"
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 /*
  * Write recovery configuration contents into a fresh PQExpBuffer, and
  * return it.
@@ -84,10 +81,7 @@ GenerateRecoveryConfig(PGconn *pgconn, char *replication_slot)
 		exit(1);
 	}
 
-<<<<<<< HEAD
 	appendPQExpBuffer(&conninfo_buf, " application_name=%s", GP_WALRECEIVER_APPNAME);
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 	/*
 	 * Escape the connection string, so that it can be put in the config file.
 	 * Note that this is different from the escaping of individual connection


### PR DESCRIPTION
Fix conflicts in pg_basebackup.c and recovery_gen.c

1) Commit caba97a in ReceiveAndUnpackTarFile function replaced
WriteRecoveryConf function call with WriteRecoveryConfig with arguments, while
earlier commit 19cd1cf already did this, and commit 4eaeb7b added
WriteInternalConfFile function call with condition below.

2) Commit caba97a moved functions escape_quotes, GenerateRecoveryConf,
WriteRecoveryConf from file src/bin/pg_basebackup/pg_basebackup.c to new file
src/fe_utils/recovery_gen.c (last two under new names GenerateRecoveryConfig
and WriteRecoveryConfig), while earlier commit 19cd1cf already did this, adding
additional macro GP_WALRECEIVER_APPNAME and its usage, and even earlier commit
6b0e52b added functions add_to_exclude_list and build_exclude_list to the same
place.