### PR TITLE
Fix conflicts in create_misc test

### DIFF
--- a/src/test/regress/expected/create_misc.out
+++ b/src/test/regress/expected/create_misc.out
@@ -132,10 +132,7 @@ INSERT INTO f_star (class, e) VALUES ('f', '-12'::int2);
 INSERT INTO f_star (class, f)
    VALUES ('f', '(11111111,33333333),(22222222,44444444)'::polygon);
 INSERT INTO f_star (class) VALUES ('f');
-<<<<<<< HEAD
-=======
 -- Analyze the X_star tables for better plan stability in later tests
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 ANALYZE a_star;
 ANALYZE b_star;
 ANALYZE c_star;

--- a/src/test/regress/sql/create_misc.sql
+++ b/src/test/regress/sql/create_misc.sql
@@ -194,10 +194,7 @@ INSERT INTO f_star (class, f)
 
 INSERT INTO f_star (class) VALUES ('f');
 
-<<<<<<< HEAD
-=======
 -- Analyze the X_star tables for better plan stability in later tests
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 ANALYZE a_star;
 ANALYZE b_star;
 ANALYZE c_star;


### PR DESCRIPTION
Fix conflicts in create_misc test

Commit b9bffa004a99 added 'analyze' on several tables together with a
respective comment, while commit 165ed6bf1786 had already added 'analyze' for
the same tables, but without the comment.
