### PR TITLE
Fix conflicts in src/bin/pg_dump/common.c

### DIFF
--- a/src/bin/pg_dump/common.c
+++ b/src/bin/pg_dump/common.c
@@ -461,13 +461,7 @@ flagInhIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 								parentidx->indextable->dobj.dumpId);
 
 			/* keep track of the list of partitions in the parent index */
-<<<<<<< HEAD
 			simple_ptr_list_append(&parentidx->partattaches, &attachinfo->dobj);
-=======
-			simple_ptr_list_append(&parentidx->partattaches, &attachinfo[k].dobj);
-
-			k++;
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		}
 	}
 }


### PR DESCRIPTION
Fix conflicts in src/bin/pg_dump/common.c

Commit 1752e35 added a call to simple_ptr_list_append in flagInhIndexes, while
earlier commit 7794c83 had already done this, and commit b250064 changed the
array to a pointer.