### PR TITLE
Fix conflicts in doc/src/sgml/ref/pg_rewind.sgml

### DIFF
--- a/doc/src/sgml/ref/pg_rewind.sgml
+++ b/doc/src/sgml/ref/pg_rewind.sgml
@@ -166,8 +166,6 @@ PostgreSQL documentation
      </varlistentry>
 
      <varlistentry>
-<<<<<<< HEAD
-=======
       <term><option>--no-ensure-shutdown</option></term>
       <listitem>
        <para>
@@ -185,7 +183,6 @@ PostgreSQL documentation
      </varlistentry>
 
      <varlistentry>
->>>>>>> 80831bcdbe80a6ca7f22105e32c2cbb54e125c4c
       <term><option>-R</option></term>
       <term><option>--write-recovery-conf</option></term>
       <listitem>


### PR DESCRIPTION
Fix conflicts in doc/src/sgml/ref/pg_rewind.sgml

Commit 5adafaf added documentation for the --no-ensure-shutdown option, and
commit caa0783 supplemented it, and commit 927474c added documentation for the
--write-recovery-conf option, while earlier commit 19cd1cf already added
documentation for the --write-recovery-conf option.