### PR TITLE
Fix SyncRepWaitForLSN invocation

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -13093,11 +13093,8 @@ wait_to_avoid_large_repl_lag(void)
 	if (rep_lag_avoidance_threshold &&
 		wal_bytes_written > (rep_lag_avoidance_threshold * 1024))
 	{
-		/* holdoff interruptions to prevent out of sync with the mirror. */
-		HOLD_INTERRUPTS();
 		/* we use local cached copy of LogwrtResult here */
 		SyncRepWaitForLSN(LogwrtResult.Flush, false);
-		RESUME_INTERRUPTS();
 		wal_bytes_written = 0;
 	}
 }
@@ -13114,9 +13111,7 @@ wait_for_mirror()
     SpinLockRelease(&xlogctl->info_lck);
 
     /* holdoff interruptions to prevent out of sync with the mirror. */
-    HOLD_INTERRUPTS();
     SyncRepWaitForLSN(tmpLogwrtResult.Flush, false);
-    RESUME_INTERRUPTS();
 }
 
 /*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -13110,7 +13110,6 @@ wait_for_mirror()
     tmpLogwrtResult = xlogctl->LogwrtResult;
     SpinLockRelease(&xlogctl->info_lck);
 
-    /* holdoff interruptions to prevent out of sync with the mirror. */
     SyncRepWaitForLSN(tmpLogwrtResult.Flush, false);
 }
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -13093,8 +13093,11 @@ wait_to_avoid_large_repl_lag(void)
 	if (rep_lag_avoidance_threshold &&
 		wal_bytes_written > (rep_lag_avoidance_threshold * 1024))
 	{
+		/* holdoff interruptions to prevent out of sync with the mirror. */
+		HOLD_INTERRUPTS();
 		/* we use local cached copy of LogwrtResult here */
 		SyncRepWaitForLSN(LogwrtResult.Flush, false);
+		RESUME_INTERRUPTS();
 		wal_bytes_written = 0;
 	}
 }
@@ -13110,7 +13113,10 @@ wait_for_mirror()
     tmpLogwrtResult = xlogctl->LogwrtResult;
     SpinLockRelease(&xlogctl->info_lck);
 
+    /* holdoff interruptions to prevent out of sync with the mirror. */
+    HOLD_INTERRUPTS();
     SyncRepWaitForLSN(tmpLogwrtResult.Flush, false);
+    RESUME_INTERRUPTS();
 }
 
 /*

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -253,7 +253,7 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	Assert(SyncRepQueueIsOrderedByLSN(mode));
 	LWLockRelease(SyncRepLock);
 
-	/* holdoff interrupters to prevent interrupt */
+	/* holdoff interrupters to prevent cancellation of sync with the mirror */
 	HOLD_INTERRUPTS();
 
 	elogif(debug_walrepl_syncrep, LOG,

--- a/src/backend/replication/syncrep.c
+++ b/src/backend/replication/syncrep.c
@@ -158,13 +158,6 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	const char *old_status;
 	int			mode;
 
-	/*
-	 * This should be called while holding interrupts during a transaction
-	 * commit to prevent the follow-up shared memory queue cleanups to be
-	 * influenced by external interruptions.
-	 */
-	Assert(InterruptHoldoffCount > 0);
-
 	/* Cap the level for anything other than commit to remote flush only. */
 	if (commit)
 		mode = SyncRepWaitMode;
@@ -259,6 +252,9 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 	SyncRepQueueInsert(mode);
 	Assert(SyncRepQueueIsOrderedByLSN(mode));
 	LWLockRelease(SyncRepLock);
+
+	/* holdoff interrupters to prevent interrupt */
+	HOLD_INTERRUPTS();
 
 	elogif(debug_walrepl_syncrep, LOG,
 			"syncrep wait -- This backend is now inserted in the syncrep queue.");
@@ -407,6 +403,8 @@ SyncRepWaitForLSN(XLogRecPtr lsn, bool commit)
 		set_ps_display(new_status, false);
 		pfree(new_status);
 	}
+
+	RESUME_INTERRUPTS();
 }
 
 /*


### PR DESCRIPTION
After adding a process to the replication waiting queue, we must either wait
for replication to complete or call SyncRepCancelWait to cancel it. Since
elog/report contain CHECK_FOR_INTERRUPTS inside, calling them may cause the
function to exit and violate the logic described earlier. Therefore, after
adding the process to the waiting queue, we need to holdoff interrupts until
replication is complete.
For details, see https://www.postgresql.org/message-id/a0806273-8bbb-43b3-bbe1-c45a58f6ae21.lingce.ldm@alibaba-inc.com