### PR TITLE
Resolve conflicts in the src/bin/pg_rewind/filemap.c

### DIFF
--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -13,18 +13,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "catalog/catalog.h"
 #include "catalog/pg_tablespace_d.h"
 #include "common/string.h"
 #include "datapagemap.h"
 #include "filemap.h"
 #include "pg_rewind.h"
-<<<<<<< HEAD
-
-#include "catalog/catalog.h"
-#include "common/string.h"
-#include "catalog/pg_tablespace_d.h"
-=======
->>>>>>> BISECT_HEAD
 #include "storage/fd.h"
 
 filemap_t  *filemap = NULL;


### PR DESCRIPTION
Commit dddf4cdc3300073ec04b2c3e482a4c1fa4b8191b changed the order of includes,
while earlier commit 4688c17ed00ed93ebd114d440e9d25a695aed76f added one more
include.