### PR TITLE
CI-4089 Use official Ubuntu mirrors by default; override via build args allowed

### DIFF
--- a/arenadata/Dockerfile.linter
+++ b/arenadata/Dockerfile.linter
@@ -1,6 +1,17 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-RUN apt update && apt install -y git parallel clang-format-11 && \
+ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
+
+RUN sed -i \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy |${UBUNTU_MAIN_MIRROR}/ jammy |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-updates |${UBUNTU_UPDATES_MIRROR}/ jammy-updates |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-backports |${UBUNTU_BACKPORTS_MIRROR}/ jammy-backports |g" \
+      -e "s|http://security.ubuntu.com/ubuntu/ jammy-security |${UBUNTU_SECURITY_MIRROR}/ jammy-security |g" \
+      /etc/apt/sources.list && \
+    apt update && apt install -y git parallel clang-format-11 && \
     ln -s /usr/bin/clang-format-11 /usr/bin/clang-format
 
 WORKDIR /opt/gpdb_src

--- a/arenadata/Dockerfile.ubuntu
+++ b/arenadata/Dockerfile.ubuntu
@@ -1,8 +1,19 @@
 FROM ubuntu:22.04 AS base
 
+ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
+
 COPY README.Ubuntu.bash ./
 
 RUN set -eux; \
+    sed -i \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy |${UBUNTU_MAIN_MIRROR}/ jammy |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-updates |${UBUNTU_UPDATES_MIRROR}/ jammy-updates |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-backports |${UBUNTU_BACKPORTS_MIRROR}/ jammy-backports |g" \
+      -e "s|http://security.ubuntu.com/ubuntu/ jammy-security |${UBUNTU_SECURITY_MIRROR}/ jammy-security |g" \
+      /etc/apt/sources.list; \
     export DEBIAN_FRONTEND=noninteractive; \
     ./README.Ubuntu.bash; \
     rm README.Ubuntu.bash; \

--- a/arenadata/Dockerfile.ubuntu.clang-check
+++ b/arenadata/Dockerfile.ubuntu.clang-check
@@ -1,10 +1,21 @@
 FROM ubuntu:22.04
 
+ARG UBUNTU_MAIN_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_UPDATES_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_BACKPORTS_MIRROR=http://archive.ubuntu.com/ubuntu
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu
+
 ARG GPDB_SRC="/home/gpadmin/gpdb_src/"
 
 COPY ./README.Ubuntu.bash $GPDB_SRC
 # Set frontend to avoid kerberos prompt.
-RUN DEBIAN_FRONTEND=noninteractive $GPDB_SRC/README.Ubuntu.bash
+RUN sed -i \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy |${UBUNTU_MAIN_MIRROR}/ jammy |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-updates |${UBUNTU_UPDATES_MIRROR}/ jammy-updates |g" \
+      -e "s|http://archive.ubuntu.com/ubuntu/ jammy-backports |${UBUNTU_BACKPORTS_MIRROR}/ jammy-backports |g" \
+      -e "s|http://security.ubuntu.com/ubuntu/ jammy-security |${UBUNTU_SECURITY_MIRROR}/ jammy-security |g" \
+      /etc/apt/sources.list; \
+    DEBIAN_FRONTEND=noninteractive $GPDB_SRC/README.Ubuntu.bash
 RUN apt install -y libxslt1-dev
 
 COPY ./ $GPDB_SRC


### PR DESCRIPTION
Configure Dockerfiles to use official Ubuntu mirrors by default, with the
ability to override them using internal mirrors via build arguments.
This setup ensures flexibility for both builds local and CI pipeline builds
using our internal mirrors.
