### PR TITLE
Resolve conflicts in the blinsert.c, gininsert.c, gistbuild.c, gistbuild.c, gistbuild.c, gistbuild.c, hash.c, heapam_handler.c, nbtsort.c, spginsert.c, tableam.h

### DIFF
--- a/contrib/bloom/blinsert.c
+++ b/contrib/bloom/blinsert.c
@@ -72,11 +72,7 @@ initCachedPage(BloomBuildState *buildstate)
  * Per-tuple callback for table_index_build_scan.
  */
 static void
-<<<<<<< HEAD
-bloomBuildCallback(Relation index, ItemPointer tupleId, Datum *values,
-=======
 bloomBuildCallback(Relation index, ItemPointer tid, Datum *values,
->>>>>>> BISECT_HEAD
 				   bool *isnull, bool tupleIsAlive, void *state)
 {
 	BloomBuildState *buildstate = (BloomBuildState *) state;
@@ -85,11 +81,7 @@ bloomBuildCallback(Relation index, ItemPointer tid, Datum *values,
 
 	oldCtx = MemoryContextSwitchTo(buildstate->tmpCtx);
 
-<<<<<<< HEAD
-	itup = BloomFormTuple(&buildstate->blstate, tupleId, values, isnull);
-=======
 	itup = BloomFormTuple(&buildstate->blstate, tid, values, isnull);
->>>>>>> BISECT_HEAD
 
 	/* Try to add next item to cached page */
 	if (BloomPageAddItem(&buildstate->blstate, buildstate->data.data, itup))

--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -276,13 +276,8 @@ ginHeapTupleBulkInsert(GinBuildState *buildstate, OffsetNumber attnum,
 }
 
 static void
-<<<<<<< HEAD
-ginBuildCallback(Relation index, ItemPointer tupleId, Datum *values,
-				 bool *isnull, bool tupleIsAlive pg_attribute_unused(), void *state)
-=======
 ginBuildCallback(Relation index, ItemPointer tid, Datum *values,
 				 bool *isnull, bool tupleIsAlive, void *state)
->>>>>>> BISECT_HEAD
 {
 	GinBuildState *buildstate = (GinBuildState *) state;
 	MemoryContext oldCtx;
@@ -292,12 +287,7 @@ ginBuildCallback(Relation index, ItemPointer tid, Datum *values,
 
 	for (i = 0; i < buildstate->ginstate.origTupdesc->natts; i++)
 		ginHeapTupleBulkInsert(buildstate, (OffsetNumber) (i + 1),
-<<<<<<< HEAD
-							   values[i], isnull[i],
-							   tupleId);
-=======
 							   values[i], isnull[i], tid);
->>>>>>> BISECT_HEAD
 
 	/* If we've maxed out our available memory, dump everything to the index */
 	if (buildstate->accum.allocatedMemory >= (Size) maintenance_work_mem * 1024L)

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -80,11 +80,7 @@ typedef struct
 static void gistInitBuffering(GISTBuildState *buildstate);
 static int	calculatePagesPerBuffer(GISTBuildState *buildstate, int levelStep);
 static void gistBuildCallback(Relation index,
-<<<<<<< HEAD
-							  ItemPointer tupleId,
-=======
 							  ItemPointer tid,
->>>>>>> BISECT_HEAD
 							  Datum *values,
 							  bool *isnull,
 							  bool tupleIsAlive,
@@ -444,11 +440,7 @@ calculatePagesPerBuffer(GISTBuildState *buildstate, int levelStep)
  */
 static void
 gistBuildCallback(Relation index,
-<<<<<<< HEAD
-				  ItemPointer tupleId,
-=======
 				  ItemPointer tid,
->>>>>>> BISECT_HEAD
 				  Datum *values,
 				  bool *isnull,
 				  bool tupleIsAlive,
@@ -462,11 +454,7 @@ gistBuildCallback(Relation index,
 
 	/* form an index tuple and point it at the heap tuple */
 	itup = gistFormTuple(buildstate->giststate, index, values, isnull, true);
-<<<<<<< HEAD
-	itup->t_tid = *tupleId;
-=======
 	itup->t_tid = *tid;
->>>>>>> BISECT_HEAD
 
 	if (buildstate->bufferingMode == GIST_BUFFERING_ACTIVE)
 	{

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -43,11 +43,7 @@ typedef struct
 } HashBuildState;
 
 static void hashbuildCallback(Relation index,
-<<<<<<< HEAD
-							  ItemPointer tupleId,
-=======
 							  ItemPointer tid,
->>>>>>> BISECT_HEAD
 							  Datum *values,
 							  bool *isnull,
 							  bool tupleIsAlive,
@@ -209,7 +205,6 @@ hashbuildCallback(Relation index,
 				  ItemPointer tupleId,
 =======
 				  ItemPointer tid,
->>>>>>> BISECT_HEAD
 				  Datum *values,
 				  bool *isnull,
 				  bool tupleIsAlive,
@@ -228,22 +223,13 @@ hashbuildCallback(Relation index,
 
 	/* Either spool the tuple for sorting, or just put it into the index */
 	if (buildstate->spool)
-<<<<<<< HEAD
-		_h_spool(buildstate->spool, tupleId,
-				 index_values, index_isnull);
-=======
 		_h_spool(buildstate->spool, tid, index_values, index_isnull);
->>>>>>> BISECT_HEAD
 	else
 	{
 		/* form an index tuple and point it at the heap tuple */
 		itup = index_form_tuple(RelationGetDescr(index),
 								index_values, index_isnull);
-<<<<<<< HEAD
-		itup->t_tid = *tupleId;
-=======
 		itup->t_tid = *tid;
->>>>>>> BISECT_HEAD
 		_hash_doinsert(index, itup, buildstate->heapRel);
 		pfree(itup);
 	}

--- a/src/backend/access/hash/hash.c
+++ b/src/backend/access/hash/hash.c
@@ -201,9 +201,6 @@ hashbuildempty(Relation index)
  */
 static void
 hashbuildCallback(Relation index,
-<<<<<<< HEAD
-				  ItemPointer tupleId,
-=======
 				  ItemPointer tid,
 				  Datum *values,
 				  bool *isnull,

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -1686,23 +1686,14 @@ heapam_index_build_range_scan(Relation heapRelation,
 						   root_offsets[offnum - 1]);
 
 			/* Call the AM's callback routine to process the tuple */
-<<<<<<< HEAD
-			callback(indexRelation, &rootTuple.t_self, values, isnull, tupleIsAlive,
-=======
 			callback(indexRelation, &tid, values, isnull, tupleIsAlive,
->>>>>>> BISECT_HEAD
 					 callback_state);
 		}
 		else
 		{
 			/* Call the AM's callback routine to process the tuple */
-<<<<<<< HEAD
-			callback(indexRelation, &heapTuple->t_self, values, isnull, tupleIsAlive,
-					 callback_state);
-=======
 			callback(indexRelation, &heapTuple->t_self, values, isnull,
 					 tupleIsAlive, callback_state);
->>>>>>> BISECT_HEAD
 		}
 	}
 

--- a/src/backend/access/nbtree/nbtsort.c
+++ b/src/backend/access/nbtree/nbtsort.c
@@ -269,11 +269,7 @@ static void _bt_spooldestroy(BTSpool *btspool);
 static void _bt_spool(BTSpool *btspool, ItemPointer self,
 					  Datum *values, bool *isnull);
 static void _bt_leafbuild(BTSpool *btspool, BTSpool *btspool2);
-<<<<<<< HEAD
-static void _bt_build_callback(Relation index, ItemPointer tupleId, Datum *values,
-=======
 static void _bt_build_callback(Relation index, ItemPointer tid, Datum *values,
->>>>>>> BISECT_HEAD
 							   bool *isnull, bool tupleIsAlive, void *state);
 static Page _bt_blnewpage(uint32 level);
 static BTPageState *_bt_pagestate(BTWriteState *wstate, uint32 level);
@@ -589,11 +585,7 @@ _bt_leafbuild(BTSpool *btspool, BTSpool *btspool2)
  */
 static void
 _bt_build_callback(Relation index,
-<<<<<<< HEAD
-				   ItemPointer tupleId,
-=======
 				   ItemPointer tid,
->>>>>>> BISECT_HEAD
 				   Datum *values,
 				   bool *isnull,
 				   bool tupleIsAlive,
@@ -606,20 +598,12 @@ _bt_build_callback(Relation index,
 	 * processing
 	 */
 	if (tupleIsAlive || buildstate->spool2 == NULL)
-<<<<<<< HEAD
-		_bt_spool(buildstate->spool, tupleId, values, isnull);
-=======
 		_bt_spool(buildstate->spool, tid, values, isnull);
->>>>>>> BISECT_HEAD
 	else
 	{
 		/* dead tuples are put into spool2 */
 		buildstate->havedead = true;
-<<<<<<< HEAD
-		_bt_spool(buildstate->spool2, tupleId, values, isnull);
-=======
 		_bt_spool(buildstate->spool2, tid, values, isnull);
->>>>>>> BISECT_HEAD
 	}
 
 	buildstate->indtuples += 1;

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -40,11 +40,7 @@ typedef struct
 
 /* Callback to process one heap tuple during table_index_build_scan */
 static void
-<<<<<<< HEAD
-spgistBuildCallback(Relation index, ItemPointer tupleId, Datum *values,
-=======
 spgistBuildCallback(Relation index, ItemPointer tid, Datum *values,
->>>>>>> BISECT_HEAD
 					bool *isnull, bool tupleIsAlive, void *state)
 {
 	SpGistBuildState *buildstate = (SpGistBuildState *) state;
@@ -59,11 +55,7 @@ spgistBuildCallback(Relation index, ItemPointer tid, Datum *values,
 	 * lock on some buffer.  So we need to be willing to retry.  We can flush
 	 * any temp data when retrying.
 	 */
-<<<<<<< HEAD
-	while (!spgdoinsert(index, &buildstate->spgstate, tupleId,
-=======
 	while (!spgdoinsert(index, &buildstate->spgstate, tid,
->>>>>>> BISECT_HEAD
 						*values, *isnull))
 	{
 		MemoryContextReset(buildstate->tmpCtx);

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -143,11 +143,7 @@ typedef struct TM_FailureData
 /* GPDB: This takes an ItemPointer, rather than HeapTuple, because this is also
  * used with AO/AOCO tables */
 typedef void (*IndexBuildCallback) (Relation index,
-<<<<<<< HEAD
-									ItemPointer tupleid,
-=======
 									ItemPointer tid,
->>>>>>> BISECT_HEAD
 									Datum *values,
 									bool *isnull,
 									bool tupleIsAlive,


### PR DESCRIPTION
Commit aae50236e4ce95c05a3962be0814c74c5a22206d added a new argument to the
batch of places while earlier commits 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4, 6b0e52beadd678c5050af9c978c26d171ba86ae0 and 598f4b0ef7a00f4a629bfc2b6de42782b3cd538a already do the same but with a
different name.