### PR TITLE
ADBDEV-7567: Fix lost update during inplace update.

### DIFF
--- a/src/backend/access/heap/README.tuplock
+++ b/src/backend/access/heap/README.tuplock
@@ -143,6 +143,48 @@ The following infomask bits are applicable:
 We currently never set the HEAP_XMAX_COMMITTED when the HEAP_XMAX_IS_MULTI bit
 is set.
 
+Locking to write inplace-updated tables
+---------------------------------------
+
+If table is pg_class or pg_database then that table receives
+systable_inplace_update_begin() calls. Preparing a heap_update() of these
+tables follows additional locking rules, to ensure we don't lose the effects of
+an inplace update. In particular, consider a moment when a backend has fetched
+the old tuple to modify, not yet having called heap_update(). Another backend's
+inplace update starting then can't conclude until the heap_update() places its
+new tuple in a buffer. We enforce that using locktags as follows. While DDL code
+is the main audience, the executor follows these rules to
+make e.g. "MERGE INTO pg_class" safer.
+Locking rules are per-catalog:
+
+  pg_class systable_inplace_update_begin() callers: before the call, acquire a
+  lock on the relation in mode ShareUpdateExclusiveLock or stricter.  If the
+  update targets a row of RELKIND_INDEX, that lock must be on the table.
+  Locking the index rel is not necessary. (This allows VACUUM to overwrite
+  per-index pg_class while holding a lock on the table alone.)
+  systable_inplace_update_begin() acquires and releases LOCKTAG_TUPLE in
+  InplaceUpdateTupleLock, an alias for ExclusiveLock, on each tuple it
+  overwrites.
+
+  pg_class heap_update() callers: before copying the tuple to modify, take a
+  lock on the tuple, a ShareUpdateExclusiveLock on the relation, or a
+  ShareRowExclusiveLock or stricter on the relation.
+
+  SearchSysCacheLocked1() is one convenient way to acquire the tuple lock.
+  Most heap_update() callers already hold a suitable lock on the relation for
+  other reasons and can skip the tuple lock.  If you do acquire the tuple
+  lock, release it immediately after the update.
+
+
+  pg_database: before copying the tuple to modify, all updaters of pg_database
+  rows acquire LOCKTAG_TUPLE.  (Few updaters acquire LOCKTAG_OBJECT on the
+  database OID, so it wasn't worth extending that as a second option.)
+
+Ideally, DDL might want to perform permissions checks before LockTuple(), as
+we do with RangeVarGetRelidExtended() callbacks.  We typically don't bother.
+LOCKTAG_TUPLE acquirers release it after each row, so the potential
+inconvenience is lower.
+
 Reading inplace-updated columns
 -------------------------------
 

--- a/src/backend/access/heap/README.tuplock
+++ b/src/backend/access/heap/README.tuplock
@@ -142,3 +142,14 @@ The following infomask bits are applicable:
 
 We currently never set the HEAP_XMAX_COMMITTED when the HEAP_XMAX_IS_MULTI bit
 is set.
+
+Reading inplace-updated columns
+-------------------------------
+
+Inplace updates create an exception to the rule that tuple data won't change
+under a reader holding a pin.  A reader of a heap_fetch() result tuple may
+witness a torn read.  Current inplace-updated fields are aligned and are no
+wider than four bytes, and current readers don't need consistency across
+fields.  Hence, they get by with just fetching each field once.  XXX such a
+caller may also read a value that has not reached WAL; see
+systable_inplace_update_finish().

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -5981,19 +5981,249 @@ heap_lock_updated_tuple(Relation rel, HeapTuple tuple, ItemPointer ctid,
 
 
 /*
- * heap_inplace_update - update a tuple "in place" (ie, overwrite it)
+ * heap_inplace_lock - protect inplace update from concurrent heap_update()
  *
- * Overwriting violates both MVCC and transactional safety, so the uses
- * of this function in Postgres are extremely limited.  Nonetheless we
- * find some places to use it.
+ * Evaluate whether the tuple's state is compatible with a no-key update.
+ * Current transaction rowmarks are fine, as is KEY SHARE from any
+ * transaction.  If compatible, return true with the buffer exclusive-locked,
+ * and the caller must release that by calling
+ * heap_inplace_update_and_unlock(), calling heap_inplace_unlock(), or raising
+ * an error.  Otherwise, return false after blocking transactions, if any,
+ * have ended.
  *
- * The tuple cannot change size, and therefore it's reasonable to assume
- * that its null bitmap (if any) doesn't change either.  So we just
- * overwrite the data portion of the tuple without touching the null
- * bitmap or any of the header fields.
+ * Since this is intended for system catalogs and SERIALIZABLE doesn't cover
+ * DDL, this doesn't guarantee any particular predicate locking.
  *
- * tuple is an in-memory tuple structure containing the data to be written
- * over the target tuple.  Also, tuple->t_self identifies the target tuple.
+ * One could modify this to return true for tuples with delete in progress,
+ * All inplace updaters take a lock that conflicts with DROP.  If explicit
+ * "DELETE FROM pg_class" is in progress, we'll wait for it like we would an
+ * update.
+ *
+ * Readers of inplace-updated fields expect changes to those fields are
+ * durable.  For example, vac_truncate_clog() reads datfrozenxid from
+ * pg_database tuples via catalog snapshots.  A future snapshot must not
+ * return a lower datfrozenxid for the same database OID (lower in the
+ * FullTransactionIdPrecedes() sense).  We achieve that since no update of a
+ * tuple can start while we hold a lock on its buffer.  In cases like
+ * BEGIN;GRANT;CREATE INDEX;COMMIT we're inplace-updating a tuple visible only
+ * to this transaction.  ROLLBACK then is one case where it's okay to lose
+ * inplace updates.  (Restoring relhasindex=false on ROLLBACK is fine, since
+ * any concurrent CREATE INDEX would have blocked, then inplace-updated the
+ * committed tuple.)
+ *
+ * In principle, we could avoid waiting by overwriting every tuple in the
+ * updated tuple chain.  Reader expectations permit updating a tuple only if
+ * it's aborted, is the tail of the chain, or we already updated the tuple
+ * referenced in its t_ctid.  Hence, we would need to overwrite the tuples in
+ * order from tail to head.  That would imply either (a) mutating all tuples
+ * in one critical section or (b) accepting a chance of partial completion.
+ * Partial completion of a relfrozenxid update would have the weird
+ * consequence that the table's next VACUUM could see the table's relfrozenxid
+ * move forward between vacuum_get_cutoffs() and finishing.
+ */
+bool
+heap_inplace_lock(Relation relation,
+				  HeapTuple oldtup_ptr, Buffer buffer)
+{
+	HeapTupleData oldtup = *oldtup_ptr; /* minimize diff vs. heap_update() */
+	HTSU_Result	result;
+	bool		ret;
+
+	Assert(BufferIsValid(buffer));
+
+	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
+
+	/*----------
+	 * Interpret HeapTupleSatisfiesUpdate() like heap_update() does, except:
+	 *
+	 * - wait unconditionally
+	 * - no tuple locks
+	 * - don't recheck header after wait: simpler to defer to next iteration
+	 * - don't try to continue even if the updater aborts: likewise
+	 * - no crosscheck
+	 */
+	result = HeapTupleSatisfiesUpdate(relation, &oldtup, GetCurrentCommandId(false),
+									  buffer);
+
+	if (result == HeapTupleInvisible)
+	{
+		/* no known way this can happen */
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg_internal("attempted to overwrite invisible tuple")));
+	}
+	else if (result == HeapTupleSelfUpdated)
+	{
+		/*
+		 * CREATE INDEX might reach this if an expression is silly enough to
+		 * call e.g. SELECT ... FROM pg_class FOR SHARE.  C code of other SQL
+		 * statements might get here after a heap_update() of the same row, in
+		 * the absence of an intervening CommandCounterIncrement().
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("tuple to be updated was already modified by an operation triggered by the current command")));
+	}
+	else if (result == HeapTupleBeingUpdated)
+	{
+		TransactionId xwait;
+		uint16		infomask;
+
+		xwait = HeapTupleHeaderGetRawXmax(oldtup.t_data);
+		infomask = oldtup.t_data->t_infomask;
+
+		if (infomask & HEAP_XMAX_IS_MULTI)
+		{
+			LockTupleMode lockmode = LockTupleNoKeyExclusive;
+			MultiXactStatus mxact_status = MultiXactStatusNoKeyUpdate;
+			int			remain;
+
+			if (DoesMultiXactIdConflict((MultiXactId) xwait, infomask,
+										lockmode))
+			{
+				LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+				ret = false;
+				MultiXactIdWait((MultiXactId) xwait, mxact_status, infomask,
+								relation, &oldtup.t_self, XLTW_Update,
+								&remain);
+			}
+			else
+				ret = true;
+		}
+		else if (TransactionIdIsCurrentTransactionId(xwait))
+			ret = true;
+		else if (HEAP_XMAX_IS_KEYSHR_LOCKED(infomask))
+			ret = true;
+		else
+		{
+			LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+			ret = false;
+			XactLockTableWait(xwait, relation, &oldtup.t_self,
+							  XLTW_Update);
+		}
+	}
+	else
+	{
+		ret = (result == HeapTupleMayBeUpdated);
+		if (!ret)
+		{
+			LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+		}
+	}
+
+	/*
+	 * GetCatalogSnapshot() relies on invalidation messages to know when to
+	 * take a new snapshot.  COMMIT of xwait is responsible for sending the
+	 * invalidation.  We're not acquiring heavyweight locks sufficient to
+	 * block if not yet sent, so we must take a new snapshot to ensure a later
+	 * attempt has a fair chance.  While we don't need this if xwait aborted,
+	 * don't bother optimizing that.
+	 */
+	if (!ret)
+		InvalidateCatalogSnapshot();
+	return ret;
+}
+
+/*
+ * heap_inplace_update_and_unlock - core of systable_inplace_update_finish
+ *
+ * The tuple cannot change size, and therefore its header fields and null
+ * bitmap (if any) don't change either.
+ */
+void
+heap_inplace_update_and_unlock(Relation relation,
+							   HeapTuple oldtup, HeapTuple tuple,
+							   Buffer buffer)
+{
+	HeapTupleHeader htup = oldtup->t_data;
+	uint32		oldlen;
+	uint32		newlen;
+
+	Assert(ItemPointerEquals(&oldtup->t_self, &tuple->t_self));
+	oldlen = oldtup->t_len - htup->t_hoff;
+	newlen = tuple->t_len - tuple->t_data->t_hoff;
+	if (oldlen != newlen || htup->t_hoff != tuple->t_data->t_hoff)
+		elog(ERROR, "wrong tuple length");
+
+	/* NO EREPORT(ERROR) from here till changes are logged */
+	START_CRIT_SECTION();
+
+	memcpy((char *) htup + htup->t_hoff,
+		   (char *) tuple->t_data + tuple->t_data->t_hoff,
+		   newlen);
+
+	/*----------
+	 * XXX A crash here can allow datfrozenxid() to get ahead of relfrozenxid:
+	 *
+	 * ["D" is a VACUUM (ONLY_DATABASE_STATS)]
+	 * ["R" is a VACUUM tbl]
+	 * D: vac_update_datfrozenid() -> systable_beginscan(pg_class)
+	 * D: systable_getnext() returns pg_class tuple of tbl
+	 * R: memcpy() into pg_class tuple of tbl
+	 * D: raise pg_database.datfrozenxid, XLogInsert(), finish
+	 * [crash]
+	 * [recovery restores datfrozenxid w/o relfrozenxid]
+	 */
+
+	MarkBufferDirty(buffer);
+
+	/* XLOG stuff */
+	if (RelationNeedsWAL(relation))
+	{
+		xl_heap_inplace xlrec;
+		XLogRecPtr	recptr;
+		XLogRecData rdata[2];
+
+		xlrec.target.node = relation->rd_node;
+		xlrec.target.tid = tuple->t_self;
+
+		rdata[0].data = (char *) &xlrec;
+		rdata[0].len = SizeOfHeapInplace;
+		rdata[0].buffer = InvalidBuffer;
+		rdata[0].next = &(rdata[1]);
+
+		rdata[1].data = (char *) htup + htup->t_hoff;
+		rdata[1].len = newlen;
+		rdata[1].buffer = buffer;
+		rdata[1].buffer_std = true;
+		rdata[1].next = NULL;
+
+		recptr = XLogInsert(RM_HEAP_ID, XLOG_HEAP_INPLACE, rdata);
+
+		PageSetLSN(BufferGetPage(buffer), recptr);
+	}
+
+	END_CRIT_SECTION();
+
+	heap_inplace_unlock(relation, oldtup, buffer);
+
+	/*
+	 * Send out shared cache inval if necessary.  Note that because we only
+	 * pass the new version of the tuple, this mustn't be used for any
+	 * operations that could change catcache lookup keys.  But we aren't
+	 * bothering with index updates either, so that's true a fortiori.
+	 *
+	 * XXX ROLLBACK discards the invalidation.  See test inplace-inval.spec.
+	 */
+	if (!IsBootstrapProcessingMode())
+		CacheInvalidateHeapTuple(relation, tuple, NULL);
+}
+
+/*
+ * heap_inplace_unlock - reverse of heap_inplace_lock
+ */
+void
+heap_inplace_unlock(Relation relation,
+					HeapTuple oldtup, Buffer buffer)
+{
+	LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+}
+
+/*
+ * heap_inplace_update - deprecated
+ *
+ * This exists only to keep modules working in back branches.  Affected
+ * modules should migrate to systable_inplace_update_begin().
  */
 void
 heap_inplace_update(Relation relation, HeapTuple tuple)

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -615,7 +615,9 @@ systable_endscan_ordered(SysScanDesc sysscan)
  *
  * Overwriting violates both MVCC and transactional safety, so the uses of
  * this function in Postgres are extremely limited.  Nonetheless we find some
- * places to use it.  Standard flow:
+ * places to use it.  See README.tuplock section "Locking to write
+ * inplace-updated tables" and later sections for expectations of readers and
+ * writers of a table that gets inplace updates.  Standard flow:
  *
  * ... [any slow preparation not requiring oldtup] ...
  * oldtup = systable_inplace_update_begin([...], &tup, &inplace_state);

--- a/src/backend/access/index/genam.c
+++ b/src/backend/access/index/genam.c
@@ -21,6 +21,8 @@
 
 #include "access/relscan.h"
 #include "access/transam.h"
+#include "access/xact.h"
+#include "catalog/catalog.h"
 #include "catalog/index.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
@@ -32,6 +34,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tqual.h"
+#include "catalog/pg_database.h"
 
 
 /* ----------------------------------------------------------------
@@ -605,4 +608,131 @@ systable_endscan_ordered(SysScanDesc sysscan)
 	if (sysscan->snapshot)
 		UnregisterSnapshot(sysscan->snapshot);
 	pfree(sysscan);
+}
+
+/*
+ * systable_inplace_update_begin --- update a row "in place" (overwrite it)
+ *
+ * Overwriting violates both MVCC and transactional safety, so the uses of
+ * this function in Postgres are extremely limited.  Nonetheless we find some
+ * places to use it.  Standard flow:
+ *
+ * ... [any slow preparation not requiring oldtup] ...
+ * oldtup = systable_inplace_update_begin([...], &tup, &inplace_state);
+ * if (!HeapTupleIsValid(oldtup))
+ *	elog(ERROR, [...]);
+ * ... [buffer is exclusive-locked; mutate "tup"] ...
+ * if (dirty)
+ *	systable_inplace_update_finish(inplace_state, oldtup, tup);
+ * else
+ *	systable_inplace_update_cancel(inplace_state, oldtup);
+ *
+ * The first several params duplicate the systable_beginscan() param list.
+ * "oldtupcopy" is an output parameter, assigned NULL if the key ceases to
+ * find a live tuple.  (In PROC_IN_VACUUM, that is a low-probability transient
+ * condition.)  If "oldtupcopy" gets non-NULL, you must pass output parameter
+ * "state" alongside with "oldtup" to systable_inplace_update_finish() or
+ * systable_inplace_update_cancel().
+ */
+HeapTuple
+systable_inplace_update_begin(Relation relation,
+							  Oid indexId,
+							  bool indexOK,
+							  Snapshot snapshot,
+							  int nkeys, const ScanKeyData *key,
+							  HeapTuple *oldtupcopy,
+							  void **state)
+{
+	Assert(nkeys > 0);
+	ScanKey		mutable_key = palloc(sizeof(ScanKeyData) * nkeys);
+	int			retries = 0;
+	SysScanDesc scan;
+	HeapTuple	oldtup;
+
+	/*
+	 * Accept a snapshot argument, for symmetry, but this function advances
+	 * its snapshot as needed to reach the tail of the updated tuple chain.
+	 */
+	Assert(snapshot == NULL);
+
+	Assert((relation->rd_id == RelationRelationId ||
+			relation->rd_id == DatabaseRelationId) ||
+			!IsSystemRelation(relation));
+
+	/* Loop for an exclusive-locked buffer of a non-updated tuple. */
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * Processes issuing heap_update (e.g. GRANT) at maximum speed could
+		 * drive us to this error.  A hostile table owner has stronger ways to
+		 * damage their own table, so that's minor.
+		 */
+		if (retries++ > 10000)
+			elog(ERROR, "giving up after too many tries to overwrite row");
+
+		memcpy(mutable_key, key, sizeof(ScanKeyData) * nkeys);
+		scan = systable_beginscan(relation, indexId, indexOK, snapshot,
+								  nkeys, mutable_key);
+		oldtup = systable_getnext(scan);
+		if (!HeapTupleIsValid(oldtup))
+		{
+			systable_endscan(scan);
+			*oldtupcopy = NULL;
+			return NULL;
+		}
+
+		Assert(scan->scan || scan->iscan);
+		if (heap_inplace_lock(scan->heap_rel,
+							  oldtup, scan->scan ?
+							  scan->scan->rs_cbuf :
+							  scan->iscan->xs_cbuf))
+			break;
+		systable_endscan(scan);
+	};
+
+	*oldtupcopy = heap_copytuple(oldtup);
+	*state = scan;
+
+	return oldtup;
+}
+
+/*
+ * systable_inplace_update_finish --- second phase of inplace update
+ *
+ * The tuple cannot change size, and therefore its header fields and null
+ * bitmap (if any) don't change either.
+ */
+void
+systable_inplace_update_finish(void *state, HeapTuple oldtup, HeapTuple tuple)
+{
+	SysScanDesc scan = (SysScanDesc) state;
+	Relation	relation = scan->heap_rel;
+	Assert(scan->scan || scan->iscan);
+	Buffer		buffer = scan->scan ?
+						 scan->scan->rs_cbuf :
+						 scan->iscan->xs_cbuf;
+
+	heap_inplace_update_and_unlock(relation, oldtup, tuple, buffer);
+	systable_endscan(scan);
+}
+
+/*
+ * systable_inplace_update_cancel --- abandon inplace update
+ *
+ * This is an alternative to making a no-op update.
+ */
+void
+systable_inplace_update_cancel(void *state, HeapTuple oldtup)
+{
+	SysScanDesc scan = (SysScanDesc) state;
+	Relation	relation = scan->heap_rel;
+	Assert(scan->scan || scan->iscan);
+	Buffer		buffer = scan->scan ?
+						 scan->scan->rs_cbuf :
+						 scan->iscan->xs_cbuf;
+
+	heap_inplace_unlock(relation, oldtup, buffer);
+	systable_endscan(scan);
 }

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -14,6 +14,7 @@
  */
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/tuptoaster.h"
 #include "access/xact.h"
 #include "catalog/binary_upgrade.h"
@@ -31,6 +32,7 @@
 #include "storage/lmgr.h"
 #include "storage/lock.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
@@ -417,21 +419,36 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	 */
 	class_rel = heap_open(RelationRelationId, RowExclusiveLock);
 
-	reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));
-	if (!HeapTupleIsValid(reltup))
-		elog(ERROR, "cache lookup failed for relation %u", relOid);
-
-	((Form_pg_class) GETSTRUCT(reltup))->reltoastrelid = toast_relid;
-
 	if (!IsBootstrapProcessingMode())
 	{
 		/* normal case, use a transactional update */
+		reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));
+		if (!HeapTupleIsValid(reltup))
+			elog(ERROR, "cache lookup failed for relation %u", relOid);
+
+		((Form_pg_class) GETSTRUCT(reltup))->reltoastrelid = toast_relid;
+
 		CatalogTupleUpdate(class_rel, &reltup->t_self, reltup);
 	}
 	else
 	{
 		/* While bootstrapping, we cannot UPDATE, so overwrite in-place */
-		heap_inplace_update(class_rel, reltup);
+
+		ScanKeyData key[1];
+		void	   *state;
+		HeapTuple oldtup;
+
+		ScanKeyInit(&key[0],
+					ObjectIdAttributeNumber,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(relOid));
+		oldtup = systable_inplace_update_begin(class_rel, ClassOidIndexId, true,
+											   NULL, 1, key, &reltup, &state);
+		if (!HeapTupleIsValid(reltup))
+			elog(ERROR, "cache lookup failed for relation %u", relOid);
+		((Form_pg_class) GETSTRUCT(reltup))->reltoastrelid = toast_relid;
+
+		systable_inplace_update_finish(state, oldtup, reltup);
 	}
 
 	heap_freetuple(reltup);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3430,6 +3430,7 @@ RenameRelationInternal(Oid myrelid, const char *newrelname, bool is_internal)
 {
 	Relation	targetrelation;
 	Relation	relrelation;	/* for RELATION relation */
+	ItemPointerData otid;
 	HeapTuple	reltup;
 	Form_pg_class relform;
 	Oid			namespaceId;
@@ -3456,7 +3457,8 @@ RenameRelationInternal(Oid myrelid, const char *newrelname, bool is_internal)
 	 */
 	relrelation = heap_open(RelationRelationId, RowExclusiveLock);
 
-	reltup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(myrelid));
+	reltup = SearchSysCacheLockedCopy1(RELOID, ObjectIdGetDatum(myrelid));
+	otid = reltup->t_self;
 	if (!HeapTupleIsValid(reltup))		/* shouldn't happen */
 		elog(ERROR, "cache lookup failed for relation %u", myrelid);
 	relform = (Form_pg_class) GETSTRUCT(reltup);
@@ -3473,7 +3475,8 @@ RenameRelationInternal(Oid myrelid, const char *newrelname, bool is_internal)
 	 */
 	namestrcpy(&(relform->relname), newrelname);
 
-	CatalogTupleUpdate(relrelation, &reltup->t_self, reltup);
+	CatalogTupleUpdate(relrelation, &otid, reltup);
+	UnlockTuple(relrelation, &otid, InplaceUpdateTupleLock);
 
 	InvokeObjectPostAlterHookArg(RelationRelationId, myrelid, 0,
 								 InvalidOid, is_internal);
@@ -12797,7 +12800,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 
 	/* Fetch heap tuple */
 	relid = RelationGetRelid(rel);
-	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	tuple = SearchSysCacheLocked1(RELOID, ObjectIdGetDatum(relid));
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "cache lookup failed for relation %u", relid);
 
@@ -12951,6 +12954,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 								 repl_val, repl_null, repl_repl);
 
 	CatalogTupleUpdate(pgclass, &newtuple->t_self, newtuple);
+	UnlockTuple(pgclass, &tuple->t_self, InplaceUpdateTupleLock);
 
 	InvokeObjectPostAlterHook(RelationRelationId, RelationGetRelid(rel), 0);
 
@@ -19546,7 +19550,8 @@ AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 	Form_pg_class classForm;
 	ObjectAddress thisobj;
 
-	classTup = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(relOid));
+	/* no rel lock for relkind=c so use LOCKTAG_TUPLE */
+	classTup = SearchSysCacheLockedCopy1(RELOID, ObjectIdGetDatum(relOid));
 	if (!HeapTupleIsValid(classTup))
 		elog(ERROR, "cache lookup failed for relation %u", relOid);
 	classForm = (Form_pg_class) GETSTRUCT(classTup);
@@ -19562,6 +19567,8 @@ AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 	 */
 	if (!object_address_present(&thisobj, objsMoved))
 	{
+		ItemPointerData otid = classTup->t_self;
+
 		/* check for duplicate name (more friendly than unique-index failure) */
 		if (get_relname_relid(NameStr(classForm->relname),
 							  newNspOid) != InvalidOid)
@@ -19574,7 +19581,9 @@ AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 		/* classTup is a copy, so OK to scribble on */
 		classForm->relnamespace = newNspOid;
 
-		CatalogTupleUpdate(classRel, &classTup->t_self, classTup);
+		CatalogTupleUpdate(classRel, &otid, classTup);
+		UnlockTuple(classRel, &otid, InplaceUpdateTupleLock);
+
 
 		/* Update dependency on schema if caller said so */
 		if (hasDependEntry &&
@@ -19590,6 +19599,8 @@ AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 
 		InvokeObjectPostAlterHook(RelationRelationId, relOid, 0);
 	}
+	else
+		UnlockTuple(classRel, &classTup->t_self, InplaceUpdateTupleLock);
 
 	heap_freetuple(classTup);
 }

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -75,6 +75,7 @@
 #include "utils/rel.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/inval.h"
 
 
 /*---------------------------------------------------------------------------
@@ -1030,6 +1031,98 @@ ReleaseSysCache(HeapTuple tuple)
 }
 
 /*
+ * SearchSysCacheLocked1
+ *
+ * Combine SearchSysCache1() with acquiring a LOCKTAG_TUPLE at mode
+ * InplaceUpdateTupleLock.  This is a tool for complying with the
+ * README.tuplock section "Locking to write inplace-updated tables".  After
+ * the caller's heap_update(), it should UnlockTuple(InplaceUpdateTupleLock)
+ * and ReleaseSysCache().
+ *
+ * The returned tuple may be the subject of an uncommitted update, so this
+ * doesn't prevent the "tuple concurrently updated" error.
+ */
+HeapTuple
+SearchSysCacheLocked1(int cacheId,
+					  Datum key1)
+{
+	ItemPointerData tid;
+	LOCKTAG		tag;
+	Oid			dboid =
+		SysCache[cacheId]->cc_relisshared ? InvalidOid : MyDatabaseId;
+	Oid			reloid = cacheinfo[cacheId].reloid;
+
+	/*----------
+	 * Since inplace updates may happen just before our LockTuple(), we must
+	 * return content acquired after LockTuple() of the TID we return.  If we
+	 * just fetched twice instead of looping, the following sequence would
+	 * defeat our locking:
+	 *
+	 * GRANT:   SearchSysCache1() = TID (1,5)
+	 * GRANT:   LockTuple(pg_class, (1,5))
+	 * [no more inplace update of (1,5) until we release the lock]
+	 * CLUSTER: SearchSysCache1() = TID (1,5)
+	 * CLUSTER: heap_update() = TID (1,8)
+	 * CLUSTER: COMMIT
+	 * GRANT:   SearchSysCache1() = TID (1,8)
+	 * GRANT:   return (1,8) from SearchSysCacheLocked1()
+	 * VACUUM:  SearchSysCache1() = TID (1,8)
+	 * VACUUM:  LockTuple(pg_class, (1,8))  # two TIDs now locked for one rel
+	 * VACUUM:  inplace update
+	 * GRANT:   heap_update() = (1,9)  # lose inplace update
+	 *
+	 * In the happy case, this takes two fetches, one to determine the TID to
+	 * lock and another to get the content and confirm the TID didn't change.
+	 *
+	 * This is valid even if the row gets updated to a new TID, the old TID
+	 * becomes LP_UNUSED, and the row gets updated back to its old TID.  We'd
+	 * still hold the right LOCKTAG_TUPLE and a copy of the row captured after
+	 * the LOCKTAG_TUPLE.
+	 */
+	ItemPointerSetInvalid(&tid);
+	for (;;)
+	{
+		HeapTuple	tuple;
+		LOCKMODE	lockmode = InplaceUpdateTupleLock;
+
+		tuple = SearchSysCache1(cacheId, key1);
+		if (ItemPointerIsValid(&tid))
+		{
+			if (!HeapTupleIsValid(tuple))
+			{
+				LockRelease(&tag, lockmode, false);
+				return tuple;
+			}
+			if (ItemPointerEquals(&tid, &tuple->t_self))
+				return tuple;
+			LockRelease(&tag, lockmode, false);
+		}
+		else if (!HeapTupleIsValid(tuple))
+			return tuple;
+
+		tid = tuple->t_self;
+		ReleaseSysCache(tuple);
+		/* like: LockTuple(rel, &tid, lockmode) */
+		SET_LOCKTAG_TUPLE(tag, dboid, reloid,
+						  ItemPointerGetBlockNumber(&tid),
+						  ItemPointerGetOffsetNumber(&tid));
+		(void) LockAcquire(&tag, lockmode, false, false);
+
+		/*
+		 * If an inplace update just finished, ensure we process the syscache
+		 * inval.  XXX this is insufficient: the inplace updater may not yet
+		 * have reached AtEOXact_Inval().  See test at inplace-inval.spec.
+		 *
+		 * If a heap_update() call just released its LOCKTAG_TUPLE, we'll
+		 * probably find the old tuple and reach "tuple concurrently updated".
+		 * If that heap_update() aborts, our LOCKTAG_TUPLE blocks inplace
+		 * updates while our caller works.
+		 */
+		AcceptInvalidationMessages();
+	}
+}
+
+/*
  * SearchSysCacheCopy
  *
  * A convenience routine that does SearchSysCache and (if successful)
@@ -1048,6 +1141,28 @@ SearchSysCacheCopy(int cacheId,
 				newtuple;
 
 	tuple = SearchSysCache(cacheId, key1, key2, key3, key4);
+	if (!HeapTupleIsValid(tuple))
+		return tuple;
+	newtuple = heap_copytuple(tuple);
+	ReleaseSysCache(tuple);
+	return newtuple;
+}
+
+/*
+ * SearchSysCacheLockedCopy1
+ *
+ * Meld SearchSysCacheLockedCopy1 with SearchSysCacheCopy().  After the
+ * caller's heap_update(), it should UnlockTuple(InplaceUpdateTupleLock) and
+ * heap_freetuple().
+ */
+HeapTuple
+SearchSysCacheLockedCopy1(int cacheId,
+						  Datum key1)
+{
+	HeapTuple	tuple,
+				newtuple;
+
+	tuple = SearchSysCacheLocked1(cacheId, key1);
 	if (!HeapTupleIsValid(tuple))
 		return tuple;
 	newtuple = heap_copytuple(tuple);

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -196,5 +196,15 @@ extern SysScanDesc systable_beginscan_ordered(Relation heapRelation,
 extern HeapTuple systable_getnext_ordered(SysScanDesc sysscan,
 						 ScanDirection direction);
 extern void systable_endscan_ordered(SysScanDesc sysscan);
+extern HeapTuple systable_inplace_update_begin(Relation relation,
+										  Oid indexId,
+										  bool indexOK,
+										  Snapshot snapshot,
+										  int nkeys, const ScanKeyData *key,
+										  HeapTuple *oldtupcopy,
+										  void **state);
+extern void systable_inplace_update_finish(void *state, HeapTuple oldtup,
+										   HeapTuple tuple);
+extern void systable_inplace_update_cancel(void *state, HeapTuple oldtup);
 
 #endif   /* GENAM_H */

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -166,6 +166,13 @@ extern HTSU_Result heap_lock_tuple(Relation relation, HeapTuple tuple,
 				CommandId cid, LockTupleMode mode, LockTupleWaitType waittype,
 				bool follow_update,
 				Buffer *buffer, HeapUpdateFailureData *hufd);
+extern bool heap_inplace_lock(Relation relation,
+							  HeapTuple oldtup_ptr, Buffer buffer);
+extern void heap_inplace_update_and_unlock(Relation relation,
+										   HeapTuple oldtup, HeapTuple tuple,
+										   Buffer buffer);
+extern void heap_inplace_unlock(Relation relation,
+								HeapTuple oldtup, Buffer buffer);
 extern void heap_inplace_update(Relation relation, HeapTuple tuple);
 extern bool heap_freeze_tuple(HeapTupleHeader tuple,
 				  TransactionId relfrozenxid, TransactionId relminmxid,

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -155,6 +155,9 @@ typedef uint16 LOCKMETHODID;
 #define AccessExclusiveLock		8		/* ALTER TABLE, DROP TABLE, VACUUM
 										 * FULL, and unqualified LOCK TABLE */
 
+/* See README.tuplock section "Locking to write inplace-updated tables" */
+#define InplaceUpdateTupleLock ExclusiveLock
+
 /*
  * Map from lock methods to lock table data structures.
  */

--- a/src/include/utils/syscache.h
+++ b/src/include/utils/syscache.h
@@ -112,9 +112,14 @@ extern HeapTuple SearchSysCache(int cacheId,
 			   Datum key1, Datum key2, Datum key3, Datum key4);
 extern void ReleaseSysCache(HeapTuple tuple);
 
+extern HeapTuple SearchSysCacheLocked1(int cacheId,
+									   Datum key1);
+
 /* convenience routines */
 extern HeapTuple SearchSysCacheCopy(int cacheId,
 				   Datum key1, Datum key2, Datum key3, Datum key4);
+extern HeapTuple SearchSysCacheLockedCopy1(int cacheId,
+										   Datum key1);
 extern bool SearchSysCacheExists(int cacheId,
 					 Datum key1, Datum key2, Datum key3, Datum key4);
 extern Oid GetSysCacheOid(int cacheId,

--- a/src/test/isolation/expected/inplace-inval.out
+++ b/src/test/isolation/expected/inplace-inval.out
@@ -1,0 +1,20 @@
+Parsed test spec with 3 sessions
+
+starting permutation: cachefill3 cir1 cic2 ddl3
+step cachefill3: TABLE newly_indexed;
+c              
+
+step cir1: BEGIN; CREATE INDEX i1 ON newly_indexed (c); ROLLBACK;
+step cic2: CREATE INDEX i2 ON newly_indexed (c);
+step ddl3: ALTER TABLE newly_indexed ADD extra int;
+
+starting permutation: cir1 cic2 ddl3 read1
+step cir1: BEGIN; CREATE INDEX i1 ON newly_indexed (c); ROLLBACK;
+step cic2: CREATE INDEX i2 ON newly_indexed (c);
+step ddl3: ALTER TABLE newly_indexed ADD extra int;
+step read1: 
+	SELECT relhasindex FROM pg_class WHERE oid = 'newly_indexed'::regclass;
+
+relhasindex    
+
+t              

--- a/src/test/isolation/isolation_schedule
+++ b/src/test/isolation/isolation_schedule
@@ -25,6 +25,7 @@
 #test: fk-deadlock
 #test: fk-deadlock2
 #test: eval-plan-qual
+test: inplace-inval
 #test: lock-update-delete
 #test: lock-update-traversal
 #test: read-write-unique

--- a/src/test/isolation/specs/inplace-inval.spec
+++ b/src/test/isolation/specs/inplace-inval.spec
@@ -1,0 +1,40 @@
+# If a heap_update() caller retrieves its oldtup from a cache, it's possible
+# for that cache entry to predate an inplace update, causing loss of that
+# inplace update.  This arises because the transaction may abort before
+# sending the inplace invalidation message to the shared queue.
+
+setup
+{
+	CREATE TABLE newly_indexed (c int);
+}
+
+teardown
+{
+	DROP TABLE newly_indexed;
+}
+
+session "s1"
+step "cir1"	{ BEGIN; CREATE INDEX i1 ON newly_indexed (c); ROLLBACK; }
+step "read1"	{
+	SELECT relhasindex FROM pg_class WHERE oid = 'newly_indexed'::regclass;
+}
+
+session "s2"
+step "cic2"	{ CREATE INDEX i2 ON newly_indexed (c); }
+
+session "s3"
+step "cachefill3"	{ TABLE newly_indexed; }
+step "ddl3"		{ ALTER TABLE newly_indexed ADD extra int; }
+
+
+# XXX shows an extant bug.  Adding step read1 at the end would usually print
+# relhasindex=f (not wanted).  This does not reach the unwanted behavior under
+# -DCATCACHE_FORCE_RELEASE and friends.
+permutation
+	"cachefill3"	# populates the pg_class row in the catcache
+	"cir1"	# sets relhasindex=true; rollback discards cache inval
+	"cic2"	# sees relhasindex=true, skips changing it (so no inval)
+	"ddl3"	# cached row as the oldtup of an update, losing relhasindex
+
+# without cachefill3, no bug
+permutation "cir1" "cic2" "ddl3" "read1"

--- a/src/test/isolation2/expected/intra-grant-inplace-db.out
+++ b/src/test/isolation2/expected/intra-grant-inplace-db.out
@@ -1,0 +1,50 @@
+-- GRANT's lock is the catalog tuple xmax.  GRANT doesn't acquire a heavyweight
+-- lock on the object undergoing an ACL change.  In-place updates, namely
+-- datfrozenxid, need special code to cope.
+
+CREATE ROLE regress_temp_grantee;
+CREATE
+
+--start_ignore
+DROP TABLE IF EXISTS frozen_witness;
+DROP
+--end_ignore
+
+3: CREATE TEMPORARY TABLE frozen_witness (x xid) distributed by (x);
+CREATE
+-- observe datfrozenxid
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+INSERT 1
+1: BEGIN;
+BEGIN
+-- heap_update(pg_database)
+1: GRANT TEMP ON DATABASE isolation2test TO regress_temp_grantee;
+GRANT
+-- inplace update
+2&: VACUUM (FREEZE);  <waiting ...>
+FAILED:  Forked command is not blocking; got output: VACUUM
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+INSERT 1
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+FAILED:  Execution failed
+-- Save the result in an environment variable.
+-- We get the raw xid to be sure that the age in the next query will be executed on the coordinator.
+3: @post_run 'TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo ""' : SELECT min(x::varchar::int) FROM frozen_witness;
+
+-- observe datfrozenxid
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT 'datfrozenxid retreated' FROM pg_database WHERE datname = current_catalog AND age(datfrozenxid) > age('@TOKEN'::xid);
+ ?column?               
+------------------------
+ datfrozenxid retreated 
+(1 row)
+
+REVOKE ALL ON DATABASE isolation2test FROM regress_temp_grantee;
+REVOKE
+DROP ROLE regress_temp_grantee;
+DROP
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>

--- a/src/test/isolation2/expected/intra-grant-inplace-db.out
+++ b/src/test/isolation2/expected/intra-grant-inplace-db.out
@@ -22,23 +22,21 @@ BEGIN
 GRANT
 -- inplace update
 2&: VACUUM (FREEZE);  <waiting ...>
-FAILED:  Forked command is not blocking; got output: VACUUM
 3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
 INSERT 1
 1: COMMIT;
 COMMIT
 2<:  <... completed>
-FAILED:  Execution failed
+VACUUM
 -- Save the result in an environment variable.
 -- We get the raw xid to be sure that the age in the next query will be executed on the coordinator.
 3: @post_run 'TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo ""' : SELECT min(x::varchar::int) FROM frozen_witness;
 
 -- observe datfrozenxid
 3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT 'datfrozenxid retreated' FROM pg_database WHERE datname = current_catalog AND age(datfrozenxid) > age('@TOKEN'::xid);
- ?column?               
-------------------------
- datfrozenxid retreated 
-(1 row)
+ ?column? 
+----------
+(0 rows)
 
 REVOKE ALL ON DATABASE isolation2test FROM regress_temp_grantee;
 REVOKE

--- a/src/test/isolation2/expected/intra-grant-inplace.out
+++ b/src/test/isolation2/expected/intra-grant-inplace.out
@@ -1,0 +1,256 @@
+-- GRANT's lock is the catalog tuple xmax.  GRANT doesn't acquire a heavyweight
+-- lock on the object undergoing an ACL change.  Inplace updates, such as
+-- relhasindex=true, need special code to cope.
+
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- Disabling ORCA because we need to use row-level locks.
+1: set optimizer = off;
+SET
+2: set optimizer = off;
+SET
+3: set optimizer = off;
+SET
+4: set optimizer = off;
+SET
+5: set optimizer = off;
+SET
+
+1: BEGIN;
+BEGIN
+1: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+GRANT
+
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+ relhasindex 
+-------------
+ f           
+(1 row)
+-- inplace waits
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
+FAILED:  Forked command is not blocking; got output: ALTER
+
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+FAILED:  Execution failed
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+ relhasindex 
+-------------
+ f           
+(1 row)
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- inplace through KEY SHARE
+5: BEGIN;
+BEGIN
+5: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR KEY SHARE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+ALTER
+5: ROLLBACK;
+ROLLBACK
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- inplace wait NO KEY UPDATE w/ KEY SHARE
+5: BEGIN;
+BEGIN
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+BEGIN
+3: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
+FAILED:  Forked command is not blocking; got output: ALTER
+3: ROLLBACK;
+ROLLBACK
+5: ROLLBACK;
+ROLLBACK
+2<:  <... completed>
+FAILED:  Execution failed
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- same-xact rowmark
+2: BEGIN;
+BEGIN
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+ALTER
+2: COMMIT;
+COMMIT
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- same-xact rowmark in multixact
+5: BEGIN;
+BEGIN
+5: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR KEY SHARE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+2: BEGIN;
+BEGIN
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+ALTER
+2: COMMIT;
+COMMIT
+5: ROLLBACK;
+ROLLBACK
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+BEGIN
+3: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+1: BEGIN;
+BEGIN
+-- acquire LockTuple(), await session 3 xmax
+1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;  <waiting ...>
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+ relhasindex 
+-------------
+ f           
+(1 row)
+-- block in LockTuple() behind grant1
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
+FAILED:  Forked command is not blocking; got output: ALTER
+-- unblock grant1; addk2 now awaits grant1 xmax
+3: ROLLBACK;
+ROLLBACK
+1<:  <... completed>
+GRANT
+1: COMMIT;
+COMMIT
+2<:  <... completed>
+FAILED:  Execution failed
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+ relhasindex 
+-------------
+ f           
+(1 row)
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+2: BEGIN;
+BEGIN
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+ relhasindex 
+-------------
+ f           
+(1 row)
+1: BEGIN;
+BEGIN
+-- acquire LockTuple(), await session 2 xmax
+1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;  <waiting ...>
+-- block in LockTuple() behind grant1 = deadlock
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+ALTER
+2: COMMIT;
+COMMIT
+1<:  <... completed>
+GRANT
+1: COMMIT;
+COMMIT
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+ relhasindex 
+-------------
+ f           
+(1 row)
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- SearchSysCacheLocked1() calling LockRelease()
+1: BEGIN;
+BEGIN
+1: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+GRANT
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+BEGIN
+3&: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;  <waiting ...>
+4&: DO $$ BEGIN REVOKE SELECT ON intra_grant_inplace FROM PUBLIC; EXCEPTION WHEN others THEN RAISE WARNING 'got: %', regexp_replace(sqlerrm, '[0-9]+', 'REDACTED'); END $$;  <waiting ...>
+1: COMMIT;
+COMMIT
+3<:  <... completed>
+ relhasindex 
+-------------
+ f           
+(1 row)
+3: ROLLBACK;
+ROLLBACK
+4<:  <... completed>
+DO
+
+DROP TABLE intra_grant_inplace;
+DROP
+CREATE TABLE intra_grant_inplace (c int);
+CREATE
+
+-- SearchSysCacheLocked1() finding a tuple, then no tuple
+1: BEGIN;
+BEGIN
+1: DROP TABLE intra_grant_inplace;
+DROP
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+BEGIN
+3&: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;  <waiting ...>
+4&: DO $$ BEGIN REVOKE SELECT ON intra_grant_inplace FROM PUBLIC; EXCEPTION WHEN others THEN RAISE WARNING 'got: %', regexp_replace(sqlerrm, '[0-9]+', 'REDACTED'); END $$;  <waiting ...>
+1: COMMIT;
+COMMIT
+3<:  <... completed>
+ relhasindex 
+-------------
+(0 rows)
+3: ROLLBACK;
+ROLLBACK
+4<:  <... completed>
+DO
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>

--- a/src/test/isolation2/expected/intra-grant-inplace.out
+++ b/src/test/isolation2/expected/intra-grant-inplace.out
@@ -29,16 +29,15 @@ GRANT
 (1 row)
 -- inplace waits
 2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
-FAILED:  Forked command is not blocking; got output: ALTER
 
 1: COMMIT;
 COMMIT
 2<:  <... completed>
-FAILED:  Execution failed
+ALTER
 2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
  relhasindex 
 -------------
- f           
+ t           
 (1 row)
 
 DROP TABLE intra_grant_inplace;
@@ -75,13 +74,12 @@ BEGIN
  f           
 (1 row)
 2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
-FAILED:  Forked command is not blocking; got output: ALTER
 3: ROLLBACK;
 ROLLBACK
 5: ROLLBACK;
 ROLLBACK
 2<:  <... completed>
-FAILED:  Execution failed
+ALTER
 
 DROP TABLE intra_grant_inplace;
 DROP
@@ -149,9 +147,11 @@ BEGIN
 -------------
  f           
 (1 row)
+-- XXX temporary until patch adds locking to addk2
+3: LOCK TABLE intra_grant_inplace IN ACCESS SHARE MODE;
+LOCK
 -- block in LockTuple() behind grant1
 2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
-FAILED:  Forked command is not blocking; got output: ALTER
 -- unblock grant1; addk2 now awaits grant1 xmax
 3: ROLLBACK;
 ROLLBACK
@@ -160,11 +160,11 @@ GRANT
 1: COMMIT;
 COMMIT
 2<:  <... completed>
-FAILED:  Execution failed
+ALTER
 2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
  relhasindex 
 -------------
- f           
+ t           
 (1 row)
 
 DROP TABLE intra_grant_inplace;

--- a/src/test/isolation2/expected/intra-grant-inplace.out
+++ b/src/test/isolation2/expected/intra-grant-inplace.out
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/DETAIL:  Process \d+ waits for ExclusiveLock on tuple \(\d+,\d+\) of relation \d+ of database \d+; blocked by process \d+\./
+-- s/DETAIL:  Process \d+ waits for ExclusiveLock on tuple \(\d+,\d+\) of relation \d+ of database \d+; blocked by process \d+\./DETAIL:  Process ### waits for ExclusiveLock on tuple \(##,##\) of relation ### of database ###; blocked by process ###\./
+-- end_matchsubs
+
 -- GRANT's lock is the catalog tuple xmax.  GRANT doesn't acquire a heavyweight
 -- lock on the object undergoing an ACL change.  Inplace updates, such as
 -- relhasindex=true, need special code to cope.
@@ -15,6 +20,11 @@ SET
 4: set optimizer = off;
 SET
 5: set optimizer = off;
+SET
+
+1: SET deadlock_timeout = '100s';
+SET
+2: SET deadlock_timeout = '10ms';
 SET
 
 1: BEGIN;
@@ -147,9 +157,6 @@ BEGIN
 -------------
  f           
 (1 row)
--- XXX temporary until patch adds locking to addk2
-3: LOCK TABLE intra_grant_inplace IN ACCESS SHARE MODE;
-LOCK
 -- block in LockTuple() behind grant1
 2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);  <waiting ...>
 -- unblock grant1; addk2 now awaits grant1 xmax
@@ -185,7 +192,10 @@ BEGIN
 1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;  <waiting ...>
 -- block in LockTuple() behind grant1 = deadlock
 2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
-ALTER
+ERROR:  deadlock detected
+DETAIL:  Process ### waits for ExclusiveLock on tuple (##,##) of relation ### of database ###; blocked by process ###.
+Process 69286 waits for ShareLock on transaction 2106; blocked by process 69295.
+HINT:  See server log for query details.
 2: COMMIT;
 COMMIT
 1<:  <... completed>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -47,12 +47,16 @@ test: gdd/planner_insert_while_vacuum_drop
 test: gdd/update-deadlock-root-leaf-concurrent-op
 test: gdd/dml_locks_only_targeted_table_in_query
 
+# Despite the fact that this test does not apply to gdd. gdd is required for it.
+# Therefore, this test should be in the gdd block.
+test: intra-grant-inplace
+
 # this resets the gp_global_deadlock_detector_period guc hence should
 # be last in the group.
 test: gdd/local-deadlock-03
 # gdd end
 test: gdd/end
-
+test: intra-grant-inplace-db
 test: modify_table_data_corrupt
 
 # The following test injects a fault at a generic location

--- a/src/test/isolation2/sql/intra-grant-inplace-db.sql
+++ b/src/test/isolation2/sql/intra-grant-inplace-db.sql
@@ -1,0 +1,33 @@
+-- GRANT's lock is the catalog tuple xmax.  GRANT doesn't acquire a heavyweight
+-- lock on the object undergoing an ACL change.  In-place updates, namely
+-- datfrozenxid, need special code to cope.
+
+CREATE ROLE regress_temp_grantee;
+
+--start_ignore
+DROP TABLE IF EXISTS frozen_witness;
+--end_ignore
+
+3: CREATE TEMPORARY TABLE frozen_witness (x xid) distributed by (x);
+-- observe datfrozenxid
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+1: BEGIN;
+-- heap_update(pg_database)
+1: GRANT TEMP ON DATABASE isolation2test TO regress_temp_grantee;
+-- inplace update
+2&: VACUUM (FREEZE);
+3: INSERT INTO frozen_witness SELECT datfrozenxid FROM pg_database WHERE datname = current_catalog;
+1: COMMIT;
+2<:
+-- Save the result in an environment variable.
+-- We get the raw xid to be sure that the age in the next query will be executed on the coordinator.
+3: @post_run 'TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo ""' : SELECT min(x::varchar::int) FROM frozen_witness;
+-- observe datfrozenxid
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SELECT 'datfrozenxid retreated' FROM pg_database WHERE datname = current_catalog AND age(datfrozenxid) > age('@TOKEN'::xid);
+
+REVOKE ALL ON DATABASE isolation2test FROM regress_temp_grantee;
+DROP ROLE regress_temp_grantee;
+
+1q:
+2q:
+3q:

--- a/src/test/isolation2/sql/intra-grant-inplace.sql
+++ b/src/test/isolation2/sql/intra-grant-inplace.sql
@@ -1,0 +1,132 @@
+-- GRANT's lock is the catalog tuple xmax.  GRANT doesn't acquire a heavyweight
+-- lock on the object undergoing an ACL change.  Inplace updates, such as
+-- relhasindex=true, need special code to cope.
+
+CREATE TABLE intra_grant_inplace (c int);
+
+-- Disabling ORCA because we need to use row-level locks.
+1: set optimizer = off;
+2: set optimizer = off;
+3: set optimizer = off;
+4: set optimizer = off;
+5: set optimizer = off;
+
+1: BEGIN;
+1: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+-- inplace waits
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+
+1: COMMIT;
+2<:
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- inplace through KEY SHARE
+5: BEGIN;
+5: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR KEY SHARE;
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+5: ROLLBACK;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- inplace wait NO KEY UPDATE w/ KEY SHARE
+5: BEGIN;
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+3: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+3: ROLLBACK;
+5: ROLLBACK;
+2<:
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- same-xact rowmark
+2: BEGIN;
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+2: COMMIT;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- same-xact rowmark in multixact
+5: BEGIN;
+5: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR KEY SHARE;
+2: BEGIN;
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+2: COMMIT;
+5: ROLLBACK;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+3: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;
+1: BEGIN;
+-- acquire LockTuple(), await session 3 xmax
+1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+-- block in LockTuple() behind grant1
+2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+-- unblock grant1; addk2 now awaits grant1 xmax
+3: ROLLBACK;
+1<:
+1: COMMIT;
+2<:
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+2: BEGIN;
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR NO KEY UPDATE;
+1: BEGIN;
+-- acquire LockTuple(), await session 2 xmax
+1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+-- block in LockTuple() behind grant1 = deadlock
+2: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
+2: COMMIT;
+1<:
+1: COMMIT;
+2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- SearchSysCacheLocked1() calling LockRelease()
+1: BEGIN;
+1: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+3&: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;
+4&: DO $$ BEGIN REVOKE SELECT ON intra_grant_inplace FROM PUBLIC; EXCEPTION WHEN others THEN RAISE WARNING 'got: %', regexp_replace(sqlerrm, '[0-9]+', 'REDACTED'); END $$;
+1: COMMIT;
+3<:
+3: ROLLBACK;
+4<:
+
+DROP TABLE intra_grant_inplace;
+CREATE TABLE intra_grant_inplace (c int);
+
+-- SearchSysCacheLocked1() finding a tuple, then no tuple
+1: BEGIN;
+1: DROP TABLE intra_grant_inplace;
+3: BEGIN ISOLATION LEVEL READ COMMITTED;
+3&: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass FOR UPDATE;
+4&: DO $$ BEGIN REVOKE SELECT ON intra_grant_inplace FROM PUBLIC; EXCEPTION WHEN others THEN RAISE WARNING 'got: %', regexp_replace(sqlerrm, '[0-9]+', 'REDACTED'); END $$;
+1: COMMIT;
+3<:
+3: ROLLBACK;
+4<:
+
+1q:
+2q:
+3q:
+4q:
+5q:

--- a/src/test/isolation2/sql/intra-grant-inplace.sql
+++ b/src/test/isolation2/sql/intra-grant-inplace.sql
@@ -73,6 +73,8 @@ CREATE TABLE intra_grant_inplace (c int);
 -- acquire LockTuple(), await session 3 xmax
 1&: GRANT SELECT ON intra_grant_inplace TO PUBLIC;
 2: SELECT relhasindex FROM pg_class WHERE oid = 'intra_grant_inplace'::regclass;
+-- XXX temporary until patch adds locking to addk2
+3: LOCK TABLE intra_grant_inplace IN ACCESS SHARE MODE;
 -- block in LockTuple() behind grant1
 2&: ALTER TABLE intra_grant_inplace ADD PRIMARY KEY (c);
 -- unblock grant1; addk2 now awaits grant1 xmax


### PR DESCRIPTION
Fix lost update during inplace update.

These two commits address an issue where an inplace update could modify an already-dead tuple. This could occur when a transaction updates a row in pg_class or pg_database without acquiring a lock on the target relation. In such cases, a concurrent transaction performing an inplace update might update the old version of the tuple, and after the first transaction commits, that update would be lost.

Commit 809ae0f587dfb168477265590ef1a20bde4d4391 fixes this by acquiring a lock on tuples before updating them.

Most of the infrastructure required for this was introduced in commit b83e8fd701a9bc98a8eb41d8dd3811f2f0ec8fe5.

The tests were taken from commit 796d191028bb642bb04d9b3fd18d6f0aab7b1f1f and ported to isolation2, since in GPDB they require gdd to be enabled in order to pass.

---

Do not squash.