### PR TITLE
Fix tests in cdbappendonlyxlog_test.c and gplibpq.c

### DIFF
--- a/src/backend/cdb/test/cdbappendonlyxlog_test.c
+++ b/src/backend/cdb/test/cdbappendonlyxlog_test.c
@@ -45,7 +45,7 @@ ao_invalid_segment_file_test(uint8 xl_info)
 	record.xl_info = xl_info;
 	record.xl_rmid = RM_APPEND_ONLY_ID;
 
-	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, NULL);
+	mockrecord = XLogReaderAllocate(DEFAULT_XLOG_SEG_SIZE, NULL, NULL, NULL);
 
 	if (xl_info == XLOG_APPENDONLY_INSERT)
 	{

--- a/src/test/walrep/gplibpq.c
+++ b/src/test/walrep/gplibpq.c
@@ -458,7 +458,7 @@ check_ao_record_present(unsigned char type, char *buf, Size len,
 	test_PrintLog("wal start record", dataStart, sendTime);
 	test_PrintLog("wal end record", walEnd, sendTime);
 
-	xlogreader = XLogReaderAllocate(wal_segment_size, &read_local_xlog_page, NULL);
+	xlogreader = XLogReaderAllocate(wal_segment_size, NULL, &read_local_xlog_page, NULL);
 
 	/*
 	 * Find the first valid record at or after the given starting point.


### PR DESCRIPTION
Fix tests in cdbappendonlyxlog_test.c and gplibpq.c

Commit 709d003 added a new argument waldir to the XLogReaderAllocate function,
we need to do this in the GPDB-specific functions/files.