### PR TITLE
Fix guc_test

### DIFF
--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -1,6 +1,6 @@
 /* items in this file should be ordered */
-		"bytea_output",
 		"backtrace_functions",
+		"bytea_output",
 		"client_min_messages",
 		"commit_delay",
 		"commit_siblings",

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -1,5 +1,6 @@
 /* items in this file should be ordered */
 		"bytea_output",
+		"backtrace_functions",
 		"client_min_messages",
 		"commit_delay",
 		"commit_siblings",
@@ -92,6 +93,7 @@
 		"log_duration",
 		"log_error_verbosity",
 		"log_executor_stats",
+		"log_min_duration_sample",
 		"log_min_duration_statement",
 		"log_min_error_statement",
 		"log_min_messages",


### PR DESCRIPTION
Commits 71a8a4f6e36547bb060dbcc961ea9b57420f7190 and 
6e3e6cc0e884a6091e1094dff29db430af08fb93 added new GUCs so we need to add them
to the sync_guc_name or to unsync_guc_name. Since both GUC make sense on the QE
add them to the sync_guc_name.