### PR TITLE
Fix tests in alter_table.out and alter_table_ao.out for ORCA

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -686,9 +686,6 @@ tlist_matches_tupdesc(PlanState *ps, List *tlist, Index varno, TupleDesc tupdesc
 	if (tlist_item)
 		return false;			/* tlist too long */
 
-	if (IsA(ps->plan, DynamicSeqScan))
-		return false;
-
 	return true;
 }
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -686,6 +686,9 @@ tlist_matches_tupdesc(PlanState *ps, List *tlist, Index varno, TupleDesc tupdesc
 	if (tlist_item)
 		return false;			/* tlist too long */
 
+	if (IsA(ps->plan, DynamicSeqScan))
+		return false;
+
 	return true;
 }
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -171,9 +171,10 @@ initNextTableToScan(DynamicSeqScanState *node)
 		PlanState  *planstate = &node->seqScanState->ss.ps;
 
 		if (!planstate->ps_ResultTupleSlot)
+		{
 			ExecInitResultSlot(planstate, &TTSOpsVirtual);
-
-		ExecAssignProjectionInfo(planstate, partTupDesc);
+			ExecAssignProjectionInfo(planstate, partTupDesc);
+		}
 	}
 
 	return true;

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -166,23 +166,10 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	PlanState  *planstate = &node->seqScanState->ss.ps;
 
-	if (!planstate->ps_ResultTupleSlot)
+	if (!planstate->ps_ProjInfo && scanState->ps.resultops == &TTSOpsVirtual)
 	{
-		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0),
-											   AccessShareLock);
-		Form_pg_class firstForm = RelationGetForm(firstRelation);
-		Form_pg_class currentForm = RelationGetForm(currentRelation);
-		bool		isCompatibleRelations =
-					firstForm->relnatts == currentForm->relnatts &&
-					firstForm->relam == currentForm->relam;
-
-		table_close(firstRelation, AccessShareLock);
-
-		if (!isCompatibleRelations)
-		{
-			ExecInitResultSlot(planstate, &TTSOpsVirtual);
-			ExecAssignProjectionInfo(planstate, partTupDesc);
-		}
+		ExecInitResultSlot(planstate, &TTSOpsVirtual);
+		ExecAssignProjectionInfo(planstate, partTupDesc);
 	}
 
 	return true;

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -164,6 +164,18 @@ initNextTableToScan(DynamicSeqScanState *node)
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
 
+	PlanState *planstate = &node->seqScanState->ss.ps;
+
+	if (!planstate->ps_ResultTupleSlot &&
+		!equalTupleDescs(lastTupDesc, partTupDesc, false))
+	{
+		ExecInitResultSlot(planstate, &TTSOpsVirtual);
+		planstate->resultops = &TTSOpsVirtual;
+		planstate->resultopsfixed = true;
+		planstate->resultopsset = true;
+		ExecAssignProjectionInfo(planstate, partTupDesc);
+	}
+
 	return true;
 }
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -164,10 +164,6 @@ initNextTableToScan(DynamicSeqScanState *node)
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
 
-	if (node->seqScanState->ss.ps.resultops != &TTSOpsVirtual &&
-		!node->seqScanState->ss.ps.ps_ResultTupleSlot)
-		return false;
-
 	return true;
 }
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -163,6 +163,10 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
+
+	if (!node->seqScanState->ss.ps.ps_ResultTupleSlot)
+		return false;
+
 	return true;
 }
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -166,7 +166,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	PlanState  *planstate = &node->seqScanState->ss.ps;
 
-	if (!planstate->ps_ProjInfo && scanState->ps.resultops == &TTSOpsVirtual)
+	if (!planstate->ps_ProjInfo && planstate->scanops != &TTSOpsVirtual)
 	{
 		ExecInitResultSlot(planstate, &TTSOpsVirtual);
 		ExecAssignProjectionInfo(planstate, partTupDesc);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -164,7 +164,8 @@ initNextTableToScan(DynamicSeqScanState *node)
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
 
-	if (!node->seqScanState->ss.ps.ps_ResultTupleSlot)
+	if (node->seqScanState->ss.ps.resultops != &TTSOpsVirtual &&
+		!node->seqScanState->ss.ps.ps_ResultTupleSlot)
 		return false;
 
 	return true;

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -168,8 +168,20 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	if (!planstate->ps_ProjInfo && planstate->resultops != &TTSOpsVirtual)
 	{
-		ExecInitResultSlot(planstate, &TTSOpsVirtual);
-		ExecAssignProjectionInfo(planstate, partTupDesc);
+		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0),
+											   AccessShareLock);
+		Form_pg_class firstForm = RelationGetForm(firstRelation);
+		Form_pg_class currentForm = RelationGetForm(currentRelation);
+		bool		isCompatibleRelations =
+					firstForm->relnatts == currentForm->relnatts;
+
+		table_close(firstRelation, AccessShareLock);
+
+		if (!isCompatibleRelations)
+		{
+			ExecInitResultSlot(planstate, &TTSOpsVirtual);
+			ExecAssignProjectionInfo(planstate, partTupDesc);
+		}
 	}
 
 	return true;

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -170,9 +170,6 @@ initNextTableToScan(DynamicSeqScanState *node)
 		!equalTupleDescs(lastTupDesc, partTupDesc, false))
 	{
 		ExecInitResultSlot(planstate, &TTSOpsVirtual);
-		planstate->resultops = &TTSOpsVirtual;
-		planstate->resultopsfixed = true;
-		planstate->resultopsset = true;
 		ExecAssignProjectionInfo(planstate, partTupDesc);
 	}
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -166,7 +166,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	PlanState  *planstate = &node->seqScanState->ss.ps;
 
-	if (!planstate->ps_ProjInfo && planstate->scanops != &TTSOpsVirtual)
+	if (!planstate->ps_ProjInfo && planstate->resultops != &TTSOpsVirtual)
 	{
 		ExecInitResultSlot(planstate, &TTSOpsVirtual);
 		ExecAssignProjectionInfo(planstate, partTupDesc);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -116,7 +116,6 @@ initNextTableToScan(DynamicSeqScanState *node)
 	AttrNumber *attMap;
 	Oid		   *pid;
 	Relation	currentRelation;
-	bool		isEqualTupleDescs;
 
 	if (++node->whichPart < node->nOids)
 		pid = &node->partOids[node->whichPart];
@@ -141,7 +140,6 @@ initNextTableToScan(DynamicSeqScanState *node)
 	lastScannedRel = table_open(node->lastRelOid, AccessShareLock);
 	lastTupDesc = RelationGetDescr(lastScannedRel);
 	partTupDesc = RelationGetDescr(scanState->ss_currentRelation);
-	isEqualTupleDescs = equalTupleDescs(lastTupDesc, partTupDesc, true);
 	/*
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
@@ -166,11 +164,21 @@ initNextTableToScan(DynamicSeqScanState *node)
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
 
-	if (!isEqualTupleDescs)
-	{
-		PlanState  *planstate = &node->seqScanState->ss.ps;
+	PlanState  *planstate = &node->seqScanState->ss.ps;
 
-		if (!planstate->ps_ResultTupleSlot)
+	if (!planstate->ps_ResultTupleSlot)
+	{
+		Relation	firstRelation = table_open(node->partOids[0], AccessShareLock);
+		bool		isIncompatibleRelations =
+			((RelationGetNumberOfAttributes(firstRelation) !=
+			RelationGetNumberOfAttributes(currentRelation)) ||
+			(RelationIsHeap(firstRelation) != RelationIsHeap(currentRelation)) ||
+			(RelationIsAoRows(firstRelation) != RelationIsAoRows(currentRelation)) ||
+			(RelationIsAoCols(firstRelation) != RelationIsAoCols(currentRelation)));
+
+		table_close(firstRelation, AccessShareLock);
+
+		if (isIncompatibleRelations)
 		{
 			ExecInitResultSlot(planstate, &TTSOpsVirtual);
 			ExecAssignProjectionInfo(planstate, partTupDesc);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -166,22 +166,12 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	PlanState  *planstate = &node->seqScanState->ss.ps;
 
-	if (!planstate->ps_ProjInfo && planstate->resultops != &TTSOpsVirtual)
+	if (!planstate->ps_ProjInfo &&
+		scanState->ps.resultops == &TTSOpsVirtual &&
+		planstate->resultops != &TTSOpsVirtual)
 	{
-		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0),
-											   AccessShareLock);
-		Form_pg_class firstForm = RelationGetForm(firstRelation);
-		Form_pg_class currentForm = RelationGetForm(currentRelation);
-		bool		isCompatibleRelations =
-					firstForm->relnatts == currentForm->relnatts;
-
-		table_close(firstRelation, AccessShareLock);
-
-		if (!isCompatibleRelations)
-		{
-			ExecInitResultSlot(planstate, &TTSOpsVirtual);
-			ExecAssignProjectionInfo(planstate, partTupDesc);
-		}
+		ExecInitResultSlot(planstate, &TTSOpsVirtual);
+		ExecAssignProjectionInfo(planstate, partTupDesc);
 	}
 
 	return true;

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -168,7 +168,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	if (!planstate->ps_ResultTupleSlot)
 	{
-		Relation	firstRelation = table_open(node->partOids[0], AccessShareLock);
+		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0), AccessShareLock);
 		bool		isIncompatibleRelations =
 			((RelationGetNumberOfAttributes(firstRelation) !=
 			RelationGetNumberOfAttributes(currentRelation)) ||

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -166,11 +166,13 @@ initNextTableToScan(DynamicSeqScanState *node)
 	node->seqScanState = ExecInitSeqScanForPartition(&plan->seqscan, estate,
 													 currentRelation);
 
-	PlanState *planstate = &node->seqScanState->ss.ps;
-
-	if (!planstate->ps_ResultTupleSlot && !isEqualTupleDescs)
+	if (!isEqualTupleDescs)
 	{
-		ExecInitResultSlot(planstate, &TTSOpsVirtual);
+		PlanState  *planstate = &node->seqScanState->ss.ps;
+
+		if (!planstate->ps_ResultTupleSlot)
+			ExecInitResultSlot(planstate, &TTSOpsVirtual);
+
 		ExecAssignProjectionInfo(planstate, partTupDesc);
 	}
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -116,6 +116,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	AttrNumber *attMap;
 	Oid		   *pid;
 	Relation	currentRelation;
+	bool		isEqualTupleDescs;
 
 	if (++node->whichPart < node->nOids)
 		pid = &node->partOids[node->whichPart];
@@ -140,6 +141,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 	lastScannedRel = table_open(node->lastRelOid, AccessShareLock);
 	lastTupDesc = RelationGetDescr(lastScannedRel);
 	partTupDesc = RelationGetDescr(scanState->ss_currentRelation);
+	isEqualTupleDescs = equalTupleDescs(lastTupDesc, partTupDesc, true);
 	/*
 	 * FIXME: should we use execute_attr_map_tuple instead? Seems like a
 	 * higher level abstraction that fits the bill
@@ -166,8 +168,7 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	PlanState *planstate = &node->seqScanState->ss.ps;
 
-	if (!planstate->ps_ResultTupleSlot &&
-		!equalTupleDescs(lastTupDesc, partTupDesc, false))
+	if (!planstate->ps_ResultTupleSlot && !isEqualTupleDescs)
 	{
 		ExecInitResultSlot(planstate, &TTSOpsVirtual);
 		ExecAssignProjectionInfo(planstate, partTupDesc);

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -168,17 +168,17 @@ initNextTableToScan(DynamicSeqScanState *node)
 
 	if (!planstate->ps_ResultTupleSlot)
 	{
-		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0), AccessShareLock);
-		bool		isIncompatibleRelations =
-			((RelationGetNumberOfAttributes(firstRelation) !=
-			RelationGetNumberOfAttributes(currentRelation)) ||
-			(RelationIsHeap(firstRelation) != RelationIsHeap(currentRelation)) ||
-			(RelationIsAoRows(firstRelation) != RelationIsAoRows(currentRelation)) ||
-			(RelationIsAoCols(firstRelation) != RelationIsAoCols(currentRelation)));
+		Relation	firstRelation = table_open(list_nth_oid(plan->partOids, 0),
+											   AccessShareLock);
+		Form_pg_class firstForm = RelationGetForm(firstRelation);
+		Form_pg_class currentForm = RelationGetForm(currentRelation);
+		bool		isCompatibleRelations =
+					firstForm->relnatts == currentForm->relnatts &&
+					firstForm->relam == currentForm->relam;
 
 		table_close(firstRelation, AccessShareLock);
 
-		if (isIncompatibleRelations)
+		if (!isCompatibleRelations)
 		{
 			ExecInitResultSlot(planstate, &TTSOpsVirtual);
 			ExecAssignProjectionInfo(planstate, partTupDesc);


### PR DESCRIPTION
Fix tests in alter_table.out and alter_table_ao.out for ORCA

In commit 36d22dd, an optimization was added that disables the generation of
EEOP_*_FETCHSOME operations for virtual slots. This optimization is used for
faster value fetching from the virtual slot. Obviously, each incoming slot from
underlying nodes should have the same structure (number of attributes, types,
etc.). This optimization is casually enabled during executor initialization
when the resulting tuple type (virtual or not) can be defined.  However, the
slot type can be not the same during execution of GPDB-specific DynamicSeqscan
node generated by the ORCA planner for partitioned tables.  Namely, if the heap
table and heap partition have different numbers of columns (e.x. after dropping
attributes from parent and adding a new leaf partition), then tuples from new
partition (without dropped columns and having the same attributes as final
targetlist) may have tuple type different from virtual since the projection has
not been applied in ExecInitSeqScanForPartition(). Such examples are used in
the tests src/test/regress/sql/alter_table.sql and
src/test/regress/sql/alter_table_ao.sql. This tuple type mismatch leads to
errors during fetching values in ExecJustVarVirtImpl() (we expected tuple to be
virtual but DynamicSeqScan returned heap tuple from single partition).

Therefore, this patch tries to catch the situation when scanned tuple has
different type from virtual in case when EEOP_*_FETCHSOME optimization is
enabled, and to force the projection to make tuple virtual.

Co-authored-by: Alexander Kondakov \<a.kondakov@arenadata.io\>
Co-authored-by: Maksim Michkov \<m.michkov@arenadata.io\>