### PR TITLE
ADBDEV-7618: Change General to OuterQuery locus in bring_to_outer_query()

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -522,10 +522,7 @@ bring_to_outer_query(PlannerInfo *root, RelOptInfo *rel, List *outer_quals)
 		Path	   *path;
 		CdbPathLocus outerquery_locus;
 
-		if (CdbPathLocus_IsGeneral(origpath->locus) ||
-			CdbPathLocus_IsOuterQuery(origpath->locus))
-			path = origpath;
-		else
+		if (!CdbPathLocus_IsOuterQuery(origpath->locus))
 		{
 			/*
 			 * Cannot pass a param through motion, so if this is a parameterized
@@ -554,7 +551,8 @@ bring_to_outer_query(PlannerInfo *root, RelOptInfo *rel, List *outer_quals)
 											  false,
 											  outerquery_locus);
 		}
-
+		else
+			path = origpath;
 		if (outer_quals)
 			path = (Path *) create_projection_path_with_quals(root,
 															  rel,

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -2279,7 +2279,7 @@ rel_need_to_separate_outer_query_restrictinfos(PlannerInfo *root, RelOptInfo *re
 			return false;
 
 		case RTE_VALUES:
-			return false;
+			return true;
 
 		case RTE_TABLEFUNCTION:
 			/* no correlated subqueries are allowed in a tablefunctions. So not sure

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2189,3 +2189,36 @@ select * from table1 where 10 in
 (2 rows)
 
 drop table table1, table2;
+--Fix Values Scan with parameters in subselect
+create table table1 (i int, j int) distributed replicated;
+insert into table1 select i, i from generate_series(1, 3) i;
+create table table2 (i int, j int) distributed by (i);
+insert into table2 select i, i from generate_series(1, 3) i;
+explain (costs off)
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on table1
+         Filter: (j > (SubPlan 1))
+         SubPlan 1
+           ->  Limit
+                 ->  Nested Loop
+                       ->  Result
+                             Filter: ("*VALUES*".column1 > table1.i)
+                             ->  Values Scan on "*VALUES*"
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on table2
+ Optimizer: Postgres-based planner
+(13 rows)
+
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+ i | j 
+---+---
+ 2 | 2
+(1 row)
+
+drop table table1, table2;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2193,7 +2193,7 @@ drop table table1, table2;
 create table table1 (i int, j int) distributed replicated;
 insert into table1 select i, i from generate_series(1, 3) i;
 create table table2 (i int, j int) distributed by (i);
-insert into table2 select i, i from generate_series(1, 3) i;
+insert into table2 values (1, 1);
 explain (costs off)
 select * from table1 where table1.j >
     (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2278,3 +2278,38 @@ select * from table1 where 10 in
 (2 rows)
 
 drop table table1, table2;
+--Fix Values Scan with parameters in subselect
+create table table1 (i int, j int) distributed replicated;
+insert into table1 select i, i from generate_series(1, 3) i;
+create table table2 (i int, j int) distributed by (i);
+insert into table2 select i, i from generate_series(1, 3) i;
+explain (costs off)
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Result
+   Filter: (table1.j > (SubPlan 1))
+   ->  Gather Motion 1:1  (slice1; segments: 1)
+         ->  Seq Scan on table1
+   SubPlan 1
+     ->  Limit
+           ->  Result
+                 Filter: ("Values".column1 > table1.i)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Nested Loop
+                                   Join Filter: true
+                                   ->  Seq Scan on table2
+                                   ->  Values Scan on "Values"
+ Optimizer: GPORCA
+(15 rows)
+
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+ i | j 
+---+---
+ 2 | 2
+(1 row)
+
+drop table table1, table2;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2283,7 +2283,7 @@ drop table table1, table2;
 create table table1 (i int, j int) distributed replicated;
 insert into table1 select i, i from generate_series(1, 3) i;
 create table table2 (i int, j int) distributed by (i);
-insert into table2 select i, i from generate_series(1, 3) i;
+insert into table2 values (1, 1);
 explain (costs off)
 select * from table1 where table1.j >
     (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1098,7 +1098,7 @@ create table table1 (i int, j int) distributed replicated;
 insert into table1 select i, i from generate_series(1, 3) i;
 
 create table table2 (i int, j int) distributed by (i);
-insert into table2 select i, i from generate_series(1, 3) i;
+insert into table2 values (1, 1);
 
 explain (costs off)
 select * from table1 where table1.j >

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1089,3 +1089,22 @@ select * from table1 where 10 in
     (select b from table2 where table2.a = 0 or table1.b = table2.b);
 
 drop table table1, table2;
+
+--Fix Values Scan with parameters in subselect
+-- start_ignore
+drop table if exists table1, table2;
+-- end_ignore
+create table table1 (i int, j int) distributed replicated;
+insert into table1 select i, i from generate_series(1, 3) i;
+
+create table table2 (i int, j int) distributed by (i);
+insert into table2 select i, i from generate_series(1, 3) i;
+
+explain (costs off)
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+
+select * from table1 where table1.j >
+    (select i from table2, (values (1), (2), (3)) k (a) where a > table1.i limit 1);
+
+drop table table1, table2;


### PR DESCRIPTION
Change General to OuterQuery locus in bring_to_outer_query (#1691)

We assume that if we have a correlated subquery for a given path we process
the OuterQuery locus. The patch 605f84e broke this logic - this left the
General locus, even for the correlated subplan (main problem). So we revert it.
Another issue was that the Values ​​Scan node was not treated as OuterQuery
with parameterized qual. This resulted in invalid plans with parameterized
qual in Values ​​Scan if Motion was added on top.
The solution is to allow restrictinfo to be moved to upperrestrictinfo
(see definition) instead of baserestrictinfo for parameterized Values Scan.
Since upperrestrictinfo is not empty, this calls the bring_to_outer_query
handler to distribute the data and prevents to add Motion above the
parameterized node.