### PR TITLE
Fix conflicts in src/bin/pg_rewind/t/RewindTest.pm

### DIFF
--- a/src/bin/pg_rewind/t/101_ao_rewind.pl
+++ b/src/bin/pg_rewind/t/101_ao_rewind.pl
@@ -115,7 +115,7 @@ sub run_test
 	# "in production" in the control file. At the beginning of
 	# pg_rewind, a single-user mode postgres session should be run to
 	# ensure clean shutdown on the target instance.
-	RewindTest::run_pg_rewind($test_mode, stop_master_mode => 'immediate');
+	RewindTest::run_pg_rewind($test_mode);
 
 	check_query(
 		'SELECT * FROM aotbl1',

--- a/src/bin/pg_rewind/t/RewindTest.pm
+++ b/src/bin/pg_rewind/t/RewindTest.pm
@@ -252,28 +252,15 @@ sub run_pg_rewind
 	my $standby_connstr = $node_standby->connstr('postgres');
 	my $tmp_folder      = TestLib::tempdir;
 
-	$params{stop_master_mode} = 0 unless defined $params{stop_master_mode};
 	$params{do_not_start_master} = 0 unless defined $params{do_not_start_master};
 
 	# Append the rewind-specific role to the connection string.
 	$standby_connstr = "$standby_connstr user=rewind_user";
 
-<<<<<<< HEAD
-	# Stop the master and be ready to perform the rewind
-	if ($params{stop_master_mode})
-	{
-		$node_master->stop($params{stop_master_mode});
-	}
-	else
-	{
-		$node_master->stop;
-	}
-=======
 	# Stop the master and be ready to perform the rewind.  The cluster
 	# needs recovery to finish once, and pg_rewind makes sure that it
 	# happens automatically.
 	$node_master->stop('immediate');
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 	# At this point, the rewind processing is ready to run.
 	# We now have a very simple scenario with a few diverged WAL record.
@@ -316,15 +303,6 @@ sub run_pg_rewind
 			[
 				'pg_rewind',                      "--debug",
 				"--source-server",                $standby_connstr,
-<<<<<<< HEAD
-				"--target-pgdata=$master_pgdata", "-R",
-				"--no-sync"
-			],
-			'pg_rewind remote');
-
-		# Check that standby.signal has been created.
-		ok(-e "$master_pgdata/standby.signal");
-=======
 				"--target-pgdata=$master_pgdata", "--no-sync",
 				"--write-recovery-conf"
 			],
@@ -334,7 +312,6 @@ sub run_pg_rewind
 		# was requested.
 		ok( -e "$master_pgdata/standby.signal",
 			'standby.signal created after pg_rewind');
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 		# Now, when pg_rewind apparently succeeded with minimal permissions,
 		# add REPLICATION privilege.  So we could test that new standby


### PR DESCRIPTION
Fix conflicts in src/bin/pg_rewind/t/RewindTest.pm

1) Commit caa0783 added unconditional immediate cluster shutdown to
run_pg_rewind, while earlier commit 19cd1cf already added such conditional
capability when called with stop_master_mode option, but now this option is not
needed.

2) Commit 7524c78 added -R option to run_pg_rewind, while earlier commit
19cd1cf already did this, and then commit caa0783 replaced -R with
--write-recovery-conf option, and also comments nearby.