### PR TITLE
Resolve conflicts in the src/backend/executor/Makefile

### DIFF
--- a/src/backend/executor/Makefile
+++ b/src/backend/executor/Makefile
@@ -14,26 +14,6 @@ include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 
 
-<<<<<<< HEAD
-OBJS = execAmi.o execCurrent.o execExpr.o execExprInterp.o \
-       execGrouping.o execIndexing.o execJunk.o \
-       execMain.o execParallel.o execPartition.o execProcnode.o \
-       execReplication.o execScan.o execSRF.o execTuples.o \
-       execUtils.o functions.o instrument.o nodeAppend.o nodeAgg.o \
-       nodeBitmapAnd.o nodeBitmapOr.o \
-       nodeBitmapHeapscan.o nodeBitmapIndexscan.o \
-       nodeCustom.o nodeFunctionscan.o nodeGather.o \
-       nodeHash.o nodeHashjoin.o nodeIndexscan.o nodeIndexonlyscan.o \
-       nodeLimit.o nodeLockRows.o nodeGatherMerge.o \
-       nodeMaterial.o nodeMergeAppend.o nodeMergejoin.o nodeModifyTable.o \
-       nodeNestloop.o nodeProjectSet.o nodeRecursiveunion.o nodeResult.o \
-       nodeSamplescan.o nodeSeqscan.o nodeSetOp.o nodeSort.o nodeUnique.o \
-       nodeValuesscan.o \
-       nodeCtescan.o nodeNamedtuplestorescan.o nodeWorktablescan.o \
-       nodeSubplan.o nodeSubqueryscan.o nodeTidscan.o \
-       nodeForeignscan.o nodeWindowAgg.o tstoreReceiver.o tqueue.o spi.o \
-       nodeTableFuncscan.o
-=======
 OBJS = \
 	execAmi.o \
 	execCurrent.o \
@@ -65,7 +45,6 @@ OBJS = \
 	nodeFunctionscan.o \
 	nodeGather.o \
 	nodeGatherMerge.o \
-	nodeGroup.o \
 	nodeHash.o \
 	nodeHashjoin.o \
 	nodeIndexonlyscan.o \
@@ -96,7 +75,6 @@ OBJS = \
 	spi.o \
 	tqueue.o \
 	tstoreReceiver.o
->>>>>>> BISECT_HEAD
 
 OBJS += nodeMotion.o \
        nodeShareInputScan.o \


### PR DESCRIPTION
Commit 01368e5d9da77099b38aac527b01b85cc7869b25 reformat object file list,
while earlier commit 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 removed
nodeGroup.o from list since it is not used in gpdb.