### PR TITLE
Resolve conflicts in the src/bin/pg_rewind/pg_rewind.c

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -26,13 +26,9 @@
 #include "file_ops.h"
 #include "filemap.h"
 #include "getopt_long.h"
-<<<<<<< HEAD
-#include "common/restricted_token.h"
-#include "utils/palloc.h"
-=======
 #include "pg_rewind.h"
->>>>>>> BISECT_HEAD
 #include "storage/bufpage.h"
+#include "utils/palloc.h"
 
 static void usage(const char *progname);
 


### PR DESCRIPTION
Commit dddf4cdc3300073ec04b2c3e482a4c1fa4b8191b changed the order of includes,
while earlier commits 686145bd532062c954c3f8473f59143a59af88fb and 
8ae22d15ebf0cf68b0854e2a2630b7b997e3ce1c added 2 more.