### PR TITLE
ADBDEV-7388: Adapt "Optimize pg_lock_status() memory usage" to 7X

### DIFF
--- a/src/test/isolation2/expected/lock_status.out
+++ b/src/test/isolation2/expected/lock_status.out
@@ -1,0 +1,121 @@
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+CREATE
+-- end_ignore
+
+CREATE TABLE t_part(i int) PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
+CREATE TABLE
+
+-- Create a lot of locks.
+1: BEGIN;
+BEGIN
+1: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE
+
+--
+-- Test pg_locks view behavior.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'error', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Materializes everything regardless of LIMIT clause, as of now.
+SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
+ f     
+-------
+ f     
+(1 row)
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- only from coordinator.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Doesn't materialize anything, gets squelched after the first row from
+-- coordinator.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
+ f     
+-------
+ f     
+(1 row)
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- both from coordinator and from segments.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid), gp_inject_fault('pg_lock_status_squelched', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault | gp_inject_fault 
+-----------------+-----------------
+ Success:        | Success:        
+(1 row)
+
+-- Retrieves some rows from coordinator and from a segment, then gets
+-- squelched.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 12;
+ f     
+-------
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+ f     
+(12 rows)
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid), gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+ gp_wait_until_triggered_fault | gp_wait_until_triggered_fault 
+-------------------------------+-------------------------------
+ Success:                      | Success:                      
+(1 row)
+
+SELECT gp_inject_fault('all', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1: ROLLBACK;
+ROLLBACK
+
+DROP TABLE t_part;
+DROP TABLE

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1044,6 +1044,9 @@ BEGIN
 1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
+--
+-- ORCA doesn't acquire AccessShareLock, since it maintains partition cache for
+-- this query.
 1: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation                        
 ----------+-----------------+---------+---------------------------------
@@ -1060,6 +1063,9 @@ BEGIN
 1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
 INSERT 0 10
 -- without GDD, it will lock all leaf partitions on QD
+--
+-- ORCA obtains AccessShareLock. cache has been invalidated after a call to
+-- pg_lock_status() due to its implementation.
 1: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1044,6 +1044,9 @@ BEGIN
 1: DELETE FROM t_lockmods_part_tbl_dml;
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
+--
+-- ORCA doesn't acquire AccessShareLock, since it maintains partition cache for
+-- this query.
 1: select * from show_locks_lockmodes;
  locktype | mode          | granted | relation                        
 ----------+---------------+---------+---------------------------------
@@ -1059,13 +1062,17 @@ BEGIN
 1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
 INSERT 0 10
 -- without GDD, it will lock all leaf partitions on QD
+--
+-- ORCA obtains AccessShareLock. cache has been invalidated after a call to
+-- pg_lock_status() due to its implementation.
 1: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
-(3 rows)
+(4 rows)
 1: ROLLBACK;
 ROLLBACK
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -375,3 +375,5 @@ test: brin_heap
 
 # Intensive tests for BRIN
 test: uao/brin_chain_row uao/brin_chain_column
+
+test: lock_status

--- a/src/test/isolation2/sql/lock_status.sql
+++ b/src/test/isolation2/sql/lock_status.sql
@@ -1,0 +1,70 @@
+-- start_ignore
+CREATE EXTENSION gp_inject_fault;
+-- end_ignore
+
+CREATE TABLE t_part(i int)
+PARTITION BY RANGE (i) (START (0) END (5) EVERY (1));
+
+-- Create a lot of locks.
+1: BEGIN;
+1: LOCK TABLE t_part IN ACCESS EXCLUSIVE MODE;
+
+--
+-- Test pg_locks view behavior.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+       gp_inject_fault('pg_lock_status_squelched', 'error', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Materializes everything regardless of LIMIT clause, as of now.
+SELECT locktype = 'nothing' AS f FROM pg_locks LIMIT 1;
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+SELECT gp_inject_fault('all', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- only from coordinator.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'error', dbid),
+       gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Doesn't materialize anything, gets squelched after the first row from
+-- coordinator.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 1;
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+SELECT gp_inject_fault('all', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+--
+-- Test pg_lock_status() behavior with LIMIT clause that should return results
+-- both from coordinator and from segments.
+--
+
+SELECT gp_inject_fault('pg_lock_status_local_locks_collected', 'skip', dbid),
+       gp_inject_fault('pg_lock_status_squelched', 'skip', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Retrieves some rows from coordinator and from a segment, then gets
+-- squelched.
+SELECT pg_lock_status()::text = 'nothing' AS f LIMIT 12;
+
+SELECT gp_wait_until_triggered_fault('pg_lock_status_squelched', 1, dbid),
+       gp_wait_until_triggered_fault('pg_lock_status_local_locks_collected', 1, dbid)
+FROM gp_segment_configuration WHERE role = 'p' and content = -1;
+
+SELECT gp_inject_fault('all', 'reset', dbid)
+FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+1: ROLLBACK;
+
+DROP TABLE t_part;

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -334,12 +334,18 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1: BEGIN;
 1: DELETE FROM t_lockmods_part_tbl_dml;
 -- on QD, there's a lock on the root and the target partition
+--
+-- ORCA doesn't acquire AccessShareLock, since it maintains partition cache for
+-- this query.
 1: select * from show_locks_lockmodes;
 1: ROLLBACK;
 
 1: BEGIN;
 1: INSERT INTO t_lockmods_part_tbl_dml SELECT i, 1, i FROM generate_series(1,10)i;
 -- without GDD, it will lock all leaf partitions on QD
+--
+-- ORCA obtains AccessShareLock. cache has been invalidated after a call to
+-- pg_lock_status() due to its implementation.
 1: select * from show_locks_lockmodes;
 1: ROLLBACK;
 


### PR DESCRIPTION
This is a cherry-pick of 3ce2e6a from #1388. The patch was adapted for 7X with small version-dependent changes.

`lockmodes` test output was adjusted. The change is caused by cache eviction between test cases. Query that is internal to `pg_lock_status()` falls back to postgres' planner because `gp_dist_random()` isn't supported by ORCA, and every fallback clears cached relations. Opening a non-cached relation, in this case, to read partition qualifications, requires an Access Share lock.

The PR should be rebased to preserve authorship.
