### PR TITLE
Resolve conflicts in the src/bin/pg_rewind/parsexlog.c

### DIFF
--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -19,14 +19,10 @@
 #include "catalog/pg_control.h"
 #include "catalog/storage_xlog.h"
 #include "commands/dbcommands_xlog.h"
-<<<<<<< HEAD
-
-/* GPDB specific headers */
-#include "cdb/cdbappendonlyxlog.h"
-=======
 #include "filemap.h"
 #include "pg_rewind.h"
->>>>>>> BISECT_HEAD
+/* GPDB specific headers */
+#include "cdb/cdbappendonlyxlog.h"
 
 /*
  * RmgrNames is an array of resource manager names, to make error messages


### PR DESCRIPTION
Commit dddf4cdc3300073ec04b2c3e482a4c1fa4b8191b changed the order of includes,
while earlier commit 97a76214c589751203956316d406ffd61f994aaf added one more
include.