### PR TITLE
ADBDEV-7428: Add missing field initialization in wal record of bitmap index

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1495,6 +1495,7 @@ _bitmap_write_bitmapwords_on_page(Page bitmapPage, BMTIDBuffer *buf, int startWo
 		if (xlrec_perpage)
 		{
 			xlrec_perpage->bmp_last_tid = bitmapPageOpaque->bm_last_tid_location;
+			xlrec_perpage->bm_next_blkno = bitmapPageOpaque->bm_bitmap_next;
 			xlrec_perpage->bmp_start_hword_no = 0;
 			xlrec_perpage->bmp_num_hwords = 0;
 			xlrec_perpage->bmp_start_cword_no = cwords;
@@ -1596,7 +1597,10 @@ _bitmap_write_bitmapwords_on_page(Page bitmapPage, BMTIDBuffer *buf, int startWo
 	bitmapPageOpaque->bm_last_tid_location =
 		buf->last_tids[startWordNo + words_written-1];
 	if (xlrec_perpage)
+	{
 		xlrec_perpage->bmp_last_tid = bitmapPageOpaque->bm_last_tid_location;
+		xlrec_perpage->bm_next_blkno = bitmapPageOpaque->bm_bitmap_next;
+	}
 
 	return words_written;
 }

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_ao_bitmap.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_ao_bitmap.out
@@ -42,3 +42,47 @@ COMMIT
 (1 row)
 3: INSERT INTO reindex_ao VALUES (0);
 INSERT 0 1
+
+-- Check the consistency of the bitmap index on the primary and mirror after vacuum.
+-- Vacuum with previously opened transaction does not lead to reindex, but changes pages of existing index.
+CREATE OR REPLACE FUNCTION seg_datadir(seg int, rol text) RETURNS table (dir text) AS $$ /*in func*/ BEGIN /*in func*/ RETURN QUERY /*in func*/ select datadir from gp_segment_configuration where content = seg and role = rol; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE EXECUTE ON ANY;
+CREATE FUNCTION
+
+CREATE OR REPLACE FUNCTION rel_seg_path(relname text, seg int) RETURNS table (path text) AS $$ /*in func*/ BEGIN /*in func*/ RETURN QUERY /*in func*/ select pg_relation_filepath(relname) from gp_dist_random('gp_id') where gp_segment_id = seg; /*in func*/ END $$ /*in func*/ LANGUAGE plpgsql VOLATILE EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION
+
+-- start_ignore
+drop table if exists ao_table;
+DROP TABLE
+-- end_ignore
+create table ao_table (a int) with (appendonly=true);
+CREATE TABLE
+insert into ao_table select generate_series(1,10);
+INSERT 0 10
+insert into ao_table select generate_series(1,10);
+INSERT 0 10
+create index bitmap_idx_ao on ao_table using bitmap(a);
+CREATE INDEX
+delete from ao_table where a < 8;
+DELETE 14
+
+1: begin;
+BEGIN
+2: vacuum ao_table;
+VACUUM
+1: commit;
+COMMIT
+1q: ... <quitting>
+2q: ... <quitting>
+!\retcode gpstop -afr;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+-- Check the identity of index files on primary and mirror.
+! seg0_datadir=$(psql -At -c "select * from seg_datadir(0, 'p')" isolation2test) && mir0_datadir=$(psql -At -c "select dir from seg_datadir(0, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 0)" isolation2test) && diff ${seg0_datadir}/${relfilenode_dir} ${mir0_datadir}/${relfilenode_dir};
+
+! seg1_datadir=$(psql -At -c "select * from seg_datadir(1, 'p')" isolation2test) && mir1_datadir=$(psql -At -c "select dir from seg_datadir(1, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 1)" isolation2test) && diff ${seg1_datadir}/${relfilenode_dir} ${mir1_datadir}/${relfilenode_dir};
+
+! seg2_datadir=$(psql -At -c "select * from seg_datadir(2, 'p')" isolation2test) && mir2_datadir=$(psql -At -c "select dir from seg_datadir(2, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 2)" isolation2test) && diff ${seg2_datadir}/${relfilenode_dir} ${mir2_datadir}/${relfilenode_dir};
+

--- a/src/test/isolation2/sql/reindex/vacuum_while_reindex_ao_bitmap.sql
+++ b/src/test/isolation2/sql/reindex/vacuum_while_reindex_ao_bitmap.sql
@@ -35,3 +35,39 @@ DELETE FROM reindex_ao WHERE a < 128;
 2: COMMIT;
 3: SELECT COUNT(*) FROM reindex_ao WHERE a = 1500;
 3: INSERT INTO reindex_ao VALUES (0);
+
+-- Check the consistency of the bitmap index on the primary and mirror after vacuum.
+-- Vacuum with previously opened transaction does not lead to reindex, but changes pages of existing index.
+CREATE OR REPLACE FUNCTION seg_datadir(seg int, rol text) RETURNS table (dir text) AS $$ /*in func*/
+BEGIN /*in func*/
+RETURN QUERY /*in func*/
+	select datadir from gp_segment_configuration where content = seg and role = rol; /*in func*/
+END $$ /*in func*/
+LANGUAGE plpgsql VOLATILE EXECUTE ON ANY;
+
+CREATE OR REPLACE FUNCTION rel_seg_path(relname text, seg int) RETURNS table (path text) AS $$ /*in func*/
+BEGIN /*in func*/
+	RETURN QUERY /*in func*/
+	select pg_relation_filepath(relname) from gp_dist_random('gp_id') where gp_segment_id = seg; /*in func*/
+END $$ /*in func*/
+LANGUAGE plpgsql VOLATILE EXECUTE ON ALL SEGMENTS;
+
+-- start_ignore
+drop table if exists ao_table;
+-- end_ignore
+create table ao_table (a int) with (appendonly=true);
+insert into ao_table select generate_series(1,10);
+insert into ao_table select generate_series(1,10);
+create index bitmap_idx_ao on ao_table using bitmap(a);
+delete from ao_table where a < 8;
+
+1: begin;
+2: vacuum ao_table;
+1: commit;
+1q:
+2q:
+!\retcode gpstop -afr;
+-- Check the identity of index files on primary and mirror.
+! seg0_datadir=$(psql -At -c "select * from seg_datadir(0, 'p')" isolation2test) && mir0_datadir=$(psql -At -c "select dir from seg_datadir(0, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 0)" isolation2test) && diff ${seg0_datadir}/${relfilenode_dir} ${mir0_datadir}/${relfilenode_dir};
+! seg1_datadir=$(psql -At -c "select * from seg_datadir(1, 'p')" isolation2test) && mir1_datadir=$(psql -At -c "select dir from seg_datadir(1, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 1)" isolation2test) && diff ${seg1_datadir}/${relfilenode_dir} ${mir1_datadir}/${relfilenode_dir};
+! seg2_datadir=$(psql -At -c "select * from seg_datadir(2, 'p')" isolation2test) && mir2_datadir=$(psql -At -c "select dir from seg_datadir(2, 'm')" isolation2test) && relfilenode_dir=$(psql -At -c "select path from rel_seg_path('bitmap_idx_ao', 2)" isolation2test) && diff ${seg2_datadir}/${relfilenode_dir} ${mir2_datadir}/${relfilenode_dir};


### PR DESCRIPTION
Add missing field initialization in wal record of bitmap index (#1723)

In `_bitmap_write_bitmapwords_on_page()` the wal record (`xlrec_perpage` structure)
is initialized, which is used to replicate the bitmap index data to the mirror.
Initialization of `bm_next_blkno` was missed here.
After vacuum, this led to inconsistency and corruption of the bitmap index on
the mirror (the difference between wal record and the bitmap index page data
can be detected in `_bitmap_log_bitmapwords()`).