### PR TITLE
Resolve conflicts in the src/backend/lib/Makefile

### DIFF
--- a/src/backend/lib/Makefile
+++ b/src/backend/lib/Makefile
@@ -12,10 +12,6 @@ subdir = src/backend/lib
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-<<<<<<< HEAD
-OBJS = binaryheap.o bipartite_match.o bloomfilter.o dshash.o hyperloglog.o \
-       ilist.o integerset.o knapsack.o pairingheap.o rbtree.o
-=======
 OBJS = \
 	binaryheap.o \
 	bipartite_match.o \
@@ -27,6 +23,5 @@ OBJS = \
 	knapsack.o \
 	pairingheap.o \
 	rbtree.o \
->>>>>>> BISECT_HEAD
 
 include $(top_srcdir)/src/backend/common.mk


### PR DESCRIPTION
Commit 01368e5d9da77099b38aac527b01b85cc7869b25 reformat object file list,
while earlier commit 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 removed
stringinfo.o from list.