### PR TITLE
Resolve conflict in spginsert.c

### DIFF
--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -40,11 +40,7 @@ typedef struct
 
 /* Callback to process one heap tuple during table_index_build_scan */
 static void
-<<<<<<< HEAD
-spgistBuildCallback(Relation index, ItemPointer tupleId, Datum *values,
-=======
 spgistBuildCallback(Relation index, ItemPointer tid, Datum *values,
->>>>>>> BISECT_HEAD
 					bool *isnull, bool tupleIsAlive, void *state)
 {
 	SpGistBuildState *buildstate = (SpGistBuildState *) state;
@@ -59,11 +55,7 @@ spgistBuildCallback(Relation index, ItemPointer tid, Datum *values,
 	 * lock on some buffer.  So we need to be willing to retry.  We can flush
 	 * any temp data when retrying.
 	 */
-<<<<<<< HEAD
-	while (!spgdoinsert(index, &buildstate->spgstate, tupleId,
-=======
 	while (!spgdoinsert(index, &buildstate->spgstate, tid,
->>>>>>> BISECT_HEAD
 						*values, *isnull))
 	{
 		MemoryContextReset(buildstate->tmpCtx);


### PR DESCRIPTION
Commit 19cd1cf  introduced function spgistBuildCallback, and commit 
a9048e8 changed argument list.

Commit 598f4b0 changed parameter from HeapTuple to ItemPointer, 
while commit aae5023 did the same with a different parameter name. 
Prefer PostgreSQL style.
