### PR TITLE
Fix conflicts in partition_prune test

### DIFF
--- a/src/test/regress/expected/partition_prune.out
+++ b/src/test/regress/expected/partition_prune.out
@@ -1,7 +1,6 @@
 --
 -- Test partitioning planner code
 --
-<<<<<<< HEAD
 -- GPDB:
 -- One of the queries EXPLAINed in this file executes on one or two segments,
 -- depending on random choice by the planner. Accept either plan.
@@ -33,8 +32,6 @@
 -- m/segment \d+/
 -- s/segment \d+/segment ###/
 -- end_matchsubs
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 -- Force generic plans to be used for all prepared statements in this file.
 set plan_cache_mode = force_generic_plan;
 create table lp (a char) partition by list (a);
@@ -2208,35 +2205,18 @@ set parallel_tuple_cost = 0;
 set min_parallel_table_scan_size = 0;
 set max_parallel_workers_per_gather = 2;
 select explain_parallel_append('execute ab_q4 (2, 2)');
-<<<<<<< HEAD
                          explain_parallel_append                         
 -------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-                     Subplans Removed: 6
-                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
-                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
-                           Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
-=======
-                            explain_parallel_append                            
--------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Workers Launched: N
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Parallel Append (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Parallel Seq Scan on ab_a2_b1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Parallel Seq Scan on ab_a2_b2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Parallel Seq Scan on ab_a2_b3 (actual rows=N loops=N)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+                     ->  Seq Scan on ab_a2_b3 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2247,31 +2227,16 @@ select avg(a) from ab where a in($1,$2,$3) and b < 4;
 select explain_parallel_append('execute ab_q5 (1, 1, 1)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
-<<<<<<< HEAD
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-                     Subplans Removed: 6
-                     ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
-=======
  Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Workers Launched: N
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Parallel Append (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Parallel Seq Scan on ab_a1_b1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a1_b2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a1_b3 (actual rows=N loops=N)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+                     ->  Seq Scan on ab_a1_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2279,43 +2244,22 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
 select explain_parallel_append('execute ab_q5 (2, 3, 3)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
-<<<<<<< HEAD
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-                     Subplans Removed: 3
-                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
-                           Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 (actual rows=0 loops=1)
-=======
  Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Workers Launched: N
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Parallel Append (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 3
-                     ->  Parallel Seq Scan on ab_a2_b1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a2_b2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a2_b3 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b1 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b2 (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Parallel Seq Scan on ab_a3_b3 (actual rows=N loops=N)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+                     ->  Seq Scan on ab_a3_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
@@ -2325,19 +2269,10 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
 select explain_parallel_append('execute ab_q5 (33, 44, 55)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
-<<<<<<< HEAD
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-=======
  Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Workers Launched: N
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Parallel Append (actual rows=N loops=N)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 8
                      ->  Seq Scan on ab_a1_b1 (never executed)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
@@ -2346,46 +2281,24 @@ select explain_parallel_append('execute ab_q5 (33, 44, 55)');
 
 -- Test Parallel Append with PARAM_EXEC Params
 select explain_parallel_append('select count(*) from ab where (a = (select 1) or a = (select 3)) and b = 2');
-<<<<<<< HEAD
                         explain_parallel_append                         
 ------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Result (actual rows=1 loops=1)
+     ->  Result (actual rows=N loops=N)
    InitPlan 2 (returns $1)  (slice3)
-     ->  Result (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
+     ->  Result (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
                      ->  Seq Scan on ab_a2_b2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
-=======
-                         explain_parallel_append                         
--------------------------------------------------------------------------
- Aggregate (actual rows=N loops=N)
-   InitPlan 1 (returns $0)
-     ->  Result (actual rows=N loops=N)
-   InitPlan 2 (returns $1)
-     ->  Result (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 2
-         Params Evaluated: $0, $1
-         Workers Launched: N
-         ->  Parallel Append (actual rows=N loops=N)
-               ->  Parallel Seq Scan on ab_a1_b2 (actual rows=N loops=N)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-               ->  Parallel Seq Scan on ab_a2_b2 (never executed)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-               ->  Parallel Seq Scan on ab_a3_b2 (actual rows=N loops=N)
-                     Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-(16 rows)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 -- Test pruning during parallel nested loop query
 create table lprt_a (a int not null);
@@ -2406,102 +2319,56 @@ create index ab_a3_b3_a_idx on ab_a3_b3 (a);
 set enable_hashjoin = 0;
 set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
-<<<<<<< HEAD
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{0,0,1}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
-=======
-                                      explain_parallel_append                                      
----------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 1
-         Workers Launched: N
-         ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 (never executed)
-                                 Index Cond: (a = a.a)
-(27 rows)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 -- Ensure the same partitions are pruned when we make the nested loop
 -- parameter an Expr rather than a plain Param.
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a + 0 where a.a in(0, 0, 1)');
                                       explain_parallel_append                                      
 ---------------------------------------------------------------------------------------------------
-<<<<<<< HEAD
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Nested Loop (actual rows=0 loops=1)
-                     ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=102 loops=1)
-                           Hash Key: (a.a + 0)
-                           ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
-                                 Filter: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Append (actual rows=0 loops=102)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=0 loops=2)
-=======
  Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 1
-         Workers Launched: N
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
          ->  Partial Aggregate (actual rows=N loops=N)
                ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{0,0,1}'::integer[]))
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=N loops=N)
+                           Hash Key: (a.a + 0)
+                           ->  Seq Scan on lprt_a a (actual rows=N loops=N)
+                                 Filter: (a = ANY ('{0,0,1}'::integer[]))
                      ->  Append (actual rows=N loops=N)
                            ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=N loops=N)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
                                  Index Cond: (a = (a.a + 0))
                            ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
@@ -2524,86 +2391,85 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 
 insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
-<<<<<<< HEAD
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 50kB
                            Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 55kB
                            Executor Memory: 88kB  Segments: 2  Max: 59kB (segment 0)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,3}'::integer[]))
  Optimizer: Postgres query optimizer
-(41 rows)
+(43 rows)
 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
@@ -2612,16 +2478,16 @@ delete from lprt_a where a = 1;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
                                     explain_parallel_append                                     
 ------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2635,114 +2501,15 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=100 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=100 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
-=======
-                                      explain_parallel_append                                      
----------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 1
-         Workers Launched: N
-         ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,3}'::integer[]))
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-(27 rows)
-
-select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                      explain_parallel_append                                      
----------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 1
-         Workers Launched: N
-         ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,0}'::integer[]))
-                           Rows Removed by Filter: 1
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (actual rows=N loops=N)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 (never executed)
-                                 Index Cond: (a = a.a)
-(28 rows)
-
-delete from lprt_a where a = 1;
-select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
-                                  explain_parallel_append                                   
---------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=N loops=N)
-   ->  Gather (actual rows=N loops=N)
-         Workers Planned: 1
-         Workers Launched: N
-         ->  Partial Aggregate (actual rows=N loops=N)
-               ->  Nested Loop (actual rows=N loops=N)
-                     ->  Parallel Seq Scan on lprt_a a (actual rows=N loops=N)
-                           Filter: (a = ANY ('{1,0,0}'::integer[]))
-                           Rows Removed by Filter: 1
-                     ->  Append (actual rows=N loops=N)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b2_a_idx on ab_a2_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a2_b3_a_idx on ab_a2_b3 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b1_a_idx on ab_a3_b1 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b2_a_idx on ab_a3_b2 (never executed)
-                                 Index Cond: (a = a.a)
-                           ->  Index Scan using ab_a3_b3_a_idx on ab_a3_b3 (never executed)
-                                 Index Cond: (a = a.a)
-(28 rows)
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 
 reset enable_hashjoin;
 reset enable_mergejoin;

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -2098,9 +2098,14 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
 rollback;
 drop table list_part;
 -- Parallel append
--- Suppress the number of loops each parallel node runs for.  This is because
--- more than one worker may run the same parallel node if timing conditions
--- are just right, which destabilizes the test.
+-- Parallel queries won't necessarily get as many workers as the planner
+-- asked for.  This affects not only the "Workers Launched:" field of EXPLAIN
+-- results, but also row counts and loop counts for parallel scans, Gathers,
+-- and everything in between.  This function filters out the values we can't
+-- rely on to be stable.
+-- This removes enough info that you might wonder why bother with EXPLAIN
+-- ANALYZE at all.  The answer is that we need to see '(never executed)'
+-- notations because that's the only way to verify runtime pruning.
 create function explain_parallel_append(text) returns setof text
 language plpgsql as
 $$
@@ -2111,9 +2116,8 @@ begin
         execute format('explain (analyze, costs off, summary off, timing off) %s',
             $1)
     loop
-        if ln like '%Parallel%' then
-            ln := regexp_replace(ln, 'loops=\d*',  'loops=N');
-        end if;
+        ln := regexp_replace(ln, 'Workers Launched: \d+', 'Workers Launched: N');
+        ln := regexp_replace(ln, 'actual rows=\d+ loops=\d+', 'actual rows=N loops=N');
         return next ln;
     end loop;
 end;
@@ -2128,16 +2132,16 @@ set max_parallel_workers_per_gather = 2;
 select explain_parallel_append('execute ab_q4 (2, 2)');
                          explain_parallel_append                         
 -------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
-                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=N loops=N)
                            Filter: ((a >= $1) AND (a <= $2) AND (b < 4))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2148,16 +2152,16 @@ select avg(a) from ab where a in($1,$2,$3) and b < 4;
 select explain_parallel_append('execute ab_q5 (1, 1, 1)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 6
-                     ->  Seq Scan on ab_a1_b1 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a1_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a1_b3 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a1_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (12 rows)
@@ -2165,22 +2169,22 @@ select explain_parallel_append('execute ab_q5 (1, 1, 1)');
 select explain_parallel_append('execute ab_q5 (2, 3, 3)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 3
-                     ->  Seq Scan on ab_a2_b1 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a2_b3 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a2_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b1 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a3_b1 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
-                     ->  Seq Scan on ab_a3_b3 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a3_b3 (actual rows=N loops=N)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
  Optimizer: Postgres query optimizer
 (18 rows)
@@ -2190,10 +2194,10 @@ select explain_parallel_append('execute ab_q5 (2, 3, 3)');
 select explain_parallel_append('execute ab_q5 (33, 44, 55)');
                             explain_parallel_append                            
 -------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
                      Subplans Removed: 8
                      ->  Seq Scan on ab_a1_b1 (never executed)
                            Filter: ((b < 4) AND (a = ANY (ARRAY[$1, $2, $3])))
@@ -2204,19 +2208,19 @@ select explain_parallel_append('execute ab_q5 (33, 44, 55)');
 select explain_parallel_append('select count(*) from ab where (a = (select 1) or a = (select 3)) and b = 2');
                         explain_parallel_append                         
 ------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
    InitPlan 1 (returns $0)  (slice2)
-     ->  Result (actual rows=1 loops=1)
+     ->  Result (actual rows=N loops=N)
    InitPlan 2 (returns $1)  (slice3)
-     ->  Result (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=0 loops=1)
-                     ->  Seq Scan on ab_a1_b2 (actual rows=0 loops=1)
+     ->  Result (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Append (actual rows=N loops=N)
+                     ->  Seq Scan on ab_a1_b2 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
                      ->  Seq Scan on ab_a2_b2 (never executed)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
-                     ->  Seq Scan on ab_a3_b2 (actual rows=0 loops=1)
+                     ->  Seq Scan on ab_a3_b2 (actual rows=N loops=N)
                            Filter: ((b = 2) AND ((a = $0) OR (a = $1)))
  Optimizer: Postgres query optimizer
 (15 rows)
@@ -2244,35 +2248,35 @@ set enable_mergejoin = 0;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(0, 0, 1)');
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{0,0,1}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{0,0,1}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
@@ -2282,20 +2286,20 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a + 0 where a.a in(0, 0, 1)');
                                       explain_parallel_append                                      
 ---------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=3 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Nested Loop (actual rows=0 loops=1)
-                     ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=102 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Nested Loop (actual rows=N loops=N)
+                     ->  Redistribute Motion 1:3  (slice2; segments: 1) (actual rows=N loops=N)
                            Hash Key: (a.a + 0)
-                           ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                  Filter: (a = ANY ('{0,0,1}'::integer[]))
-                     ->  Append (actual rows=0 loops=102)
-                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=0 loops=2)
+                     ->  Append (actual rows=N loops=N)
+                           ->  Index Scan using ab_a1_b1_a_idx on ab_a1_b1 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=0 loops=2)
+                           ->  Index Scan using ab_a1_b2_a_idx on ab_a1_b2 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
-                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (actual rows=0 loops=2)
+                           ->  Index Scan using ab_a1_b3_a_idx on ab_a1_b3 (actual rows=N loops=N)
                                  Index Cond: (a = (a.a + 0))
                            ->  Index Scan using ab_a2_b1_a_idx on ab_a2_b1 (never executed)
                                  Index Cond: (a = (a.a + 0))
@@ -2316,47 +2320,47 @@ insert into lprt_a values(3),(3);
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 3)');
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=2 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 2:1  (slice1; segments: 2) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 50kB
                            Executor Memory: 51kB  Segments: 2  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a3_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a3_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,3}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a3_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,3}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 55kB
                            Executor Memory: 88kB  Segments: 2  Max: 59kB (segment 0)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,3}'::integer[]))
  Optimizer: Postgres query optimizer
 (43 rows)
@@ -2364,35 +2368,35 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
                                         explain_parallel_append                                        
 -------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
-                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b1 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b1_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b2 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b2_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=0 loops=1)
+                                 ->  Bitmap Heap Scan on ab_a1_b3 (actual rows=N loops=N)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
-                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=0 loops=1)
+                                       ->  Bitmap Index Scan on ab_a1_b3_a_idx (actual rows=N loops=N)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=102 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=102 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)
@@ -2401,16 +2405,16 @@ delete from lprt_a where a = 1;
 select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on ab.a = a.a where a.a in(1, 0, 0)');
                                     explain_parallel_append                                     
 ------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
-         ->  Partial Aggregate (actual rows=1 loops=1)
-               ->  Merge Join (actual rows=0 loops=1)
+ Finalize Aggregate (actual rows=N loops=N)
+   ->  Gather Motion 1:1  (slice1; segments: 1) (actual rows=N loops=N)
+         ->  Partial Aggregate (actual rows=N loops=N)
+               ->  Merge Join (actual rows=N loops=N)
                      Merge Cond: (ab_a1_b1.a = a.a)
-                     ->  Sort (actual rows=0 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: ab_a1_b1.a
                            Sort Method:  quicksort  Memory: 25kB
                            Executor Memory: 26kB  Segments: 1  Max: 26kB (segment 1)
-                           ->  Append (actual rows=0 loops=1)
+                           ->  Append (actual rows=N loops=N)
                                  Partition Selectors: $0
                                  ->  Bitmap Heap Scan on ab_a1_b1 (never executed)
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
@@ -2424,12 +2428,12 @@ select explain_parallel_append('select avg(ab.a) from ab inner join lprt_a a on 
                                        Recheck Cond: (a = ANY ('{1,0,0}'::integer[]))
                                        ->  Bitmap Index Scan on ab_a1_b3_a_idx (never executed)
                                              Index Cond: (a = ANY ('{1,0,0}'::integer[]))
-                     ->  Sort (actual rows=1 loops=1)
+                     ->  Sort (actual rows=N loops=N)
                            Sort Key: a.a
                            Sort Method:  quicksort  Memory: 30kB
                            Executor Memory: 29kB  Segments: 1  Max: 29kB (segment 1)
-                           ->  Partition Selector (selector id: $0) (actual rows=100 loops=1)
-                                 ->  Seq Scan on lprt_a a (actual rows=100 loops=1)
+                           ->  Partition Selector (selector id: $0) (actual rows=N loops=N)
+                                 ->  Seq Scan on lprt_a a (actual rows=N loops=N)
                                        Filter: (a = ANY ('{1,0,0}'::integer[]))
  Optimizer: Postgres query optimizer
 (31 rows)

--- a/src/test/regress/sql/partition_prune.sql
+++ b/src/test/regress/sql/partition_prune.sql
@@ -2,7 +2,6 @@
 -- Test partitioning planner code
 --
 
-<<<<<<< HEAD
 -- GPDB:
 -- One of the queries EXPLAINed in this file executes on one or two segments,
 -- depending on random choice by the planner. Accept either plan.
@@ -35,8 +34,6 @@
 -- s/segment \d+/segment ###/
 -- end_matchsubs
 
-=======
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
 -- Force generic plans to be used for all prepared statements in this file.
 set plan_cache_mode = force_generic_plan;
 


### PR DESCRIPTION
Fix conflicts in partition_prune test

1. Commit d52eaa094847d395f942827a6f413904e516994c added setting
plan_cache_mode GUC, but this commit was already cherry picked
(77ba28ca7445d810f81f2104cdb4aa4ada74ad00). Then commit
fe0a9ddbdd7eee572f7321f9680280044fd5f258 added additional matchsubs, causing
conflicts.
2. Commit 4ea03f3f4eba3c76abae2e69bf48c921799a68a3 changed regex in a
function, replacing numbers in plans with N. Plans with GPDB changes were
affected, causing conflicts. Changes from this commit should also be added to
Orca output.