### PR TITLE
Resolve conflicts in the src/backend/utils/cache/syscache.c

### DIFF
--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -79,12 +79,9 @@
 #include "catalog/pg_ts_template.h"
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
-<<<<<<< HEAD
 #include "catalog/pg_resgroup.h"
 #include "catalog/pg_extprotocol.h"
-=======
 #include "lib/qunique.h"
->>>>>>> BISECT_HEAD
 #include "utils/rel.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"


### PR DESCRIPTION
Commit 7815e7efdb4ce9575b5d8460beb0dd2569d7ca3a added a new include to the
syscache.c while earlier commits c975440f04cde28913deb8037f7602d394bdaa66 and 
d4d4a16ccf91527f53d7032418476017cb7a3712 added 2 more includes to the same place