### PR TITLE
Resolve conflicts in the src/backend/tcop/postgres.c

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5051,11 +5051,7 @@ PostgresMain(int argc, char *argv[],
 		 */
 		disable_all_timeouts(false);
 		QueryCancelPending = false; /* second to avoid race condition */
-<<<<<<< HEAD
 		QueryFinishPending = false;
-		stmt_timeout_active = false;
-=======
->>>>>>> BISECT_HEAD
 
 		/* Not reading from the client anymore. */
 		DoingCommandRead = false;


### PR DESCRIPTION
Commit 22f6f2c1ccb56e0d6a159d4562418587e4b10e01 removed stmt_timeout_active
while earlier commit 6b0e52beadd678c5050af9c978c26d171ba86ae0 added
gpdb-specific code nearby.