### PR TITLE
Resolve conflict in contrib/pageinspect/Makefile

### DIFF
--- a/contrib/pageinspect/Makefile
+++ b/contrib/pageinspect/Makefile
@@ -1,12 +1,9 @@
 # contrib/pageinspect/Makefile
 
 MODULE_big	= pageinspect
-<<<<<<< HEAD
-OBJS		= rawpage.o heapfuncs.o bmfuncs.o btreefuncs.o fsmfuncs.o \
-		  brinfuncs.o ginfuncs.o hashfuncs.o $(WIN32RES)
-=======
 OBJS = \
 	$(WIN32RES) \
+	bmfuncs.o \
 	brinfuncs.o \
 	btreefuncs.o \
 	fsmfuncs.o \
@@ -14,7 +11,6 @@ OBJS = \
 	hashfuncs.o \
 	heapfuncs.o \
 	rawpage.o
->>>>>>> BISECT_HEAD
 
 EXTENSION = pageinspect
 DATA = pageinspect--1.7--1.8.sql pageinspect--1.6--1.7.sql \


### PR DESCRIPTION
01368e5 refactored Makefile obj files into  one-line-per-entry style.
6896b2e added functions for bitmap index inspection.