### PR TITLE
Resolve conflicts in the src/backend/utils/hash/Makefile

### DIFF
--- a/src/backend/utils/hash/Makefile
+++ b/src/backend/utils/hash/Makefile
@@ -14,10 +14,6 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS = \
 	dynahash.o \
-<<<<<<< HEAD
-=======
-	hashfn.o \
->>>>>>> BISECT_HEAD
 	pg_crc.o
 
 include $(top_srcdir)/src/backend/common.mk


### PR DESCRIPTION
Commit 5d3dc2e81f272396281eddc082bd998ab96fd0da reformat object file list and
removed hashfn.o from list while this commit was already backported.