### PR TITLE
Fix conflicts in src/bin/pg_rewind/libpq_fetch.c

### DIFF
--- a/src/bin/pg_rewind/libpq_fetch.c
+++ b/src/bin/pg_rewind/libpq_fetch.c
@@ -24,11 +24,8 @@
 #include "fe_utils/connect.h"
 #include "port/pg_bswap.h"
 
-<<<<<<< HEAD
 #include "pqexpbuffer.h"
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 PGconn *conn = NULL;
 
 /*


### PR DESCRIPTION
Fix conflicts in src/bin/pg_rewind/libpq_fetch.c

Commit 927474c removed the static attribute from the global conn variable,
while the earlier commit 0e0153b already added an include pqexpbuffer.h before
this place.