### PR TITLE
Resolve conflicts in the src/backend/libpq/auth.c

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -1799,10 +1799,6 @@ pg_SSPI_recvauth(Port *port)
 		outbuf.pBuffers = OutBuffers;
 		outbuf.ulVersion = SECBUFFER_VERSION;
 
-<<<<<<< HEAD
-
-=======
->>>>>>> BISECT_HEAD
 		elog(DEBUG4, "processing received SSPI token of length %u",
 			 (unsigned int) buf.len);
 
@@ -2401,21 +2397,17 @@ auth_peer(hbaPort *port)
 	/* Make a copy of static getpw*() result area. */
 	peer_user = pstrdup(pw->pw_name);
 
-<<<<<<< HEAD
 	/*
 	 * GPDB: check for port->hba == NULL here, because auth_peer is used
 	 * without an HBA entry in the short-circuited QD->QE authentication,
 	 * from internal_client_authentication().
 	 */
-	return check_usermap(port->hba ? port->hba->usermap : NULL,
-						 port->user_name, ident_user, false);
-=======
-	ret = check_usermap(port->hba->usermap, port->user_name, peer_user, false);
+	ret = check_usermap(port->hba ? port->hba->usermap : NULL, port->user_name,
+						peer_user, false);
 
 	pfree(peer_user);
 
 	return ret;
->>>>>>> BISECT_HEAD
 }
 #endif							/* HAVE_UNIX_SOCKETS */
 


### PR DESCRIPTION
Commit 66c61c81b90c68db84d422092fbbf8a1a82ee09a update log message in
pg_SSPI_recvauth while earlier commit 8a4c2db278f1c9494bcf47992513b1b19b81f6f4
already done it.
Commit c5e1df951d9d70ab7d53ce47caaf73f3b2d6b1e1 rename ident_user to peer_user
while earlier commit 25a90396cd1c52d252a37986e12b63e8e037aa83 add condition for
port->hba begin null to the same line.