### PR TITLE
Fix tests in src/test/regress/expected/rangetypes_optimizer.out

### DIFF
--- a/src/test/regress/expected/rangetypes_optimizer.out
+++ b/src/test/regress/expected/rangetypes_optimizer.out
@@ -525,7 +525,7 @@ select numrange(1.0, 2.0) * numrange(2.5, 3.0);
 (1 row)
 
 create table numrange_test2(nr numrange);
-create index numrange_test2_hash_idx on numrange_test2 (nr);
+create index numrange_test2_hash_idx on numrange_test2 using hash (nr);
 INSERT INTO numrange_test2 VALUES('[, 5)');
 INSERT INTO numrange_test2 VALUES(numrange(1.1, 2.2));
 INSERT INTO numrange_test2 VALUES(numrange(1.1, 2.2));


### PR DESCRIPTION
Fix tests in src/test/regress/expected/rangetypes_optimizer.out

Commit bb0e3ce added a using hash statement to one test in
src/test/regress/sql/rangetypes.sql, we need to add it to ORCA.