### PR TITLE
Fix conflicts in src/bin/pgbench/pgbench.c

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -3771,20 +3771,15 @@ initCreateTables(PGconn *con)
 		/* Partition pgbench_accounts table */
 		if (partition_method != PART_NONE && strcmp(ddl->table, "pgbench_accounts") == 0)
 			snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
-<<<<<<< HEAD
-					 " with (fillfactor=%d, %s)",
-					 fillfactor, storage_clause);
-		else
-			snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
-					 " with (%s)",
-					 storage_clause);
-=======
 					 " partition by %s (aid)", PARTITION_METHOD[partition_method]);
 		else if (ddl->declare_fillfactor)
 			/* fillfactor is only expected on actual tables */
 			append_fillfactor(opts, sizeof(opts));
+		else
+			snprintf(opts + strlen(opts), sizeof(opts) - strlen(opts),
+					 " with (%s)",
+					 storage_clause);
 
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 		if (tablespace != NULL)
 		{
 			char	   *escape_tablespace;
@@ -3821,7 +3816,8 @@ static void
 append_fillfactor(char *opts, int len)
 {
 	snprintf(opts + strlen(opts), len - strlen(opts),
-			 " with (fillfactor=%d)", fillfactor);
+			 " with (fillfactor=%d, %s)",
+			 fillfactor, storage_clause);
 }
 
 /*


### PR DESCRIPTION
Fix conflicts in src/bin/pgbench/pgbench.c

Commit b1c1aa5 added a new function append_fillfactor, while an earlier commit
f6ec65f fixed the --tablespace option for distributed by, and an even earlier
commit 6b0e52b added the global storage_clause variable and its use here.