### PR TITLE
ao/co: fix an issue with COPY zero-column CO table

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3146,9 +3146,14 @@ CopyTo(CopyState cstate)
 					proj[attnum-1] = true;
 				}
 
+				/*
+				 * We specifically pass NULL proj if the table has no column, and leave it
+				 * to the underlying CO AM layer to handle it - the behavior should be same
+				 * as SELECT * which is to choose one column to scan.
+				 */
 				scan = aocs_beginscan(rel, GetActiveSnapshot(),
 									  GetActiveSnapshot(),
-									  NULL /* relationTupleDesc */, proj);
+									  NULL /* relationTupleDesc */, cstate->attnumlist ? proj : NULL);
 
 				while (aocs_getnext(scan, ForwardScanDirection, slot))
 				{

--- a/src/test/regress/input/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/input/uao_ddl/alter_drop_allcol.source
@@ -14,14 +14,17 @@ select * from alter_drop_allcoll order by a,b;
 ALTER TABLE alter_drop_allcoll DROP COLUMN c;
 select count(*) as c from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='c';
 select * from alter_drop_allcoll order by a,b;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
 select * from alter_drop_allcoll order by a;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -29,3 +32,4 @@ select * from alter_drop_allcoll;
 COMMIT;
 vacuum alter_drop_allcoll;
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;

--- a/src/test/regress/input/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/input/uao_ddl/create_ao_tables.source
@@ -205,3 +205,19 @@ set gp_select_invisible=false;
 select * into sto_heap_10 from sto_uao_8;
 select count(*) from sto_heap_10;
 COMMIT;
+
+-- Table with zero column
+create table sto_uao_0col() with (appendonly=true);
+select * from sto_uao_0col;
+select count(*) from sto_uao_0col;
+copy sto_uao_0col to stdout;
+
+-- Non-empty table with all dropped columns
+create table sto_aocs_dropped_cols (i int, c text)
+with (appendonly=true)
+distributed randomly;
+insert into sto_aocs_dropped_cols select i, now() from generate_series(1,100)i;
+alter table sto_aocs_dropped_cols drop column c;
+alter table sto_aocs_dropped_cols drop column i;
+-- Result does not matter, query should not hang
+copy sto_aocs_dropped_cols to '/dev/null';

--- a/src/test/regress/output/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/output/uao_ddl/alter_drop_allcol.source
@@ -38,6 +38,12 @@ select * from alter_drop_allcoll order by a,b;
  5 | 5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1	1
+2	2
+3	3
+4	4
+5	5
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
  b 
@@ -55,6 +61,12 @@ select * from alter_drop_allcoll order by a;
  5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1
+2
+3
+4
+5
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -66,6 +78,12 @@ select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oi
 select * from alter_drop_allcoll;
 --
 (5 rows)
+
+copy alter_drop_allcoll to stdout;
+
+
+
+
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -96,3 +114,9 @@ select * from alter_drop_allcoll;
  10
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+10
+10
+10
+10
+10

--- a/src/test/regress/output/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/output/uao_ddl/create_ao_tables.source
@@ -323,3 +323,25 @@ select count(*) from sto_heap_10;
 (1 row)
 
 COMMIT;
+-- Table with zero column
+create table sto_uao_0col() with (appendonly=true);
+select * from sto_uao_0col;
+--
+(0 rows)
+
+select count(*) from sto_uao_0col;
+ count 
+-------
+     0
+(1 row)
+
+copy sto_uao_0col to stdout;
+-- Non-empty table with all dropped columns
+create table sto_aocs_dropped_cols (i int, c text)
+with (appendonly=true)
+distributed randomly;
+insert into sto_aocs_dropped_cols select i, now() from generate_series(1,100)i;
+alter table sto_aocs_dropped_cols drop column c;
+alter table sto_aocs_dropped_cols drop column i;
+-- Result does not matter, query should not hang
+copy sto_aocs_dropped_cols to '/dev/null';


### PR DESCRIPTION
ao/co: fix an issue with COPY zero-column CO table

The issue is that if the CO table once had column (and data), but later all
columns are dropped, then COPY this table would hang:

```
create table co(a int) using ao_column;
insert into co select * from generate_series(1,10);
alter table co drop column a;

copy co to stdout; -- this hangs forever
```

The is because aocs_getnext is not handling this case well: it would open the
segment files but skip the actually scanning (because no projected columns),
write no tupleslot values, and finally return TRUE which doesn't make any sense
as it did not read any tuple. So a loop to get next tuple would loop forever.
If we return FALSE here, we would stop the loop early.

Note that, however, this does not make COPY's behavior for CO to be the same as
heap or AO, where we would still copy out the same number of rows as in the
table, just no data in the row. In order to get it right, we can make a
targeted change to COPY TO so it leave the decision to the CO AM layer
regarding which column to project, which is also more consistent with SELECT *.

The change to aocs_getnext() would serve as just defensive checks.

Reviewed-by: Kevin Yeap <kyeap@vmware.com>
(cherry picked from commit 50b4438f9c28b52a29951d2be76a1a1ed6c38ca7)

Original commit was modified and adapted due to different sources of AOCS tables
at 7X and 6X. One more test was added to check case with dropped columns.
Note about aoco_beginscan_extractcolumns() was removed, because there is no
aoco_beginscan_extractcolumns() in 6X.

---

Do not squash