### PR TITLE
Resolve conflict in contrib/postgres_fdw/connection.c

### DIFF
--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -719,26 +719,12 @@ pgfdw_xact_callback(XactEvent event, void *arg)
 				case XACT_EVENT_PRE_PREPARE:
 
 					/*
-<<<<<<< HEAD
 					 * FDW update is not the same as Greenplum segments update,
 					 * doesn't need the two-phase commit.
 					 *
 					 * Besides that, Greenplum prepares on many cases including
 					 * DTX distributing for MPP usages, just break here.
 					 */
-=======
-					 * We disallow any remote transactions, since it's not
-					 * very reasonable to hold them open until the prepared
-					 * transaction is committed.  For the moment, throw error
-					 * unconditionally; later we might allow read-only cases.
-					 * Note that the error will cause us to come right back
-					 * here with event == XACT_EVENT_ABORT, so we'll clean up
-					 * the connection state at that point.
-					 */
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("cannot PREPARE a transaction that has operated on postgres_fdw foreign tables")));
->>>>>>> BISECT_HEAD
 					break;
 				case XACT_EVENT_PARALLEL_COMMIT:
 				case XACT_EVENT_COMMIT:


### PR DESCRIPTION
GPDB-specific 16d9de1 logic does not throw an error in XACT_EVENT_PRE_PREPARE of
pgfdw_xact_callback function, since the postgres_fdw extension does not require
participation in Greenplum's distributed 2PC. The conflict occured due to error
message rephrasing from upstream in 879c117
