### PR TITLE
Resolve conflicts in the elog.c and elog.h

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1091,8 +1091,6 @@ errmsg(const char *fmt,...)
 	errno = edata->saved_errno; /*CDB*/
 }
 
-<<<<<<< HEAD
-=======
 /*
  * Add a backtrace to the containing ereport() call.  This is intended to be
  * added temporarily during debugging.
@@ -1153,7 +1151,6 @@ set_backtrace(ErrorData *edata, int num_skip)
 	edata->backtrace = errtrace.data;
 }
 
->>>>>>> BISECT_HEAD
 /*
  * errmsg_internal --- add a primary error message text to the current error
  *
@@ -1625,31 +1622,7 @@ errFatalReturn(bool fatalReturn)
 
 	edata->fatal_return = fatalReturn;
 
-<<<<<<< HEAD
 	return 0;					/* return value does not matter */
-=======
-	/*
-	 * Format error message just like errmsg_internal().
-	 */
-	recursion_depth++;
-	oldcontext = MemoryContextSwitchTo(edata->assoc_context);
-
-	if (!edata->backtrace &&
-		edata->funcname &&
-		matches_backtrace_functions(edata->funcname))
-		set_backtrace(edata, 2);
-
-	edata->message_id = fmt;
-	EVALUATE_MESSAGE(edata->domain, message, false, false);
-
-	MemoryContextSwitchTo(oldcontext);
-	recursion_depth--;
-
-	/*
-	 * And let errfinish() finish up.
-	 */
-	errfinish(0);
->>>>>>> BISECT_HEAD
 }
 
 

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -229,14 +229,9 @@ extern void errcontext_msg(const char *fmt,...) pg_attribute_printf(1, 2);
 extern void errhidestmt(bool hide_stmt);
 extern void errhidecontext(bool hide_ctx);
 
-<<<<<<< HEAD
 extern int	errprintstack(bool printstack);
-=======
-extern int	errbacktrace(void);
 
-extern int	errfunction(const char *funcname);
-extern int	errposition(int cursorpos);
->>>>>>> BISECT_HEAD
+extern int	errbacktrace(void);
 
 extern void errfunction(const char *funcname);
 extern void errposition(int cursorpos);


### PR DESCRIPTION
Commit 71a8a4f6e36547bb060dbcc961ea9b57420f7190 added backtrace support, while
earlier commit 6b0e52beadd678c5050af9c978c26d171ba86ae0 added errprintstack
function to the same place.
Also commit 71a8a4f6e36547bb060dbcc961ea9b57420f7190 added errbacktrace function
while earlier commit 6b0e52beadd678c5050af9c978c26d171ba86ae0 added a new line
to the end of errmsg function.
In addition commit 060c26557f58905e7138a0face165e3fdcef9f52 removed the function
elog_finish that was modified in the commit
71a8a4f6e36547bb060dbcc961ea9b57420f7190