### PR TITLE
Resolve conflict in pg_waldump.c

### DIFF
--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -525,15 +525,12 @@ XLogDumpDisplayRecord(XLogDumpConfig *config, XLogReaderState *record)
 		   (uint32) (record->ReadRecPtr >> 32), (uint32) record->ReadRecPtr,
 		   (uint32) (xl_prev >> 32), (uint32) xl_prev);
 
-<<<<<<< HEAD
-=======
 	id = desc->rm_identify(info);
 	if (id == NULL)
 		printf("desc: UNKNOWN (%x) ", info & ~XLR_INFO_MASK);
 	else
 		printf("desc: %s ", id);
 
->>>>>>> BISECT_HEAD
 	initStringInfo(&s);
 	desc->rm_desc(&s, record);
 	printf("%s", s.data);


### PR DESCRIPTION
Commit e0f76f2 added extended print of desc identity if it NULL to PostgreSQL, 
while commit 2056a33 added code below.