### PR TITLE
Fix tests in src/test/regress/expected/select_parallel_optimizer.out

### DIFF
--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -93,20 +93,6 @@ select round(avg(aa)), sum(aa) from a_star a3;
     14 | 355
 (1 row)
 
--- Temporary hack to investigate whether extra vacuum/analyze is happening
-select relname, relpages, reltuples
-from pg_class
-where relname like '__star' order by relname;
- relname | relpages | reltuples 
----------+----------+-----------
- a_star  |        1 |         3
- b_star  |        1 |         4
- c_star  |        1 |         4
- d_star  |        1 |        16
- e_star  |        1 |         7
- f_star  |        1 |        16
-(6 rows)
-
 -- Disable Parallel Append
 alter table a_star reset (parallel_workers);
 alter table b_star reset (parallel_workers);


### PR DESCRIPTION
Fix tests in src/test/regress/expected/select_parallel_optimizer.out

The d9cacca commit removed tests in src/test/regress/sql/select_parallel.sql,
we need to remove them in ORCA.