### PR TITLE
Fix src/test/regress/sql/create_index_spgist.sql test

### DIFF
--- a/src/test/regress/expected/create_index_spgist.out
+++ b/src/test/regress/expected/create_index_spgist.out
@@ -633,8 +633,9 @@ WHERE seq.dist IS DISTINCT FROM idx.dist;
 (0 rows)
 
 -- check ORDER BY distance to NULL
-SELECT (SELECT p FROM kd_point_tbl ORDER BY p <-> pt, p <-> '0,0' LIMIT 1)
-FROM (VALUES (point '1,2'), (NULL), ('1234,5678')) pts(pt);
+SELECT DISTINCT ON (i) p FROM kd_point_tbl,
+    (VALUES (1, point '1,2'), (2, NULL), (3, '1234,5678')) pts(i, pt)
+ORDER BY i, p <-> pt, p <-> '0,0';
       p      
 -------------
  (59,21)

--- a/src/test/regress/sql/create_index_spgist.sql
+++ b/src/test/regress/sql/create_index_spgist.sql
@@ -229,8 +229,9 @@ ON seq.n = idx.n
 WHERE seq.dist IS DISTINCT FROM idx.dist;
 
 -- check ORDER BY distance to NULL
-SELECT (SELECT p FROM kd_point_tbl ORDER BY p <-> pt, p <-> '0,0' LIMIT 1)
-FROM (VALUES (point '1,2'), (NULL), ('1234,5678')) pts(pt);
+SELECT DISTINCT ON (i) p FROM kd_point_tbl,
+    (VALUES (1, point '1,2'), (2, NULL), (3, '1234,5678')) pts(i, pt)
+ORDER BY i, p <-> pt, p <-> '0,0';
 
 
 EXPLAIN (COSTS OFF)


### PR DESCRIPTION
Fix src/test/regress/sql/create_index_spgist.sql test

Commit 5033e9580869fec514d787dc9d3b0b63cce0bcfb added a new test, however in
GPDB this test breaks due to its plan requiring passing parameters through
motion (see commit ef0a34d1152277925883942a85ba06b202f6e14f). Rework the query
into equivalent one.

---

Note: This commit also exists in GPDB 7 since it was backported to Postgres 12. However, during merge with 12.12 (commit 0f5f6635da048d1e74ce28c1c3140475571d949b) this test was left with an [error](https://github.com/arenadata/gpdb/blob/96dd08578db2458e484d81e8dc2415db64f6664e/src/test/regress/expected/create_index_spgist.out#L638). Maybe we should port this patch to GPDB 7 too.