### PR TITLE
Resolve conflict in contrib/pageinspect/heapfuncs.c

### DIFF
--- a/contrib/pageinspect/heapfuncs.c
+++ b/contrib/pageinspect/heapfuncs.c
@@ -29,11 +29,8 @@
 #include "access/relation.h"
 #include "catalog/pg_am_d.h"
 #include "catalog/pg_type.h"
-<<<<<<< HEAD
-#include "mb/pg_wchar.h"
-=======
 #include "funcapi.h"
->>>>>>> BISECT_HEAD
+#include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "pageinspect.h"
 #include "port/pg_bitutils.h"


### PR DESCRIPTION
Incoming 7e73503 has changed the order of include header files. The abf1165
included one more header. Here both changes are accepted.
