### PR TITLE
Resolve conflicts in the src/bin/pg_upgrade/controldata.c

### DIFF
--- a/src/bin/pg_upgrade/controldata.c
+++ b/src/bin/pg_upgrade/controldata.c
@@ -9,12 +9,7 @@
 
 #include "postgres_fe.h"
 
-<<<<<<< HEAD
-#include "pg_upgrade.h"
 #include "greenplum/pg_upgrade_greenplum.h"
-
-=======
->>>>>>> BISECT_HEAD
 #include <ctype.h>
 
 #include "pg_upgrade.h"


### PR DESCRIPTION
Commit dddf4cdc3300073ec04b2c3e482a4c1fa4b8191b moved include while earlier
commit 3a2b9d9e198470e6225e4fa496b505ed1b5220e7 added gpdb-specific include to
the same place.