### PR TITLE
Resolve conflicts in the configure and configure.in

### DIFF
--- a/configure
+++ b/configure
@@ -12876,11 +12876,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-<<<<<<< HEAD
-# *BSD
-=======
 # *BSD:
->>>>>>> BISECT_HEAD
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing backtrace_symbols" >&5
 $as_echo_n "checking for library containing backtrace_symbols... " >&6; }
 if ${ac_cv_search_backtrace_symbols+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -1327,11 +1327,7 @@ AC_SEARCH_LIBS(sched_yield, rt)
 AC_SEARCH_LIBS(gethostbyname_r, nsl)
 # Cygwin:
 AC_SEARCH_LIBS(shmget, cygipc)
-<<<<<<< HEAD
-# *BSD
-=======
 # *BSD:
->>>>>>> BISECT_HEAD
 AC_SEARCH_LIBS(backtrace_symbols, execinfo)
 
 if test "$with_readline" = yes; then


### PR DESCRIPTION
Commit 71a8a4f6e36547bb060dbcc961ea9b57420f7190 added new libs to the
configure.in while earlier commit 8fee61d0ea08a712cba54f0e0d8b8506f7bcf5fa
already done it but without a colon in the comment.