### PR TITLE
Resolve conflicts in the contrib/ltree/Makefile

### DIFF
--- a/contrib/ltree/Makefile
+++ b/contrib/ltree/Makefile
@@ -1,10 +1,6 @@
 # contrib/ltree/Makefile
 
 MODULE_big = ltree
-<<<<<<< HEAD
-OBJS = 	ltree_io.o ltree_op.o lquery_op.o _ltree_op.o crc32.o \
-	ltxtquery_io.o ltxtquery_op.o ltree_gist.o _ltree_gist.o
-=======
 OBJS = \
 	$(WIN32RES) \
 	_ltree_gist.o \
@@ -16,7 +12,6 @@ OBJS = \
 	ltree_op.o \
 	ltxtquery_io.o \
 	ltxtquery_op.o
->>>>>>> BISECT_HEAD
 PG_CPPFLAGS = -DLOWER_NODE
 
 EXTENSION = ltree


### PR DESCRIPTION
Commit 01368e5d9da77099b38aac527b01b85cc7869b25 reformat object file list,
while earlier commit 8682589d1a6debe7386b8a114bd96f0e2824c5fd removed WIN32RES
from that list.