### PR TITLE
Fix conflicts in window test

### DIFF
--- a/src/test/regress/expected/window.out
+++ b/src/test/regress/expected/window.out
@@ -4011,9 +4011,6 @@ SELECT i, b, bool_and(b) OVER w, bool_or(b) OVER w
  5 | t | t        | t
 (5 rows)
 
-<<<<<<< HEAD
-RESET optimizer_trace_fallback;
-=======
 -- Tests for problems with failure to walk or mutate expressions
 -- within window frame clauses.
 -- test walker (fails with collation error if expressions are not walked)
@@ -4041,6 +4038,7 @@ EXPLAIN (costs off) SELECT * FROM pg_temp.f(2);
 ------------------------------------------------------
  Subquery Scan on f
    ->  WindowAgg
+         Order By: s.s
          ->  Sort
                Sort Key: s.s
                ->  Function Scan on generate_series s
@@ -4056,4 +4054,4 @@ SELECT * FROM pg_temp.f(2);
  {5}
 (5 rows)
 
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+RESET optimizer_trace_fallback;

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -4078,4 +4078,45 @@ SELECT i, b, bool_and(b) OVER w, bool_or(b) OVER w
  5 | t | t        | t
 (5 rows)
 
+-- Tests for problems with failure to walk or mutate expressions
+-- within window frame clauses.
+-- test walker (fails with collation error if expressions are not walked)
+SELECT array_agg(i) OVER w
+  FROM generate_series(1,5) i
+WINDOW w AS (ORDER BY i ROWS BETWEEN (('foo' < 'foobar')::integer) PRECEDING AND CURRENT ROW);
+ array_agg 
+-----------
+ {1,2}
+ {1}
+ {2,3}
+ {3,4}
+ {4,5}
+(5 rows)
+
+-- test mutator (fails when inlined if expressions are not mutated)
+CREATE FUNCTION pg_temp.f(group_size BIGINT) RETURNS SETOF integer[]
+AS $$
+    SELECT array_agg(s) OVER w
+      FROM generate_series(1,5) s
+    WINDOW w AS (ORDER BY s ROWS BETWEEN CURRENT ROW AND GROUP_SIZE FOLLOWING)
+$$ LANGUAGE SQL STABLE;
+EXPLAIN (costs off) SELECT * FROM pg_temp.f(2);
+              QUERY PLAN
+---------------------------------------
+ Function Scan on f
+ Optimizer: Pivotal Optimizer (GPORCA)
+(2 rows)
+
+SELECT * FROM pg_temp.f(2);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
+    f    
+---------
+ {1,2,3}
+ {2,3,4}
+ {3,4,5}
+ {4,5}
+ {5}
+(5 rows)
+
 RESET optimizer_trace_fallback;

--- a/src/test/regress/sql/window.sql
+++ b/src/test/regress/sql/window.sql
@@ -1388,9 +1388,6 @@ SELECT i, b, bool_and(b) OVER w, bool_or(b) OVER w
   FROM (VALUES (1,true), (2,true), (3,false), (4,false), (5,true)) v(i,b)
   WINDOW w AS (ORDER BY i ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING);
 
-<<<<<<< HEAD
-RESET optimizer_trace_fallback;
-=======
 -- Tests for problems with failure to walk or mutate expressions
 -- within window frame clauses.
 
@@ -1409,4 +1406,5 @@ $$ LANGUAGE SQL STABLE;
 
 EXPLAIN (costs off) SELECT * FROM pg_temp.f(2);
 SELECT * FROM pg_temp.f(2);
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+
+RESET optimizer_trace_fallback;


### PR DESCRIPTION
Fix conflicts in window test

Commit b7a1c5539ad3 added new test case into the window test, while commit
a9014373fb1c added GUC reset into the same place. Resolve the conflict by moving
the GUC reset after the new test.

Plus, explain output for the new test case is updated and full test output is
added to the '_optimizer' file for Orca.
