### PR TITLE
Resolve conflicts in the src/backend/replication/syncrep.c

### DIFF
--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -809,15 +809,12 @@ cmp_lsn(const void *a, const void *b)
 List *
 SyncRepGetSyncStandbys(bool *am_sync)
 {
-<<<<<<< HEAD
 	List	   *result = NIL;
 	bool		syncStandbyPresent;
 	int			i;
 	volatile WalSnd *walsnd;	/* Use volatile pointer to prevent code
 								 * rearrangement */
-=======
 	Assert(LWLockHeldByMe(SyncRepLock));
->>>>>>> BISECT_HEAD
 
 	/* Set default result */
 	if (am_sync != NULL)


### PR DESCRIPTION
Commit e174f699c476a4cc01875211a5f43e57c3190a37 added assert to the
SyncRepGetSyncStandbys function, while earlier commits
38d88155520790b268b1a380caa9a2d9508edc66 and
19cd1cf4b68faff2e29bc2fa884c480e4644cdb4 added gpdb-specific code nearby.